### PR TITLE
Move creation of strongly typed param values

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/IGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IGenerator.cs
@@ -15,5 +15,7 @@ namespace Microsoft.TemplateEngine.Abstractions
         bool TryGetTemplateFromConfig(IFileSystemInfo config, out ITemplate template);
 
         bool TryGetTemplateFromSource(IMountPoint target, string name, out ITemplate template);
+
+        object ConvertVariableValueToType(ITemplateParameter parameter, string untypedValue);
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/IGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IGenerator.cs
@@ -16,6 +16,6 @@ namespace Microsoft.TemplateEngine.Abstractions
 
         bool TryGetTemplateFromSource(IMountPoint target, string name, out ITemplate template);
 
-        object ConvertVariableValueToType(ITemplateParameter parameter, string untypedValue);
+        object ConvertParameterValueToType(ITemplateParameter parameter, string untypedValue);
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/IParameterSet.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IParameterSet.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TemplateEngine.Abstractions
 
         IEnumerable<string> RequiredBrokerCapabilities { get; }
 
-        IDictionary<ITemplateParameter, string> ResolvedValues { get; }
+        IDictionary<ITemplateParameter, object> ResolvedValues { get; }
 
         bool TryGetParameterDefinition(string name, out ITemplateParameter parameter);
     }

--- a/src/Microsoft.TemplateEngine.Abstractions/ITemplateParameter.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ITemplateParameter.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.TemplateEngine.Abstractions
+﻿using System.Collections.Generic;
+
+namespace Microsoft.TemplateEngine.Abstractions
 {
     public interface ITemplateParameter
     {
@@ -15,5 +17,7 @@
         string DefaultValue { get; }
 
         string DataType { get; }
+
+        IReadOnlyList<string> Choices { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
@@ -144,11 +144,11 @@ namespace Microsoft.TemplateEngine.Edge.Template
                 }
                 else if (host.TryGetHostParamDefault(param.Name, out hostParamValue) && hostParamValue != null)
                 {
-                    templateParams.ResolvedValues[param] = template.Generator.ConvertVariableValueToType(param, hostParamValue);
+                    templateParams.ResolvedValues[param] = template.Generator.ConvertParameterValueToType(param, hostParamValue);
                 }
                 else if (param.Priority != TemplateParameterPriority.Required && param.DefaultValue != null)
                 {
-                    templateParams.ResolvedValues[param] = template.Generator.ConvertVariableValueToType(param, param.DefaultValue);
+                    templateParams.ResolvedValues[param] = template.Generator.ConvertParameterValueToType(param, param.DefaultValue);
                 }
             }
 
@@ -175,7 +175,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                         {
                             // could probably directly assign bool true here, but best to have evrything go through the same process
                             // ... in case something changes downstream.
-                            templateParams.ResolvedValues[paramFromTemplate] = template.Generator.ConvertVariableValueToType(paramFromTemplate, "true");
+                            templateParams.ResolvedValues[paramFromTemplate] = template.Generator.ConvertParameterValueToType(paramFromTemplate, "true");
                         }
                         else
                         {
@@ -184,7 +184,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                     }
                     else
                     {
-                        templateParams.ResolvedValues[paramFromTemplate] = template.Generator.ConvertVariableValueToType(paramFromTemplate, inputParam.Value);
+                        templateParams.ResolvedValues[paramFromTemplate] = template.Generator.ConvertParameterValueToType(paramFromTemplate, inputParam.Value);
                     }
                 }
             }

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
@@ -104,7 +104,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                 return 0;
             }
 
-            ResolveUserParameters(templateParams, inputParameters);
+            ResolveUserParameters(template, templateParams, inputParameters);
             bool missingParams = CheckForMissingRequiredParameters(host, templateParams);
 
             if (missingParams)
@@ -144,11 +144,11 @@ namespace Microsoft.TemplateEngine.Edge.Template
                 }
                 else if (host.TryGetHostParamDefault(param.Name, out hostParamValue) && hostParamValue != null)
                 {
-                    templateParams.ResolvedValues[param] = hostParamValue;
+                    templateParams.ResolvedValues[param] = template.Generator.ConvertVariableValueToType(param, hostParamValue);
                 }
                 else if (param.Priority != TemplateParameterPriority.Required && param.DefaultValue != null)
                 {
-                    templateParams.ResolvedValues[param] = param.DefaultValue;
+                    templateParams.ResolvedValues[param] = template.Generator.ConvertVariableValueToType(param, param.DefaultValue);
                 }
             }
 
@@ -159,7 +159,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
         // The template params for which there are same-named input parameters have their values set to the corresponding input paramers value.
         // input parameters that do not have corresponding template params are ignored.
         //
-        public static void ResolveUserParameters(IParameterSet templateParams, IReadOnlyDictionary<string, string> inputParameters)
+        public static void ResolveUserParameters(ITemplate template, IParameterSet templateParams, IReadOnlyDictionary<string, string> inputParameters)
         {
             foreach (KeyValuePair<string, string> inputParam in inputParameters)
             {
@@ -173,7 +173,9 @@ namespace Microsoft.TemplateEngine.Edge.Template
                     {
                         if (paramFromTemplate.DataType == "bool")
                         {
-                            templateParams.ResolvedValues[paramFromTemplate] = "true";
+                            // could probably directly assign bool true here, but best to have evrything go through the same process
+                            // ... in case something changes downstream.
+                            templateParams.ResolvedValues[paramFromTemplate] = template.Generator.ConvertVariableValueToType(paramFromTemplate, "true");
                         }
                         else
                         {
@@ -182,7 +184,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                     }
                     else
                     {
-                        templateParams.ResolvedValues[paramFromTemplate] = inputParam.Value;
+                        templateParams.ResolvedValues[paramFromTemplate] = template.Generator.ConvertVariableValueToType(paramFromTemplate, inputParam.Value);
                     }
                 }
             }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ReplacementConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ReplacementConfig.cs
@@ -29,7 +29,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
                     Replacement r;
                     try
                     {
-                        string val = parameters.ResolvedValues[param];
+                        string val = (string)(parameters.ResolvedValues[param]);
                         r = new Replacement(property.Name, val, null);
                     }
                     catch (KeyNotFoundException ex)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
@@ -195,6 +195,35 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             return vc;
         }
 
+        private static VariableCollection ProduceUserVariablesCollection(IParameterSet parameters, string format, bool allParameters)
+        {
+            VariableCollection vc = new VariableCollection();
+            foreach (ITemplateParameter parameter in parameters.ParameterDefinitions)
+            {
+                Parameter param = (Parameter)parameter;
+                if (allParameters || param.IsVariable)
+                {
+                    object value;
+                    string key = string.Format(format ?? "{0}", param.Name);
+
+                    if (!parameters.ResolvedValues.TryGetValue(param, out value))
+                    {
+                        throw new TemplateParamException("Parameter value was not specified", param.Name, null, param.DataType);
+                    }
+                    else if (value == null)
+                    {
+                        throw new TemplateParamException("Parameter value is null", param.Name, null, param.DataType);
+                    }
+                    else
+                    {
+                        vc[key] = value;
+                    }
+                }
+            }
+
+            return vc;
+        }
+
         internal class ProcessorState : IProcessorState
         {
             public ProcessorState(IVariableCollection vars, byte[] buffer, Encoding encoding)
@@ -256,35 +285,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             {
                 throw new NotImplementedException();
             }
-        }
-
-        private static VariableCollection ProduceUserVariablesCollection(IParameterSet parameters, string format, bool allParameters)
-        {
-            VariableCollection vc = new VariableCollection();
-            foreach (ITemplateParameter parameter in parameters.ParameterDefinitions)
-            {
-                Parameter param = (Parameter)parameter;
-                if (allParameters || param.IsVariable)
-                {
-                    object value;
-                    string key = string.Format(format ?? "{0}", param.Name);
-
-                    if (!parameters.ResolvedValues.TryGetValue(param, out value))
-                    {
-                        throw new TemplateParamException("Parameter value was not specified", param.Name, null, param.DataType);
-                    }
-                    else if (value == null)
-                    {
-                        throw new TemplateParamException("Parameter value is null", param.Name, null, param.DataType);
-                    }
-                    else
-                    {
-                        vc[key] = value;
-                    }
-                }
-            }
-
-            return vc;
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
@@ -266,177 +266,25 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 Parameter param = (Parameter)parameter;
                 if (allParameters || param.IsVariable)
                 {
-                    string value;
+                    object value;
                     string key = string.Format(format ?? "{0}", param.Name);
-                    bool valueGetResult = parameters.ResolvedValues.TryGetValue(param, out value);
 
-                    if (value == null)
+                    if (!parameters.ResolvedValues.TryGetValue(param, out value))
+                    {
+                        throw new TemplateParamException("Parameter value was not specified", param.Name, null, param.DataType);
+                    }
+                    else if (value == null)
                     {
                         throw new TemplateParamException("Parameter value is null", param.Name, null, param.DataType);
                     }
-
-                    if (!string.IsNullOrEmpty(param.DataType))
-                    {
-                        object convertedValue = DataTypeSpecifiedConvertLiteral(param, value);
-
-                        if (convertedValue == null)
-                        {
-                            throw new TemplateParamException("Parameter value could not be converted", param.Name, value, param.DataType);
-                        }
-
-                        vc[key] = convertedValue;
-                    }
                     else
                     {
-                        vc[key] = InferTypeAndConvertLiteral(value);
+                        vc[key] = value;
                     }
                 }
             }
 
             return vc;
-        }
-
-        /// For explicitly data-typed variables, attempt to convert the variable value to the specified type.
-        /// Data type names:
-        ///     - choice
-        ///     - bool
-        ///     - float
-        ///     - int
-        ///     - hex
-        ///     - text
-        /// The data type names are case insensitive.
-        ///
-        /// Returns the converted value if it can be converted, throw otherwise
-        private static object DataTypeSpecifiedConvertLiteral(Parameter param, string literal)
-        {
-            if (string.Equals(param.DataType, "bool", StringComparison.OrdinalIgnoreCase))
-            {
-                if (string.Equals(literal, "true", StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-                else if (string.Equals(literal, "false", StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
-                else
-                {
-                    // Note: if the literal is ever null, it is probably due to a problem in TemplateCreator.Instantiate()
-                    // which takes care of making null bool -> true as appropriate.
-                    // This else can also happen if there is a value but it can't be converted.
-                    throw new TemplateParamException("Value is not a bool", param.Name, literal, param.DataType);
-                }
-            }
-            else if (string.Equals(param.DataType, "choice", StringComparison.OrdinalIgnoreCase))
-            {
-                if ((literal != null) && param.Choices.Contains(literal))
-                {
-                    return literal;
-                }
-                else
-                {
-                    string conversionErrorMessage = string.Format("Choice is invalid. Valid choices are: [{0}]", string.Join(",", param.Choices));
-                    throw new TemplateParamException(conversionErrorMessage, param.Name, literal, param.DataType);
-                }
-            }
-            else if (string.Equals(param.DataType, "float", StringComparison.OrdinalIgnoreCase))
-            {
-                double convertedFloat;
-                if (double.TryParse(literal, out convertedFloat))
-                {
-                    return convertedFloat;
-                }
-                else
-                {
-                    throw new TemplateParamException("Value is not a float", param.Name, literal, param.DataType);
-                }
-            }
-            else if (string.Equals(param.DataType, "int", StringComparison.OrdinalIgnoreCase))
-            {
-                long convertedInt;
-                if (long.TryParse(literal, out convertedInt))
-                {
-                    return convertedInt;
-                }
-                else
-                {
-                    throw new TemplateParamException("Value is not an int", param.Name, literal, param.DataType);
-                }
-            }
-            else if (string.Equals(param.DataType, "hex", StringComparison.OrdinalIgnoreCase))
-            {
-                long convertedHex;
-                if (long.TryParse(literal.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out convertedHex))
-                {
-                    return convertedHex;
-                }
-                else
-                {
-                    throw new TemplateParamException("Value is not hex format", param.Name, literal, param.DataType);
-                }
-            }
-            else if (string.Equals(param.DataType, "text", StringComparison.OrdinalIgnoreCase))
-            {   // "text" is a valid data type, but doesn't need any special handling.
-                return literal;
-            }
-            else
-            {
-                string customMessage = string.Format("Param name = [{0}] had unknown data type = [{1}]", param.Name, param.DataType);
-                throw new TemplateParamException(customMessage, param.Name, literal, param.DataType);
-            }
-        }
-
-        private static object InferTypeAndConvertLiteral(string literal)
-        {
-            if (literal == null)
-            {
-                return null;
-            }
-
-            if (!literal.Contains("\""))
-            {
-                if (string.Equals(literal, "true", StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-
-                if (string.Equals(literal, "false", StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
-
-                if (string.Equals(literal, "null", StringComparison.OrdinalIgnoreCase))
-                {
-                    return null;
-                }
-
-                double literalDouble;
-                if (literal.Contains(".") && double.TryParse(literal, out literalDouble))
-                {
-                    return literalDouble;
-                }
-
-                long literalLong;
-                if (long.TryParse(literal, out literalLong))
-                {
-                    return literalLong;
-                }
-
-                if (literal.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
-                    && long.TryParse(literal.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out literalLong))
-                {
-                    return literalLong;
-                }
-
-                if (string.Equals("null", literal, StringComparison.OrdinalIgnoreCase))
-                {
-                    return null;
-                }
-
-                return literal;
-            }
-
-            return literal.Substring(1, literal.Length - 2);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMacro.cs
@@ -23,9 +23,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
                     if (!vars.TryGetValue(sourceVar, out working))
                     {
                         ITemplateParameter param;
-                        if (!parameters.TryGetParameterDefinition(sourceVar, out param) || !parameters.ResolvedValues.TryGetValue(param, out value))
+                        object resolvedValue;
+                        if (!parameters.TryGetParameterDefinition(sourceVar, out param) || !parameters.ResolvedValues.TryGetValue(param, out resolvedValue))
                         {
                             value = string.Empty;
+                        }
+                        else
+                        {
+                            value = (string)resolvedValue;
                         }
                     }
                     else

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Parameter.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Parameter.cs
@@ -44,5 +44,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         bool ITemplateParameter.IsName => IsName;
 
         string ITemplateParameter.DefaultValue => DefaultValue;
+
+        string ITemplateParameter.DataType => DataType;
+
+        IReadOnlyList<string> ITemplateParameter.Choices => Choices;
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -9,6 +9,7 @@ using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Globalization;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
@@ -114,6 +115,179 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             return template != null;
         }
 
+        //
+        // Converts the raw, string version of a parameter to a strongly typed value.
+        // If the param has a datatype specified, use that. Otherwise attempt to infer the type.
+        // Throws a TemplateParamException if the conversion fails for any reason.
+        //
+        public object ConvertVariableValueToType(ITemplateParameter parameter, string untypedValue)
+        {
+            if (untypedValue == null)
+            {
+                throw new TemplateParamException("Parameter value is null", parameter.Name, null, parameter.DataType);
+            }
+
+            if (!string.IsNullOrEmpty(parameter.DataType))
+            {
+                object convertedValue = DataTypeSpecifiedConvertLiteral(parameter, untypedValue);
+
+                if (convertedValue == null)
+                {
+                    throw new TemplateParamException("Parameter value could not be converted", parameter.Name, untypedValue, parameter.DataType);
+                }
+
+                return convertedValue;
+            }
+            else
+            {
+                return InferTypeAndConvertLiteral(untypedValue);
+            }
+        }
+
+        // For explicitly data-typed variables, attempt to convert the variable value to the specified type.
+        // Data type names:
+        //     - choice
+        //     - bool
+        //     - float
+        //     - int
+        //     - hex
+        //     - text
+        // The data type names are case insensitive.
+        //
+        // Returns the converted value if it can be converted, throw otherwise
+        private static object DataTypeSpecifiedConvertLiteral(ITemplateParameter param, string literal)
+        {
+            if (string.Equals(param.DataType, "bool", StringComparison.OrdinalIgnoreCase))
+            {
+                if (string.Equals(literal, "true", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+                else if (string.Equals(literal, "false", StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+                else
+                {
+                    // Note: if the literal is ever null, it is probably due to a problem in TemplateCreator.Instantiate()
+                    // which takes care of making null bool -> true as appropriate.
+                    // This else can also happen if there is a value but it can't be converted.
+                    throw new TemplateParamException("Value is not a bool", param.Name, literal, param.DataType);
+                }
+            }
+            else if (string.Equals(param.DataType, "choice", StringComparison.OrdinalIgnoreCase))
+            {
+                if ((literal != null) && param.Choices.Contains(literal))
+                {
+                    return literal;
+                }
+                else
+                {
+                    string conversionErrorMessage = string.Format("Choice is invalid. Valid choices are: [{0}]", string.Join(",", param.Choices));
+                    throw new TemplateParamException(conversionErrorMessage, param.Name, literal, param.DataType);
+                }
+            }
+            else if (string.Equals(param.DataType, "float", StringComparison.OrdinalIgnoreCase))
+            {
+                double convertedFloat;
+                if (double.TryParse(literal, out convertedFloat))
+                {
+                    return convertedFloat;
+                }
+                else
+                {
+                    throw new TemplateParamException("Value is not a float", param.Name, literal, param.DataType);
+                }
+            }
+            else if (string.Equals(param.DataType, "int", StringComparison.OrdinalIgnoreCase))
+            {
+                long convertedInt;
+                if (long.TryParse(literal, out convertedInt))
+                {
+                    return convertedInt;
+                }
+                else
+                {
+                    throw new TemplateParamException("Value is not an int", param.Name, literal, param.DataType);
+                }
+            }
+            else if (string.Equals(param.DataType, "hex", StringComparison.OrdinalIgnoreCase))
+            {
+                long convertedHex;
+                if (long.TryParse(literal.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out convertedHex))
+                {
+                    return convertedHex;
+                }
+                else
+                {
+                    throw new TemplateParamException("Value is not hex format", param.Name, literal, param.DataType);
+                }
+            }
+            else if (string.Equals(param.DataType, "text", StringComparison.OrdinalIgnoreCase))
+            {   // "text" is a valid data type, but doesn't need any special handling.
+                return literal;
+            }
+            else
+            {
+                string customMessage = string.Format("Param name = [{0}] had unknown data type = [{1}]", param.Name, param.DataType);
+                throw new TemplateParamException(customMessage, param.Name, literal, param.DataType);
+            }
+        }
+
+        private static object InferTypeAndConvertLiteral(string literal)
+        {
+            if (literal == null)
+            {
+                return null;
+            }
+
+            if (!literal.Contains("\""))
+            {
+                if (string.Equals(literal, "true", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                if (string.Equals(literal, "false", StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                if (string.Equals(literal, "null", StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+
+                double literalDouble;
+                if (literal.Contains(".") && double.TryParse(literal, out literalDouble))
+                {
+                    return literalDouble;
+                }
+
+                long literalLong;
+                if (long.TryParse(literal, out literalLong))
+                {
+                    return literalLong;
+                }
+
+                if (literal.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+                    && long.TryParse(literal.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out literalLong))
+                {
+                    return literalLong;
+                }
+
+                if (string.Equals("null", literal, StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+
+                return literal;
+            }
+
+            return literal.Substring(1, literal.Length - 2);
+        }
+
+
         internal class ParameterSet : IParameterSet
         {
             private readonly IDictionary<string, ITemplateParameter> _parameters = new Dictionary<string, ITemplateParameter>(StringComparer.OrdinalIgnoreCase);
@@ -129,7 +303,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
             public IEnumerable<ITemplateParameter> ParameterDefinitions => _parameters.Values;
 
-            public IDictionary<ITemplateParameter, string> ResolvedValues { get; } = new Dictionary<ITemplateParameter, string>();
+            public IDictionary<ITemplateParameter, object> ResolvedValues { get; } = new Dictionary<ITemplateParameter, object>();
 
             public IEnumerable<string> RequiredBrokerCapabilities => Enumerable.Empty<string>();
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,7 +10,6 @@ using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System.Globalization;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
@@ -120,7 +120,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         // If the param has a datatype specified, use that. Otherwise attempt to infer the type.
         // Throws a TemplateParamException if the conversion fails for any reason.
         //
-        public object ConvertVariableValueToType(ITemplateParameter parameter, string untypedValue)
+        public object ConvertParameterValueToType(ITemplateParameter parameter, string untypedValue)
         {
             if (untypedValue == null)
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
@@ -506,13 +506,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     Dictionary<string, string> renames = new Dictionary<string, string>();
                     // Console.WriteLine(_simpleConfigModel.NameParameter);
 
-                    string val;
-                    if (parameters.ResolvedValues.TryGetValue(_simpleConfigModel.NameParameter, out val))
+                    object resolvedValue;
+                    if (parameters.ResolvedValues.TryGetValue(_simpleConfigModel.NameParameter, out resolvedValue))
                     {
                         foreach(IFileSystemInfo entry in configFile.Parent.EnumerateFileSystemInfos("*", SearchOption.AllDirectories))
                         {
                             string tmpltRel = entry.PathRelativeTo(configFile.Parent);
-                            string outRel = tmpltRel.Replace(_simpleConfigModel.SourceName, val);
+                            string outRel = tmpltRel.Replace(_simpleConfigModel.SourceName, (string)resolvedValue);
                             renames[tmpltRel] = outRel;
                             //Console.WriteLine($"Mapping {tmpltRel} -> {outRel}");
                         }
@@ -538,13 +538,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     Dictionary<string, string> renames = new Dictionary<string, string>();
                     // Console.WriteLine(_simpleConfigModel.NameParameter);
 
-                    string val;
-                    if (parameters.ResolvedValues.TryGetValue(_simpleConfigModel.NameParameter, out val))
+                    object resolvedValue;
+                    if (parameters.ResolvedValues.TryGetValue(_simpleConfigModel.NameParameter, out resolvedValue))
                     {
                         foreach (IFileSystemInfo entry in configFile.Parent.EnumerateFileSystemInfos("*", SearchOption.AllDirectories))
                         {
                             string tmpltRel = entry.PathRelativeTo(configFile.Parent);
-                            string outRel = tmpltRel.Replace(_simpleConfigModel.SourceName, val);
+                            string outRel = tmpltRel.Replace(_simpleConfigModel.SourceName, (string)resolvedValue);
                             renames[tmpltRel] = outRel;
                             //Console.WriteLine($"Mapping {tmpltRel} -> {outRel}");
                         }


### PR DESCRIPTION
Resolving the data types of parameters used to be in GlobalRunSpec, but could happen many times per parameter. Now the logic is in RunnableProjectGenerator.cs and it's leveraged via TemplateCreator.cs