### PR TITLE
Fixed bug where existing mount point info was overwritten when installing from it a second time

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Settings/MountPointManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/MountPointManager.cs
@@ -34,7 +34,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             using (Timing.Over("Get mount point"))
             {
                 MountPointInfo info;
-                if (SettingsLoader.TryGetMountPoint(mountPointId, out info))
+                if (SettingsLoader.TryGetMountPointInfo(mountPointId, out info))
                 {
                     return TryDemandMountPoint(info, out mountPoint);
                 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/SettingsLoader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/SettingsLoader.cs
@@ -221,11 +221,39 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             _userSettings.Save();
         }
 
-        public static bool TryGetMountPoint(Guid mountPointId, out MountPointInfo info)
+        public static bool TryGetMountPointInfo(Guid mountPointId, out MountPointInfo info)
         {
             EnsureLoaded();
             using(Timing.Over("Mount point lookup"))
             return _mountPoints.TryGetValue(mountPointId, out info);
+        }
+
+        public static bool TryGetMountPointInfoFromPlace(string mountPointPlace, out MountPointInfo info)
+        {
+            EnsureLoaded();
+            using (Timing.Over("Mount point place lookup"))
+                foreach (MountPointInfo mountInfoToCheck in _mountPoints.Values)
+                {
+                    if (mountPointPlace.Equals(mountInfoToCheck.Place, StringComparison.OrdinalIgnoreCase))
+                    {
+                        info = mountInfoToCheck;
+                        return true;
+                    }
+                }
+
+            info = null;
+            return false;
+        }
+
+        public static bool TryGetMountPointFromPlace(string mountPointPlace, out IMountPoint mountPoint)
+        {
+            if (! TryGetMountPointInfoFromPlace(mountPointPlace, out MountPointInfo info))
+            {
+                mountPoint = null;
+                return false;
+            }
+
+            return _mountPointManager.TryDemandMountPoint(info.MountPointId, out mountPoint);
         }
 
         public static void AddMountPoint(IMountPoint mountPoint)

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -73,6 +73,11 @@ namespace dotnet_new3
                     app.ParseArgs(app.InternalParamValueList("--extra-args"));
                 }
 
+                if (app.RemainingParameters.ContainsKey("--debug:attach"))
+                {
+                    Console.ReadLine();
+                }
+
                 string locale = app.InternalParamValue("--locale") ?? CultureInfo.CurrentCulture.Name;
                 if (!ValidateLocaleFormat(locale))
                 {
@@ -261,7 +266,7 @@ namespace dotnet_new3
                 return -1;
             }
 
-            if (app.RemainingParameters.Any())
+            if (app.RemainingParameters.Any(x => !x.Key.StartsWith("--debug:")))
             {
                 EngineEnvironmentSettings.Host.LogMessage("Invalid input switch:");
                 foreach (string flag in app.RemainingParameters.Keys)


### PR DESCRIPTION
Code now checks if the mount point already exists in the settings.json cache. If so, don't recreate it because it's mountPointId Guid would change. But already installed templates would have the old mountPointGuid in the locale template caches.