### PR TITLE
Lots of changes

### DIFF
--- a/src/Microsoft.TemplateEngine.Core.Contracts/IRunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IRunSpec.cs
@@ -4,6 +4,8 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 {
     public interface IRunSpec
     {
+        string VariableFormatString { get; }
+
         bool TryGetTargetRelPath(string sourceRelPath, out string targetRelPath);
 
         IReadOnlyList<IOperationProvider> GetOperations(IReadOnlyList<IOperationProvider> sourceOperations);

--- a/src/Microsoft.TemplateEngine.Core/Operations/ConditionalType.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/ConditionalType.cs
@@ -10,6 +10,7 @@
         CLineComments,
         CBlockComments,
         HashSignLineComment,
-        RemLineComment
+        RemLineComment,
+        MSBuild
     }
 }

--- a/src/Microsoft.TemplateEngine.Core/Operations/InlineMarkupConditional.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/InlineMarkupConditional.cs
@@ -11,13 +11,14 @@ namespace Microsoft.TemplateEngine.Core.Operations
     {
         private readonly string _id;
 
-        public InlineMarkupConditional(MarkupTokens tokens, bool wholeLine, bool trimWhitespace, ConditionEvaluator evaluator, string id)
+        public InlineMarkupConditional(MarkupTokens tokens, bool wholeLine, bool trimWhitespace, ConditionEvaluator evaluator, string variableFormat, string id)
         {
             Tokens = tokens;
             _id = id;
             Evaluator = evaluator;
             WholeLine = wholeLine;
             TrimWhitespace = trimWhitespace;
+            VariableFormat = variableFormat;
         }
 
         public ConditionEvaluator Evaluator { get; }
@@ -25,6 +26,8 @@ namespace Microsoft.TemplateEngine.Core.Operations
         public MarkupTokens Tokens { get; }
 
         public bool TrimWhitespace { get; }
+
+        public string VariableFormat { get; }
 
         public bool WholeLine { get; }
 
@@ -94,7 +97,8 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 List<byte> conditionBytes = new List<byte>();
                 ScanToCloseCondition(processor, conditionBytes, ref bufferLength, ref currentBufferPosition);
                 byte[] condition = conditionBytes.ToArray();
-                IProcessorState localState = new ProcessorState(new MemoryStream(condition), new MemoryStream(), conditionBytes.Count, int.MaxValue, processor.Config, new IOperationProvider[0]);
+                EngineConfig adjustedConfig = new EngineConfig(processor.Config.Whitespaces, processor.Config.LineEndings, processor.Config.Variables, _definition.VariableFormat);
+                IProcessorState localState = new ProcessorState(new MemoryStream(condition), new MemoryStream(), conditionBytes.Count, int.MaxValue, adjustedConfig, new IOperationProvider[0]);
                 int pos = 0;
                 int len = conditionBytes.Count;
 

--- a/src/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
@@ -61,7 +61,7 @@ namespace Microsoft.TemplateEngine.Core.Util
                 foreach (KeyValuePair<IPathMatcher, IRunSpec> runSpec in spec.Special)
                 {
                     IReadOnlyList<IOperationProvider> operations = runSpec.Value.GetOperations(spec.Operations);
-                    EngineConfig config = new EngineConfig(EngineConfig.DefaultWhitespaces, EngineConfig.DefaultLineEndings, spec.RootVariableCollection);
+                    EngineConfig config = new EngineConfig(EngineConfig.DefaultWhitespaces, EngineConfig.DefaultLineEndings, spec.RootVariableCollection, runSpec.Value.VariableFormatString);
                     IProcessor processor = Processor.Create(config, operations);
 
                     processorList.Add(new KeyValuePair<IPathMatcher, IProcessor>(runSpec.Key, processor));

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalConfig.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.Core.Expressions.MSBuild;
 using Microsoft.TemplateEngine.Core.Operations;
 using Newtonsoft.Json.Linq;
 
@@ -51,6 +52,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
 
             switch (style)
             {
+                case ConditionalType.MSBuild:
+                    setup = MSBuildConditionalSetup(evaluatorType, wholeLine, trimWhiteSpace, id);
+                    break;
                 case ConditionalType.Xml:
                     setup = XmlConditionalSetup(evaluatorType, wholeLine, trimWhiteSpace, id);
                     break;
@@ -107,6 +111,24 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
             {
                 conditional,
                 balancedComments
+            };
+        }
+
+        public static List<IOperationProvider> MSBuildConditionalSetup(string evaluatorType, bool wholeLine, bool trimWhiteSpace, string id)
+        {
+            ConditionEvaluator evaluator = EvaluatorSelector.Select(evaluatorType);
+            IOperationProvider conditional = new InlineMarkupConditional(
+                new MarkupTokens("<", "</", ">", "/>", "Condition=\"", "\""),
+                wholeLine,
+                trimWhiteSpace,
+                evaluator,
+                "$({0})",
+                id
+            );
+
+            return new List<IOperationProvider>()
+            {
+                conditional
             };
         }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/MacrosOperationConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/MacrosOperationConfig.cs
@@ -31,14 +31,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
             // run the macros that are already setup, stash the deferred ones for afterwards
             foreach (IMacroConfig config in allMacroConfigs)
             {
-                if (config is GeneratedSymbolDeferredMacroConfig)
+                if (config is GeneratedSymbolDeferredMacroConfig deferredConfig)
                 {
-                    deferredConfigList.Add(config as GeneratedSymbolDeferredMacroConfig);
+                    deferredConfigList.Add(deferredConfig);
                     continue;
                 }
 
-                IMacro macroObject;
-                if (_macroObjects.TryGetValue(config.Type, out macroObject))
+                if (_macroObjects.TryGetValue(config.Type, out IMacro macroObject))
                 {
                     macroObject.EvaluateConfig(variables, config, parameters, setter);
                 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CustomFileGlobModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CustomFileGlobModel.cs
@@ -72,7 +72,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             }
             else
             {
-                variableConfig = VariableConfig.DefaultVariableSetup();
+                variableConfig = VariableConfig.DefaultVariableSetup(null);
             }
 
             // setup the custom operations

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
@@ -88,7 +88,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                         specialVariables = VariableCollection.SetupVariables(parameters, specialEntry.Value.VariableSetup);
                     }
 
-                    RunSpec spec = new RunSpec(specialOps, specialVariables ?? variables);
+                    RunSpec spec = new RunSpec(specialOps, specialVariables ?? variables, specialEntry.Value.VariableSetup.FallbackFormat);
                     specials.Add(new KeyValuePair<IPathMatcher, IRunSpec>(new GlobbingPatternMatcher(specialEntry.Key), spec));
                 }
             }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunSpec.cs
@@ -9,10 +9,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         private readonly IReadOnlyList<IOperationProvider> _overrides;
         private readonly IVariableCollection _vars;
 
-        public RunSpec(IReadOnlyList<IOperationProvider> operationOverrides, IVariableCollection vars)
+        public RunSpec(IReadOnlyList<IOperationProvider> operationOverrides, IVariableCollection vars, string variableFormatString)
         {
             _overrides = operationOverrides;
             _vars = vars ?? new VariableCollection();
+            VariableFormatString = variableFormatString ?? "{0}";
         }
 
         public bool TryGetTargetRelPath(string sourceRelPath, out string targetRelPath)
@@ -30,5 +31,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         {
             return _vars;
         }
+
+        public string VariableFormatString { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
@@ -233,7 +233,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             {
                 if (_operationConfig == null)
                 {
-                    SpecialOperationConfigParams defaultOperationParams = new SpecialOperationConfigParams(string.Empty, "//", ConditionalType.CLineComments);
+                    SpecialOperationConfigParams defaultOperationParams = new SpecialOperationConfigParams(string.Empty, "//", "C++", ConditionalType.CLineComments);
                     _operationConfig = ProduceOperationSetup(defaultOperationParams, true, CustomOperations);
                 }
 
@@ -243,8 +243,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         private class SpecialOperationConfigParams
         {
-            public SpecialOperationConfigParams(string glob, string flagPrefix, ConditionalType type)
+            public SpecialOperationConfigParams(string glob, string flagPrefix, string evaluatorName, ConditionalType type)
             {
+                EvaluatorName = evaluatorName;
                 Glob = glob;
                 FlagPrefix = flagPrefix;
                 ConditionalStyle = type;
@@ -252,11 +253,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
             public string Glob { get; }
 
+            public string EvaluatorName { get; }
+
             public string FlagPrefix { get; }
 
             public ConditionalType ConditionalStyle { get; }
 
-            private static readonly SpecialOperationConfigParams _Defaults = new SpecialOperationConfigParams(string.Empty, string.Empty, ConditionalType.None);
+            public string VariableFormat { get; set; }
+
+            private static readonly SpecialOperationConfigParams _Defaults = new SpecialOperationConfigParams(string.Empty, string.Empty, "C++", ConditionalType.None);
 
             public static SpecialOperationConfigParams Defaults
             {
@@ -265,6 +270,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     return _Defaults;
                 }
             }
+
         }
 
         // file -> replacements
@@ -279,26 +285,27 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             {
                 if (_specialOperationConfig == null)
                 {
-                    List<SpecialOperationConfigParams> defaultSpecials = new List<SpecialOperationConfigParams>();
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.json", "//", ConditionalType.CLineComments));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.css.min", "/*", ConditionalType.CBlockComments));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.css", "/*", ConditionalType.CBlockComments));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.cshtml", "@*", ConditionalType.Razor));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.cs", "//", ConditionalType.CNoComments));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.cpp", "//", ConditionalType.CNoComments));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.h", "//", ConditionalType.CNoComments));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.hpp", "//", ConditionalType.CNoComments));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.*proj", "<!--/", ConditionalType.Xml));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.*htm", "<!--", ConditionalType.Xml));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.*html", "<!--", ConditionalType.Xml));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.jsp", "<!--", ConditionalType.Xml));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.asp", "<!--", ConditionalType.Xml));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.aspx", "<!--", ConditionalType.Xml));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.bat", "rem --:", ConditionalType.RemLineComment));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/*.cmd", "rem --:", ConditionalType.RemLineComment));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/nginx.conf", "#--", ConditionalType.HashSignLineComment));
-                    defaultSpecials.Add(new SpecialOperationConfigParams("**/robots.txt", "#--", ConditionalType.HashSignLineComment));
-
+                    List<SpecialOperationConfigParams> defaultSpecials = new List<SpecialOperationConfigParams>
+                    {
+                        new SpecialOperationConfigParams("**/*.json", "//", "C++", ConditionalType.CLineComments),
+                        new SpecialOperationConfigParams("**/*.css.min", "/*", "C++", ConditionalType.CBlockComments),
+                        new SpecialOperationConfigParams("**/*.css", "/*", "C++", ConditionalType.CBlockComments),
+                        new SpecialOperationConfigParams("**/*.cshtml", "@*", "C++", ConditionalType.Razor),
+                        new SpecialOperationConfigParams("**/*.cs", "//", "C++", ConditionalType.CNoComments),
+                        new SpecialOperationConfigParams("**/*.cpp", "//", "C++", ConditionalType.CNoComments),
+                        new SpecialOperationConfigParams("**/*.h", "//", "C++", ConditionalType.CNoComments),
+                        new SpecialOperationConfigParams("**/*.hpp", "//", "C++", ConditionalType.CNoComments),
+                        new SpecialOperationConfigParams("**/*.*proj", "<!--/", "MSBUILD", ConditionalType.MSBuild),
+                        new SpecialOperationConfigParams("**/*.*htm", "<!--", "C++", ConditionalType.Xml),
+                        new SpecialOperationConfigParams("**/*.*html", "<!--", "C++", ConditionalType.Xml),
+                        new SpecialOperationConfigParams("**/*.jsp", "<!--", "C++", ConditionalType.Xml),
+                        new SpecialOperationConfigParams("**/*.asp", "<!--", "C++", ConditionalType.Xml),
+                        new SpecialOperationConfigParams("**/*.aspx", "<!--", "C++", ConditionalType.Xml),
+                        new SpecialOperationConfigParams("**/*.bat", "rem --:", "C++", ConditionalType.RemLineComment),
+                        new SpecialOperationConfigParams("**/*.cmd", "rem --:", "C++", ConditionalType.RemLineComment),
+                        new SpecialOperationConfigParams("**/nginx.conf", "#--", "C++", ConditionalType.HashSignLineComment),
+                        new SpecialOperationConfigParams("**/robots.txt", "#--", "C++", ConditionalType.HashSignLineComment)
+                    };
                     List<KeyValuePair<string, IGlobalRunConfig>> specialOperationConfig = new List<KeyValuePair<string, IGlobalRunConfig>>();
 
                     // put the custom configs first in the list
@@ -350,7 +357,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             // TODO: if we allow custom config to specify a built-in conditional type, decide what to do.
             if (defaultModel.ConditionalStyle != ConditionalType.None)
             {
-                operations.AddRange(ConditionalConfig.ConditionalSetup(defaultModel.ConditionalStyle, "C++", true, true, null));
+                operations.AddRange(ConditionalConfig.ConditionalSetup(defaultModel.ConditionalStyle, defaultModel.EvaluatorName, true, true, null));
             }
 
             if (customGlobModel == null || string.IsNullOrEmpty(customGlobModel.FlagPrefix))
@@ -369,7 +376,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             }
             else
             {
-                variableConfig = VariableConfig.DefaultVariableSetup();
+                variableConfig = VariableConfig.DefaultVariableSetup(defaultModel.VariableFormat);
             }
 
             IReadOnlyList<IMacroConfig> macros = null;
@@ -476,8 +483,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
             if (_safeNameName == null)
             {
-                IList<KeyValuePair<string, string>> steps = new List<KeyValuePair<string, string>>();
-                steps.Add(new KeyValuePair<string, string>(@"\W", "_"));
+                IList<KeyValuePair<string, string>> steps = new List<KeyValuePair<string, string>>
+                {
+                    new KeyValuePair<string, string>(@"\W", "_")
+                };
+
                 generatedMacroConfigs.Add(new RegexMacroConfig("safe_name", NameParameter.Name, steps));
                 _safeNameName = "safe_name";
             }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SymbolModelConverter.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SymbolModelConverter.cs
@@ -13,6 +13,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     return ParameterSymbol.FromJObject(jObject, localizedDescriptipn);
                 case "computed":
                     return ComputedSymbol.FromJObject(jObject);
+                case "bind":
                 case "generated":
                     return GeneratedSymbol.FromJObject(jObject);
                 default:

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/VariableConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/VariableConfig.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         public bool Expand { get; set; }
 
-        public static IVariableConfig DefaultVariableSetup()
+        public static IVariableConfig DefaultVariableSetup(string fallbackFormat)
         {
             IVariableConfig config = new VariableConfig
             {
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     { "user", "usr_{0}" }
                 },
                 Order = new List<string>() { "environment", "user" },
-                FallbackFormat = "{0}",
+                FallbackFormat = fallbackFormat ?? "{0}",
                 Expand = false
             };
 

--- a/src/Microsoft.TemplateEngine.Utils/DefaultTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Utils/DefaultTemplateEngineHost.cs
@@ -65,13 +65,8 @@ namespace Microsoft.TemplateEngine.Utils
 
         public virtual bool OnParameterError(ITemplateParameter parameter, string receivedValue, string message, out string newValue)
         {
-            //Console.WriteLine("DefaultTemplateEngineHost::OnParameterError() called");
-            Console.WriteLine("Parameter Error: {0}", message);
-            Console.WriteLine("Parameter name = {0}", parameter.Name);
-            Console.WriteLine("Parameter value = {0}", receivedValue);
-            Console.WriteLine("Enter a new value for the param, or:");
-            newValue = Console.ReadLine();
-            return !string.IsNullOrEmpty(newValue);
+            newValue = null;
+            return false;
         }
 
         public virtual void OnSymbolUsed(string symbol, object value)

--- a/src/dotnet-new3/New3Command.cs
+++ b/src/dotnet-new3/New3Command.cs
@@ -69,7 +69,7 @@ namespace dotnet_new3
             };
 
             // Initial host setup has the current locale. May need to be changed based on inputs.
-            Host = new DefaultTemplateEngineHost(HostIdentifier, HostVersion, CultureInfo.CurrentCulture.Name, null, builtIns.ToList());
+            Host = new DefaultTemplateEngineHost(HostIdentifier, HostVersion, CultureInfo.CurrentCulture.Name, new Dictionary<string, string>(), builtIns.ToList());
             EngineEnvironmentSettings.Host = Host;
 
             ExtendedCommandParser app = new ExtendedCommandParser()

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.InlineMarkup.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.InlineMarkup.cs
@@ -16,6 +16,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 true,
                 true,
                 MSBuildStyleEvaluatorDefinition.Evaluate,
+                "$({0})",
                 null
             ));
         }


### PR DESCRIPTION
Fixes #84 
Fixes #83 

Allow the inline markup conditional variant to demand a particular variable format
Pass in the default parameters dictionary as non-null to the default host environment in the test app
Allow glob filtered specializations to demand different variable formats
Hook up the MSBuild evaluator
Fix more code analysis issues
Allow default values that do not match choice entries
Stop throwing exceptions for parameter validation issues, pass them to the host for handling instead
Create "bind" symbol type that maps a value to replace to a parameter value with no modifications
Remove the assumption that the host has a console session from the parameter error handler
Update the inline markup test to pass the varaible format