### PR TITLE
Get rid of statics - enable parallel test runs & multiple instantiations of the engine in the same process

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ root = true
 
 # Newline ending every file
 [*]
+end_of_line = crlf
 indent_style = space
 indent_size = 4
 tab_width = 4

--- a/Version.props
+++ b/Version.props
@@ -3,7 +3,8 @@
     <PackageReleaseVersion>1.0.0</PackageReleaseVersion>
     <PackageBuildQuality Condition=" '$(PackageBuildQuality)' == '' ">beta1</PackageBuildQuality>
     <PackageVersion>$(PackageReleaseVersion)-$(PackageBuildQuality)</PackageVersion>
-    <PackageVersion Condition=" '$(CreateTimestampPackages)' == 'true' AND '$(BUILD_NUMBER)' != '' ">$(PackageVersion)-$([System.DateTime]::Now.ToString("yyyyMMdd"))-$(BUILD_NUMBER)</PackageVersion>
+    <BUILD_NUMBER Condition="'$(BUILD_NUMBER)' == ''">0</BUILD_NUMBER>
+    <PackageVersion Condition="'$(NO_TIMESTAMP)' != 'true'">$(PackageVersion)-$([System.DateTime]::Now.ToString("yyyyMMdd"))-$(BUILD_NUMBER)</PackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Microsoft</Authors>

--- a/src/Microsoft.TemplateEngine.Abstractions/IGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IGenerator.cs
@@ -6,14 +6,14 @@ namespace Microsoft.TemplateEngine.Abstractions
 {
     public interface IGenerator : IIdentifiedComponent
     {
-        Task<ICreationResult> CreateAsync(ITemplate template, IParameterSet parameters, IComponentManager componentManager, string targetDirectory);
+        Task<ICreationResult> CreateAsync(IEngineEnvironmentSettings environmentSettings, ITemplate template, IParameterSet parameters, IComponentManager componentManager, string targetDirectory);
 
-        IParameterSet GetParametersForTemplate(ITemplate template);
+        IParameterSet GetParametersForTemplate(IEngineEnvironmentSettings environmentSettings, ITemplate template);
 
         bool TryGetTemplateFromConfigInfo(IFileSystemInfo config, out ITemplate template, IFileSystemInfo localeConfig, IFile hostTemplateConfigFile);
 
         IList<ITemplate> GetTemplatesAndLangpacksFromDir(IMountPoint source, out IList<ILocalizationLocator> localizations);
 
-        object ConvertParameterValueToType(ITemplateParameter parameter, string untypedValue, out bool valueResolutionError);
+        object ConvertParameterValueToType(IEngineEnvironmentSettings environmentSettings, ITemplateParameter parameter, string untypedValue, out bool valueResolutionError);
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/ISettingsLoader.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ISettingsLoader.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions.Mount;
+
+namespace Microsoft.TemplateEngine.Abstractions
+{
+    public interface ISettingsLoader
+    {
+        IComponentManager Components { get; }
+   
+        IEngineEnvironmentSettings EnvironmentSettings { get; }
+
+        IEnumerable<MountPointInfo> MountPoints { get; }
+
+        void AddMountPoint(IMountPoint mountPoint);
+
+        void AddProbingPath(string probeIn);
+
+        void GetTemplates(HashSet<ITemplateInfo> templates);
+
+        ITemplate LoadTemplate(ITemplateInfo info);
+
+        void Save();
+
+        bool TryGetFileFromIdAndPath(Guid mountPointId, string place, out IFile file);
+
+        bool TryGetMountPointFromPlace(string mountPointPlace, out IMountPoint mountPoint);
+
+        bool TryGetMountPointInfo(Guid mountPointId, out MountPointInfo info);
+
+        void WriteTemplateCache(IList<ITemplateInfo> templates, string locale, bool isCurrentCache);
+    }
+
+    public interface IEngineEnvironmentSettings
+    {
+        ISettingsLoader SettingsLoader { get; }
+
+        ITemplateEngineHost Host { get; }
+
+        IEnvironment Environment { get; }
+
+        IPathInfo Paths { get; }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs
@@ -32,5 +32,7 @@ namespace Microsoft.TemplateEngine.Abstractions
         bool TryGetHostParamDefault(string paramName, out string value);
 
         void UpdateLocale(string newLocale);
+
+        void VirtualizeDirectory(string path);
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPoint.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPoint.cs
@@ -6,6 +6,8 @@ namespace Microsoft.TemplateEngine.Abstractions.Mount
 
         IDirectory Root { get; }
 
+        IEngineEnvironmentSettings EnvironmentSettings { get; }
+
         IFile FileInfo(string fullPath);
 
         IDirectory DirectoryInfo(string fullPath);

--- a/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPointFactory.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPointFactory.cs
@@ -2,7 +2,7 @@ namespace Microsoft.TemplateEngine.Abstractions.Mount
 {
     public interface IMountPointFactory : IIdentifiedComponent
     {
-        bool TryMount(IMountPoint parent, string place, out IMountPoint mountPoint);
+        bool TryMount(IEngineEnvironmentSettings environmentSettings, IMountPoint parent, string place, out IMountPoint mountPoint);
 
         bool TryMount(IMountPointManager manager, MountPointInfo info, out IMountPoint mountPoint);
 

--- a/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPointManager.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPointManager.cs
@@ -4,6 +4,8 @@ namespace Microsoft.TemplateEngine.Abstractions.Mount
 {
     public interface IMountPointManager
     {
+        IEngineEnvironmentSettings EnvironmentSettings { get; }
+
         bool TryDemandMountPoint(MountPointInfo info, out IMountPoint mountPoint);
 
         bool TryDemandMountPoint(Guid mountPointId, out IMountPoint mountPoint);

--- a/src/Microsoft.TemplateEngine.Cli/ExtendedTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Cli/ExtendedTemplateEngineHost.cs
@@ -64,6 +64,11 @@ namespace Microsoft.TemplateEngine.Cli
             }
         }
 
+        public void VirtualizeDirectory(string path)
+        {
+            _baseHost.VirtualizeDirectory(path);
+        }
+
         private bool GlobalJsonFileExistsInPath
         {
             get

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -19,8 +19,6 @@ using Microsoft.TemplateEngine.Edge.Template;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using static Microsoft.TemplateEngine.Utils.EngineEnvironmentSettings;
-using Paths = Microsoft.TemplateEngine.Edge.Paths;
 
 namespace Microsoft.TemplateEngine.Cli
 {
@@ -32,6 +30,10 @@ namespace Microsoft.TemplateEngine.Cli
         private IReadOnlyList<IFilteredTemplateInfo> _matchedTemplates;
         private CommandArgument _templateName;
         private ITemplateInfo _unambiguousTemplateToUse;
+        private readonly TemplateCreator _templateCreator;
+        private readonly TemplateCache _templateCache;
+        private readonly AliasRegistry _aliasRegistry;
+        private readonly Paths _paths;
 
         private static readonly Regex LocaleFormatRegex = new Regex(@"
                     ^
@@ -40,12 +42,18 @@ namespace Microsoft.TemplateEngine.Cli
                     $"
             , RegexOptions.IgnorePatternWhitespace);
         private bool _forceAmbiguousFlow;
-        private readonly Action<ITemplateEngineHost, IInstaller> _onFirstRun;
+        private readonly Action<IEngineEnvironmentSettings, IInstaller> _onFirstRun;
 
-        public New3Command(string commandName, ITemplateEngineHost host, Action<ITemplateEngineHost, IInstaller> onFirstRun, ExtendedCommandParser app, CommandArgument templateNames)
+        public New3Command(string commandName, ITemplateEngineHost host, Action<IEngineEnvironmentSettings, IInstaller> onFirstRun, ExtendedCommandParser app, CommandArgument templateNames)
         {
-            Host = new ExtendedTemplateEngineHost(host, this);
+            host = new ExtendedTemplateEngineHost(host, this);
+            EnvironmentSettings = new EngineEnvironmentSettings(host, x => new SettingsLoader(x));
+            Installer = new Installer(EnvironmentSettings);
+            _templateCreator = new TemplateCreator(EnvironmentSettings);
+            _templateCache = new TemplateCache(EnvironmentSettings);
+            _aliasRegistry = new AliasRegistry(EnvironmentSettings);
             CommandName = commandName;
+            _paths = new Paths(EnvironmentSettings);
             _app = app;
             _templateName = templateNames;
             _onFirstRun = onFirstRun;
@@ -61,7 +69,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         public IList<string> Install => _app.InternalParamValueList("--install");
 
-        public static IInstaller Installer { get; set; } = new Installer();
+        public static IInstaller Installer { get; set; }
 
         public bool InstallHasValue => _app.InternalParamHasValue("--install");
 
@@ -104,7 +112,7 @@ namespace Microsoft.TemplateEngine.Cli
                     return _unambiguousTemplateToUse = _matchedTemplates.First().Info;
                 }
 
-                if (Host.TryGetHostParamDefault("prefs:language", out string defaultLanguage))
+                if (EnvironmentSettings.Host.TryGetHostParamDefault("prefs:language", out string defaultLanguage))
                 {
                     IFilteredTemplateInfo match = null;
 
@@ -130,7 +138,9 @@ namespace Microsoft.TemplateEngine.Cli
             }
         }
 
-        public static int Run(string commandName, ITemplateEngineHost host, Action<ITemplateEngineHost, IInstaller> onFirstRun, string[] args)
+        public EngineEnvironmentSettings EnvironmentSettings { get; private set; }
+
+        public static int Run(string commandName, ITemplateEngineHost host, Action<IEngineEnvironmentSettings, IInstaller> onFirstRun, string[] args)
         {
             ExtendedCommandParser app = new ExtendedCommandParser()
             {
@@ -187,13 +197,13 @@ namespace Microsoft.TemplateEngine.Cli
 
         private void ConfigureEnvironment()
         {
-            _onFirstRun?.Invoke(Host, Installer);
+            _onFirstRun?.Invoke(EnvironmentSettings, Installer);
         }
 
         private async Task<int> CreateTemplateAsync(ITemplateInfo template)
         {
             string fallbackName = new DirectoryInfo(OutputPath ?? Directory.GetCurrentDirectory()).Name;
-            TemplateCreationResult instantiateResult = await TemplateCreator.InstantiateAsync(template, Name, fallbackName, OutputPath, _app.AllTemplateParams, SkipUpdateCheck).ConfigureAwait(false);
+            TemplateCreationResult instantiateResult = await _templateCreator.InstantiateAsync(template, Name, fallbackName, OutputPath, _app.AllTemplateParams, SkipUpdateCheck).ConfigureAwait(false);
             string resultTemplateName = string.IsNullOrEmpty(instantiateResult.TemplateFullName) ? _templateName.Value : instantiateResult.TemplateFullName;
 
             switch (instantiateResult.Status)
@@ -221,7 +231,7 @@ namespace Microsoft.TemplateEngine.Cli
             IEnumerable<ITemplateInfo> results = _matchedTemplates.Where(x => x.IsMatch).Select(x => x.Info);
 
             IEnumerable<IGrouping<string, ITemplateInfo>> grouped = results.GroupBy(x => x.GroupIdentity);
-            Host.TryGetHostParamDefault("prefs:language", out string defaultLanguage);
+            EnvironmentSettings.Host.TryGetHostParamDefault("prefs:language", out string defaultLanguage);
 
             Dictionary<ITemplateInfo, string> templatesVersusLanguages = new Dictionary<ITemplateInfo, string>();
 
@@ -245,7 +255,7 @@ namespace Microsoft.TemplateEngine.Cli
                 templatesVersusLanguages[grouping.First()] = string.Join(", ", languages);
             }
 
-            HelpFormatter<KeyValuePair<ITemplateInfo, string>> formatter = new HelpFormatter<KeyValuePair<ITemplateInfo, string>>(templatesVersusLanguages, 6, '-', false)
+            HelpFormatter<KeyValuePair<ITemplateInfo, string>> formatter = HelpFormatter.For(EnvironmentSettings, templatesVersusLanguages, 6, '-', false)
                 .DefineColumn(t => t.Key.Name, LocalizableStrings.Templates)
                 .DefineColumn(t => t.Key.ShortName, LocalizableStrings.ShortName)
                 .DefineColumn(t => t.Value, out object languageColumn, LocalizableStrings.Language)
@@ -344,7 +354,7 @@ namespace Microsoft.TemplateEngine.Cli
                     return -1;
                 }
 
-                AliasRegistry.SetTemplateAlias(Alias, UnambiguousTemplateToUse);
+                _aliasRegistry.SetTemplateAlias(Alias, UnambiguousTemplateToUse);
                 Reporter.Output.WriteLine(LocalizableStrings.AliasCreated);
                 return 0;
             }
@@ -423,7 +433,7 @@ namespace Microsoft.TemplateEngine.Cli
                     Reporter.Error.WriteLine(string.Format(LocalizableStrings.BadLocaleError, newLocale).Bold().Red());
                 }
 
-                Host.UpdateLocale(newLocale);
+                EnvironmentSettings.Host.UpdateLocale(newLocale);
             }
         }
 
@@ -436,8 +446,8 @@ namespace Microsoft.TemplateEngine.Cli
 
         private void GenerateUsageForTemplate(ITemplateInfo templateInfo)
         {
-            ITemplate template = SettingsLoader.LoadTemplate(templateInfo);
-            IParameterSet allParams = template.Generator.GetParametersForTemplate(template);
+            ITemplate template = EnvironmentSettings.SettingsLoader.LoadTemplate(templateInfo);
+            IParameterSet allParams = template.Generator.GetParametersForTemplate(EnvironmentSettings, template);
             HostSpecificTemplateData hostTemplateData = ReadHostSpecificTemplateData(template);
 
             Reporter.Output.Write($"    dotnet {CommandName} {template.ShortName}");
@@ -469,20 +479,20 @@ namespace Microsoft.TemplateEngine.Cli
             bool reinitFlag = _app.RemainingArguments.Any(x => x == "--debug:reinit");
             if (reinitFlag)
             {
-                Paths.User.FirstRunCookie.Delete();
+                _paths.Delete(_paths.User.FirstRunCookie);
             }
 
             // Note: this leaves things in a weird state. Might be related to the localized caches.
             // not sure, need to look into it.
             if (reinitFlag || _app.RemainingArguments.Any(x => x == "--debug:reset-config"))
             {
-                Paths.User.AliasesFile.Delete();
-                Paths.User.SettingsFile.Delete();
-                TemplateCache.DeleteAllLocaleCacheFiles();
+                _paths.Delete(_paths.User.AliasesFile);
+                _paths.Delete(_paths.User.SettingsFile);
+                _templateCache.DeleteAllLocaleCacheFiles();
                 return false;
             }
 
-            if (!Paths.User.BaseDir.Exists() || !Paths.User.FirstRunCookie.Exists())
+            if (!_paths.Exists(_paths.User.BaseDir) || !_paths.Exists(_paths.User.FirstRunCookie))
             {
                 if (!IsQuietFlagSpecified)
                 {
@@ -490,7 +500,7 @@ namespace Microsoft.TemplateEngine.Cli
                 }
 
                 ConfigureEnvironment();
-                Paths.User.FirstRunCookie.WriteAllText("");
+                _paths.WriteAllText(_paths.User.FirstRunCookie, "");
             }
 
             if (_app.RemainingArguments.Any(x => x == "--debug:showconfig"))
@@ -514,7 +524,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             if (filteredParams.Any())
             {
-                HelpFormatter<ITemplateParameter> formatter = new HelpFormatter<ITemplateParameter>(filteredParams, 2, null, true);
+                HelpFormatter<ITemplateParameter> formatter = new HelpFormatter<ITemplateParameter>(EnvironmentSettings, filteredParams, 2, null, true);
 
                 formatter.DefineColumn(
                     param =>
@@ -601,8 +611,8 @@ namespace Microsoft.TemplateEngine.Cli
 
         private void ParseTemplateArgs(ITemplateInfo templateInfo)
         {
-            ITemplate template = SettingsLoader.LoadTemplate(templateInfo);
-            IParameterSet allParams = template.Generator.GetParametersForTemplate(template);
+            ITemplate template = EnvironmentSettings.SettingsLoader.LoadTemplate(templateInfo);
+            IParameterSet allParams = template.Generator.GetParametersForTemplate(EnvironmentSettings, template);
             _hostSpecificTemplateData = ReadHostSpecificTemplateData(template);
             _app.SetupTemplateParameters(allParams, _hostSpecificTemplateData.LongNameOverrides, _hostSpecificTemplateData.ShortNameOverrides);
 
@@ -612,12 +622,12 @@ namespace Microsoft.TemplateEngine.Cli
 
         private Task PerformCoreTemplateQueryAsync()
         {
-            string outputPath = OutputPath ?? Host.FileSystem.GetCurrentDirectory();
+            string outputPath = OutputPath ?? EnvironmentSettings.Host.FileSystem.GetCurrentDirectory();
 
             string context = null;
             if (!IsShowAllFlagSpecified)
             {
-                if (Host.FileSystem.DirectoryExists(outputPath) && Host.FileSystem.EnumerateFiles(outputPath, "*.*proj", SearchOption.TopDirectoryOnly).Any())
+                if (EnvironmentSettings.Host.FileSystem.DirectoryExists(outputPath) && EnvironmentSettings.Host.FileSystem.EnumerateFiles(outputPath, "*.*proj", SearchOption.TopDirectoryOnly).Any())
                 {
                     context = "item";
                 }
@@ -628,7 +638,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
 
             //Perform the core query to search for templates
-            IReadOnlyCollection<IFilteredTemplateInfo> templates = TemplateCreator.List
+            IReadOnlyCollection<IFilteredTemplateInfo> templates = _templateCreator.List
             (
                 false,
                 WellKnownSearchFilters.AliasFilter(_templateName.Value),
@@ -660,9 +670,9 @@ namespace Microsoft.TemplateEngine.Cli
             return Task.FromResult(true);
         }
 
-        private static HostSpecificTemplateData ReadHostSpecificTemplateData(ITemplate templateInfo)
+        private HostSpecificTemplateData ReadHostSpecificTemplateData(ITemplate templateInfo)
         {
-            if (SettingsLoader.TryGetFileFromIdAndPath(templateInfo.HostConfigMountPointId, templateInfo.HostConfigPlace, out IFile file))
+            if (EnvironmentSettings.SettingsLoader.TryGetFileFromIdAndPath(templateInfo.HostConfigMountPointId, templateInfo.HostConfigPlace, out IFile file))
             {
                 JObject jsonData;
                 using (Stream s = file.OpenRead())
@@ -701,11 +711,11 @@ namespace Microsoft.TemplateEngine.Cli
             appExt.HiddenInternalOption("--skip-update-check", "--skip-update-check", CommandOptionType.NoValue);
         }
 
-        private static void ShowConfig()
+        private void ShowConfig()
         {
             Reporter.Output.WriteLine(LocalizableStrings.CurrentConfiguration);
             Reporter.Output.WriteLine(" ");
-            TableFormatter.Print(SettingsLoader.MountPoints, LocalizableStrings.NoItems, "   ", '-', new Dictionary<string, Func<MountPointInfo, object>>
+            TableFormatter.Print(EnvironmentSettings.SettingsLoader.MountPoints, LocalizableStrings.NoItems, "   ", '-', new Dictionary<string, Func<MountPointInfo, object>>
             {
                 {LocalizableStrings.MountPoints, x => x.Place},
                 {LocalizableStrings.Id, x => x.MountPointId},
@@ -713,14 +723,14 @@ namespace Microsoft.TemplateEngine.Cli
                 {LocalizableStrings.Factory, x => x.MountPointFactoryId}
             });
 
-            TableFormatter.Print(SettingsLoader.Components.OfType<IMountPointFactory>(), LocalizableStrings.NoItems, "   ", '-', new Dictionary<string, Func<IMountPointFactory, object>>
+            TableFormatter.Print(EnvironmentSettings.SettingsLoader.Components.OfType<IMountPointFactory>(), LocalizableStrings.NoItems, "   ", '-', new Dictionary<string, Func<IMountPointFactory, object>>
             {
                 {LocalizableStrings.MountPointFactories, x => x.Id},
                 {LocalizableStrings.Type, x => x.GetType().FullName},
                 {LocalizableStrings.Assembly, x => x.GetType().GetTypeInfo().Assembly.FullName}
             });
 
-            TableFormatter.Print(SettingsLoader.Components.OfType<IGenerator>(), LocalizableStrings.NoItems, "   ", '-', new Dictionary<string, Func<IGenerator, object>>
+            TableFormatter.Print(EnvironmentSettings.SettingsLoader.Components.OfType<IGenerator>(), LocalizableStrings.NoItems, "   ", '-', new Dictionary<string, Func<IGenerator, object>>
             {
                 {LocalizableStrings.Generators, x => x.Id},
                 {LocalizableStrings.Type, x => x.GetType().FullName},
@@ -789,9 +799,9 @@ namespace Microsoft.TemplateEngine.Cli
                 Reporter.Output.WriteLine(string.Format(LocalizableStrings.Description, UnambiguousTemplateToUse.Description));
             }
 
-            ITemplate template = SettingsLoader.LoadTemplate(UnambiguousTemplateToUse);
-            IParameterSet allParams = TemplateCreator.SetupDefaultParamValuesFromTemplateAndHost(template, template.DefaultName, out IList<string> defaultParamsWithInvalidValues);
-            TemplateCreator.ResolveUserParameters(template, allParams, _app.AllTemplateParams, out IList<string> userParamsWithInvalidValues);
+            ITemplate template = EnvironmentSettings.SettingsLoader.LoadTemplate(UnambiguousTemplateToUse);
+            IParameterSet allParams = _templateCreator.SetupDefaultParamValuesFromTemplateAndHost(template, template.DefaultName, out IList<string> defaultParamsWithInvalidValues);
+            _templateCreator.ResolveUserParameters(template, allParams, _app.AllTemplateParams, out IList<string> userParamsWithInvalidValues);
 
             string additionalInfo = null;
             if (userParamsWithInvalidValues.Any())

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -476,6 +476,13 @@ namespace Microsoft.TemplateEngine.Cli
 
         private bool Initialize()
         {
+            bool ephemeralHiveFlag = _app.RemainingArguments.Any(x => x == "--debug:ephemeral-hive");
+
+            if (ephemeralHiveFlag)
+            {
+                EnvironmentSettings.Host.VirtualizeDirectory(_paths.User.BaseDir);
+            }
+
             bool reinitFlag = _app.RemainingArguments.Any(x => x == "--debug:reinit");
             if (reinitFlag)
             {

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IConditionedConfigurationElement.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IConditionedConfigurationElement.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Core.Contracts
+{
+    public interface IConditionedConfigurationElement
+    {
+        string Condition { get; }
+
+        bool ConditionResult { get; }
+
+        void EvaluateCondition(IEngineEnvironmentSettings environmentSettings, IVariableCollection variables);
+    }
+}

--- a/src/Microsoft.TemplateEngine.Core.Contracts/ICustomFileGlobModel.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/ICustomFileGlobModel.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.TemplateEngine.Core.Contracts
 {
-    public interface ICustomFileGlobModel
+    public interface ICustomFileGlobModel : IConditionedConfigurationElement
     {
         string Glob { get; }
 
@@ -11,11 +11,5 @@ namespace Microsoft.TemplateEngine.Core.Contracts
         IVariableConfig VariableFormat { get; }
 
         string FlagPrefix { get; }
-
-        string Condition { get; }
-
-        bool ConditionResult { get; }
-
-        void EvaluateCondition(IVariableCollection variables);
     }
 }

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IEngineConfig.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IEngineConfig.cs
@@ -1,9 +1,12 @@
 ﻿using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Core.Contracts
 {
     public interface IEngineConfig
     {
+        IEngineEnvironmentSettings EnvironmentSettings { get; }
+
         IReadOnlyList<string> LineEndings { get; }
 
         string VariableFormatString { get; }

--- a/src/Microsoft.TemplateEngine.Core/Expressions/Cpp/CppStyleEvaluatorDefinition.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/Cpp/CppStyleEvaluatorDefinition.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Util;
 
@@ -17,12 +18,12 @@ namespace Microsoft.TemplateEngine.Core.Expressions.Cpp
         private static readonly IOperationProvider[] NoOperationProviders = new IOperationProvider[0];
         private static readonly char[] SupportedQuotes = {'"', '\''};
 
-        public static bool EvaluateFromString(string text, IVariableCollection variables)
+        public static bool EvaluateFromString(IEngineEnvironmentSettings environmentSettings, string text, IVariableCollection variables)
         {
             using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(text)))
             using (MemoryStream res = new MemoryStream())
             {
-                EngineConfig cfg = new EngineConfig(variables);
+                EngineConfig cfg = new EngineConfig(environmentSettings, variables);
                 IProcessorState state = new ProcessorState(ms, res, (int)ms.Length, (int)ms.Length, cfg, NoOperationProviders);
                 int len = (int)ms.Length;
                 int pos = 0;

--- a/src/Microsoft.TemplateEngine.Core/Expressions/Cpp2/Cpp2StyleEvaluatorDefinition.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/Cpp2/Cpp2StyleEvaluatorDefinition.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Util;
 
@@ -100,12 +101,12 @@ namespace Microsoft.TemplateEngine.Core.Expressions.Cpp2
             }
         }
 
-        public static bool EvaluateFromString(string text, IVariableCollection variables)
+        public static bool EvaluateFromString(IEngineEnvironmentSettings environmentSettings, string text, IVariableCollection variables)
         {
             using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(text)))
             using (MemoryStream res = new MemoryStream())
             {
-                EngineConfig cfg = new EngineConfig(variables);
+                EngineConfig cfg = new EngineConfig(environmentSettings, variables);
                 IProcessorState state = new ProcessorState(ms, res, (int)ms.Length, (int)ms.Length, cfg, NoOperationProviders);
                 int len = (int)ms.Length;
                 int pos = 0;

--- a/src/Microsoft.TemplateEngine.Core/Expressions/MSBuild/MSBuildStyleEvaluatorDefinition.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/MSBuild/MSBuildStyleEvaluatorDefinition.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Util;
 
@@ -55,12 +56,12 @@ namespace Microsoft.TemplateEngine.Core.Expressions.MSBuild
             Literal = 18,
         }
 
-        public static bool EvaluateFromString(string text, IVariableCollection variables)
+        public static bool EvaluateFromString(IEngineEnvironmentSettings environmentSettings, string text, IVariableCollection variables)
         {
             using (MemoryStream ms = new MemoryStream(Encoding.UTF8.GetBytes(text)))
             using (MemoryStream res = new MemoryStream())
             {
-                EngineConfig cfg = new EngineConfig(variables);
+                EngineConfig cfg = new EngineConfig(environmentSettings, variables);
                 IProcessorState state = new ProcessorState(ms, res, (int) ms.Length, (int) ms.Length, cfg, NoOperationProviders);
                 int len = (int) ms.Length;
                 int pos = 0;

--- a/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
+++ b/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
@@ -10,6 +10,6 @@
     <ProjectReference Include="..\Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.TemplateEngine.Core/Operations/BalancedNesting.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/BalancedNesting.cs
@@ -99,7 +99,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                     // The reset operation should limit the scope of the problem.
                     // The depth-zero pseudo-comment is the only one that will be "fixed".
                     // But this could be changed to also fix any where depth < 0.
-                    EngineEnvironmentSettings.Host.LogMessage($"Balanced nesting depth < 0. CurrentBufferPosition = {currentBufferPosition}");
+                    processor.Config.EnvironmentSettings.Host.LogMessage($"Balanced nesting depth < 0. CurrentBufferPosition = {currentBufferPosition}");
                 }
 
                 if (_depth == 0 && token == PseudoEndTokenIndex)

--- a/src/Microsoft.TemplateEngine.Core/Operations/InlineMarkupConditional.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/InlineMarkupConditional.cs
@@ -97,7 +97,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 List<byte> conditionBytes = new List<byte>();
                 ScanToCloseCondition(processor, conditionBytes, ref bufferLength, ref currentBufferPosition);
                 byte[] condition = conditionBytes.ToArray();
-                EngineConfig adjustedConfig = new EngineConfig(processor.Config.Whitespaces, processor.Config.LineEndings, processor.Config.Variables, _definition.VariableFormat);
+                EngineConfig adjustedConfig = new EngineConfig(processor.Config.EnvironmentSettings, processor.Config.Whitespaces, processor.Config.LineEndings, processor.Config.Variables, _definition.VariableFormat);
                 IProcessorState localState = new ProcessorState(new MemoryStream(condition), new MemoryStream(), conditionBytes.Count, int.MaxValue, adjustedConfig, new IOperationProvider[0]);
                 int pos = 0;
                 int len = conditionBytes.Count;

--- a/src/Microsoft.TemplateEngine.Core/Util/EngineConfig.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/EngineConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Core.Util
@@ -9,13 +10,14 @@ namespace Microsoft.TemplateEngine.Core.Util
 
         public static IReadOnlyList<string> DefaultWhitespaces = new[] {" ", "\t"};
 
-        public EngineConfig(IVariableCollection variables, string variableFormatString = "{0}")
-            : this(DefaultWhitespaces, DefaultLineEndings, variables, variableFormatString)
+        public EngineConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection variables, string variableFormatString = "{0}")
+            : this(environmentSettings, DefaultWhitespaces, DefaultLineEndings, variables, variableFormatString)
         {
         }
 
-        public EngineConfig(IReadOnlyList<string> whitespaces, IReadOnlyList<string> lineEndings, IVariableCollection variables, string variableFormatString = "{0}")
+        public EngineConfig(IEngineEnvironmentSettings environmentSettings, IReadOnlyList<string> whitespaces, IReadOnlyList<string> lineEndings, IVariableCollection variables, string variableFormatString = "{0}")
         {
+            EnvironmentSettings = environmentSettings;
             Whitespaces = whitespaces;
             LineEndings = lineEndings;
             Variables = variables;
@@ -32,5 +34,7 @@ namespace Microsoft.TemplateEngine.Core.Util
         public IReadOnlyList<string> Whitespaces { get; }
 
         public IDictionary<string, bool> Flags { get; }
+
+        public IEngineEnvironmentSettings EnvironmentSettings { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Core/VariableCollection.cs
+++ b/src/Microsoft.TemplateEngine.Core/VariableCollection.cs
@@ -86,22 +86,22 @@ namespace Microsoft.TemplateEngine.Core
             }
         }
 
-        public static VariableCollection Environment() => Environment(null, true, true, "{0}");
+        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings) => Environment(environmentSettings, null, true, true, "{0}");
 
-        public static VariableCollection Environment(string formatString) => Environment(null, true, true, formatString);
+        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings, string formatString) => Environment(environmentSettings, null, true, true, formatString);
 
-        public static VariableCollection Environment(VariableCollection parent) => Environment(parent, true, true, "{0}");
+        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings, VariableCollection parent) => Environment(environmentSettings, parent, true, true, "{0}");
 
-        public static VariableCollection Environment(VariableCollection parent, string formatString) => Environment(parent, true, true, formatString);
+        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings, VariableCollection parent, string formatString) => Environment(environmentSettings, parent, true, true, formatString);
 
-        public static VariableCollection Environment(bool changeCase, bool upperCase) => Environment(null, changeCase, upperCase, "{0}");
+        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings, bool changeCase, bool upperCase) => Environment(environmentSettings, null, changeCase, upperCase, "{0}");
 
-        public static VariableCollection Environment(bool changeCase, bool upperCase, string formatString) => Environment(null, changeCase, upperCase, formatString);
+        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings, bool changeCase, bool upperCase, string formatString) => Environment(environmentSettings, null, changeCase, upperCase, formatString);
 
-        public static VariableCollection Environment(VariableCollection parent, bool changeCase, bool upperCase, string formatString)
+        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings, VariableCollection parent, bool changeCase, bool upperCase, string formatString)
         {
             VariableCollection vc = new VariableCollection(parent);
-            IReadOnlyDictionary<string, string> variables = EngineEnvironmentSettings.Environment.GetEnvironmentVariables();
+            IReadOnlyDictionary<string, string> variables = environmentSettings.Environment.GetEnvironmentVariables();
 
             foreach (KeyValuePair<string, string> entry in variables)
             {
@@ -221,7 +221,7 @@ namespace Microsoft.TemplateEngine.Core
         }
 
 
-        public static IVariableCollection SetupVariables(IParameterSet parameters, IVariableConfig variableConfig)
+        public static IVariableCollection SetupVariables(IEngineEnvironmentSettings environmentSettings, IParameterSet parameters, IVariableConfig variableConfig)
         {
             IVariableCollection variables = Root();
 
@@ -235,19 +235,19 @@ namespace Microsoft.TemplateEngine.Core
                 switch (source.Key)
                 {
                     case "environment":
-                        variablesForSource = Environment(format);
+                        variablesForSource = Environment(environmentSettings, format);
 
                         if (variableConfig.FallbackFormat != null)
                         {
-                            variablesForSource = Environment(variablesForSource, variableConfig.FallbackFormat);
+                            variablesForSource = Environment(environmentSettings, variablesForSource, variableConfig.FallbackFormat);
                         }
                         break;
                     case "user":
-                        variablesForSource = VariableCollectionFromParameters(parameters, format);
+                        variablesForSource = VariableCollectionFromParameters(environmentSettings, parameters, format);
 
                         if (variableConfig.FallbackFormat != null)
                         {
-                            VariableCollection variablesFallback = VariableCollectionFromParameters(parameters, variableConfig.FallbackFormat);
+                            VariableCollection variablesFallback = VariableCollectionFromParameters(environmentSettings, parameters, variableConfig.FallbackFormat);
                             variablesFallback.Parent = variablesForSource;
                             variablesForSource = variablesFallback;
                         }
@@ -274,7 +274,7 @@ namespace Microsoft.TemplateEngine.Core
             return variables;
         }
 
-        public static VariableCollection VariableCollectionFromParameters(IParameterSet parameters, string format)
+        public static VariableCollection VariableCollectionFromParameters(IEngineEnvironmentSettings environmentSettings, IParameterSet parameters, string format)
         {
             VariableCollection vc = new VariableCollection();
             foreach (ITemplateParameter param in parameters.ParameterDefinitions)
@@ -285,7 +285,7 @@ namespace Microsoft.TemplateEngine.Core
                 {
                     if (param.Priority != TemplateParameterPriority.Optional && param.Priority != TemplateParameterPriority.Suggested)
                     {
-                        while(!EngineEnvironmentSettings.Host.OnParameterError(param, null, "ParameterValueNotSpecified", out string val))
+                        while(!environmentSettings.Host.OnParameterError(param, null, "ParameterValueNotSpecified", out string val))
                         {
                         }
 
@@ -296,7 +296,7 @@ namespace Microsoft.TemplateEngine.Core
                 {
                     if (param.Priority != TemplateParameterPriority.Optional && param.Priority != TemplateParameterPriority.Suggested)
                     {
-                        while (!EngineEnvironmentSettings.Host.OnParameterError(param, null, "ParameterValueNull", out string val))
+                        while (!environmentSettings.Host.OnParameterError(param, null, "ParameterValueNull", out string val))
                         {
                         }
 

--- a/src/Microsoft.TemplateEngine.Edge/AssemblyLoadContextHelper.cs
+++ b/src/Microsoft.TemplateEngine.Edge/AssemblyLoadContextHelper.cs
@@ -11,24 +11,24 @@ namespace Microsoft.TemplateEngine.Edge
     public static class AssemblyLoadContextHelper
     {
 #if !NET45
-        public static IEnumerable<Assembly> LoadAllFromCodebase(this AssemblyLoadContext context, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<Assembly> LoadAllFromCodebase(this AssemblyLoadContext context, Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
 #else
-        public static IEnumerable<Assembly> LoadAllFromCodebase(this AppDomain context, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<Assembly> LoadAllFromCodebase(this AppDomain context, Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
 #endif
         {
-            return LoadAllFromPath(context, out loadFailures, Paths.Global.BaseDir, pattern, searchOption);
+            return LoadAllFromPath(context, paths, out loadFailures, paths.Global.BaseDir, pattern, searchOption);
         }
 
 #if !NET45
-        public static IEnumerable<Assembly> LoadAllFromPath(this AssemblyLoadContext context, out IEnumerable<string> loadFailures, string path, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<Assembly> LoadAllFromPath(this AssemblyLoadContext context, Paths paths, out IEnumerable<string> loadFailures, string path, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
 #else
-        public static IEnumerable<Assembly> LoadAllFromPath(this AppDomain context, out IEnumerable<string> loadFailures, string path, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<Assembly> LoadAllFromPath(this AppDomain context, Paths paths, out IEnumerable<string> loadFailures, string path, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
 #endif
         {
             List<Assembly> loaded = new List<Assembly>();
             List<string> failures = new List<string>();
 
-            foreach (string file in path.EnumerateFiles(pattern, searchOption))
+            foreach (string file in paths.EnumerateFiles(path, pattern, searchOption))
             {
                 try
                 {

--- a/src/Microsoft.TemplateEngine.Edge/AssemblyLoadContextHelper.cs
+++ b/src/Microsoft.TemplateEngine.Edge/AssemblyLoadContextHelper.cs
@@ -11,21 +11,21 @@ namespace Microsoft.TemplateEngine.Edge
     public static class AssemblyLoadContextHelper
     {
 #if !NET45
-        public static IEnumerable<Assembly> LoadAllFromCodebase(this AssemblyLoadContext context, Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<KeyValuePair<string, Assembly>> LoadAllFromCodebase(this AssemblyLoadContext context, Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
 #else
-        public static IEnumerable<Assembly> LoadAllFromCodebase(this AppDomain context, Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<KeyValuePair<string, Assembly>> LoadAllFromCodebase(this AppDomain context, Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
 #endif
         {
             return LoadAllFromPath(context, paths, out loadFailures, paths.Global.BaseDir, pattern, searchOption);
         }
 
 #if !NET45
-        public static IEnumerable<Assembly> LoadAllFromPath(this AssemblyLoadContext context, Paths paths, out IEnumerable<string> loadFailures, string path, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<KeyValuePair<string, Assembly>> LoadAllFromPath(this AssemblyLoadContext context, Paths paths, out IEnumerable<string> loadFailures, string path, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
 #else
-        public static IEnumerable<Assembly> LoadAllFromPath(this AppDomain context, Paths paths, out IEnumerable<string> loadFailures, string path, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<KeyValuePair<string, Assembly>> LoadAllFromPath(this AppDomain context, Paths paths, out IEnumerable<string> loadFailures, string path, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
 #endif
         {
-            List<Assembly> loaded = new List<Assembly>();
+            List<KeyValuePair<string, Assembly>> loaded = new List<KeyValuePair<string, Assembly>>();
             List<string> failures = new List<string>();
 
             foreach (string file in paths.EnumerateFiles(path, pattern, searchOption))
@@ -49,7 +49,7 @@ namespace Microsoft.TemplateEngine.Edge
 
                     if (assembly != null)
                     {
-                        loaded.Add(assembly);
+                        loaded.Add(new KeyValuePair<string, Assembly>(file, assembly));
                     }
                 }
                 catch

--- a/src/Microsoft.TemplateEngine.Edge/AssemblyLoadContextHelper.cs
+++ b/src/Microsoft.TemplateEngine.Edge/AssemblyLoadContextHelper.cs
@@ -37,12 +37,13 @@ namespace Microsoft.TemplateEngine.Edge
 #if !NET45
                     if(file.IndexOf("netcoreapp", StringComparison.OrdinalIgnoreCase) > -1 || file.IndexOf("netstandard", StringComparison.OrdinalIgnoreCase) > -1)
                     {
-                        assembly = context.LoadFromAssemblyPath(file);
+                        assembly = context.LoadFromStream(paths.OpenRead(file));
                     }
 #else
                     if (file.IndexOf("net4", StringComparison.OrdinalIgnoreCase) > -1)
                     {
-                        assembly = Assembly.LoadFile(file);
+                        byte[] fileBytes = paths.ReadAllBytes(file);
+                        assembly = Assembly.Load(fileBytes);
                     }
 #endif
 

--- a/src/Microsoft.TemplateEngine.Edge/AssemblyLoader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/AssemblyLoader.cs
@@ -22,33 +22,33 @@ namespace Microsoft.TemplateEngine.Edge
 #endif
         }
 
-        public static IEnumerable<Assembly> LoadAllAssemblies(out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<Assembly> LoadAllAssemblies(Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
         {
-            IEnumerable<Assembly> loaded = LoadAllFromUserDir(out IEnumerable<string> failures1, pattern, searchOption).Union(LoadAllFromCodebase(out IEnumerable<string> failures2, pattern, searchOption));
+            IEnumerable<Assembly> loaded = LoadAllFromUserDir(paths, out IEnumerable<string> failures1, pattern, searchOption).Union(LoadAllFromCodebase(paths, out IEnumerable<string> failures2, pattern, searchOption));
             loadFailures = failures1.Union(failures2);
             return loaded;
         }
 
-        public static IEnumerable<Assembly> LoadAllFromCodebase(out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<Assembly> LoadAllFromCodebase(Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
         {
 #if !NET45
-            return AssemblyLoadContext.Default.LoadAllFromCodebase(out loadFailures, pattern, searchOption);
+            return AssemblyLoadContext.Default.LoadAllFromCodebase(paths, out loadFailures, pattern, searchOption);
 #else
-            return AppDomain.CurrentDomain.LoadAllFromCodebase(out loadFailures, pattern, searchOption);
+            return AppDomain.CurrentDomain.LoadAllFromCodebase(paths, out loadFailures, pattern, searchOption);
 #endif
         }
 
-        public static IEnumerable<Assembly> LoadAllFromUserDir(out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<Assembly> LoadAllFromUserDir(Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
         {
-            return LoadAllFromPath(out loadFailures, Paths.User.Content, pattern, searchOption);
+            return LoadAllFromPath(paths, out loadFailures, paths.User.Content, pattern, searchOption);
         }
 
-        public static IEnumerable<Assembly> LoadAllFromPath(out IEnumerable<string> loadFailures, string path, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<Assembly> LoadAllFromPath(Paths paths, out IEnumerable<string> loadFailures, string path, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
         {
 #if !NET45
-            return AssemblyLoadContext.Default.LoadAllFromPath(out loadFailures, path, pattern, searchOption);
+            return AssemblyLoadContext.Default.LoadAllFromPath(paths, out loadFailures, path, pattern, searchOption);
 #else
-            return AppDomain.CurrentDomain.LoadAllFromPath(out loadFailures, path, pattern, searchOption);
+            return AppDomain.CurrentDomain.LoadAllFromPath(paths, out loadFailures, path, pattern, searchOption);
 #endif
         }
     }

--- a/src/Microsoft.TemplateEngine.Edge/AssemblyLoader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/AssemblyLoader.cs
@@ -22,14 +22,14 @@ namespace Microsoft.TemplateEngine.Edge
 #endif
         }
 
-        public static IEnumerable<Assembly> LoadAllAssemblies(Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<KeyValuePair<string, Assembly>> LoadAllAssemblies(Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
         {
-            IEnumerable<Assembly> loaded = LoadAllFromUserDir(paths, out IEnumerable<string> failures1, pattern, searchOption).Union(LoadAllFromCodebase(paths, out IEnumerable<string> failures2, pattern, searchOption));
+            IEnumerable<KeyValuePair<string, Assembly>> loaded = LoadAllFromUserDir(paths, out IEnumerable<string> failures1, pattern, searchOption).Union(LoadAllFromCodebase(paths, out IEnumerable<string> failures2, pattern, searchOption));
             loadFailures = failures1.Union(failures2);
             return loaded;
         }
 
-        public static IEnumerable<Assembly> LoadAllFromCodebase(Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<KeyValuePair<string, Assembly>> LoadAllFromCodebase(Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
         {
 #if !NET45
             return AssemblyLoadContext.Default.LoadAllFromCodebase(paths, out loadFailures, pattern, searchOption);
@@ -38,12 +38,12 @@ namespace Microsoft.TemplateEngine.Edge
 #endif
         }
 
-        public static IEnumerable<Assembly> LoadAllFromUserDir(Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<KeyValuePair<string, Assembly>> LoadAllFromUserDir(Paths paths, out IEnumerable<string> loadFailures, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
         {
             return LoadAllFromPath(paths, out loadFailures, paths.User.Content, pattern, searchOption);
         }
 
-        public static IEnumerable<Assembly> LoadAllFromPath(Paths paths, out IEnumerable<string> loadFailures, string path, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
+        public static IEnumerable<KeyValuePair<string, Assembly>> LoadAllFromPath(Paths paths, out IEnumerable<string> loadFailures, string path, string pattern = "*.dll", SearchOption searchOption = SearchOption.AllDirectories)
         {
 #if !NET45
             return AssemblyLoadContext.Default.LoadAllFromPath(paths, out loadFailures, path, pattern, searchOption);

--- a/src/Microsoft.TemplateEngine.Edge/Mount/Archive/ZipFileMountPoint.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/Archive/ZipFileMountPoint.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO.Compression;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 
 namespace Microsoft.TemplateEngine.Edge.Mount.Archive
@@ -8,8 +9,9 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
     {
         private IReadOnlyDictionary<string, IFileSystemInfo> _universe;
 
-        public ZipFileMountPoint(MountPointInfo info, ZipArchive archive)
+        public ZipFileMountPoint(IEngineEnvironmentSettings environmentSettings, MountPointInfo info, ZipArchive archive)
         {
+            EnvironmentSettings = environmentSettings;
             Archive = archive;
             Info = info;
             Root = new ZipFileDirectory(this, "/", "");
@@ -94,5 +96,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
                 return _universe;
             }
         }
+
+        public IEngineEnvironmentSettings EnvironmentSettings { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemFile.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemFile.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using Microsoft.TemplateEngine.Abstractions.Mount;
-using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
 {
@@ -14,11 +13,11 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
             _physicalPath = physicalPath;
         }
 
-        public override bool Exists => _physicalPath.FileExists();
+        public override bool Exists => MountPoint.EnvironmentSettings.Host.FileSystem.FileExists(_physicalPath);
 
         public override Stream OpenRead()
         {
-            return EngineEnvironmentSettings.Host.FileSystem.OpenRead(_physicalPath);
+            return MountPoint.EnvironmentSettings.Host.FileSystem.OpenRead(_physicalPath);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemMountPoint.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemMountPoint.cs
@@ -1,12 +1,17 @@
 using System.IO;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 
 namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
 {
     public class FileSystemMountPoint : IMountPoint
     {
-        public FileSystemMountPoint(MountPointInfo info)
+        private Paths _paths;
+
+        public FileSystemMountPoint(IEngineEnvironmentSettings environmentSettings, MountPointInfo info)
         {
+            EnvironmentSettings = environmentSettings;
+            _paths = new Paths(environmentSettings);
             Info = info;
             Root = new FileSystemDirectory(this, "/", "", info.Place);
         }
@@ -15,16 +20,18 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
 
         public IDirectory Root { get; }
 
+        public IEngineEnvironmentSettings EnvironmentSettings { get; }
+
         public IFile FileInfo(string fullPath)
         {
             string realPath = Path.Combine(Info.Place, fullPath.TrimStart('/'));
-            return new FileSystemFile(this, realPath, realPath.Name(), realPath);
+            return new FileSystemFile(this, realPath, _paths.Name(realPath), realPath);
         }
 
         public IDirectory DirectoryInfo(string fullPath)
         {
             string realPath = Path.Combine(Info.Place, fullPath.TrimStart('/'));
-            return new FileSystemDirectory(this, fullPath, realPath.Name(), realPath);
+            return new FileSystemDirectory(this, fullPath, _paths.Name(realPath), realPath);
         }
 
         public IFileSystemInfo FileSystemInfo(string fullPath)
@@ -32,10 +39,10 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
             string realPath = Path.Combine(Info.Place, fullPath.TrimStart('/'));
             if (Directory.Exists(realPath))
             {
-                return new FileSystemDirectory(this, fullPath, realPath.Name(), realPath);
+                return new FileSystemDirectory(this, fullPath, _paths.Name(realPath), realPath);
             }
 
-            return new FileSystemFile(this, fullPath, realPath.Name(), realPath);
+            return new FileSystemFile(this, fullPath, _paths.Name(realPath), realPath);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemMountPointFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemMountPointFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 
 namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
@@ -10,7 +11,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
 
         public Guid Id => FactoryId;
 
-        public bool TryMount(IMountPoint parent, string place, out IMountPoint mountPoint)
+        public bool TryMount(IEngineEnvironmentSettings environmentSettings, IMountPoint parent, string place, out IMountPoint mountPoint)
         {
             if (parent != null || !Directory.Exists(place))
             {
@@ -20,7 +21,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
 
             Guid mountPointId = Guid.NewGuid();
             MountPointInfo info = new MountPointInfo(Guid.Empty, Id, mountPointId, place);
-            mountPoint = new FileSystemMountPoint(info);
+            mountPoint = new FileSystemMountPoint(environmentSettings, info);
             return true;
         }
 
@@ -32,7 +33,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
                 return false;
             }
 
-            mountPoint = new FileSystemMountPoint(info);
+            mountPoint = new FileSystemMountPoint(manager.EnvironmentSettings, info);
             return true;
         }
 

--- a/src/Microsoft.TemplateEngine.Edge/Paths.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Paths.cs
@@ -69,6 +69,26 @@ namespace Microsoft.TemplateEngine.Edge
             }
         }
 
+        public Stream OpenRead(string path)
+        {
+            return _environmentSettings.Host.FileSystem.OpenRead(path);
+        }
+
+        public byte[] ReadAllBytes(string path)
+        {
+            if (Exists(path))
+            {
+                using (Stream s = _environmentSettings.Host.FileSystem.OpenRead(path))
+                {
+                    byte[] buffer = new byte[s.Length];
+                    s.Read(buffer, 0, buffer.Length);
+                    return buffer;
+                }
+            }
+            
+            return null;
+        }
+
         public void CreateDirectory(string path, string parent)
         {
             string[] parts = path.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Microsoft.TemplateEngine.Edge/Settings/ComponentManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/ComponentManager.cs
@@ -18,6 +18,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         private readonly Dictionary<Guid, string> _componentIdToAssemblyQualifiedTypeName = new Dictionary<Guid, string>();
         private readonly Dictionary<Type, HashSet<Guid>> _componentIdsByType;
         private readonly SettingsStore _settings;
+        private readonly ISettingsLoader _loader;
 
         private interface ICache
         {
@@ -37,8 +38,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
         }
 
-        public ComponentManager(SettingsStore userSettings)
+        public ComponentManager(ISettingsLoader loader, SettingsStore userSettings)
         {
+            _loader = loader;
             _settings = userSettings;
             _loadLocations.AddRange(userSettings.ProbingPaths);
 
@@ -81,7 +83,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 Cache<IMountPointFactory>.Instance.AddPart(new ZipFileMountPointFactory());
             }
 
-            foreach(KeyValuePair<Guid, Func<Type>> components in EngineEnvironmentSettings.Host.BuiltInComponents)
+            foreach(KeyValuePair<Guid, Func<Type>> components in _loader.EnvironmentSettings.Host.BuiltInComponents)
             {
                 if (!ids.Contains(components.Key))
                 {
@@ -159,7 +161,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
                 try
                 {
-                    _settings.Save();
+                    _loader.Save();
                     successfulWrite = true;
                 }
                 catch (IOException)

--- a/src/Microsoft.TemplateEngine.Edge/Settings/MountPointManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/MountPointManager.cs
@@ -9,10 +9,13 @@ namespace Microsoft.TemplateEngine.Edge.Settings
     {
         private readonly IComponentManager _componentManager;
 
-        public MountPointManager(IComponentManager componentManager)
+        public MountPointManager(IEngineEnvironmentSettings environmentSettings, IComponentManager componentManager)
         {
             _componentManager = componentManager;
+            EnvironmentSettings = environmentSettings;
         }
+
+        public IEngineEnvironmentSettings EnvironmentSettings { get; }
 
         public bool TryDemandMountPoint(MountPointInfo info, out IMountPoint mountPoint)
         {
@@ -34,7 +37,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             using (Timing.Over("Get mount point"))
             {
                 MountPointInfo info;
-                if (SettingsLoader.TryGetMountPointInfo(mountPointId, out info))
+                if (EnvironmentSettings.SettingsLoader.TryGetMountPointInfo(mountPointId, out info))
                 {
                     return TryDemandMountPoint(info, out mountPoint);
                 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/SettingsLoader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/SettingsLoader.cs
@@ -10,26 +10,34 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Edge.Settings
 {
-    public static class SettingsLoader
+    public class SettingsLoader : ISettingsLoader
     {
         private const int MaxLoadAttempts = 20;
         public static readonly string HostTemplateFileConfigBaseName = ".host.json";
 
-        private static SettingsStore _userSettings;
-        private static TemplateCache _userTemplateCache;
-        private static IMountPointManager _mountPointManager;
-        private static IComponentManager _componentManager;
-        private static bool _isLoaded;
-        private static Dictionary<Guid, MountPointInfo> _mountPoints;
-        private static bool _templatesLoaded;
+        private SettingsStore _userSettings;
+        private TemplateCache _userTemplateCache;
+        private IMountPointManager _mountPointManager;
+        private IComponentManager _componentManager;
+        private bool _isLoaded;
+        private Dictionary<Guid, MountPointInfo> _mountPoints;
+        private bool _templatesLoaded;
+        private readonly Paths _paths;
+        private readonly IEngineEnvironmentSettings _environmentSettings;
 
-        public static void Save(this SettingsStore store)
+        public SettingsLoader(IEngineEnvironmentSettings environmentSettings)
         {
-            JObject serialized = JObject.FromObject(store);
-            Paths.User.SettingsFile.WriteAllText(serialized.ToString());
+            _environmentSettings = environmentSettings;
+            _paths = new Paths(environmentSettings);
         }
 
-        private static void EnsureLoaded()
+        public void Save()
+        {
+            JObject serialized = JObject.FromObject(_userSettings);
+            _paths.WriteAllText(_paths.User.SettingsFile, serialized.ToString());
+        }
+
+        private void EnsureLoaded()
         {
             if (_isLoaded)
             {
@@ -42,7 +50,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 {
                     try
                     {
-                        userSettings = Paths.User.SettingsFile.ReadAllText("{}");
+                        userSettings = _paths.ReadAllText(_paths.User.SettingsFile, "{}");
                         break;
                     }
                     catch (IOException)
@@ -64,13 +72,13 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             using (Timing.Over("Init probing paths"))
                 if (_userSettings.ProbingPaths.Count == 0)
                 {
-                    _userSettings.ProbingPaths.Add(Paths.User.Content);
+                    _userSettings.ProbingPaths.Add(_paths.User.Content);
                 }
 
             using (Timing.Over("Init Component manager"))
-                _componentManager = new ComponentManager(_userSettings);
+                _componentManager = new ComponentManager(this, _userSettings);
             using (Timing.Over("Init Mount Point manager"))
-                _mountPointManager = new MountPointManager(_componentManager);
+                _mountPointManager = new MountPointManager(_environmentSettings, _componentManager);
 
             using (Timing.Over("Demand template load"))
                 EnsureTemplatesLoaded();
@@ -87,7 +95,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         }
 
         // Loads from the template cache
-        private static void EnsureTemplatesLoaded()
+        private void EnsureTemplatesLoaded()
         {
             if (_templatesLoaded)
             {
@@ -96,20 +104,20 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
             string userTemplateCache;
 
-            if (Paths.User.CurrentLocaleTemplateCacheFile.Exists())
+            if (_paths.Exists(_paths.User.CurrentLocaleTemplateCacheFile))
             {
                 using (Timing.Over("Read template cache"))
-                    userTemplateCache = Paths.User.CurrentLocaleTemplateCacheFile.ReadAllText("{}");
+                    userTemplateCache = _paths.ReadAllText(_paths.User.CurrentLocaleTemplateCacheFile, "{}");
             }
-            else if (Paths.User.CultureNeutralTemplateCacheFile.Exists())
+            else if (_paths.Exists(_paths.User.CultureNeutralTemplateCacheFile))
             {
                 // clone the culture neutral cache
                 // this should not occur if there are any langpacks installed for this culture.
                 // when they got installed, the cache should have been created for that locale.
                 using (Timing.Over("Clone cultural neutral cache"))
                 {
-                    userTemplateCache = Paths.User.CultureNeutralTemplateCacheFile.ReadAllText("{}");
-                    Paths.User.CurrentLocaleTemplateCacheFile.WriteAllText(userTemplateCache);
+                    userTemplateCache = _paths.ReadAllText(_paths.User.CultureNeutralTemplateCacheFile, "{}");
+                    _paths.WriteAllText(_paths.User.CurrentLocaleTemplateCacheFile, userTemplateCache);
                 }
             }
             else
@@ -121,24 +129,24 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             using (Timing.Over("Parse template cache"))
                 parsed = JObject.Parse(userTemplateCache);
             using (Timing.Over("Init template cache"))
-                _userTemplateCache = new TemplateCache(parsed);
+                _userTemplateCache = new TemplateCache(_environmentSettings, parsed);
 
             _templatesLoaded = true;
         }
 
-        public static void Reload()
+        public void Reload()
         {
             _isLoaded = false;
             EnsureLoaded();
         }
 
-        private static void UpdateTemplateListFromCache(TemplateCache cache, ISet<ITemplateInfo> templates)
+        private void UpdateTemplateListFromCache(TemplateCache cache, ISet<ITemplateInfo> templates)
         {
             using (Timing.Over("Enumerate infos"))
                 templates.UnionWith(cache.TemplateInfo);
         }
 
-        public static ITemplate LoadTemplate(ITemplateInfo info)
+        public ITemplate LoadTemplate(ITemplateInfo info)
         {
             IGenerator generator;
             if (!Components.TryGetComponent(info.GeneratorId, out generator))
@@ -169,9 +177,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
 
             IFile hostTemplateConfigFile = null;
-            if (!string.IsNullOrEmpty(EngineEnvironmentSettings.Host.HostIdentifier))
+            if (!string.IsNullOrEmpty(_environmentSettings.Host.HostIdentifier))
             {
-                string hostTemplateFileName = string.Join(string.Empty, EngineEnvironmentSettings.Host.HostIdentifier, HostTemplateFileConfigBaseName);
+                string hostTemplateFileName = string.Join(string.Empty, _environmentSettings.Host.HostIdentifier, HostTemplateFileConfigBaseName);
                 hostTemplateConfigFile = config.Parent.EnumerateFiles(hostTemplateFileName, SearchOption.TopDirectoryOnly).FirstOrDefault();
             }
 
@@ -190,7 +198,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             return null;
         }
 
-        public static IComponentManager Components
+        public IComponentManager Components
         {
             get
             {
@@ -199,7 +207,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
         }
 
-        public static IEnumerable<MountPointInfo> MountPoints
+        public IEnumerable<MountPointInfo> MountPoints
         {
             get
             {
@@ -208,7 +216,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
         }
 
-        public static void GetTemplates(HashSet<ITemplateInfo> templates)
+        public IEngineEnvironmentSettings EnvironmentSettings => throw new NotImplementedException();
+
+        public void GetTemplates(HashSet<ITemplateInfo> templates)
         {
             using (Timing.Over("Settings init"))
                 EnsureLoaded();
@@ -216,12 +226,12 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 UpdateTemplateListFromCache(_userTemplateCache, templates);
         }
 
-        public static void WriteTemplateCache(IList<TemplateInfo> templates, string locale, bool isCurrentCache)
+        public void WriteTemplateCache(IList<ITemplateInfo> templates, string locale, bool isCurrentCache)
         {
-            TemplateCache cache = new TemplateCache();
-            cache.TemplateInfo.AddRange(templates);
+            TemplateCache cache = new TemplateCache(_environmentSettings);
+            cache.TemplateInfo.AddRange(templates.Cast<TemplateInfo>());
             JObject serialized = JObject.FromObject(cache);
-            Paths.User.ExplicitLocaleTemplateCacheFile(locale).WriteAllText(serialized.ToString());
+            _paths.WriteAllText(_paths.User.ExplicitLocaleTemplateCacheFile(locale), serialized.ToString());
 
             if (isCurrentCache)
             {
@@ -229,7 +239,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
         }
 
-        public static void AddProbingPath(string probeIn)
+        public void AddProbingPath(string probeIn)
         {
             const int maxAttempts = 10;
             int attemptCount = 0;
@@ -245,7 +255,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
                 try
                 {
-                    _userSettings.Save();
+                    Save();
                     successfulWrite = true;
                 }
                 catch
@@ -256,14 +266,14 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
         }
 
-        public static bool TryGetMountPointInfo(Guid mountPointId, out MountPointInfo info)
+        public bool TryGetMountPointInfo(Guid mountPointId, out MountPointInfo info)
         {
             EnsureLoaded();
             using(Timing.Over("Mount point lookup"))
             return _mountPoints.TryGetValue(mountPointId, out info);
         }
 
-        public static bool TryGetMountPointInfoFromPlace(string mountPointPlace, out MountPointInfo info)
+        public bool TryGetMountPointInfoFromPlace(string mountPointPlace, out MountPointInfo info)
         {
             EnsureLoaded();
             using (Timing.Over("Mount point place lookup"))
@@ -280,7 +290,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             return false;
         }
 
-        public static bool TryGetMountPointFromPlace(string mountPointPlace, out IMountPoint mountPoint)
+        public bool TryGetMountPointFromPlace(string mountPointPlace, out IMountPoint mountPoint)
         {
             if (! TryGetMountPointInfoFromPlace(mountPointPlace, out MountPointInfo info))
             {
@@ -291,7 +301,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             return _mountPointManager.TryDemandMountPoint(info.MountPointId, out mountPoint);
         }
 
-        public static void AddMountPoint(IMountPoint mountPoint)
+        public void AddMountPoint(IMountPoint mountPoint)
         {
             if(_mountPoints.Values.Any(x => string.Equals(x.Place, mountPoint.Info.Place) && x.ParentMountPointId == mountPoint.Info.ParentMountPointId))
             {
@@ -301,10 +311,10 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             _mountPoints[mountPoint.Info.MountPointId] = mountPoint.Info;
             _userSettings.MountPoints.Add(mountPoint.Info);
             JObject serialized = JObject.FromObject(_userSettings);
-            Paths.User.SettingsFile.WriteAllText(serialized.ToString());
+            _paths.WriteAllText(_paths.User.SettingsFile, serialized.ToString());
         }
 
-        public static bool TryGetFileFromIdAndPath(Guid mountPointId, string place, out IFile file)
+        public bool TryGetFileFromIdAndPath(Guid mountPointId, string place, out IFile file)
         {
             if (!string.IsNullOrEmpty(place) && _mountPointManager.TryDemandMountPoint(mountPointId, out IMountPoint mountPoint))
             {

--- a/src/Microsoft.TemplateEngine.Edge/Settings/SettingsLoader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/SettingsLoader.cs
@@ -216,7 +216,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
         }
 
-        public IEngineEnvironmentSettings EnvironmentSettings => throw new NotImplementedException();
+        public IEngineEnvironmentSettings EnvironmentSettings => _environmentSettings;
 
         public void GetTemplates(HashSet<ITemplateInfo> templates)
         {

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -145,16 +145,16 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     diskPath = path;
                 }
 
-                foreach (Assembly asm in AssemblyLoader.LoadAllAssemblies(_paths, out IEnumerable<string> failures))
+                foreach (KeyValuePair<string, Assembly> asm in AssemblyLoader.LoadAllAssemblies(_paths, out IEnumerable<string> failures))
                 {
                     try
                     {
-                        foreach (Type type in asm.GetTypes())
+                        foreach (Type type in asm.Value.GetTypes())
                         {
                             _environmentSettings.SettingsLoader.Components.Register(type);
                         }
 
-                        _environmentSettings.SettingsLoader.AddProbingPath(Path.GetDirectoryName(asm.Location));
+                        _environmentSettings.SettingsLoader.AddProbingPath(Path.GetDirectoryName(asm.Key));
                     }
                     catch
                     {

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -17,19 +17,22 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 {
     public class TemplateCache
     {
-        private static IDictionary<string, ITemplate> _templateMemoryCache = new Dictionary<string, ITemplate>();
+        private IDictionary<string, ITemplate> _templateMemoryCache = new Dictionary<string, ITemplate>();
 
         // locale -> identity -> locator
-        private static IDictionary<string, IDictionary<string, ILocalizationLocator>> _localizationMemoryCache
-                = new Dictionary<string, IDictionary<string, ILocalizationLocator>>();
+        private readonly IDictionary<string, IDictionary<string, ILocalizationLocator>> _localizationMemoryCache = new Dictionary<string, IDictionary<string, ILocalizationLocator>>();
+        private readonly IEngineEnvironmentSettings _environmentSettings;
+        private readonly Paths _paths;
 
-        public TemplateCache()
+        public TemplateCache(IEngineEnvironmentSettings environmentSettings)
         {
+            _environmentSettings = environmentSettings;
+            _paths = new Paths(environmentSettings);
             TemplateInfo = new List<TemplateInfo>();
         }
 
-        public TemplateCache(JObject parsed)
-            : this()
+        public TemplateCache(IEngineEnvironmentSettings environmentSettings, JObject parsed)
+            : this(environmentSettings)
         {
             if (parsed.TryGetValue("TemplateInfo", StringComparison.OrdinalIgnoreCase, out JToken templateInfoToken))
             {
@@ -49,7 +52,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         [JsonProperty]
         public List<TemplateInfo> TemplateInfo { get; set; }
 
-        public static void Scan(IReadOnlyList<string> templateRoots)
+        public void Scan(IReadOnlyList<string> templateRoots)
         {
             foreach (string templateDir in templateRoots)
             {
@@ -58,12 +61,12 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         }
 
         // reads all the templates and langpacks for the current dir.
-        // stores info about them in static members.
+        // stores info about them in members.
         // can't correctly write locale cache(s) until all of both are read.
-        public static void Scan(string templateDir)
+        public void Scan(string templateDir)
         {
-            string searchTarget = Path.Combine(EngineEnvironmentSettings.Host.FileSystem.GetCurrentDirectory(), templateDir.Trim());
-            List<string> matches = EngineEnvironmentSettings.Host.FileSystem.EnumerateFileSystemEntries(Path.GetDirectoryName(searchTarget), Path.GetFileName(searchTarget), SearchOption.TopDirectoryOnly).ToList();
+            string searchTarget = Path.Combine(_environmentSettings.Host.FileSystem.GetCurrentDirectory(), templateDir.Trim());
+            List<string> matches = _environmentSettings.Host.FileSystem.EnumerateFileSystemEntries(Path.GetDirectoryName(searchTarget), Path.GetFileName(searchTarget), SearchOption.TopDirectoryOnly).ToList();
 
             if (matches.Count == 1)
             {
@@ -79,33 +82,33 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 return;
             }
 
-            if (SettingsLoader.TryGetMountPointFromPlace(searchTarget, out IMountPoint existingMountPoint))
+            if (_environmentSettings.SettingsLoader.TryGetMountPointFromPlace(searchTarget, out IMountPoint existingMountPoint))
             {
                 ScanMountPointForTemplatesAndLangpacks(existingMountPoint, templateDir);
             }
             else
             {
-                foreach (IMountPointFactory factory in SettingsLoader.Components.OfType<IMountPointFactory>().ToList())
+                foreach (IMountPointFactory factory in _environmentSettings.SettingsLoader.Components.OfType<IMountPointFactory>().ToList())
                 {
-                    if (factory.TryMount(null, templateDir, out IMountPoint mountPoint))
+                    if (factory.TryMount(_environmentSettings, null, templateDir, out IMountPoint mountPoint))
                     {
                         // TODO: consider not adding the mount point if there is nothing to install.
                         // It'd require choosing to not write it upstream from here, which might be better anyway.
                         // "nothing to install" could have a couple different meanings:
                         // 1) no templates, and no langpacks were found.
                         // 2) only langpacks were found, but they aren't for any existing templates - but we won't know that at this point.
-                        SettingsLoader.AddMountPoint(mountPoint);
+                        _environmentSettings.SettingsLoader.AddMountPoint(mountPoint);
                         ScanMountPointForTemplatesAndLangpacks(mountPoint, templateDir);
                     }
                 }
             }
         }
 
-        private static void ScanMountPointForTemplatesAndLangpacks(IMountPoint mountPoint, string templateDir)
+        private void ScanMountPointForTemplatesAndLangpacks(IMountPoint mountPoint, string templateDir)
         {
             ScanForComponents(mountPoint, templateDir);
 
-            foreach (IGenerator generator in SettingsLoader.Components.OfType<IGenerator>())
+            foreach (IGenerator generator in _environmentSettings.SettingsLoader.Components.OfType<IGenerator>())
             {
                 IEnumerable<ITemplate> templateList = generator.GetTemplatesAndLangpacksFromDir(mountPoint, out IList<ILocalizationLocator> localizationInfo);
 
@@ -121,14 +124,14 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
         }
 
-        private static void ScanForComponents(IMountPoint mountPoint, string templateDir)
+        private void ScanForComponents(IMountPoint mountPoint, string templateDir)
         {
             if (mountPoint.Root.EnumerateFiles("*.dll", SearchOption.AllDirectories).Any())
             {
                 string diskPath = templateDir;
                 if (mountPoint.Info.MountPointFactoryId != FileSystemMountPointFactory.FactoryId)
                 {
-                    string path = Path.Combine(Paths.User.Content, Path.GetFileName(templateDir));
+                    string path = Path.Combine(_paths.User.Content, Path.GetFileName(templateDir));
 
                     try
                     {
@@ -142,16 +145,16 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     diskPath = path;
                 }
 
-                foreach (Assembly asm in AssemblyLoader.LoadAllAssemblies(out IEnumerable<string> failures))
+                foreach (Assembly asm in AssemblyLoader.LoadAllAssemblies(_paths, out IEnumerable<string> failures))
                 {
                     try
                     {
                         foreach (Type type in asm.GetTypes())
                         {
-                            SettingsLoader.Components.Register(type);
+                            _environmentSettings.SettingsLoader.Components.Register(type);
                         }
 
-                        SettingsLoader.AddProbingPath(Path.GetDirectoryName(asm.Location));
+                        _environmentSettings.SettingsLoader.AddProbingPath(Path.GetDirectoryName(asm.Location));
                     }
                     catch
                     {
@@ -160,9 +163,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
         }
 
-        public static List<TemplateInfo> LoadTemplateCacheForLocale(string locale)
+        public List<TemplateInfo> LoadTemplateCacheForLocale(string locale)
         {
-            string cacheContent = Paths.User.ExplicitLocaleTemplateCacheFile(locale).ReadAllText("{}");
+            string cacheContent = _paths.ReadAllText(_paths.User.ExplicitLocaleTemplateCacheFile(locale), "{}");
             JObject parsed = JObject.Parse(cacheContent);
             List<TemplateInfo> templates = new List<TemplateInfo>();
 
@@ -188,9 +191,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         //  - cultures for which new langpacks are installed
         //  - other locales with existing caches are regenerated.
         //  - neutral locale
-        public static void WriteTemplateCaches()
+        public void WriteTemplateCaches()
         {
-            string currentLocale = EngineEnvironmentSettings.Host.Locale;
+            string currentLocale = _environmentSettings.Host.Locale;
             HashSet<string> localesWritten = new HashSet<string>();
 
             // If the current locale exists, always write it.
@@ -209,15 +212,15 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
             // read the cache dir for other locale caches, and re-write them.
             // there may be new templates to add to them.
-            string fileSearchPattern = "*." + Paths.User.TemplateCacheFileBaseName;
-            foreach (string fullFilename in Paths.User.BaseDir.EnumerateFiles(fileSearchPattern, System.IO.SearchOption.TopDirectoryOnly))
+            string fileSearchPattern = "*." + _paths.User.TemplateCacheFileBaseName;
+            foreach (string fullFilename in _paths.EnumerateFiles(_paths.User.BaseDir, fileSearchPattern, SearchOption.TopDirectoryOnly))
             {
                 string filename = Path.GetFileName(fullFilename);
                 string[] fileParts = filename.Split(new char[] { '.' }, 2);
                 string fileLocale = fileParts[0];
 
                 if (!string.IsNullOrEmpty(fileLocale) &&
-                    (fileParts[1] == Paths.User.TemplateCacheFileBaseName)
+                    (fileParts[1] == _paths.User.TemplateCacheFileBaseName)
                     && !localesWritten.Contains(fileLocale))
                 {
                     WriteTemplateCacheForLocale(fileLocale);
@@ -235,26 +238,26 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             WriteTemplateCacheForLocale(null);
         }
 
-        public static void DeleteAllLocaleCacheFiles()
+        public void DeleteAllLocaleCacheFiles()
         {
-            string fileSearchPattern = "*." + Paths.User.TemplateCacheFileBaseName;
-            foreach (string fullFilename in Paths.User.BaseDir.EnumerateFiles(fileSearchPattern, System.IO.SearchOption.TopDirectoryOnly))
+            string fileSearchPattern = "*." + _paths.User.TemplateCacheFileBaseName;
+            foreach (string fullFilename in _paths.EnumerateFiles(_paths.User.BaseDir, fileSearchPattern, SearchOption.TopDirectoryOnly))
             {
                 string filename = Path.GetFileName(fullFilename);
                 string[] fileParts = filename.Split(new char[] { '.' }, 2);
                 string fileLocale = fileParts[0];
 
                 if (!string.IsNullOrEmpty(fileLocale) &&
-                    (fileParts[1] == Paths.User.TemplateCacheFileBaseName))
+                    (fileParts[1] == _paths.User.TemplateCacheFileBaseName))
                 {
-                    fullFilename.Delete();
+                    _paths.Delete(fullFilename);
                 }
             }
 
-            Paths.User.CultureNeutralTemplateCacheFile.Delete();
+            _paths.Delete(_paths.User.CultureNeutralTemplateCacheFile);
         }
 
-        private static void WriteTemplateCacheForLocale(string locale)
+        private void WriteTemplateCacheForLocale(string locale)
         {
             List<TemplateInfo> existingTemplatesForLocale = LoadTemplateCacheForLocale(locale);
             IDictionary<string, ILocalizationLocator> existingLocatorsForLocale;
@@ -270,7 +273,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
 
             HashSet<string> foundTemplates = new HashSet<string>();
-            List<TemplateInfo> mergedTemplateList = new List<TemplateInfo>();
+            List<ITemplateInfo> mergedTemplateList = new List<ITemplateInfo>();
 
             // These are from langpacks being installed... identity -> locator
             if (string.IsNullOrEmpty(locale)
@@ -299,13 +302,13 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
 
             bool isCurrentLocale = string.IsNullOrEmpty(locale)
-                && string.IsNullOrEmpty(EngineEnvironmentSettings.Host.Locale)
-                || (locale == EngineEnvironmentSettings.Host.Locale);
-            SettingsLoader.WriteTemplateCache(mergedTemplateList, locale, isCurrentLocale);
+                && string.IsNullOrEmpty(_environmentSettings.Host.Locale)
+                || (locale == _environmentSettings.Host.Locale);
+            _environmentSettings.SettingsLoader.WriteTemplateCache(mergedTemplateList, locale, isCurrentLocale);
         }
 
         // find the best locator (if any). New is preferred over old
-        private static ILocalizationLocator GetPreferredLocatorForTemplate(string identity, IDictionary<string, ILocalizationLocator> existingLocatorsForLocale, IDictionary<string, ILocalizationLocator> newLocatorsForLocale)
+        private ILocalizationLocator GetPreferredLocatorForTemplate(string identity, IDictionary<string, ILocalizationLocator> existingLocatorsForLocale, IDictionary<string, ILocalizationLocator> newLocatorsForLocale)
         {
             if (!newLocatorsForLocale.TryGetValue(identity, out ILocalizationLocator locatorForTemplate))
             {
@@ -315,7 +318,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             return locatorForTemplate;
         }
 
-        private static TemplateInfo LocalizeTemplate(ITemplateInfo template, ILocalizationLocator localizationInfo)
+        private TemplateInfo LocalizeTemplate(ITemplateInfo template, ILocalizationLocator localizationInfo)
         {
             TemplateInfo localizedTemplate = new TemplateInfo
             {
@@ -339,7 +342,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         }
 
         // return dict is: Identity -> locator
-        private static IDictionary<string, ILocalizationLocator> GetLocalizationsFromTemplates(IList<TemplateInfo> templateList, string locale)
+        private IDictionary<string, ILocalizationLocator> GetLocalizationsFromTemplates(IList<TemplateInfo> templateList, string locale)
         {
             IDictionary<string, ILocalizationLocator> locatorLookup = new Dictionary<string, ILocalizationLocator>();
 
@@ -371,12 +374,12 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         // Adds the template to the memory cache, keyed on identity.
         // If the identity is the same as an existing one, it's overwritten.
         // (last in wins)
-        private static void AddTemplateToMemoryCache(ITemplate template)
+        private void AddTemplateToMemoryCache(ITemplate template)
         {
             _templateMemoryCache[template.Identity] = template;
         }
 
-        private static void AddLocalizationToMemoryCache(ILocalizationLocator locator)
+        private void AddLocalizationToMemoryCache(ILocalizationLocator locator)
         {
             if (!_localizationMemoryCache.TryGetValue(locator.Locale, out IDictionary<string, ILocalizationLocator> localeLocators))
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConditionedConfigurationElementBase.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConditionedConfigurationElementBase.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.Core.Expressions.Cpp;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
+{
+    public abstract class ConditionedConfigurationElementBase : IConditionedConfigurationElement
+    {
+        private bool _conditionResult;
+
+        public string Condition { get; set; }
+
+        public bool ConditionResult
+        {
+            get
+            {
+                if (!IsConditionEvaluated)
+                {
+                    throw new InvalidOperationException("ConditionResult access attempted prior to evaluation");
+                }
+
+                return _conditionResult;
+            }
+            private set
+            {
+                _conditionResult = value;
+                IsConditionEvaluated = true;
+            }
+        }
+
+        // tracks whether or not the condition has been evaluated.
+        // will cause ConditionResult.get to throw if evaluation hasn't happened.
+        private bool IsConditionEvaluated { get; set; }
+
+        public void EvaluateCondition(IEngineEnvironmentSettings environmentSettings, IVariableCollection variables)
+        {
+            if (string.IsNullOrEmpty(Condition)
+                || CppStyleEvaluatorDefinition.EvaluateFromString(environmentSettings, Condition, variables))
+            {
+                ConditionResult = true;
+            }
+            else
+            {
+                ConditionResult = false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/MacrosOperationConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/MacrosOperationConfig.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
 
         // Warning: if there are unknown macro "types", they are quietly ignored here.
         // This applies to both the regular and deferred macros.
-        public IEnumerable<IOperationProvider> ProcessMacros(IComponentManager componentManager, IReadOnlyList<IMacroConfig> macroConfigs, IVariableCollection variables, IParameterSet parameters)
+        public IEnumerable<IOperationProvider> ProcessMacros(IEngineEnvironmentSettings environmentSettings, IComponentManager componentManager, IReadOnlyList<IMacroConfig> macroConfigs, IVariableCollection variables, IParameterSet parameters)
         {
             EnsureMacros(componentManager);
             EnsureDeferredMacros(componentManager);
@@ -22,7 +22,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
             ParameterSetter setter = (p, value) =>
             {
                 ((RunnableProjectGenerator.ParameterSet)parameters).AddParameter(p);
-                parameters.ResolvedValues[p] = RunnableProjectGenerator.InternalConvertParameterValueToType(p, value, out bool valueResolutionError);
+                parameters.ResolvedValues[p] = RunnableProjectGenerator.InternalConvertParameterValueToType(environmentSettings, p, value, out bool valueResolutionError);
                 // TODO: consider checking the valueResolutionError and act on it, if needed.
                 // Should be safe to ignore, params should be verified by the time this occurs.
             };
@@ -41,7 +41,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
 
                 if (_macroObjects.TryGetValue(config.Type, out IMacro macroObject))
                 {
-                    macroObject.EvaluateConfig(variables, config, parameters, setter);
+                    macroObject.EvaluateConfig(environmentSettings, variables, config, parameters, setter);
                 }
             }
 
@@ -51,7 +51,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
                 IDeferredMacro deferredMacroObject;
                 if (_deferredMacroObjects.TryGetValue(deferredConfig.Type, out deferredMacroObject))
                 {
-                    deferredMacroObject.EvaluateDeferredConfig(variables, deferredConfig, parameters, setter);
+                    deferredMacroObject.EvaluateDeferredConfig(environmentSettings, variables, deferredConfig, parameters, setter);
                 }
             }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ReplacementConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ReplacementConfig.cs
@@ -15,16 +15,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
 
         public Guid Id => new Guid("62DB7F1F-A10E-46F0-953F-A28A03A81CD1");
 
-        public static IOperationProvider Setup(IReplacementTokens tokens, IParameterSet parameters)
+        public static IOperationProvider Setup(IEngineEnvironmentSettings environmentSettings, IReplacementTokens tokens, IParameterSet parameters)
         {
-            if (RuntimeValueUtil.TryGetRuntimeValue(parameters, tokens.VariableName, out object newValueObject))
+            if (parameters.TryGetRuntimeValue(environmentSettings, tokens.VariableName, out object newValueObject))
             {
                 string newValue = newValueObject.ToString();
                 return new Replacement(tokens.OriginalValue, newValue, null);
             }
             else
             {
-                EngineEnvironmentSettings.Host.LogMessage($"Couldn't find a parameter called {tokens.VariableName}");
+                environmentSettings.Host.LogMessage($"Couldn't find a parameter called {tokens.VariableName}");
                 return null;
             }
         }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationPath.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationPath.cs
@@ -10,7 +10,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
     {
         public string Path { get; set; }
 
-        public static IReadOnlyList<ICreationPath> ListFromModel(IReadOnlyList<ICreationPathModel> modelList, IVariableCollection rootVariableCollection)
+        public static IReadOnlyList<ICreationPath> ListFromModel(IEngineEnvironmentSettings environmentSettings, IReadOnlyList<ICreationPathModel> modelList, IVariableCollection rootVariableCollection)
         {
             List<ICreationPath> pathList = new List<ICreationPath>();
 
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 // Note: this check is probably superfluous. The Model has evaluation info.
                 // OTOH: this is probaby a cleaner way to do it. 
                 if (string.IsNullOrEmpty(model.Condition)
-                    || CppStyleEvaluatorDefinition.EvaluateFromString(model.Condition, rootVariableCollection))
+                    || CppStyleEvaluatorDefinition.EvaluateFromString(environmentSettings, model.Condition, rootVariableCollection))
                 {
                     ICreationPath path = new CreationPath()
                     {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationPathModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationPathModel.cs
@@ -1,60 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using Microsoft.TemplateEngine.Core.Contracts;
-using Microsoft.TemplateEngine.Core.Expressions.Cpp;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
-    public class CreationPathModel : ICreationPathModel
+    public class CreationPathModel : ConditionedConfigurationElementBase, ICreationPathModel
     {
-        public CreationPathModel()
-        {
-            IsConditionEvaluated = false;
-        }
-
         public string PathOriginal { get; set; }
 
         public string PathResolved { get; set; }
-
-        public string Condition { get; set; }
-
-        private bool _conditionResult;
-
-        public bool ConditionResult
-        {
-            get
-            {
-                if (! IsConditionEvaluated)
-                {
-                    throw new InvalidOperationException("ConditionResult access attempted prior to evaluation");
-                }
-
-                return _conditionResult;
-            }
-            private set
-            {
-                _conditionResult = value;
-                IsConditionEvaluated = true;
-            }
-        }
-
-        // tracks whether or not the condition has been evaluated.
-        // will cause ConditionResult.get to throw if evaluation hasn't happened.
-        private bool IsConditionEvaluated { get; set; }
-
-        public void EvaluateCondition(IVariableCollection variables)
-        {
-            if (string.IsNullOrEmpty(Condition)
-                || CppStyleEvaluatorDefinition.EvaluateFromString(Condition, variables))
-            {
-                ConditionResult = true;
-            }
-            else
-            {
-                ConditionResult = false;
-            }
-        }
 
         public static IReadOnlyList<ICreationPathModel> ListFromJArray(JArray jsonData)
         {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CustomFileGlobModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CustomFileGlobModel.cs
@@ -1,18 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Core.Contracts;
-using Microsoft.TemplateEngine.Core.Expressions.Cpp;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
-    public class CustomFileGlobModel : ICustomFileGlobModel
+    public class CustomFileGlobModel : ConditionedConfigurationElementBase, ICustomFileGlobModel
     {
-        public CustomFileGlobModel()
-        {
-            IsConditionEvaluated = false;
-        }
-
         public string Glob { get; set; }
 
         public IReadOnlyList<ICustomOperationModel> Operations { get; set; }
@@ -22,45 +16,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         public IVariableConfig VariableFormat { get; set; }
 
         public string FlagPrefix { get; set; }
-
-        public string Condition { get; set; }
-
-        private bool _conditionResult;
-
-        public bool ConditionResult
-        {
-            get
-            {
-                if (! IsConditionEvaluated)
-                {
-                    throw new InvalidOperationException("ConditionResult access attempted prior to evaluation");
-                }
-
-                return _conditionResult;
-            }
-            private set
-            {
-                _conditionResult = value;
-                IsConditionEvaluated = true;
-            }
-        }
-
-        // tracks whether or not the condition has been evaluated.
-        // will cause ConditionResult.get to throw if evaluation hasn't happened.
-        private bool IsConditionEvaluated { get; set; }
-
-        public void EvaluateCondition(IVariableCollection variables)
-        {
-            if (string.IsNullOrEmpty(Condition)
-                || CppStyleEvaluatorDefinition.EvaluateFromString(Condition, variables))
-            {
-                ConditionResult = true;
-            }
-            else
-            {
-                ConditionResult = false;
-            }
-        }
 
         public static CustomFileGlobModel FromJObject(JObject globData, string globName)
         {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ICreationPathModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ICreationPathModel.cs
@@ -1,18 +1,11 @@
-﻿
-using Microsoft.TemplateEngine.Core.Contracts;
+﻿using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
-    public interface ICreationPathModel
+    public interface ICreationPathModel : IConditionedConfigurationElement
     {
         string PathOriginal { get; }
 
         string PathResolved { get; set; }
-
-        string Condition { get; }
-
-        bool ConditionResult { get; }
-
-        void EvaluateCondition(IVariableCollection variables);
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CaseChangeMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CaseChangeMacro.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public string Type => "casing";
 
-        public void EvaluateConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             string value = null;
             CaseChangeMacroConfig config = rawConfig as CaseChangeMacroConfig;
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
             if (!vars.TryGetValue(config.SourceVariable, out object working))
             {
-                if (RuntimeValueUtil.TryGetRuntimeValue(parameters, config.SourceVariable, out object resolvedValue, true))
+                if (RuntimeValueUtil.TryGetRuntimeValue(parameters, environmentSettings, config.SourceVariable, out object resolvedValue, true))
                 {
                     value = resolvedValue.ToString();
                 }
@@ -50,7 +50,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             setter(p, value);
         }
 
-        public void EvaluateDeferredConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateDeferredConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
@@ -73,7 +73,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             }
 
             IMacroConfig realConfig = new CaseChangeMacroConfig(deferredConfig.VariableName, sourceVariable, lowerCase);
-            EvaluateConfig(vars, realConfig, parameters, setter);
+            EvaluateConfig(environmentSettings, vars, realConfig, parameters, setter);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ConstantMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ConstantMacro.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public string Type => "constant";
 
-        public void EvaluateConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             ConstantMacroConfig config = rawConfig as ConstantMacroConfig;
 
@@ -30,7 +30,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             setter(p, config.Value);
         }
 
-        public void EvaluateDeferredConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateDeferredConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
@@ -46,7 +46,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
             string value = valueToken.ToString();
             IMacroConfig realConfig = new ConstantMacroConfig(deferredConfig.VariableName, value);
-            EvaluateConfig(vars, realConfig, parameters, setter);
+            EvaluateConfig(environmentSettings, vars, realConfig, parameters, setter);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/EvaluateMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/EvaluateMacro.cs
@@ -16,7 +16,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public static readonly string DefaultEvaluator = "C++";
 
-        public void EvaluateConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             EvaluateMacroConfig config = rawConfig as EvaluateMacroConfig;
 
@@ -30,7 +30,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             byte[] data = Encoding.UTF8.GetBytes(config.Value);
             int len = data.Length;
             int pos = 0;
-            IProcessorState state = new GlobalRunSpec.ProcessorState(vars, data, Encoding.UTF8);
+            IProcessorState state = new GlobalRunSpec.ProcessorState(environmentSettings, vars, data, Encoding.UTF8);
             bool result = evaluator(state, ref len, ref pos, out bool faulted);
 
             Parameter p = new Parameter

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GuidMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GuidMacro.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public string Type => "guid";
 
-        public void EvaluateConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             GuidMacroConfig config = rawConfig as GuidMacroConfig;
 
@@ -58,7 +58,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             }
         }
 
-        public void EvaluateDeferredConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateDeferredConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
@@ -74,7 +74,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             string format = formatToken?.ToString();
 
             IMacroConfig realConfig = new GuidMacroConfig(deferredConfig.VariableName, format);
-            EvaluateConfig(vars, realConfig, parameters, setter);
+            EvaluateConfig(environmentSettings, vars, realConfig, parameters, setter);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/IDeferredMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/IDeferredMacro.cs
@@ -8,6 +8,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
     {
         string Type { get; }
 
-        void EvaluateDeferredConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter);
+        void EvaluateDeferredConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter);
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/IMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/IMacro.cs
@@ -7,6 +7,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
     {
         string Type { get; }
 
-        void EvaluateConfig(IVariableCollection vars, IMacroConfig config, IParameterSet parameters, ParameterSetter setter);
+        void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig config, IParameterSet parameters, ParameterSetter setter);
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/NowMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/NowMacro.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public string Type => "now";
          
-        public void EvaluateConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             NowMacroConfig config = rawConfig as NowMacroConfig;
 
@@ -32,7 +32,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             setter(p, value);
         }
 
-        public void EvaluateDeferredConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateDeferredConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
@@ -58,7 +58,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             }
 
             IMacroConfig realConfig = new NowMacroConfig(deferredConfig.VariableName, format, utc);
-            EvaluateConfig(vars, realConfig, parameters, setter);
+            EvaluateConfig(environmentSettings, vars, realConfig, parameters, setter);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RandomMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RandomMacro.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public string Type => "random";
 
-        public void EvaluateConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             RandomMacroConfig config = rawConfig as RandomMacroConfig;
 
@@ -33,7 +33,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             setter(p, value.ToString());
         }
 
-        public void EvaluateDeferredConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateDeferredConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
@@ -64,7 +64,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             }
 
             IMacroConfig realConfig = new RandomMacroConfig(deferredConfig.VariableName, low, high);
-            EvaluateConfig(vars, realConfig, parameters, setter);
+            EvaluateConfig(environmentSettings, vars, realConfig, parameters, setter);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMacro.cs
@@ -15,7 +15,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public string Type => "regex";
 
-        public void EvaluateConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             string value = null;
             RegexMacroConfig config = rawConfig as RegexMacroConfig;
@@ -27,7 +27,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
             if (!vars.TryGetValue(config.SourceVariable, out object working))
             {
-                if (RuntimeValueUtil.TryGetRuntimeValue(parameters, config.SourceVariable, out object resolvedValue, true))
+                if (parameters.TryGetRuntimeValue(environmentSettings, config.SourceVariable, out object resolvedValue, true))
                 {
                     value = resolvedValue.ToString();
                 }
@@ -57,7 +57,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             setter(p, value);
         }
 
-        public void EvaluateDeferredConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateDeferredConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
@@ -86,7 +86,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             }
 
             IMacroConfig realConfig = new RegexMacroConfig(deferredConfig.VariableName, sourceVariable, replacementSteps);
-            EvaluateConfig(vars, realConfig, parameters, setter);
+            EvaluateConfig(environmentSettings, vars, realConfig, parameters, setter);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/SwitchMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/SwitchMacro.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public static readonly string DefaultEvaluator = "C++";
 
-        public void EvaluateConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             SwitchMacroConfig config = rawConfig as SwitchMacroConfig;
 
@@ -44,7 +44,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
                     byte[] conditionBytes = Encoding.UTF8.GetBytes(condition);
                     int length = conditionBytes.Length;
                     int position = 0;
-                    IProcessorState state = new GlobalRunSpec.ProcessorState(vars, conditionBytes, Encoding.UTF8);
+                    IProcessorState state = new GlobalRunSpec.ProcessorState(environmentSettings, vars, conditionBytes, Encoding.UTF8);
 
                     if (evaluator(state, ref length, ref position, out bool faulted))
                     {
@@ -63,7 +63,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             setter(p, result.ToString());
         }
 
-        public void EvaluateDeferredConfig(IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        public void EvaluateDeferredConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
             GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
@@ -98,7 +98,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             }
 
             IMacroConfig realConfig = new SwitchMacroConfig(deferredConfig.VariableName, evaluator, dataType, switchList);
-            EvaluateConfig(vars, realConfig, parameters, setter);
+            EvaluateConfig(environmentSettings, vars, realConfig, parameters, setter);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostAction.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostAction.cs
@@ -34,7 +34,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         string IPostAction.ConfigFile => ConfigFile;
 
-        public static List<IPostAction> ListFromModel(IReadOnlyList<IPostActionModel> modelList, IVariableCollection rootVariableCollection)
+        public static List<IPostAction> ListFromModel(IEngineEnvironmentSettings environmentSettings, IReadOnlyList<IPostActionModel> modelList, IVariableCollection rootVariableCollection)
         {
             List<IPostAction> actionList = new List<IPostAction>();
 
@@ -57,7 +57,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                             chosenInstruction = modelInstruction.Key;
                         }
                     }
-                    else if (CppStyleEvaluatorDefinition.EvaluateFromString(modelInstruction.Value, rootVariableCollection))
+                    else if (CppStyleEvaluatorDefinition.EvaluateFromString(environmentSettings, modelInstruction.Value, rootVariableCollection))
                     {   // condition is not blank and true, take this one. This results in a last-in-wins behaviour for conditions that are true.
                         chosenInstruction = modelInstruction.Key;
                     }

--- a/src/Microsoft.TemplateEngine.Utils/DefaultTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Utils/DefaultTemplateEngineHost.cs
@@ -32,7 +32,7 @@ namespace Microsoft.TemplateEngine.Utils
             _hostBuiltInComponents = builtIns ?? NoComponents;
         }
 
-        public IPhysicalFileSystem FileSystem { get; }
+        public IPhysicalFileSystem FileSystem { get; private set; }
 
         public string Locale { get; private set; }
 
@@ -91,5 +91,9 @@ namespace Microsoft.TemplateEngine.Utils
             return _hostDefaults.TryGetValue(paramName, out value);
         }
 
+        public void VirtualizeDirectory(string path)
+        {
+            FileSystem = new InMemoryFileSystem(path, FileSystem);
+        }
     }
 }

--- a/src/Microsoft.TemplateEngine.Utils/FileSystemInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Utils/FileSystemInfoExtensions.cs
@@ -9,11 +9,11 @@ namespace Microsoft.TemplateEngine.Utils
     {
         public static void CopyTo(this IDirectory source, string target)
         {
-            EngineEnvironmentSettings.Host.FileSystem.CreateDirectory(target);
+            source.MountPoint.EnvironmentSettings.Host.FileSystem.CreateDirectory(target);
 
             foreach (IFile file in source.EnumerateFiles("*", SearchOption.TopDirectoryOnly))
             {
-                using (Stream f = EngineEnvironmentSettings.Host.FileSystem.CreateFile(Path.Combine(target, file.Name)))
+                using (Stream f = source.MountPoint.EnvironmentSettings.Host.FileSystem.CreateFile(Path.Combine(target, file.Name)))
                 using (Stream s = file.OpenRead())
                 {
                     s.CopyTo(f);

--- a/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
+++ b/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
@@ -1,0 +1,752 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
+
+namespace Microsoft.TemplateEngine.Utils
+{
+    public class InMemoryFileSystem : IPhysicalFileSystem
+    {
+        private class FileSystemDirectory
+        {
+            public string Name { get; }
+
+            public string FullPath { get; }
+
+            public Dictionary<string, FileSystemDirectory> Directories { get; }
+
+            public Dictionary<string, FileSystemFile> Files { get; }
+
+            public FileSystemDirectory(string name, string fullPath)
+            {
+                Name = name;
+                FullPath = fullPath;
+                Directories = new Dictionary<string, FileSystemDirectory>();
+                Files = new Dictionary<string, FileSystemFile>();
+            }
+        }
+
+        private readonly FileSystemDirectory _root;
+        private readonly IPhysicalFileSystem _basis;
+
+        private class FileSystemFile
+        {
+            private byte[] _data;
+            private int _currentReaders;
+            private int _currentWriters;
+            private readonly object _sync = new object();
+
+            public string Name { get; }
+
+            public string FullPath { get; }
+
+            public FileSystemFile(string name, string fullPath)
+            {
+                Name = name;
+                FullPath = fullPath;
+                _data = new byte[0];
+            }
+
+            public Stream OpenRead()
+            {
+                if (_currentWriters > 0)
+                {
+                    throw new IOException("File is currently locked for writing");
+                }
+
+                lock (_sync)
+                {
+                    if (_currentWriters > 0)
+                    {
+                        throw new IOException("File is currently locked for writing");
+                    }
+
+                    ++_currentReaders;
+                    return new DisposingStream(new MemoryStream(_data, false), () => { lock (_sync) { --_currentReaders; } });
+                }
+            }
+
+            public Stream OpenWrite()
+            {
+                if (_currentReaders > 0)
+                {
+                    throw new IOException("File is currently locked for reading");
+                }
+
+                if (_currentWriters > 0)
+                {
+                    throw new IOException("File is currently locked for writing");
+                }
+
+                lock (_sync)
+                {
+                    if (_currentReaders > 0)
+                    {
+                        throw new IOException("File is currently locked for reading");
+                    }
+
+                    if (_currentWriters > 0)
+                    {
+                        throw new IOException("File is currently locked for writing");
+                    }
+
+                    ++_currentWriters;
+                    MemoryStream target = new MemoryStream();
+                    target.Write(_data, 0, _data.Length);
+                    target.Position = 0;
+                    return new DisposingStream(target, () =>
+                    {
+                        lock (_sync)
+                        {
+                            --_currentWriters;
+                            _data = new byte[target.Length];
+                            target.Position = 0;
+                            target.Read(_data, 0, _data.Length);
+                        }
+                    });
+                }
+            }
+        }
+
+        private class DisposingStream : Stream
+        {
+            private bool _isDisposed;
+            private readonly Stream _basis;
+            private readonly Action _onDispose;
+
+            public DisposingStream(Stream basis, Action onDispose)
+            {
+                _onDispose = onDispose;
+                _basis = basis;
+            }
+
+            public override bool CanRead => _basis.CanRead;
+
+            public override bool CanSeek => _basis.CanSeek;
+
+            public override bool CanWrite => _basis.CanWrite;
+
+            public override long Length => _basis.Length;
+
+            public override long Position { get => _basis.Position; set => _basis.Position = value; }
+
+            public override void Flush() => _basis.Flush();
+
+            public override int Read(byte[] buffer, int offset, int count) => _basis.Read(buffer, offset, count);
+
+            public override long Seek(long offset, SeekOrigin origin) => _basis.Seek(offset, origin);
+
+            public override void SetLength(long value) => _basis.SetLength(value);
+
+            public override void Write(byte[] buffer, int offset, int count) => _basis.Write(buffer, offset, count);
+
+            protected override void Dispose(bool disposing)
+            {
+                if (!_isDisposed)
+                {
+                    _isDisposed = true;
+                    _onDispose();
+                }
+
+                base.Dispose(disposing);
+            }
+        }
+
+        public InMemoryFileSystem(string root, IPhysicalFileSystem basis)
+        {
+            _basis = basis;
+            _root = new FileSystemDirectory(Path.GetFileName(root.TrimEnd('/', '\\')), root);
+            IsPathInCone(root, out root);
+            _root = new FileSystemDirectory(Path.GetFileName(root.TrimEnd('/', '\\')), root);
+        }
+
+        public void CreateDirectory(string path)
+        {
+            if (!IsPathInCone(path, out string processedPath))
+            {
+                _basis.CreateDirectory(path);
+                return;
+            }
+
+            path = processedPath;
+            string rel = path.Substring(_root.FullPath.Length).Trim('/', '\\');
+
+            if (string.IsNullOrEmpty(rel))
+            {
+                return;
+            }
+
+            string[] parts = rel.Split('/', '\\');
+            FileSystemDirectory currentDir = _root;
+
+            for (int i = 0; i < parts.Length; ++i)
+            {
+                FileSystemDirectory dir;
+                if (!currentDir.Directories.TryGetValue(parts[i], out dir))
+                {
+                    dir = new FileSystemDirectory(parts[i], Path.Combine(currentDir.FullPath, parts[i]));
+                    currentDir.Directories[parts[i]] = dir;
+                }
+
+                currentDir = dir;
+            }
+        }
+
+        public Stream CreateFile(string path)
+        {
+            if (!IsPathInCone(path, out string processedPath))
+            {
+                return _basis.CreateFile(path);
+            }
+
+            path = processedPath;
+            string rel = path.Substring(_root.FullPath.Length).Trim('/', '\\');
+            string[] parts = rel.Split('/', '\\');
+            FileSystemDirectory currentDir = _root;
+
+            for (int i = 0; i < parts.Length - 1; ++i)
+            {
+                FileSystemDirectory dir;
+                if (!currentDir.Directories.TryGetValue(parts[i], out dir))
+                {
+                    dir = new FileSystemDirectory(parts[i], Path.Combine(currentDir.FullPath, parts[i]));
+                    currentDir.Directories[parts[i]] = dir;
+                }
+
+                currentDir = dir;
+            }
+
+            FileSystemFile targetFile;
+            if (!currentDir.Files.TryGetValue(parts[parts.Length - 1], out targetFile))
+            {
+                targetFile = new FileSystemFile(parts[parts.Length - 1], Path.Combine(currentDir.FullPath, parts[parts.Length - 1]));
+                currentDir.Files[parts[parts.Length - 1]] = targetFile;
+            }
+
+            return targetFile.OpenWrite();
+        }
+
+        public void DirectoryDelete(string path, bool recursive)
+        {
+            if (!IsPathInCone(path, out string processedPath))
+            {
+                //TODO: handle cases where a portion of what would be deleted is inside our cone
+                //  and parts are outside
+                _basis.DirectoryDelete(path, recursive);
+                return;
+            }
+
+            path = processedPath;
+            string rel = path.Substring(_root.FullPath.Length).Trim('/', '\\');
+
+            if (string.IsNullOrEmpty(rel))
+            {
+                return;
+            }
+
+            string[] parts = rel.Split('/', '\\');
+            FileSystemDirectory currentDir = _root;
+            FileSystemDirectory parent = null;
+
+            for (int i = 0; i < parts.Length; ++i)
+            {
+                parent = currentDir;
+                FileSystemDirectory dir;
+                if (!currentDir.Directories.TryGetValue(parts[i], out dir))
+                {
+                    return;
+                }
+
+                currentDir = dir;
+            }
+
+            if (!recursive && (currentDir.Directories.Count > 0 || currentDir.Files.Count > 0))
+            {
+                throw new IOException("Directory is not empty");
+            }
+
+            parent.Directories.Remove(currentDir.Name);
+        }
+
+        public bool DirectoryExists(string directory)
+        {
+            if (!IsPathInCone(directory, out string processedPath))
+            {
+                return _basis.DirectoryExists(directory);
+            }
+
+            directory = processedPath;
+            string rel = directory.Substring(_root.FullPath.Length).Trim('/', '\\');
+
+            if (string.IsNullOrEmpty(rel))
+            {
+                return true;
+            }
+
+            string[] parts = rel.Split('/', '\\');
+            FileSystemDirectory currentDir = _root;
+
+            for (int i = 0; i < parts.Length; ++i)
+            {
+                FileSystemDirectory dir;
+                if (!currentDir.Directories.TryGetValue(parts[i], out dir))
+                {
+                    return false;
+                }
+
+                currentDir = dir;
+            }
+
+            return true;
+        }
+
+        public IEnumerable<string> EnumerateDirectories(string path, string pattern, SearchOption searchOption)
+        {
+            if (!IsPathInCone(path, out string processedPath))
+            {
+                //TODO: Handle cases where part of the directory set is inside our cone and part is not
+                foreach (string s in _basis.EnumerateDirectories(path, pattern, searchOption))
+                {
+                    yield return s;
+                }
+
+                yield break;
+            }
+
+            path = processedPath;
+            string rel = path.Substring(_root.FullPath.Length).Trim('/', '\\');
+            FileSystemDirectory currentDir = _root;
+
+            if (!string.IsNullOrEmpty(rel))
+            {
+                string[] parts = rel.Split('/', '\\');
+                for (int i = 0; i < parts.Length; ++i)
+                {
+                    FileSystemDirectory dir;
+                    if (!currentDir.Directories.TryGetValue(parts[i], out dir))
+                    {
+                        yield break;
+                    }
+
+                    currentDir = dir;
+                }
+            }
+
+            Regex rx = new Regex(Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", "."));
+
+            if (searchOption == SearchOption.TopDirectoryOnly)
+            {
+                foreach (KeyValuePair<string, FileSystemDirectory> entry in currentDir.Directories)
+                {
+                    if (rx.IsMatch(entry.Key))
+                    {
+                        yield return entry.Value.FullPath;
+                    }
+                }
+
+                yield break;
+            }
+
+            Stack<IEnumerator<KeyValuePair<string, FileSystemDirectory>>> directories = new Stack<IEnumerator<KeyValuePair<string, FileSystemDirectory>>>();
+            IEnumerator<KeyValuePair<string, FileSystemDirectory>> current = currentDir.Directories.GetEnumerator();
+            bool moveNext;
+
+            while ((moveNext = current.MoveNext()) || directories.Count > 0)
+            {
+                while (!moveNext)
+                {
+                    current.Dispose();
+
+                    if (directories.Count == 0)
+                    {
+                        break;
+                    }
+
+                    current = directories.Pop();
+                    moveNext = current.MoveNext();
+                }
+
+                if (!moveNext)
+                {
+                    break;
+                }
+
+                if (rx.IsMatch(current.Current.Key))
+                {
+                    yield return current.Current.Value.FullPath;
+                }
+
+                directories.Push(current);
+                current = current.Current.Value.Directories.GetEnumerator();
+            }
+        }
+
+        public IEnumerable<string> EnumerateFiles(string path, string pattern, SearchOption searchOption)
+        {
+            if (!IsPathInCone(path, out string processedPath))
+            {
+                //TODO: Handle cases where part of the directory set is inside our cone and part is not
+                foreach (string s in _basis.EnumerateFiles(path, pattern, searchOption))
+                {
+                    yield return s;
+                }
+
+                yield break;
+            }
+
+            path = processedPath;
+            string rel = path.Substring(_root.FullPath.Length).Trim('/', '\\');
+            FileSystemDirectory currentDir = _root;
+
+            if (!string.IsNullOrEmpty(rel))
+            {
+                string[] parts = rel.Split('/', '\\');
+                for (int i = 0; i < parts.Length; ++i)
+                {
+                    FileSystemDirectory dir;
+                    if (!currentDir.Directories.TryGetValue(parts[i], out dir))
+                    {
+                        yield break;
+                    }
+
+                    currentDir = dir;
+                }
+            }
+
+            Regex rx = new Regex(Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", "."));
+            foreach (KeyValuePair<string, FileSystemFile> entry in currentDir.Files)
+            {
+                if (rx.IsMatch(entry.Key))
+                {
+                    yield return entry.Value.FullPath;
+                }
+            }
+
+            if (searchOption == SearchOption.TopDirectoryOnly)
+            {
+                yield break;
+            }
+
+            Stack<IEnumerator<KeyValuePair<string, FileSystemDirectory>>> directories = new Stack<IEnumerator<KeyValuePair<string, FileSystemDirectory>>>();
+            Stack<FileSystemDirectory> parentDirectories = new Stack<FileSystemDirectory>();
+            IEnumerator<KeyValuePair<string, FileSystemDirectory>> current = currentDir.Directories.GetEnumerator();
+            bool moveNext;
+
+            while ((moveNext = current.MoveNext()) || directories.Count > 0)
+            {
+                while (!moveNext)
+                {
+                    current.Dispose();
+
+                    if (directories.Count == 0)
+                    {
+                        break;
+                    }
+
+                    current = directories.Pop();
+                    moveNext = current.MoveNext();
+                }
+
+                if (!moveNext)
+                {
+                    break;
+                }
+
+                foreach (KeyValuePair<string, FileSystemFile> entry in current.Current.Value.Files)
+                {
+                    if (rx.IsMatch(entry.Key))
+                    {
+                        yield return entry.Value.FullPath;
+                    }
+                }
+
+                directories.Push(current);
+                current = current.Current.Value.Directories.GetEnumerator();
+            }
+        }
+
+        public IEnumerable<string> EnumerateFileSystemEntries(string directoryName, string pattern, SearchOption searchOption)
+        {
+            if (!IsPathInCone(directoryName, out string processedPath))
+            {
+                //TODO: Handle cases where part of the directory set is inside our cone and part is not
+                foreach (string s in _basis.EnumerateFileSystemEntries(directoryName, pattern, searchOption))
+                {
+                    yield return s;
+                }
+
+                yield break;
+            }
+
+            directoryName = processedPath;
+            string rel = directoryName.Substring(_root.FullPath.Length).Trim('/', '\\');
+            FileSystemDirectory currentDir = _root;
+
+            if (!string.IsNullOrEmpty(rel))
+            {
+                string[] parts = rel.Split('/', '\\');
+                for (int i = 0; i < parts.Length; ++i)
+                {
+                    FileSystemDirectory dir;
+                    if (!currentDir.Directories.TryGetValue(parts[i], out dir))
+                    {
+                        yield break;
+                    }
+
+                    currentDir = dir;
+                }
+            }
+
+            Regex rx = new Regex(Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", "."));
+
+            foreach (KeyValuePair<string, FileSystemFile> entry in currentDir.Files)
+            {
+                if (rx.IsMatch(entry.Key))
+                {
+                    yield return entry.Value.FullPath;
+                }
+            }
+
+            foreach (KeyValuePair<string, FileSystemDirectory> entry in currentDir.Directories)
+            {
+                if (rx.IsMatch(entry.Key))
+                {
+                    yield return entry.Value.FullPath;
+                }
+            }
+
+            if (searchOption == SearchOption.TopDirectoryOnly)
+            {
+                yield break;
+            }
+
+            Stack<IEnumerator<KeyValuePair<string, FileSystemDirectory>>> directories = new Stack<IEnumerator<KeyValuePair<string, FileSystemDirectory>>>();
+            IEnumerator<KeyValuePair<string, FileSystemDirectory>> current = currentDir.Directories.GetEnumerator();
+            bool moveNext;
+
+            while ((moveNext = current.MoveNext()) || directories.Count > 0)
+            {
+                while (!moveNext)
+                {
+                    current.Dispose();
+
+                    if (directories.Count == 0)
+                    {
+                        break;
+                    }
+
+                    current = directories.Pop();
+                    moveNext = current.MoveNext();
+                }
+
+                if (!moveNext)
+                {
+                    break;
+                }
+
+                if (rx.IsMatch(current.Current.Key))
+                {
+                    yield return current.Current.Value.FullPath;
+                }
+
+                foreach (KeyValuePair<string, FileSystemFile> entry in currentDir.Files)
+                {
+                    if (rx.IsMatch(entry.Key))
+                    {
+                        yield return entry.Value.FullPath;
+                    }
+                }
+
+                directories.Push(current);
+                current = current.Current.Value.Directories.GetEnumerator();
+            }
+        }
+
+        public void FileCopy(string sourcePath, string targetPath, bool overwrite)
+        {
+            if (!overwrite && FileExists(targetPath))
+            {
+                throw new IOException($"File already exists {targetPath}");
+            }
+
+            using (Stream s = OpenRead(sourcePath))
+            using (Stream t = CreateFile(targetPath))
+            {
+                s.CopyTo(t);
+            }
+        }
+
+        public void FileDelete(string path)
+        {
+            if (!IsPathInCone(path, out string processedPath))
+            {
+                _basis.FileDelete(path);
+                return;
+            }
+
+            path = processedPath;
+            string rel = path.Substring(_root.FullPath.Length).Trim('/', '\\');
+            string[] parts = rel.Split('/', '\\');
+            FileSystemDirectory currentDir = _root;
+
+            for (int i = 0; i < parts.Length - 1; ++i)
+            {
+                FileSystemDirectory dir;
+                if (!currentDir.Directories.TryGetValue(parts[i], out dir))
+                {
+                    dir = new FileSystemDirectory(parts[i], Path.Combine(currentDir.FullPath, parts[i]));
+                    currentDir.Directories[parts[i]] = dir;
+                }
+
+                currentDir = dir;
+            }
+
+            currentDir.Files.Remove(parts[parts.Length - 1]);
+        }
+
+        public bool FileExists(string file)
+        {
+            if (!IsPathInCone(file, out string processedPath))
+            {
+                return _basis.FileExists(file);
+            }
+
+            file = processedPath;
+            string rel = file.Substring(_root.FullPath.Length).Trim('/', '\\');
+            string[] parts = rel.Split('/', '\\');
+            FileSystemDirectory currentDir = _root;
+
+            for (int i = 0; i < parts.Length - 1; ++i)
+            {
+                FileSystemDirectory dir;
+                if (!currentDir.Directories.TryGetValue(parts[i], out dir))
+                {
+                    return false;
+                }
+
+                currentDir = dir;
+            }
+
+            return currentDir.Files.ContainsKey(parts[parts.Length - 1]);
+        }
+
+        public string GetCurrentDirectory()
+        {
+            return _basis.GetCurrentDirectory();
+        }
+
+        public Stream OpenRead(string path)
+        {
+            if (!IsPathInCone(path, out string processedPath))
+            {
+                return _basis.OpenRead(path);
+            }
+
+            path = processedPath;
+            string rel = path.Substring(_root.FullPath.Length).Trim('/', '\\');
+            string[] parts = rel.Split('/', '\\');
+            FileSystemDirectory currentDir = _root;
+
+            for (int i = 0; i < parts.Length - 1; ++i)
+            {
+                FileSystemDirectory dir;
+                if (!currentDir.Directories.TryGetValue(parts[i], out dir))
+                {
+                    dir = new FileSystemDirectory(parts[i], Path.Combine(currentDir.FullPath, parts[i]));
+                    currentDir.Directories[parts[i]] = dir;
+                }
+
+                currentDir = dir;
+            }
+
+            FileSystemFile targetFile;
+            if (!currentDir.Files.TryGetValue(parts[parts.Length - 1], out targetFile))
+            {
+                throw new FileNotFoundException("File not found", path);
+            }
+
+            return targetFile.OpenRead();
+        }
+
+        public string ReadAllText(string path)
+        {
+            using (Stream s = OpenRead(path))
+            using (StreamReader r = new StreamReader(s, Encoding.UTF8, true, 8192, true))
+            {
+                return r.ReadToEnd();
+            }
+        }
+
+        public void WriteAllText(string path, string value)
+        {
+            using (Stream s = CreateFile(path))
+            using (StreamWriter r = new StreamWriter(s, Encoding.UTF8, 8192, true))
+            {
+                r.Write(value);
+            }
+        }
+
+        private bool IsPathInCone(string path, out string processedPath)
+        {
+            if (!Path.IsPathRooted(path))
+            {
+                path = Path.Combine(GetCurrentDirectory(), path);
+            }
+
+            path = path.Replace('\\', '/');
+
+            bool leadSlash = path[0] == '/';
+
+            if (leadSlash)
+            {
+                path = path.Substring(1);
+            }
+
+            string[] parts = path.Split('/');
+
+            List<string> realParts = new List<string>();
+
+            for (int i = 0; i < parts.Length; ++i)
+            {
+                if (string.IsNullOrEmpty(parts[i]))
+                {
+                    if (i != 0)
+                    {
+                        continue;
+                    }
+
+                    realParts.Add(parts[i]);
+                }
+
+                switch (parts[i])
+                {
+                    case ".":
+                        continue;
+                    case "..":
+                        realParts.RemoveAt(realParts.Count - 1);
+                        break;
+                    default:
+                        realParts.Add(parts[i]);
+                        break;
+                }
+            }
+
+            if (leadSlash)
+            {
+                realParts.Insert(0, "");
+            }
+
+            processedPath = string.Join(Path.DirectorySeparatorChar + "", realParts);
+            if (processedPath.Equals(_root.FullPath) || processedPath.StartsWith(_root.FullPath.TrimEnd('/', '\\') + Path.DirectorySeparatorChar))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
+++ b/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
@@ -8,6 +8,6 @@
     <ProjectReference Include="..\Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup  Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.0.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.TemplateEngine.Utils/RuntimeValueUtil.cs
+++ b/src/Microsoft.TemplateEngine.Utils/RuntimeValueUtil.cs
@@ -4,7 +4,7 @@ namespace Microsoft.TemplateEngine.Utils
 {
     public static class RuntimeValueUtil
     {
-        public static bool TryGetRuntimeValue(this IParameterSet parameters, string name, out object value, bool skipEnvironmentVariableSearch = false)
+        public static bool TryGetRuntimeValue(this IParameterSet parameters, IEngineEnvironmentSettings environmentSettings, string name, out object value, bool skipEnvironmentVariableSearch = false)
         {
             if (parameters.TryGetParameterDefinition(name, out ITemplateParameter param)
                 && parameters.ResolvedValues.TryGetValue(param, out object newValueObject)
@@ -14,8 +14,8 @@ namespace Microsoft.TemplateEngine.Utils
                 return true;
             }
 
-            if ((EngineEnvironmentSettings.Host.TryGetHostParamDefault(name, out string newValue) && newValue != null)
-                || (!skipEnvironmentVariableSearch && EngineEnvironmentSettings.Environment.GetEnvironmentVariables().TryGetValue(name, out newValue) && newValue != null))
+            if ((environmentSettings.Host.TryGetHostParamDefault(name, out string newValue) && newValue != null)
+                || (!skipEnvironmentVariableSearch && environmentSettings.Environment.GetEnvironmentVariables().TryGetValue(name, out newValue) && newValue != null))
             {
                 value = newValue;
                 return true;

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -46,22 +46,23 @@ namespace dotnet_new3
             return new DefaultTemplateEngineHost(HostIdentifier, HostVersion, CultureInfo.CurrentCulture.Name, preferences);
         }
 
-        private static void FirstRun(ITemplateEngineHost host, IInstaller installer)
+        private static void FirstRun(IEngineEnvironmentSettings environmentSettings, IInstaller installer)
         { 
             string[] packageList;
+            Paths paths = new Paths(environmentSettings);
 
-            if (Paths.Global.DefaultInstallPackageList.FileExists())
+            if (paths.FileExists(paths.Global.DefaultInstallPackageList))
             {
-                packageList = Paths.Global.DefaultInstallPackageList.ReadAllText().Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                packageList = paths.ReadAllText(paths.Global.DefaultInstallPackageList).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
                 if (packageList.Length > 0)
                 {
                     installer.InstallPackages(packageList);
                 }
             }
 
-            if (Paths.Global.DefaultInstallTemplateList.FileExists())
+            if (paths.FileExists(paths.Global.DefaultInstallTemplateList))
             {
-                packageList = Paths.Global.DefaultInstallTemplateList.ReadAllText().Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                packageList = paths.ReadAllText(paths.Global.DefaultInstallTemplateList).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
                 if (packageList.Length > 0)
                 {
                     installer.InstallPackages(packageList);

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -16,7 +16,7 @@ namespace dotnet_new3
 {
     public class Program
     {
-        private const string HostIdentifier = "dotnetcli";
+        private const string HostIdentifier = "dotnetcli-preview";
         private const string HostVersion = "1.0.0";
         private const string CommandName = "new3";
 

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/BalancedNestingTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/BalancedNestingTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 {
     public class BalancedNestingTests : TestBase
     {
-        private static IProcessor SetupXmlBalancedNestingProcessor(bool? isCommentFixingInitiallyOn = null)
+        private IProcessor SetupXmlBalancedNestingProcessor(bool? isCommentFixingInitiallyOn = null)
         {
             string commentFixOperationId = "Fix Comments";
             string resetId = "Reset";
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 new BalancedNesting("<!--", "-->", "-- >", commentFixOperationId, resetId),
             };
             VariableCollection variables = new VariableCollection();
-            EngineConfig engineConfig = new EngineConfig(variables);
+            EngineConfig engineConfig = new EngineConfig(EnvironmentSettings, variables);
             IProcessor processor = Processor.Create(engineConfig, operations);
 
             if (isCommentFixingInitiallyOn.HasValue)

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/CommonOperationsTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/CommonOperationsTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     return 0;
                 }, Encoding.UTF8.GetBytes("Hello"));
 
-            EngineConfig cfg = new EngineConfig(new VariableCollection());
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, new VariableCollection());
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There");
             Stream d = new MemoryStream(data);
@@ -45,7 +45,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     return 0;
                 }, Encoding.UTF8.GetBytes("There"));
 
-            EngineConfig cfg = new EngineConfig(new VariableCollection());
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, new VariableCollection());
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There");
             Stream d = new MemoryStream(data);
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     return 0;
                 }, Encoding.UTF8.GetBytes("There"));
 
-            EngineConfig cfg = new EngineConfig(new VariableCollection());
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, new VariableCollection());
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There    \r\n    You");
             Stream d = new MemoryStream(data);
@@ -95,7 +95,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     return 0;
                 }, Encoding.UTF8.GetBytes("There"));
 
-            EngineConfig cfg = new EngineConfig(new VariableCollection());
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, new VariableCollection());
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There    \r\n    You");
             Stream d = new MemoryStream(data);
@@ -120,7 +120,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     return 0;
                 }, Encoding.UTF8.GetBytes("There"));
 
-            EngineConfig cfg = new EngineConfig(new VariableCollection());
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, new VariableCollection());
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There    \r\n    You");
             Stream d = new MemoryStream(data);
@@ -153,7 +153,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     return 0;
                 }, Encoding.UTF8.GetBytes("There"));
 
-            EngineConfig cfg = new EngineConfig(new VariableCollection());
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, new VariableCollection());
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There    \r\n    You");
             Stream d = new MemoryStream(data);
@@ -182,7 +182,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     return 0;
                 }, Encoding.UTF8.GetBytes("There"));
 
-            EngineConfig cfg = new EngineConfig(new VariableCollection());
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, new VariableCollection());
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There    \r\n    You");
             Stream d = new MemoryStream(data);
@@ -207,7 +207,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     return 0;
                 }, Encoding.UTF8.GetBytes("There"));
 
-            EngineConfig cfg = new EngineConfig(new VariableCollection());
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, new VariableCollection());
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There     \r\n    You");
             Stream d = new MemoryStream(data);
@@ -232,7 +232,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     return 0;
                 }, Encoding.UTF8.GetBytes("There"));
 
-            EngineConfig cfg = new EngineConfig(new VariableCollection());
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, new VariableCollection());
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There     \r\n    You");
             Stream d = new MemoryStream(data);
@@ -257,7 +257,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     return 0;
                 }, Encoding.UTF8.GetBytes("There"));
 
-            EngineConfig cfg = new EngineConfig(new VariableCollection());
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, new VariableCollection());
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There     \r\n    You");
             Stream d = new MemoryStream(data);

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
@@ -8,8 +8,6 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 {
     public partial class ConditionalTests
     {
-        #region Original Tests
-
         [Fact(DisplayName=nameof(VerifyIfEndifTrueCondition))]
         public void VerifyIfEndifTrueCondition()
         {
@@ -1514,7 +1512,5 @@ There";
             //  pretend it's false because the inputs and outputs are the same
             Verify(Encoding.UTF8, output, false, value, expected);
         }
-
-        #endregion Original Tests
     }
 }

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.InlineMarkup.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.InlineMarkup.cs
@@ -9,9 +9,9 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 {
     public class InlineMarkupConditionalTests : TestBase
     {
-        private static IProcessor SetupXmlPlusMsBuildProcessor(IVariableCollection vc)
+        private IProcessor SetupXmlPlusMsBuildProcessor(IVariableCollection vc)
         {
-            EngineConfig cfg = new EngineConfig(vc, "$({0})");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, vc, "$({0})");
             return Processor.Create(cfg, new InlineMarkupConditional(
                 new MarkupTokens("<", "</", ">", "/>", "Condition=\"", "\""),
                 true,

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.RazorBlockComments.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.RazorBlockComments.cs
@@ -5,9 +5,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 {
     public partial class ConditionalTests
     {
-        public class EmbeddedBlockComments
-        {
-            private const string NoDefaultValue = @"Start
+        private const string NoDefaultValue = @"Start
 @*#if (OUTER_IF_CLAUSE)
     content: outer-if
 #elseif (OUTER_ELSEIF_CLAUSE)
@@ -25,7 +23,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 Trailing stuff
 @* trailing comment *@";
 
-            private const string OuterIfDefaultValue = @"Start
+        private const string OuterIfDefaultValue = @"Start
 @*#if (OUTER_IF_CLAUSE) *@
     content: outer-if
 @*#elseif (OUTER_ELSEIF_CLAUSE)
@@ -43,12 +41,12 @@ Trailing stuff
 Trailing stuff
 @* trailing comment *@";
 
-            private const string OuterIfTrueExpectedValue = @"Start
+        private const string OuterIfTrueExpectedValue = @"Start
     content: outer-if
 Trailing stuff
 @* trailing comment *@";
 
-            private const string OuterElseifDefaultValue = @"Start
+        private const string OuterElseifDefaultValue = @"Start
 @*#if (OUTER_IF_CLAUSE)
     content: outer-if
 #elseif (OUTER_ELSEIF_CLAUSE) *@
@@ -66,8 +64,8 @@ Trailing stuff
 Trailing stuff
 @* trailing comment *@";
 
-            // this one seems formatted weird, but correct.
-            private const string OuterElseDefaultValue = @"Start
+        // this one seems formatted weird, but correct.
+        private const string OuterElseDefaultValue = @"Start
 @*#if (OUTER_IF_CLAUSE)
     content: outer-if
 #elseif (OUTER_ELSEIF_CLAUSE)
@@ -85,7 +83,7 @@ Trailing stuff
 Trailing stuff
 @* trailing comment *@";
 
-            private const string InnerIfDefaultValue = @"Start
+        private const string InnerIfDefaultValue = @"Start
 @*#if (OUTER_IF_CLAUSE)
     content: outer-if
 #elseif (OUTER_ELSEIF_CLAUSE)
@@ -103,7 +101,7 @@ Trailing stuff
 Trailing stuff
 @* trailing comment *@";
 
-            private const string InnerElseifDefaultValue = @"Start
+        private const string InnerElseifDefaultValue = @"Start
 @*#if (OUTER_IF_CLAUSE)
     content: outer-if
 #elseif (OUTER_ELSEIF_CLAUSE)
@@ -121,7 +119,7 @@ Trailing stuff
 Trailing stuff
 @* trailing comment *@";
 
-            private const string InnerElseDefaultValue = @"Start
+        private const string InnerElseDefaultValue = @"Start
 @*#if (OUTER_IF_CLAUSE)
     content: outer-if
 #elseif (OUTER_ELSEIF_CLAUSE)
@@ -139,145 +137,142 @@ Trailing stuff
 Trailing stuff
 @* trailing comment *@";
 
-            private const string OuterElseifTrueExpectedValue = @"Start
+        private const string OuterElseifTrueExpectedValue = @"Start
     content: outer-elseif
 Trailing stuff
 @* trailing comment *@";
 
-            private const string OuterElseHappensInnerIfTrueExpectedValue = @"Start
+        private const string OuterElseHappensInnerIfTrueExpectedValue = @"Start
     content: outer-else
         content: inner-if
 Trailing stuff
 @* trailing comment *@";
 
-            private const string OuterElseHappensInnerElseifTrueExpectedValue = @"Start
+        private const string OuterElseHappensInnerElseifTrueExpectedValue = @"Start
     content: outer-else
         content: inner-elseif
 Trailing stuff
 @* trailing comment *@";
 
-            private const string OuterElseHappensInnerElseHappensExpectedValue = @"Start
+        private const string OuterElseHappensInnerElseHappensExpectedValue = @"Start
     content: outer-else
         content: inner-else
 Trailing stuff
 @* trailing comment *@";
 
 
-            private static readonly VariableCollection OuterElseifTrueVariableCollection = new VariableCollection
-            {
-                ["OUTER_IF_CLAUSE"] = false,
-                ["OUTER_ELSEIF_CLAUSE"] = true,
-                ["INNER_IF_CLAUSE"] = false,
-                ["INNER_ELSEIF_CLAUSE"] = false
-            };
+        private static readonly VariableCollection OuterElseifTrueVariableCollection = new VariableCollection
+        {
+            ["OUTER_IF_CLAUSE"] = false,
+            ["OUTER_ELSEIF_CLAUSE"] = true,
+            ["INNER_IF_CLAUSE"] = false,
+            ["INNER_ELSEIF_CLAUSE"] = false
+        };
 
-            private static readonly VariableCollection InnerIfTrueVariableCollection = new VariableCollection
-            {
-                ["OUTER_IF_CLAUSE"] = false,
-                ["OUTER_ELSEIF_CLAUSE"] = false,
-                ["INNER_IF_CLAUSE"] = true,
-                ["INNER_ELSEIF_CLAUSE"] = false
-            };
+        private static readonly VariableCollection InnerIfTrueVariableCollection = new VariableCollection
+        {
+            ["OUTER_IF_CLAUSE"] = false,
+            ["OUTER_ELSEIF_CLAUSE"] = false,
+            ["INNER_IF_CLAUSE"] = true,
+            ["INNER_ELSEIF_CLAUSE"] = false
+        };
 
-            private static readonly VariableCollection InnerElseIfTrueVariableCollection = new VariableCollection
-            {
-                ["OUTER_IF_CLAUSE"] = false,
-                ["OUTER_ELSEIF_CLAUSE"] = false,
-                ["INNER_IF_CLAUSE"] = false,
-                ["INNER_ELSEIF_CLAUSE"] = true
-            };
+        private static readonly VariableCollection InnerElseIfTrueVariableCollection = new VariableCollection
+        {
+            ["OUTER_IF_CLAUSE"] = false,
+            ["OUTER_ELSEIF_CLAUSE"] = false,
+            ["INNER_IF_CLAUSE"] = false,
+            ["INNER_ELSEIF_CLAUSE"] = true
+        };
 
 
-            private static readonly VariableCollection AllFalse = new VariableCollection
-            {
-                ["OUTER_IF_CLAUSE"] = false,
-                ["OUTER_ELSEIF_CLAUSE"] = false,
-                ["INNER_IF_CLAUSE"] = false,
-                ["INNER_ELSEIF_CLAUSE"] = false
-            };
+        private static readonly VariableCollection AllFalse = new VariableCollection
+        {
+            ["OUTER_IF_CLAUSE"] = false,
+            ["OUTER_ELSEIF_CLAUSE"] = false,
+            ["INNER_IF_CLAUSE"] = false,
+            ["INNER_ELSEIF_CLAUSE"] = false
+        };
 
-            private static VariableCollection OuterIfTrueVariableCollection => new VariableCollection
-            {
-                ["OUTER_IF_CLAUSE"] = true,
-                ["OUTER_ELSEIF_CLAUSE"] = false,
-                ["INNER_IF_CLAUSE"] = false,
-                ["INNER_ELSEIF_CLAUSE"] = false
-            };
+        private static VariableCollection OuterIfTrueVariableCollection => new VariableCollection
+        {
+            ["OUTER_IF_CLAUSE"] = true,
+            ["OUTER_ELSEIF_CLAUSE"] = false,
+            ["INNER_IF_CLAUSE"] = false,
+            ["INNER_ELSEIF_CLAUSE"] = false
+        };
 
-            [Theory(DisplayName = nameof(VerifyRazorBlockCommentEmbeddedInElseTestOuterIfTrue))]
-            [InlineData(NoDefaultValue, OuterIfTrueExpectedValue)]
-            [InlineData(OuterIfDefaultValue, OuterIfTrueExpectedValue)]
-            [InlineData(OuterElseifDefaultValue, OuterIfTrueExpectedValue)]
-            [InlineData(OuterElseDefaultValue, OuterIfTrueExpectedValue)]
-            [InlineData(InnerIfDefaultValue, OuterIfTrueExpectedValue)]
-            [InlineData(InnerElseifDefaultValue, OuterIfTrueExpectedValue)]
-            [InlineData(InnerElseDefaultValue, OuterIfTrueExpectedValue)]
-            public void VerifyRazorBlockCommentEmbeddedInElseTestOuterIfTrue(string source, string expected)
-            {
-                IProcessor processor = SetupRazorStyleProcessor(OuterIfTrueVariableCollection);
-                RunAndVerify(source, expected, processor, 9999);
-            }
-
-            [Theory(DisplayName = nameof(VerifyRazorBlockCommentEmbeddedInElseTestOuterElseifTrueExpectedValue))]
-            [InlineData(NoDefaultValue, OuterElseifTrueExpectedValue)]
-            [InlineData(OuterIfDefaultValue, OuterElseifTrueExpectedValue)]
-            [InlineData(OuterElseifDefaultValue, OuterElseifTrueExpectedValue)]
-            [InlineData(OuterElseDefaultValue, OuterElseifTrueExpectedValue)]
-            [InlineData(InnerIfDefaultValue, OuterElseifTrueExpectedValue)]
-            [InlineData(InnerElseifDefaultValue, OuterElseifTrueExpectedValue)]
-            [InlineData(InnerElseDefaultValue, OuterElseifTrueExpectedValue)]
-            public void VerifyRazorBlockCommentEmbeddedInElseTestOuterElseifTrueExpectedValue(string source, string expected)
-            {
-                IProcessor processor = SetupRazorStyleProcessor(OuterElseifTrueVariableCollection);
-                RunAndVerify(source, expected, processor, 9999);
-            }
-
-            [Theory(DisplayName = nameof(VerifyRazorBlockCommentEmbeddedInElseTestOuterElseHappensInnerIfTrueExpectedValue))]
-            [InlineData(NoDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
-            [InlineData(OuterIfDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
-            [InlineData(OuterElseifDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
-            [InlineData(OuterElseDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
-            [InlineData(InnerIfDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
-            [InlineData(InnerElseifDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
-            [InlineData(InnerElseDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
-            public void VerifyRazorBlockCommentEmbeddedInElseTestOuterElseHappensInnerIfTrueExpectedValue(string source, string expected)
-            {
-                IProcessor processor = SetupRazorStyleProcessor(InnerIfTrueVariableCollection);
-                RunAndVerify(source, expected, processor, 9999);
-            }
-
-            [Theory(DisplayName = nameof(VerifyRazorBlockCommentEmbeddedInElseTestOuterElseHappensInnerElseifTrueExpectedValue))]
-            [InlineData(NoDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
-            [InlineData(OuterIfDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
-            [InlineData(OuterElseifDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
-            [InlineData(OuterElseDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
-            [InlineData(InnerIfDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
-            [InlineData(InnerElseifDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
-            [InlineData(InnerElseDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
-            public void VerifyRazorBlockCommentEmbeddedInElseTestOuterElseHappensInnerElseifTrueExpectedValue(string source, string expected)
-            {
-                IProcessor processor = SetupRazorStyleProcessor(InnerElseIfTrueVariableCollection);
-                RunAndVerify(source, expected, processor, 9999);
-            }
-
-            [Theory(DisplayName = nameof(VerifyRazorBlockCommentEmbeddedInElseTestOuterElseHappensInnerElseHappensExpectedValue))]
-            [InlineData(NoDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
-            [InlineData(OuterIfDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
-            [InlineData(OuterElseifDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
-            [InlineData(OuterElseDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
-            [InlineData(InnerIfDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
-            [InlineData(InnerElseifDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
-            [InlineData(InnerElseDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
-            public void VerifyRazorBlockCommentEmbeddedInElseTestOuterElseHappensInnerElseHappensExpectedValue(string source, string expected)
-            {
-                IProcessor processor = SetupRazorStyleProcessor(AllFalse);
-                RunAndVerify(source, expected, processor, 9999);
-            }
+        [Theory(DisplayName = nameof(VerifyRazorBlockCommentEmbeddedInElseTestOuterIfTrue))]
+        [InlineData(NoDefaultValue, OuterIfTrueExpectedValue)]
+        [InlineData(OuterIfDefaultValue, OuterIfTrueExpectedValue)]
+        [InlineData(OuterElseifDefaultValue, OuterIfTrueExpectedValue)]
+        [InlineData(OuterElseDefaultValue, OuterIfTrueExpectedValue)]
+        [InlineData(InnerIfDefaultValue, OuterIfTrueExpectedValue)]
+        [InlineData(InnerElseifDefaultValue, OuterIfTrueExpectedValue)]
+        [InlineData(InnerElseDefaultValue, OuterIfTrueExpectedValue)]
+        public void VerifyRazorBlockCommentEmbeddedInElseTestOuterIfTrue(string source, string expected)
+        {
+            IProcessor processor = SetupRazorStyleProcessor(OuterIfTrueVariableCollection);
+            RunAndVerify(source, expected, processor, 9999);
         }
 
-        public class Basic
+        [Theory(DisplayName = nameof(VerifyRazorBlockCommentEmbeddedInElseTestOuterElseifTrueExpectedValue))]
+        [InlineData(NoDefaultValue, OuterElseifTrueExpectedValue)]
+        [InlineData(OuterIfDefaultValue, OuterElseifTrueExpectedValue)]
+        [InlineData(OuterElseifDefaultValue, OuterElseifTrueExpectedValue)]
+        [InlineData(OuterElseDefaultValue, OuterElseifTrueExpectedValue)]
+        [InlineData(InnerIfDefaultValue, OuterElseifTrueExpectedValue)]
+        [InlineData(InnerElseifDefaultValue, OuterElseifTrueExpectedValue)]
+        [InlineData(InnerElseDefaultValue, OuterElseifTrueExpectedValue)]
+        public void VerifyRazorBlockCommentEmbeddedInElseTestOuterElseifTrueExpectedValue(string source, string expected)
         {
-            private const string BasicValue = @"Start
+            IProcessor processor = SetupRazorStyleProcessor(OuterElseifTrueVariableCollection);
+            RunAndVerify(source, expected, processor, 9999);
+        }
+
+        [Theory(DisplayName = nameof(VerifyRazorBlockCommentEmbeddedInElseTestOuterElseHappensInnerIfTrueExpectedValue))]
+        [InlineData(NoDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
+        [InlineData(OuterIfDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
+        [InlineData(OuterElseifDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
+        [InlineData(OuterElseDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
+        [InlineData(InnerIfDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
+        [InlineData(InnerElseifDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
+        [InlineData(InnerElseDefaultValue, OuterElseHappensInnerIfTrueExpectedValue)]
+        public void VerifyRazorBlockCommentEmbeddedInElseTestOuterElseHappensInnerIfTrueExpectedValue(string source, string expected)
+        {
+            IProcessor processor = SetupRazorStyleProcessor(InnerIfTrueVariableCollection);
+            RunAndVerify(source, expected, processor, 9999);
+        }
+
+        [Theory(DisplayName = nameof(VerifyRazorBlockCommentEmbeddedInElseTestOuterElseHappensInnerElseifTrueExpectedValue))]
+        [InlineData(NoDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
+        [InlineData(OuterIfDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
+        [InlineData(OuterElseifDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
+        [InlineData(OuterElseDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
+        [InlineData(InnerIfDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
+        [InlineData(InnerElseifDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
+        [InlineData(InnerElseDefaultValue, OuterElseHappensInnerElseifTrueExpectedValue)]
+        public void VerifyRazorBlockCommentEmbeddedInElseTestOuterElseHappensInnerElseifTrueExpectedValue(string source, string expected)
+        {
+            IProcessor processor = SetupRazorStyleProcessor(InnerElseIfTrueVariableCollection);
+            RunAndVerify(source, expected, processor, 9999);
+        }
+
+        [Theory(DisplayName = nameof(VerifyRazorBlockCommentEmbeddedInElseTestOuterElseHappensInnerElseHappensExpectedValue))]
+        [InlineData(NoDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
+        [InlineData(OuterIfDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
+        [InlineData(OuterElseifDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
+        [InlineData(OuterElseDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
+        [InlineData(InnerIfDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
+        [InlineData(InnerElseifDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
+        [InlineData(InnerElseDefaultValue, OuterElseHappensInnerElseHappensExpectedValue)]
+        public void VerifyRazorBlockCommentEmbeddedInElseTestOuterElseHappensInnerElseHappensExpectedValue(string source, string expected)
+        {
+            IProcessor processor = SetupRazorStyleProcessor(AllFalse);
+            RunAndVerify(source, expected, processor, 9999);
+        }
+
+        private const string BasicValue = @"Start
 @*#if (CLAUSE)
     content: if
 #elseif (CLAUSE_2)
@@ -287,7 +282,7 @@ Trailing stuff
 #endif*@
 Trailing stuff";
 
-            private const string BasicWithDefault = @"Start
+        private const string BasicWithDefault = @"Start
 @*#if (CLAUSE) *@
     content: if
 @*#elseif (CLAUSE_2)
@@ -297,62 +292,61 @@ Trailing stuff";
 #endif*@
 Trailing stuff";
 
-            private const string IfEmitted = @"Start
+        private const string IfEmitted = @"Start
     content: if
 Trailing stuff";
 
-            private const string ElseIfEmitted = @"Start
+        private const string ElseIfEmitted = @"Start
     content: elseif
 Trailing stuff";
 
-            private const string ElseEmitted = @"Start
+        private const string ElseEmitted = @"Start
     content: else
 Trailing stuff";
 
-            private static readonly VariableCollection BothClausesTrue = new VariableCollection
-            {
-                ["CLAUSE"] = true,
-                ["CLAUSE_2"] = true // irrelevant
-            };
+        private static readonly VariableCollection BothClausesTrue = new VariableCollection
+        {
+            ["CLAUSE"] = true,
+            ["CLAUSE_2"] = true // irrelevant
+        };
 
-            private static readonly VariableCollection ClauseTwoTrue = new VariableCollection
-            {
-                ["CLAUSE"] = false,
-                ["CLAUSE_2"] = true
-            };
+        private static readonly VariableCollection ClauseTwoTrue = new VariableCollection
+        {
+            ["CLAUSE"] = false,
+            ["CLAUSE_2"] = true
+        };
 
-            private static readonly VariableCollection NeitherClauseTrue = new VariableCollection
-            {
-                ["CLAUSE"] = false,
-                ["CLAUSE_2"] = false
-            };
+        private static readonly VariableCollection NeitherClauseTrue = new VariableCollection
+        {
+            ["CLAUSE"] = false,
+            ["CLAUSE_2"] = false
+        };
 
-            [Theory(DisplayName = nameof(RazorBlockCommentsBasicTestBothClausesTrue))]
-            [InlineData(BasicValue, IfEmitted)]
-            [InlineData(BasicWithDefault, IfEmitted)]
-            public void RazorBlockCommentsBasicTestBothClausesTrue(string test, string expected)
-            {
-                IProcessor processor = SetupRazorStyleProcessor(BothClausesTrue);
-                RunAndVerify(test, expected, processor, 9999);
-            }
+        [Theory(DisplayName = nameof(RazorBlockCommentsBasicTestBothClausesTrue))]
+        [InlineData(BasicValue, IfEmitted)]
+        [InlineData(BasicWithDefault, IfEmitted)]
+        public void RazorBlockCommentsBasicTestBothClausesTrue(string test, string expected)
+        {
+            IProcessor processor = SetupRazorStyleProcessor(BothClausesTrue);
+            RunAndVerify(test, expected, processor, 9999);
+        }
 
-            [Theory(DisplayName = nameof(RazorBlockCommentsBasicTestClauseTwoTrue))]
-            [InlineData(BasicValue, ElseIfEmitted)]
-            [InlineData(BasicWithDefault, ElseIfEmitted)]
-            public void RazorBlockCommentsBasicTestClauseTwoTrue(string test, string expected)
-            {
-                IProcessor processor = SetupRazorStyleProcessor(ClauseTwoTrue);
-                RunAndVerify(test, expected, processor, 9999);
-            }
+        [Theory(DisplayName = nameof(RazorBlockCommentsBasicTestClauseTwoTrue))]
+        [InlineData(BasicValue, ElseIfEmitted)]
+        [InlineData(BasicWithDefault, ElseIfEmitted)]
+        public void RazorBlockCommentsBasicTestClauseTwoTrue(string test, string expected)
+        {
+            IProcessor processor = SetupRazorStyleProcessor(ClauseTwoTrue);
+            RunAndVerify(test, expected, processor, 9999);
+        }
 
-            [Theory(DisplayName = nameof(RazorBlockCommentsBasicTestNeitherClauseTrue))]
-            [InlineData(BasicValue, ElseEmitted)]
-            [InlineData(BasicWithDefault, ElseEmitted)]
-            public void RazorBlockCommentsBasicTestNeitherClauseTrue(string test, string expected)
-            {
-                IProcessor processor = SetupRazorStyleProcessor(NeitherClauseTrue);
-                RunAndVerify(test, expected, processor, 9999);
-            }
+        [Theory(DisplayName = nameof(RazorBlockCommentsBasicTestNeitherClauseTrue))]
+        [InlineData(BasicValue, ElseEmitted)]
+        [InlineData(BasicWithDefault, ElseEmitted)]
+        public void RazorBlockCommentsBasicTestNeitherClauseTrue(string test, string expected)
+        {
+            IProcessor processor = SetupRazorStyleProcessor(NeitherClauseTrue);
+            RunAndVerify(test, expected, processor, 9999);
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.cs
@@ -8,43 +8,43 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 {
     public partial class ConditionalTests : TestBase
     {
-        protected static IProcessor SetupRazorStyleProcessor(VariableCollection vc)
+        protected IProcessor SetupRazorStyleProcessor(VariableCollection vc)
         {
             IOperationProvider[] operations = RazorStyleCommentConditionalsOperations;
             return SetupTestProcessor(operations, vc);
         }
 
-        protected static IProcessor SetupMadeUpStyleProcessor(VariableCollection vc)
+        protected IProcessor SetupMadeUpStyleProcessor(VariableCollection vc)
         {
             IOperationProvider[] operations = MadeUpConditionalsOperations;
             return SetupTestProcessor(operations, vc);
         }
 
-        protected static IProcessor SetupXmlStyleProcessor(VariableCollection vc)
+        protected IProcessor SetupXmlStyleProcessor(VariableCollection vc)
         {
             IOperationProvider[] operations = XmlStyleCommentConditionalsOperations;
             return SetupTestProcessor(operations, vc);
         }
 
-        internal static IProcessor SetupCStyleWithCommentsProcessor(VariableCollection vc)
+        internal IProcessor SetupCStyleWithCommentsProcessor(VariableCollection vc)
         {
             IOperationProvider[] operations = CStyleWithCommentsConditionalOperations;
             return SetupTestProcessor(operations, vc);
         }
 
-        protected static IProcessor SetupCStyleNoCommentsProcessor(VariableCollection vc)
+        protected IProcessor SetupCStyleNoCommentsProcessor(VariableCollection vc)
         {
             IOperationProvider[] operations = CStyleNoCommentsConditionalOperations;
             return SetupTestProcessor(operations, vc);
         }
 
-        protected static IProcessor SetupHashSignLineCommentsProcessor(VariableCollection vc)
+        protected IProcessor SetupHashSignLineCommentsProcessor(VariableCollection vc)
         {
             IOperationProvider[] operations = HashSignLineCommentConditionalOperations;
             return SetupTestProcessor(operations, vc);
         }
 
-        protected static IProcessor SetupBatFileRemLineCommentsProcessor(VariableCollection vc)
+        protected IProcessor SetupBatFileRemLineCommentsProcessor(VariableCollection vc)
         {
             IOperationProvider[] operations = BatFileRemLineCommentConditionalOperations;
             return SetupTestProcessor(operations, vc);
@@ -53,9 +53,9 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
         ///
         /// Sets up a processor with the input params.
         ///
-        private static IProcessor SetupTestProcessor(IOperationProvider[] operations, VariableCollection vc)
+        private IProcessor SetupTestProcessor(IOperationProvider[] operations, VariableCollection vc)
         {
-            EngineConfig cfg = new EngineConfig(vc);
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, vc);
             return Processor.Create(cfg, operations);
         }
 

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/Cpp2EvaluatorTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/Cpp2EvaluatorTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             {
                 ["FIRST_IF"] = true
             };
-            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString("FIRST_IF", vc);
+            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString(EnvironmentSettings, "FIRST_IF", vc);
             Assert.True(result);
         }
 
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             {
                 ["FIRST_IF"] = false
             };
-            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString("FIRST_IF", vc);
+            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString(EnvironmentSettings, "FIRST_IF", vc);
             Assert.False(result);
         }
 
@@ -36,7 +36,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 ["FIRST_IF"] = false,
                 ["SECOND_IF"] = false
             };
-            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString("FIRST_IF == SECOND_IF && !FIRST_IF", vc);
+            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString(EnvironmentSettings, "FIRST_IF == SECOND_IF && !FIRST_IF", vc);
             Assert.True(result);
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 ["FIRST"] = 8,
                 ["SECOND"] = 5
             };
-            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString("FIRST >> 1 + 2 == 1 + SECOND", vc);
+            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString(EnvironmentSettings, "FIRST >> 1 + 2 == 1 + SECOND", vc);
             Assert.True(result);
         }
 
@@ -60,7 +60,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 ["FIRST_IF"] = false,
                 ["SECOND_IF"] = false
             };
-            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString("!!!FIRST_IF && !SECOND_IF == !FIRST_IF", vc);
+            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString(EnvironmentSettings, "!!!FIRST_IF && !SECOND_IF == !FIRST_IF", vc);
             Assert.True(result);
         }
 
@@ -71,7 +71,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             {
                 ["FIRST_IF"] = "1.2.3"
             };
-            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString("FIRST_IF == '1.2.3'", vc);
+            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString(EnvironmentSettings, "FIRST_IF == '1.2.3'", vc);
             Assert.True(result);
         }
 
@@ -79,7 +79,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
         public void VerifyCpp2EvaluatorNumerics()
         {
             VariableCollection vc = new VariableCollection();
-            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString("0x20 == '32'", vc);
+            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString(EnvironmentSettings, "0x20 == '32'", vc);
             Assert.True(result);
         }
 
@@ -91,7 +91,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 ["FIRST"] = "4",
                 ["SECOND"] = "64"
             };
-            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString("FIRST << 2 == SECOND >> 2", vc);
+            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString(EnvironmentSettings, "FIRST << 2 == SECOND >> 2", vc);
             Assert.True(result);
         }
 
@@ -99,7 +99,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
         public void VerifyCpp2EvaluatorMath()
         {
             VariableCollection vc = new VariableCollection();
-            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString("4 + 9 / (2 + 1) == (0x38 >> 2) / (1 << 0x01)", vc);
+            bool result = Cpp2StyleEvaluatorDefinition.EvaluateFromString(EnvironmentSettings, "4 + 9 / (2 + 1) == (0x38 >> 2) / (1 << 0x01)", vc);
             Assert.True(result);
         }
     }

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/Microsoft.TemplateEngine.Core.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/Microsoft.TemplateEngine.Core.UnitTests.csproj
@@ -3,12 +3,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp1.0</TargetFramework>
+    <RuntimeIdentifier />
+    <RuntimeIdentifiers />
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="ConditionalTests.*.cs" DependentUpon="ConditionalTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Core\Microsoft.TemplateEngine.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Core.Contracts\Microsoft.TemplateEngine.Core.Contracts.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
@@ -16,8 +17,8 @@
     <ProjectReference Include="..\Microsoft.TemplateEngine.TestHelper\Microsoft.TemplateEngine.TestHelper.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161123-03" />
-    <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170113-02" />
+    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/PhasedOperationTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/PhasedOperationTests.cs
@@ -8,9 +8,9 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 {
     public class PhasedOperationTests : TestBase
     {
-        private static IProcessor SetupConfig(IVariableCollection vc, params Phase[] phases)
+        private IProcessor SetupConfig(IVariableCollection vc, params Phase[] phases)
         {
-            EngineConfig cfg = new EngineConfig(vc, "$({0})");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, vc, "$({0})");
             return Processor.Create(cfg, new PhasedOperation(null, phases));
         }
 

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/RegionTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/RegionTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("value", "foo", false, false, false, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -40,7 +40,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("value", "foo", true, false, false, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -59,7 +59,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("value", "foo", true, false, false, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -78,7 +78,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("region", "region", true, false, false, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -97,7 +97,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("region", "region", false, false, false, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -116,7 +116,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("value", "foo", true, false, true, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -142,7 +142,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin", "#end", true, false, true, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -167,7 +167,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin", "#end", true, true, true, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -194,7 +194,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin2", "#end2", true, true, true, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -219,7 +219,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin", "#end", true, true, true, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -244,7 +244,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin", "#end", true, true, true, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -269,7 +269,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin", "#end", true, true, true, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -294,7 +294,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin", "#end", true, true, true, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -325,7 +325,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin", "#end", false, true, true, null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ReplacementTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ReplacementTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = {new Replacement("value", "foo", null)};
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -40,7 +40,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Replacement("value2", "foo", null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -59,7 +59,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Replacement("value", "foo", null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -78,7 +78,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Replacement("value", "foo", null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "${0}$");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "${0}$");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/SetFlagTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/SetFlagTests.cs
@@ -54,7 +54,7 @@ After Conditional processing = off
 Final stuff";
 
             VariableCollection vc = new VariableCollection();
-            IProcessor partialProcessor = ConditionalTests.SetupCStyleWithCommentsProcessor(vc);
+            IProcessor partialProcessor = new ConditionalTests().SetupCStyleWithCommentsProcessor(vc);
 
             string on = "//+:cnd";
             string off = "//-:cnd";
@@ -108,7 +108,7 @@ After Conditional processing = off
 Final stuff";
 
             VariableCollection vc = new VariableCollection();
-            IProcessor partialProcessor = ConditionalTests.SetupCStyleWithCommentsProcessor(vc);
+            IProcessor partialProcessor = new ConditionalTests().SetupCStyleWithCommentsProcessor(vc);
 
             string on = "//+:cnd";
             string onNoEmit = on + ":noEmit";
@@ -134,7 +134,7 @@ End";
 End";
 
             VariableCollection vc = new VariableCollection();
-            EngineConfig engineConfig = new EngineConfig(vc);
+            EngineConfig engineConfig = new EngineConfig(EnvironmentSettings, vc);
 
             string on = "//+:cnd";
             string onNoEmit = on + ":noEmit";

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/TestBase.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/TestBase.cs
@@ -21,6 +21,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             };
 
             EnvironmentSettings = new EngineEnvironmentSettings(host, s => null);
+            host.VirtualizeDirectory(Environment.ExpandEnvironmentVariables("%USERPROFILE%/.templateengine"));
         }
 
         protected IEngineEnvironmentSettings EnvironmentSettings { get; }

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/TestBase.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/TestBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.TestHelper;
 using Microsoft.TemplateEngine.Utils;
@@ -12,13 +13,17 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
     {
         protected TestBase()
         {
-            EngineEnvironmentSettings.Host = new TestHost
+            ITemplateEngineHost host = new TestHost
             {
                 HostIdentifier = "TestRunner",
                 Version = "1.0.0.0",
                 Locale = "en-US"
             };
+
+            EnvironmentSettings = new EngineEnvironmentSettings(host, s => null);
         }
+
+        protected IEngineEnvironmentSettings EnvironmentSettings { get; }
 
         protected static void RunAndVerify(string originalValue, string expectedValue, IProcessor processor, int bufferSize, bool? changeOverride = null)
         {

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/VariablesTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/VariablesTests.cs
@@ -14,14 +14,14 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
         public void VerifyVariables()
         {
             string value = @"test %PATH% test";
-            string expected = @"test " + EngineEnvironmentSettings.Environment.GetEnvironmentVariable("PATH") + " test";
+            string expected = @"test " + EnvironmentSettings.Environment.GetEnvironmentVariable("PATH") + " test";
 
             byte[] valueBytes = Encoding.UTF8.GetBytes(value);
             MemoryStream input = new MemoryStream(valueBytes);
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new ExpandVariables(null) };
-            EngineConfig cfg = new EngineConfig(VariableCollection.Environment(), "%{0}%");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, VariableCollection.Environment(EnvironmentSettings), "%{0}%");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -44,7 +44,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             {
                 ["NULL"] = null
             };
-            EngineConfig cfg = new EngineConfig(vc, "%{0}%");
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, vc, "%{0}%");
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made

--- a/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
+++ b/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
@@ -5,9 +5,9 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.TemplateEngine.Abstractions" Version="$(PackageVersion)" />
-    <PackageReference Include="Microsoft.TemplateEngine.Core.Contracts" Version="$(PackageVersion)" />
-    <PackageReference Include="Microsoft.TemplateEngine.Utils" Version="$(PackageVersion)" />
-    <PackageReference Include="Microsoft.TemplateEngine.Orchestrator.RunnableProjects" Version="$(PackageVersion)" />
+    <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Core.Contracts\Microsoft.TemplateEngine.Core.Contracts.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Orchestrator.RunnableProjects\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.TemplateEngine.Mocks/MockMountPoint.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockMountPoint.cs
@@ -1,13 +1,15 @@
 ﻿using System.IO;
 using System.Linq;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 
 namespace Microsoft.TemplateEngine.Mocks
 {
     public class MockMountPoint : IMountPoint
     {
-        public MockMountPoint()
+        public MockMountPoint(IEngineEnvironmentSettings environmentSettings)
         {
+            EnvironmentSettings = environmentSettings;
             MockRoot = new MockDirectory("/", "/", this, null);
         }
 
@@ -16,6 +18,8 @@ namespace Microsoft.TemplateEngine.Mocks
         public IDirectory Root => MockRoot;
 
         public MockDirectory MockRoot { get; }
+
+        public IEngineEnvironmentSettings EnvironmentSettings { get; set; }
 
         public IFileSystemInfo FileSystemInfo(string fullPath)
         {

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/CaseChangeMacroTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/CaseChangeMacroTests.cs
@@ -7,10 +7,11 @@ using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config;
 using static Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Microsoft.TemplateEngine.TestHelper;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
-    public class CaseChangeMacroTests
+    public class CaseChangeMacroTests : TestBase
     {
         [Fact(DisplayName = nameof(TestCaseChangeToLowerConfig))]
         public void TestCaseChangeToLowerConfig()
@@ -24,7 +25,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             string sourceValue = "Original Value SomethingCamelCase";
             Parameter sourceParam = new Parameter
@@ -35,7 +36,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             setter(sourceParam, sourceValue);
 
             CaseChangeMacro macro = new CaseChangeMacro();
-            macro.EvaluateConfig(variables, macroConfig, parameters, setter);
+            macro.EvaluateConfig(EngineEnvironmentSettings, variables, macroConfig, parameters, setter);
 
             ITemplateParameter convertedParam;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out convertedParam));
@@ -55,7 +56,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             string sourceValue = "Original Value SomethingCamelCase";
             Parameter sourceParam = new Parameter
@@ -66,7 +67,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             setter(sourceParam, sourceValue);
 
             CaseChangeMacro macro = new CaseChangeMacro();
-            macro.EvaluateConfig(variables, macroConfig, parameters, setter);
+            macro.EvaluateConfig(EngineEnvironmentSettings, variables, macroConfig, parameters, setter);
 
             ITemplateParameter convertedParam;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out convertedParam));
@@ -89,7 +90,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             string sourceValue = "Original Value SomethingCamelCase";
             Parameter sourceParam = new Parameter
@@ -99,7 +100,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             };
             setter(sourceParam, sourceValue);
 
-            macro.EvaluateDeferredConfig(variables, deferredConfig, parameters, setter);
+            macro.EvaluateDeferredConfig(EngineEnvironmentSettings, variables, deferredConfig, parameters, setter);
             ITemplateParameter convertedParam;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out convertedParam));
             string convertedValue = (string)parameters.ResolvedValues[convertedParam];

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/ConstantMacroTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/ConstantMacroTests.cs
@@ -23,10 +23,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             ConstantMacro macro = new ConstantMacro();
-            macro.EvaluateConfig(variables, macroConfig, parameters, setter);
+            macro.EvaluateConfig(EngineEnvironmentSettings, variables, macroConfig, parameters, setter);
 
             ITemplateParameter constParameter;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out constParameter));
@@ -46,10 +46,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             ConstantMacro macro = new ConstantMacro();
-            macro.EvaluateDeferredConfig(variables, deferredConfig, parameters, setter);
+            macro.EvaluateDeferredConfig(EngineEnvironmentSettings, variables, deferredConfig, parameters, setter);
             ITemplateParameter constParameter;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out constParameter));
             string constParamValue = (parameters.ResolvedValues[constParameter]).ToString();

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/EvaluateMacroTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/EvaluateMacroTests.cs
@@ -23,10 +23,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             EvaluateMacro macro = new EvaluateMacro();
-            macro.EvaluateConfig(variables, macroConfig, parameters, setter);
+            macro.EvaluateConfig(EngineEnvironmentSettings, variables, macroConfig, parameters, setter);
             ITemplateParameter resultParam;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out resultParam));
             bool resultValue = (bool)parameters.ResolvedValues[resultParam];

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/GuidMacroTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/GuidMacroTests.cs
@@ -23,10 +23,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             GuidMacro guidMacro = new GuidMacro();
-            guidMacro.EvaluateConfig(variables, macroConfig, parameters, setter);
+            guidMacro.EvaluateConfig(EngineEnvironmentSettings, variables, macroConfig, parameters, setter);
             ValidateGuidMacroCreatedParametersWithResolvedValues(paramName, parameters);
         }
 
@@ -42,9 +42,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
-            guidMacro.EvaluateDeferredConfig(variables, deferredConfig, parameters, setter);
+            guidMacro.EvaluateDeferredConfig(EngineEnvironmentSettings, variables, deferredConfig, parameters, setter);
             ValidateGuidMacroCreatedParametersWithResolvedValues(variableName, parameters);
         }
 

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/MacroTestHelpers.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/MacroTestHelpers.cs
@@ -1,19 +1,16 @@
 ﻿using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
 {
     internal static class MacroTestHelpers
     {
-        internal static ParameterSetter TestParameterSetter(IParameterSet parameters)
+        internal static ParameterSetter TestParameterSetter(IEngineEnvironmentSettings environmentSettings, IParameterSet parameters)
         {
             ParameterSetter setter = (p, value) =>
             {
                 ((RunnableProjectGenerator.ParameterSet)parameters).AddParameter(p);
-                parameters.ResolvedValues[p] = RunnableProjectGenerator.InternalConvertParameterValueToType(p, value, out bool valueResolutionError);
+                parameters.ResolvedValues[p] = RunnableProjectGenerator.InternalConvertParameterValueToType(environmentSettings, p, value, out bool valueResolutionError);
             };
 
             return setter;

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/NowMacroTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/NowMacroTests.cs
@@ -26,10 +26,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             NowMacro macro = new NowMacro();
-            macro.EvaluateConfig(variables, macroConfig, parameters, setter);
+            macro.EvaluateConfig(EngineEnvironmentSettings, variables, macroConfig, parameters, setter);
             ITemplateParameter resultParam;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out resultParam));
             string macroNowString = (string)parameters.ResolvedValues[resultParam];
@@ -57,10 +57,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             NowMacro macro = new NowMacro();
-            macro.EvaluateDeferredConfig(variables, deferredConfig, parameters, setter);
+            macro.EvaluateDeferredConfig(EngineEnvironmentSettings, variables, deferredConfig, parameters, setter);
             ITemplateParameter resultParam;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out resultParam));
             string macroNowString = (string)parameters.ResolvedValues[resultParam];

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/RandomMacroTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/RandomMacroTests.cs
@@ -27,10 +27,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             RandomMacro macro = new RandomMacro();
-            macro.EvaluateConfig(variables, macroConfig, parameters, setter);
+            macro.EvaluateConfig(EngineEnvironmentSettings, variables, macroConfig, parameters, setter);
 
             ITemplateParameter valueParam;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out valueParam));
@@ -63,10 +63,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             RandomMacro macro = new RandomMacro();
-            macro.EvaluateDeferredConfig(variables, deferredConfig, parameters, setter);
+            macro.EvaluateDeferredConfig(EngineEnvironmentSettings, variables, deferredConfig, parameters, setter);
             ITemplateParameter valueParam;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out valueParam));
             long randomValue = (long)parameters.ResolvedValues[valueParam];

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/RegexMacroTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/RegexMacroTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             string sourceValue = "QQQ121222112";
             string expectedValue = "QQQZZ1Z";
@@ -39,7 +39,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             setter(sourceParam, sourceValue);
 
             RegexMacro macro = new RegexMacro();
-            macro.EvaluateConfig(variables, macroConfig, parameters, setter);
+            macro.EvaluateConfig(EngineEnvironmentSettings, variables, macroConfig, parameters, setter);
 
             ITemplateParameter newParam;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out newParam));
@@ -68,7 +68,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             string sourceValue = "ABCAABBCC";
             string expectedValue = "ZBCZZBBCC";
@@ -80,7 +80,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             setter(sourceParam, sourceValue);
 
             RegexMacro macro = new RegexMacro();
-            macro.EvaluateDeferredConfig(variables, deferredConfig, parameters, setter);
+            macro.EvaluateDeferredConfig(EngineEnvironmentSettings, variables, deferredConfig, parameters, setter);
             ITemplateParameter newParam;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out newParam));
             string newValue = (string)parameters.ResolvedValues[newParam];

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/SwtichMacroTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/SwtichMacroTests.cs
@@ -30,10 +30,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             SwitchMacro macro = new SwitchMacro();
-            macro.EvaluateConfig(variables, macroConfig, parameters, setter);
+            macro.EvaluateConfig(EngineEnvironmentSettings, variables, macroConfig, parameters, setter);
             ITemplateParameter resultParam;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out resultParam));
             string resultValue = (string)parameters.ResolvedValues[resultParam];
@@ -76,10 +76,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel();
             IParameterSet parameters = new ParameterSet(config);
-            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(parameters);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
 
             SwitchMacro macro = new SwitchMacro();
-            macro.EvaluateDeferredConfig(variables, deferredConfig, parameters, setter);
+            macro.EvaluateDeferredConfig(EngineEnvironmentSettings, variables, deferredConfig, parameters, setter);
             ITemplateParameter resultParam;
             Assert.True(parameters.TryGetParameterDefinition(variableName, out resultParam));
             string resultValue = (string)parameters.ResolvedValues[resultParam];

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161123-03" />
-    <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
+    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
@@ -10,8 +10,8 @@
     <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161123-03" />
-    <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170113-02" />
+    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.TemplateEngine.TestHelper/TestBase.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/TestBase.cs
@@ -22,6 +22,7 @@ namespace Microsoft.TemplateEngine.TestHelper
             };
 
             EngineEnvironmentSettings = new EngineEnvironmentSettings(host, x => null);
+            host.VirtualizeDirectory(Environment.ExpandEnvironmentVariables("%USERPROFILE%/.templateengine"));
         }
 
         protected static void RunAndVerify(string originalValue, string expectedValue, IProcessor processor, int bufferSize, bool? changeOverride = null)

--- a/test/Microsoft.TemplateEngine.TestHelper/TestBase.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/TestBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Utils;
 using Xunit;
@@ -9,14 +10,18 @@ namespace Microsoft.TemplateEngine.TestHelper
 {
     public abstract class TestBase
     {
+        protected IEngineEnvironmentSettings EngineEnvironmentSettings { get; }
+
         protected TestBase()
         {
-            EngineEnvironmentSettings.Host = new TestHost
+            ITemplateEngineHost host = new TestHost
             {
                 HostIdentifier = "TestRunner",
                 Version = "1.0.0.0",
                 Locale = "en-US"
             };
+
+            EngineEnvironmentSettings = new EngineEnvironmentSettings(host, x => null);
         }
 
         protected static void RunAndVerify(string originalValue, string expectedValue, IProcessor processor, int bufferSize, bool? changeOverride = null)

--- a/test/Microsoft.TemplateEngine.TestHelper/TestHost.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/TestHost.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
+using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.TestHelper
 {
@@ -80,6 +81,11 @@ namespace Microsoft.TemplateEngine.TestHelper
 
         public void UpdateLocale(string newLocale)
         {
+        }
+
+        public void VirtualizeDirectory(string path)
+        {
+            FileSystem = new InMemoryFileSystem(path, FileSystem);
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
@@ -7,12 +7,11 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Core.Contracts\Microsoft.TemplateEngine.Core.Contracts.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Microsoft.TemplateEngine.Mocks\Microsoft.TemplateEngine.Mocks.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161123-03" />
-    <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170113-02" />
+    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
   </ItemGroup>
 </Project>

--- a/test/dotnet-new3.UnitTests/dotnet-new3.UnitTests.csproj
+++ b/test/dotnet-new3.UnitTests/dotnet-new3.UnitTests.csproj
@@ -5,16 +5,12 @@
     <TargetFramework>netcoreapp1.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20161123-03" />
-    <PackageReference Include="xunit" Version="2.2.0-beta4-build3444" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta4-build1194" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170113-02" />
+    <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\dotnet-new3\dotnet-new3.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Edge\Microsoft.TemplateEngine.Edge.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Cli\Microsoft.TemplateEngine.Cli.csproj" />
     <ProjectReference Include="..\..\test\Microsoft.TemplateEngine.Mocks\Microsoft.TemplateEngine.Mocks.csproj" />
     <ProjectReference Include="..\..\test\Microsoft.TemplateEngine.TestHelper\Microsoft.TemplateEngine.TestHelper.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Right now, quite a few things assume that exactly one template engine instance will be loaded into a process space and be executing at a given time (the concern here is mostly around the first run experience). This is problematic for environments where different configuration hives would/should be used within the same process space (ex. if using this from VS, having two different template caches for two different dialogs). While it is possible (given the assertion that exactly one things could force first run at a given moment is true) to switch the host object in use in the relevant scopes (dialog 1 sets host 1 to `EngineEnvironmentSettings.Host` just before it needs it and dialog 2 sets host 2 just when it needs it), this can introduce extra complexity & difficult to track down bugs in orchestration of this state. This will also enable test parallelization for both the dotnet cli and for this repo (as a different hive can be used for each test - or an ephemeral/in-memory hive can be introduced in test contexts that deal with concurrent first-run requests by directing them to different hives).

This change removes the static qualification from `EngineEnvironmentSettings`, `SettingsLoader`, `Paths`, and `AliasRegistry`. EngineEnvironmentSettings is included on all mount points & passed around to most everything else. SettingsLoader has been added to EngineEnvironmentSettings, Paths and AliasRegistry are now constructed from an EngineEnvironmentSettings rather than accessing it as a static class.

I'm not quite convinced that `Paths` should meet this fate (as the syntax becomes awkward), perhaps we should move it back to being static & pass the environment settings as a param for the calls.

@seancpeters please review carefully, none of the changes were tricky or change architecture significantly, but this was repetitive & could have accidentally (unlikely, as all tests pass) changed some behavior