### PR TITLE
More appropriate error messages for invalid / unresolvable templates……

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.cs
@@ -124,5 +124,17 @@ namespace Microsoft.TemplateEngine.Cli
         public const string DefaultValue = "Default: {0}";
 
         public const string NoParameters = "    (No Parameters)";
+
+        public const string AmbiguousInputTemplateName = "Unable to determine the desired template from the input template name: [{0}]";
+
+        public const string NoTemplatesMatchName = "No templates matched the input template name: [{0}]";
+
+        public const string ItemTemplateNotInProjectContext = "[{0}] is an item template. By default it's only created in a target location containing a project. Force creation with the -all flag.";
+
+        public const string ProjectTemplateInProjectContext = "[{0}] is a project template. By default it's not created in a target location containing a project. Force creation with the -all flag.";
+
+        public const string GenericPlaceholderTemplateContextError = "[{0}] cannot be created in the target location.";
+
+        public const string TemplateMultiplePartialNameMatches = "The following templates partially match the input. Please be more specific with the template name and/or language.";
     }
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates/Templates.nuspec
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates/Templates.nuspec
@@ -4,7 +4,7 @@
     <id>Microsoft.DotNet.Web.ProjectTemplates</id>
     <version>$version$</version>
     <authors>Microsoft</authors>
-    <description>ASP.NET Web Template Pack for Microsoft Template Engine</description>
+    <description>ASP.NET Core Web Template Pack for Microsoft Template Engine</description>
     <language>en-US</language>
     <projectUrl>https://github.com/dotnet/templating</projectUrl>
     <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates/content/EmptyWeb-CSharp/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "classifications": ["Web", "Empty"],
-  "name": "Empty ASP.NET Web Application",
+  "name": "Empty ASP.NET Core Web Application",
   "groupIdentity": "Microsoft.Web.Empty",
   "identity": "Microsoft.Web.Empty.CSharp",
   "shortName": "web",

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-CSharp/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "classifications": ["Web", "MVC"],
-  "name": "MVC ASP.NET Web Application",
+  "name": "MVC ASP.NET Core Web Application",
   "groupIdentity": "Microsoft.Web.Mvc",
   "identity": "Microsoft.Web.Mvc.CSharp",
   "shortName": "mvc",

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates/content/StarterWeb-FSharp/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "classifications": ["Web", "MVC"],
-  "name": "MVC ASP.NET Web Application",
+  "name": "MVC ASP.NET Core Web Application",
   "groupIdentity": "Microsoft.Web.Mvc",
   "identity": "Microsoft.Web.Mvc.FSharp",
   "shortName": "mvc",

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates/content/WebApi-CSharp/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "classifications": ["Web", "WebAPI"],
-  "name": "Web API ASP.NET Web Application",
+  "name": "Web API ASP.NET Core Web Application",
   "groupIdentity": "Microsoft.Web.WebApi",
   "identity": "Microsoft.Web.WebApi.CSharp",
   "shortName": "webapi",


### PR DESCRIPTION
… (#209)

* More appropirate error messages for invalid / unresolvable tempalates names

* Cleaned up reporting of template non-matches

* Changed 'ASP.NET Web' to 'ASP.NET Core Web' in the Web Project templates

* Moved new strings to LocalizableStrings.cs Fixed an ambiguous name output error

* Removed an extra space in an output string