### PR TITLE
Updates to help characteristics

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -1052,10 +1052,6 @@ namespace Microsoft.TemplateEngine.Cli
             if (remainingPartialMatches.Keys.Count > 0)
             {
                 Reporter.Error.WriteLine(LocalizableStrings.TemplateMultiplePartialNameMatches);
-                foreach (IFilteredTemplateInfo template in remainingPartialMatches.Values)
-                {
-                    Reporter.Error.WriteLine($"  {template.Info.Name}");
-                }
             }
 
             Reporter.Error.WriteLine();


### PR DESCRIPTION
Skip showing usage help when picking an out of scope template
Skip listing templates when a template's args are wrong
List templates in context when no template matching the name was found