### PR TITLE
Adds a switch to skip emitting tools packages

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -8,6 +8,10 @@
     },
     "Framework": {
       "longName": "framework"
+    },
+    "NoTools": {
+      "isHidden": "true",
+      "longName": "no-tools"
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/.template.config/template.json
@@ -106,6 +106,11 @@
       "parameters": {
         "format": "yyyy"
       }
+    },
+    "NoTools": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
     }
   },
   "primaryOutputs": [ { "path": "Company.WebApplication1.csproj" } ]

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/Company.WebApplication1.csproj
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/Company.WebApplication1.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IndividualAuth)' == 'True'">
+  <ItemGroup Condition="'$(IndividualAuth)' == 'True' AND '$(NoTools)' != 'True'">
     <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.0.0" />
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.0" />
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.0.0" />

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -13,6 +13,10 @@
       "longName": "runtime-framework-version",
       "shortName": "fv",
       "isHidden": "true"
+    },
+    "NoTools": {
+      "isHidden": "true",
+      "longName": "no-tools"
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/.template.config/template.json
@@ -105,6 +105,11 @@
       "parameters": {
         "format": "yyyy"
       }
+    },
+    "NoTools": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false"
     }
   },
   "primaryOutputs": [ { "path": "Company.WebApplication1.csproj" } ]

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Company.WebApplication1.csproj
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Company.WebApplication1.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.2.0-preview1-23339" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(IndividualAuth)' == 'True' AND '$(NoTools)' != 'True'">
     <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.2.0-preview1-23339" />
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="1.0.1-alpha-23339" />
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="1.2.0-preview4-23180" />


### PR DESCRIPTION
This allows the tools to be skipped in the LZMA archive generation, which is important as the .tools folder's project.assets.json files include absolute paths to the locations of the cache locations that were available at the time of restore. Since the LZMA archive creation restores to a folder and compresses the output, the project.assets.json files pointing to locations on the local machine (CI server) would be included in the archive which would presumably break consumers.