### PR TITLE
Remove implicit context filtering

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.cs
@@ -135,9 +135,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         public const string NoTemplatesMatchName = "No templates matched the input template name: [{0}].";
 
-        public const string ItemTemplateNotInProjectContext = "[{0}] is an item template. By default, it's only created in a target location containing a project. Force creation with the -all flag.";
-
-        public const string ProjectTemplateInProjectContext = "[{0}] is a project template. By default, it's not created in a target location containing a project. Force creation with the -all flag.";
+        public const string TemplateNotValidGivenTheSpecifiedFilter = "[{0}] matches the specified name, but has been excluded by the --filter parameter. Remove or change the --filter parameter to use that template.";
 
         public const string GenericPlaceholderTemplateContextError = "[{0}] cannot be created in the target location.";
 
@@ -160,5 +158,7 @@ namespace Microsoft.TemplateEngine.Cli
         public const string RerunCommandAndPassForceToCreateAnyway = "Rerun the command and pass --force to accept and create.";
 
         public const string ForcesTemplateCreation = "Forces content to be generated even if it would change existing files.";
+
+        public const string ShowsFilteredTemplates = "Shows a subset of the available templates.";
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.cs
@@ -135,7 +135,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         public const string NoTemplatesMatchName = "No templates matched the input template name: [{0}].";
 
-        public const string TemplateNotValidGivenTheSpecifiedFilter = "[{0}] matches the specified name, but has been excluded by the --filter parameter. Remove or change the --filter parameter to use that template.";
+        public const string TemplateNotValidGivenTheSpecifiedFilter = "[{0}] matches the specified name, but has been excluded by the --type parameter. Remove or change the --type parameter to use that template.";
 
         public const string GenericPlaceholderTemplateContextError = "[{0}] cannot be created in the target location.";
 
@@ -159,6 +159,6 @@ namespace Microsoft.TemplateEngine.Cli
 
         public const string ForcesTemplateCreation = "Forces content to be generated even if it would change existing files.";
 
-        public const string ShowsFilteredTemplates = "Shows a subset of the available templates.";
+        public const string ShowsFilteredTemplates = "Shows a subset of the available templates. Valid values are \"project\", \"item\" or \"other\".";
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -83,7 +83,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         public bool IsShowAllFlagSpecified => _app.InternalParamHasValue("--show-all");
 
-        public string Filter => _app.InternalParamValue("--filter");
+        public string TypeFilter => _app.InternalParamValue("--type");
 
         public string Language => _app.InternalParamValue("--language");
 
@@ -95,16 +95,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         public string OutputPath => _app.InternalParamValue("--output");
 
-        public string TemplateType => _app.InternalParamValue("--type");
-
-        public string TemplateName
-        {
-            get
-            {
-                // prefer the -t param over the argument value
-                return !string.IsNullOrEmpty(TemplateType) ? TemplateType : _templateNameArgument.Value;
-            }
-        }
+        public string TemplateName => _templateNameArgument.Value;
 
         public bool SkipUpdateCheck => _app.InternalParamHasValue("--skip-update-check");
 
@@ -897,7 +888,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         private string DetermineTemplateContext()
         {
-            return Filter?.ToLowerInvariant();
+            return TypeFilter?.ToLowerInvariant();
         }
 
         private void PerformCoreTemplateQuery()
@@ -1016,7 +1007,7 @@ namespace Microsoft.TemplateEngine.Cli
             appExt.InternalOption("-n|--name", "--name", LocalizableStrings.NameOfOutput, CommandOptionType.SingleValue);
             appExt.InternalOption("-o|--output", "--output", LocalizableStrings.OutputPath, CommandOptionType.SingleValue);
             appExt.InternalOption("-h|--help", "--help", LocalizableStrings.DisplaysHelp, CommandOptionType.NoValue);
-            appExt.InternalOption("--filter", "--filter", LocalizableStrings.ShowsFilteredTemplates, CommandOptionType.SingleValue);
+            appExt.InternalOption("--type", "--type", LocalizableStrings.ShowsFilteredTemplates, CommandOptionType.SingleValue);
             appExt.InternalOption("--force", "--force", LocalizableStrings.ForcesTemplateCreation, CommandOptionType.NoValue);
 
             // hidden
@@ -1025,7 +1016,6 @@ namespace Microsoft.TemplateEngine.Cli
             appExt.HiddenInternalOption("--locale", "--locale", CommandOptionType.SingleValue);
             appExt.HiddenInternalOption("--quiet", "--quiet", CommandOptionType.NoValue);
             appExt.HiddenInternalOption("-i|--install", "--install", CommandOptionType.MultipleValue);
-            appExt.HiddenInternalOption("-t|--type", "--type", CommandOptionType.SingleValue);
             appExt.HiddenInternalOption("-all|--show-all", "--show-all", CommandOptionType.NoValue);
 
             // reserved but not currently used

--- a/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
@@ -83,7 +83,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                     {
                         return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Exact };
                     }
-                    else if (context == "other" && !typeTag.ChoicesAndDescriptions.ContainsKey("project") && !typeTag.ChoicesAndDescriptions.ContainsKey("item"))
+                    else if (string.Equals(context, "other", StringComparison.OrdinalIgnoreCase) && !typeTag.ChoicesAndDescriptions.ContainsKey("project") && !typeTag.ChoicesAndDescriptions.ContainsKey("item"))
                     {
                         return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Exact };
                     }

--- a/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
@@ -83,6 +83,10 @@ namespace Microsoft.TemplateEngine.Edge.Template
                     {
                         return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Exact };
                     }
+                    else if (context == "other" && !typeTag.ChoicesAndDescriptions.ContainsKey("project") && !typeTag.ChoicesAndDescriptions.ContainsKey("item"))
+                    {
+                        return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Exact };
+                    }
                     else
                     {
                         return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Mismatch };


### PR DESCRIPTION
First go at this to get feedback:
* `dotnet new` or `dotnet new --list` will now present all templates by default (all contexts - project/item/other)
* Adds a `--filter {filter}` switch that allows an explicit filtering to a user specified template type (ex. `--filter project` will display only project templates)
* Error messages for "not available in this context" have been unified to indicate that the matched template has been excluded by the `--filter` parameter
* Search logic has been updated to treat a "other" (supplied as a value for `--filter`) as meaning anything that isn't of type `project` or `item`
* The logic that determines whether the template can be created given the current context has been unified with the logic that's used to determine what to list

Output examples:

_dotnet new3_
```
Template Instantiation Commands for .NET Core CLI

Usage: dotnet new3 [arguments] [options]

Arguments:
  template  The template to instantiate.

Options:
  -l|--list         Lists templates containing the specified name. If no name is specified, lists all templates.
  -lang|--language  Specifies the language of the template to create.
  -n|--name         The name for the output being created. If no name is specified, the name of the current directory is used.
  -o|--output       Location to place the generated output.
  -h|--help         Displays help for this command.
  --filter          Shows a subset of the available templates.
  --force           Forces content to be generated even if it would change existing files.


Templates                 Short Name       Language      Tags
-----------------------------------------------------------------------
Console Application       console          [C#], F#      Common/Console
Class library             classlib         [C#], F#      Common/Library
Unit Test Project         mstest           [C#], F#      Test/MSTest
xUnit Test Project        xunit            [C#], F#      Test/xUnit
ASP.NET Core Empty        web              [C#]          Web/Empty
ASP.NET Core Web App      mvc              [C#], F#      Web/MVC
ASP.NET Core Web API      webapi           [C#]          Web/WebAPI
Nuget Config              nugetconfig                    Config
Web Config                webconfig                      Config
Solution File             sln                            Solution


Examples:
    dotnet new3 mvc --auth None --Framework netcoreapp1.1
    dotnet new3 xunit --Framework netcoreapp1.1
    dotnet new3 --help
```

_dotnet new3 --list_
```
Template Instantiation Commands for .NET Core CLI

Usage: dotnet new3 [arguments] [options]

Arguments:
  template  The template to instantiate.

Options:
  -l|--list         Lists templates containing the specified name. If no name is specified, lists all templates.
  -lang|--language  Specifies the language of the template to create.
  -n|--name         The name for the output being created. If no name is specified, the name of the current directory is used.
  -o|--output       Location to place the generated output.
  -h|--help         Displays help for this command.
  --filter          Shows a subset of the available templates.
  --force           Forces content to be generated even if it would change existing files.


Templates                 Short Name       Language      Tags
-----------------------------------------------------------------------
Console Application       console          [C#], F#      Common/Console
Class library             classlib         [C#], F#      Common/Library
Unit Test Project         mstest           [C#], F#      Test/MSTest
xUnit Test Project        xunit            [C#], F#      Test/xUnit
ASP.NET Core Empty        web              [C#]          Web/Empty
ASP.NET Core Web App      mvc              [C#], F#      Web/MVC
ASP.NET Core Web API      webapi           [C#]          Web/WebAPI
Nuget Config              nugetconfig                    Config
Web Config                webconfig                      Config
Solution File             sln                            Solution
```

_dotnet new3 --filter project_
```
Template Instantiation Commands for .NET Core CLI

Usage: dotnet new3 [arguments] [options]

Arguments:
  template  The template to instantiate.

Options:
  -l|--list         Lists templates containing the specified name. If no name is specified, lists all templates.
  -lang|--language  Specifies the language of the template to create.
  -n|--name         The name for the output being created. If no name is specified, the name of the current directory is used.
  -o|--output       Location to place the generated output.
  -h|--help         Displays help for this command.
  --filter          Shows a subset of the available templates.
  --force           Forces content to be generated even if it would change existing files.


Templates                 Short Name      Language      Tags
----------------------------------------------------------------------
Console Application       console         [C#], F#      Common/Console
Class library             classlib        [C#], F#      Common/Library
Unit Test Project         mstest          [C#], F#      Test/MSTest
xUnit Test Project        xunit           [C#], F#      Test/xUnit
ASP.NET Core Empty        web             [C#]          Web/Empty
ASP.NET Core Web App      mvc             [C#], F#      Web/MVC
ASP.NET Core Web API      webapi          [C#]          Web/WebAPI
Solution File             sln                           Solution


Examples:
    dotnet new3 mvc --auth None --Framework netcoreapp1.1
    dotnet new3 console --Framework netcoreapp1.1
    dotnet new3 --help
```

_dotnet new3 --filter item_
```
Template Instantiation Commands for .NET Core CLI

Usage: dotnet new3 [arguments] [options]

Arguments:
  template  The template to instantiate.

Options:
  -l|--list         Lists templates containing the specified name. If no name is specified, lists all templates.
  -lang|--language  Specifies the language of the template to create.
  -n|--name         The name for the output being created. If no name is specified, the name of the current directory is used.
  -o|--output       Location to place the generated output.
  -h|--help         Displays help for this command.
  --filter          Shows a subset of the available templates.
  --force           Forces content to be generated even if it would change existing files.


Templates          Short Name       Language      Tags
----------------------------------------------------------
Nuget Config       nugetconfig                    Config
Web Config         webconfig                      Config
Solution File      sln                            Solution


Examples:
    dotnet new3 sln
    dotnet new3 nugetconfig
    dotnet new3 --help
```

_dotnet new3 --filter other_
```
Template Instantiation Commands for .NET Core CLI

Usage: dotnet new3 [arguments] [options]

Arguments:
  template  The template to instantiate.

Options:
  -l|--list         Lists templates containing the specified name. If no name is specified, lists all templates.
  -lang|--language  Specifies the language of the template to create.
  -n|--name         The name for the output being created. If no name is specified, the name of the current directory is used.
  -o|--output       Location to place the generated output.
  -h|--help         Displays help for this command.
  --filter          Shows a subset of the available templates.
  --force           Forces content to be generated even if it would change existing files.


Templates          Short Name      Language      Tags
---------------------------------------------------------
Solution File      sln                           Solution


Examples:
    dotnet new3 sln
    dotnet new3 --help
Solution File
Author: Microsoft
    (No Parameters)
```

_dotnet new3 web_ (no project in directory)
```
The template "ASP.NET Core Empty" was created successfully.
```

_dotnet new3 web_ (project in directory)
```
Creating this template will make changes to existing files:
  Overwrite   tmp1.csproj
  Overwrite   Program.cs
  Overwrite   Startup.cs

Rerun the command and pass --force to accept and create.
```

_dotnet new3 web --filter item_ (no web.config in directory)
```
The template "Web Config" was created successfully.
```

_dotnet new3 web --filter item_ (web.config in directory)
```
Creating this template will make changes to existing files:
  Overwrite   web.config

Rerun the command and pass --force to accept and create.
```

Fixes #323 
Fixes #302 
Fixes #301 
Fixes #262 
Fixes #106 

@sayedihashimi @blackdwarf 