### PR TITLE
Have errors instruct to call --help instead of displaying help

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-
 namespace Microsoft.TemplateEngine.Cli
 {
     internal class LocalizableStrings

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Microsoft.TemplateEngine.Cli
 {
     internal class LocalizableStrings
@@ -160,5 +162,7 @@ namespace Microsoft.TemplateEngine.Cli
         public const string ForcesTemplateCreation = "Forces content to be generated even if it would change existing files.";
 
         public const string ShowsFilteredTemplates = "Shows a subset of the available templates. Valid values are \"project\", \"item\" or \"other\".";
+
+        public const string RunHelpForInformationAboutAcceptedParameters = "Run dotnet {0} --help for usage information.";
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.cs
@@ -69,6 +69,11 @@ namespace Microsoft.TemplateEngine.Cli
 
         public const string InvalidParameterValues = "Error: Invalid values for parameter(s) [{0}] for template [{1}].";
 
+        public const string InvalidTemplateParameterValues = "Error: Invalid parameter(s):";
+
+        public const string InvalidParameterDetail = @"  {0} {1}
+    '{1}' is not a valid value for {0} ({2}).";
+
         public const string GettingReady = "Getting ready...";
 
         public const string InvalidInputSwitch = "Invalid input switch:";

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -286,7 +286,7 @@ namespace Microsoft.TemplateEngine.Cli
                     break;
                 case CreationResultStatus.InvalidParamValues:
                     Reporter.Error.WriteLine(string.Format(LocalizableStrings.InvalidParameterValues, instantiateResult.Message, resultTemplateName).Bold().Red());
-                    ShowTemplateHelp(template);
+                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.RunHelpForInformationAboutAcceptedParameters, $"{CommandName} {TemplateName}").Bold().Red());
                     break;
                 default:
                     break;
@@ -459,7 +459,15 @@ namespace Microsoft.TemplateEngine.Cli
         {
             if (!ValidateRemainingParameters())
             {
-                ShowUsageHelp();
+                if (IsHelpFlagSpecified)
+                {
+                    ShowUsageHelp();
+                }
+                else
+                {
+                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.RunHelpForInformationAboutAcceptedParameters, CommandName).Bold().Red());
+                }
+
                 return CreationResultStatus.InvalidParamValues;
             }
 
@@ -491,7 +499,7 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 if (!ValidateRemainingParameters())
                 {
-                    ShowUsageHelp();
+                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.RunHelpForInformationAboutAcceptedParameters, $"{CommandName} {TemplateName}").Bold().Red());
                     return CreationResultStatus.InvalidParamValues;
                 }
 
@@ -503,7 +511,7 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 if (!ValidateRemainingParameters())
                 {
-                    ShowUsageHelp();
+                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.RunHelpForInformationAboutAcceptedParameters, CommandName).Bold().Red());
                     return CreationResultStatus.InvalidParamValues;
                 }
 
@@ -529,16 +537,26 @@ namespace Microsoft.TemplateEngine.Cli
                 argsError = !ValidateRemainingParameters();
             }
 
-            if (argsError || IsHelpFlagSpecified)
+            if(IsHelpFlagSpecified)
             {
-                if(commandParseFailureMessage != null)
+                if (commandParseFailureMessage != null)
                 {
                     Reporter.Error.WriteLine(commandParseFailureMessage.Bold().Red());
                 }
 
                 ShowUsageHelp();
                 ShowTemplateHelp(UnambiguousTemplateToUse.Info);
-                return argsError ? CreationResultStatus.InvalidParamValues : CreationResultStatus.Success;
+                return CreationResultStatus.Success;
+            }
+            else if (argsError)
+            {
+                if (commandParseFailureMessage != null)
+                {
+                    Reporter.Error.WriteLine(commandParseFailureMessage.Bold().Red());
+                }
+
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.RunHelpForInformationAboutAcceptedParameters, $"{CommandName} {TemplateName}").Bold().Red());
+                return CreationResultStatus.InvalidParamValues;
             }
             else
             {
@@ -598,7 +616,7 @@ namespace Microsoft.TemplateEngine.Cli
             catch (CommandParserException ex)
             {
                 Reporter.Error.WriteLine(ex.Message.Bold().Red());
-                ShowUsageHelp();
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.RunHelpForInformationAboutAcceptedParameters, CommandName).Bold().Red());
                 return CreationResultStatus.InvalidParamValues;
             }
 
@@ -611,7 +629,7 @@ namespace Microsoft.TemplateEngine.Cli
                 catch (CommandParserException ex)
                 {
                     Reporter.Error.WriteLine(ex.Message.Bold().Red());
-                    ShowUsageHelp();
+                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.RunHelpForInformationAboutAcceptedParameters, CommandName).Bold().Red());
                     return CreationResultStatus.InvalidParamValues;
                 }
             }
@@ -770,7 +788,7 @@ namespace Microsoft.TemplateEngine.Cli
             return true;
         }
 
-        private void ParameterHelp(IReadOnlyDictionary<string, string> inputParams, IParameterSet allParams, string additionalInfo, HashSet<string> hiddenParams)
+        private void ShowParameterHelp(IReadOnlyDictionary<string, string> inputParams, IParameterSet allParams, string additionalInfo, HashSet<string> hiddenParams)
         {
             if (!string.IsNullOrEmpty(additionalInfo))
             {
@@ -1138,7 +1156,7 @@ namespace Microsoft.TemplateEngine.Cli
                 additionalInfo = string.Format(LocalizableStrings.InvalidParameterValues, badParams, templateInfo.Name);
             }
 
-            ParameterHelp(_app.AllTemplateParams, allParams, additionalInfo, _hostSpecificTemplateData?.HiddenParameterNames ?? new HashSet<string>());
+            ShowParameterHelp(_app.AllTemplateParams, allParams, additionalInfo, _hostSpecificTemplateData?.HiddenParameterNames ?? new HashSet<string>());
         }
 
         // Returns true if any partial matches were displayed, false otherwise

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -549,7 +549,7 @@ namespace Microsoft.TemplateEngine.Cli
 
                 ShowUsageHelp();
                 ShowTemplateHelp(UnambiguousTemplateToUse.Info);
-                return CreationResultStatus.Success;
+                return argsError ? CreationResultStatus.InvalidParamValues : CreationResultStatus.Success;
             }
             else if (argsError)
             {

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
@@ -41,7 +41,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                 return new TemplateCreationResult(message, CreationResultStatus.InvalidParamValues, template.Name);
             }
 
-            ResolveUserParameters(template, templateParams, inputParameters, out IList<string> userParamsWithInvalidValues);
+            ResolveUserParameters(template, templateParams, inputParameters, out IReadOnlyList<string> userParamsWithInvalidValues);
             if (userParamsWithInvalidValues.Any())
             {
                 string message = string.Join(", ", userParamsWithInvalidValues);
@@ -150,9 +150,10 @@ namespace Microsoft.TemplateEngine.Edge.Template
         // The template params for which there are same-named input parameters have their values set to the corresponding input parameters value.
         // input parameters that do not have corresponding template params are ignored.
         //
-        public void ResolveUserParameters(ITemplate template, IParameterSet templateParams, IReadOnlyDictionary<string, string> inputParameters, out IList<string> paramsWithInvalidValues)
+        public void ResolveUserParameters(ITemplate template, IParameterSet templateParams, IReadOnlyDictionary<string, string> inputParameters, out IReadOnlyList<string> paramsWithInvalidValues)
         {
-            paramsWithInvalidValues = new List<string>();
+            List<string> tmpParamsWithInvalidValues = new List<string>();
+            paramsWithInvalidValues = tmpParamsWithInvalidValues;
 
             foreach (KeyValuePair<string, string> inputParam in inputParameters)
             {
@@ -180,7 +181,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                         templateParams.ResolvedValues[paramFromTemplate] = template.Generator.ConvertParameterValueToType(_environmentSettings, paramFromTemplate, inputParam.Value, out bool valueResolutionError);
                         if (valueResolutionError)
                         {
-                            paramsWithInvalidValues.Add(paramFromTemplate.Name);
+                            tmpParamsWithInvalidValues.Add(paramFromTemplate.Name);
                         }
                     }
                 }


### PR DESCRIPTION
Tried this out a few ways:

Error + help specified (no template)
```
D:\Projects\templating>dotnet new3 -h -c
Invalid input switch:
  -c
Template Instantiation Commands for .NET Core CLI

Usage: dotnet new3 [arguments] [options]

Arguments:
  template  The template to instantiate.

Options:
  -l|--list         Lists templates containing the specified name. If no name is specified, lists all templates.
  -lang|--language  Specifies the language of the template to create.
  -n|--name         The name for the output being created. If no name is specified, the name of the current directory is used.
  -o|--output       Location to place the generated output.
  -h|--help         Displays help for this command.
  --type            Shows a subset of the available templates. Valid values are "project", "item" or "other".
  --force           Forces content to be generated even if it would change existing files.
```

Error + help specified (template)
```
D:\Projects\templating>dotnet new3 mvc -h -c
Invalid input switch:
  -c


Usage:  [options]

Options:
  -l|--list         Lists templates containing the specified name. If no name is specified, lists all templates.
  -lang|--language  Specifies the language of the template to create.
  -n|--name         The name for the output being created. If no name is specified, the name of the current directory is used.
  -o|--output       Location to place the generated output.
  -h|--help         Displays help for this command.
  --type            Shows a subset of the available templates. Valid values are "project", "item" or "other".
  --force           Forces content to be generated even if it would change existing files.


ASP.NET Core Web App (C#)
Author: Microsoft
Options:
  -au|--auth           The type of authentication to use
                           None          - No authentication
                           Individual    - Individual authentication
                       Default: None

  -uld|--use-local-db  Whether or not to use LocalDB instead of SQLite
                       bool - Optional
                       Default: false

  -f|--framework
                           netcoreapp1.0    - Target netcoreapp1.0
                           netcoreapp1.1    - Target netcoreapp1.1
                       Default: netcoreapp1.1
```

Error without help specified (no template)
```
D:\Projects\templating>dotnet new3 -c
Invalid input switch:
  -c
Run dotnet new3 --help for usage information.
```

Error without help specified (template)
```
D:\Projects\templating>dotnet new3 mvc -c
Invalid input switch:
  -c
Run dotnet new3 mvc --help for usage information.
```

@sayedihashimi 