### PR TITLE
Set IsPackable=false for new test projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,7 +142,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj
@@ -243,3 +243,6 @@ Microsoft.TemplateEngine.VC.db
 
 # Dotnet CLI
 .dotnet
+
+# Mac
+.DS_Store

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -4,6 +4,7 @@
       "longName": "framework"
     },
     "EnablePack": {
+      "shortName": "p",
       "longName": "enable-pack"
     }
   }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -2,6 +2,9 @@
   "symbolInfo": {
     "Framework": {
       "longName": "framework"
+    },
+    "EnablePack": {
+      "longName": "enable-pack"
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/.template.config/template.json
@@ -37,7 +37,7 @@
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
-    },
+    }
   },
   "primaryOutputs": [ { "path": "Company.TestProject1.csproj" } ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/.template.config/template.json
@@ -31,7 +31,13 @@
         }
       ],
       "defaultValue": "netcoreapp1.1"
-    }
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
+    },
   },
   "primaryOutputs": [ { "path": "Company.TestProject1.csproj" } ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -4,7 +4,8 @@
     <TargetFramework Condition="'$(Framework)' != 'netcoreapp1.1'">netcoreapp1.0</TargetFramework>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp1.1'">netcoreapp1.1</TargetFramework>
 
-    <IsPackable>false</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(Framework)' != 'netcoreapp1.1'">netcoreapp1.0</TargetFramework>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp1.1'">netcoreapp1.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/.template.config/dotnetcli.host.json
@@ -2,6 +2,10 @@
   "symbolInfo": {
     "Framework": {
       "longName": "framework"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/.template.config/template.json
@@ -31,6 +31,12 @@
         }
       ],
       "defaultValue": "netcoreapp1.1"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
     }
   },
   "primaryOutputs": [ { "path": "Company.TestProject1.fsproj" } ]

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -4,7 +4,8 @@
     <TargetFramework Condition="'$(Framework)' != 'netcoreapp1.1'">netcoreapp1.0</TargetFramework>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp1.1'">netcoreapp1.1</TargetFramework>
 
-    <IsPackable>false</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(Framework)' != 'netcoreapp1.1'">netcoreapp1.0</TargetFramework>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp1.1'">netcoreapp1.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/.template.config/dotnetcli.host.json
@@ -2,6 +2,10 @@
   "symbolInfo": {
     "Framework": {
       "longName": "framework"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/.template.config/template.json
@@ -31,6 +31,12 @@
         }
       ],
       "defaultValue": "netcoreapp1.1"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
     }
   },
   "primaryOutputs": [ { "path": "Company.TestProject1.csproj" } ]

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -4,7 +4,8 @@
     <TargetFramework Condition="'$(Framework)' != 'netcoreapp1.1'">netcoreapp1.0</TargetFramework>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp1.1'">netcoreapp1.1</TargetFramework>
 
-    <IsPackable>false</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(Framework)' != 'netcoreapp1.1'">netcoreapp1.0</TargetFramework>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp1.1'">netcoreapp1.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/.template.config/dotnetcli.host.json
@@ -2,6 +2,10 @@
   "symbolInfo": {
     "Framework": {
       "longName": "framework"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/.template.config/template.json
@@ -31,6 +31,12 @@
         }
       ],
       "defaultValue": "netcoreapp1.1"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
     }
   },
   "primaryOutputs": [ { "path": "Company.TestProject1.fsproj" } ]

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -4,7 +4,8 @@
     <TargetFramework Condition="'$(Framework)' != 'netcoreapp1.1'">netcoreapp1.0</TargetFramework>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp1.1'">netcoreapp1.1</TargetFramework>
 
-    <IsPackable>false</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(Framework)' != 'netcoreapp1.1'">netcoreapp1.0</TargetFramework>
     <TargetFramework Condition="'$(Framework)' == 'netcoreapp1.1'">netcoreapp1.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -7,6 +7,10 @@
       "longName": "runtime-framework-version",
       "shortName": "fv",
       "isHidden": "true"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/.template.config/template.json
@@ -34,6 +34,12 @@
       ],
       "replaces": "netcoreapp2.0",
       "defaultValue": "netcoreapp2.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
     }
   },
   "primaryOutputs": [ { "path": "Company.TestProject1.csproj" } ]

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -4,7 +4,8 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-beta-001507</RuntimeFrameworkVersion>
 
-    <IsPackable>false</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-beta-001507</RuntimeFrameworkVersion>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
@@ -7,6 +7,10 @@
       "longName": "runtime-framework-version",
       "shortName": "fv",
       "isHidden": "true"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/.template.config/template.json
@@ -34,6 +34,12 @@
       ],
       "replaces": "netcoreapp2.0",
       "defaultValue": "netcoreapp2.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
     }
   },
   "primaryOutputs": [ { "path": "Company.TestProject1.fsproj" } ]

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -4,7 +4,8 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-beta-001507</RuntimeFrameworkVersion>
 
-    <IsPackable>false</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-beta-001507</RuntimeFrameworkVersion>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/.template.config/dotnetcli.host.json
@@ -7,6 +7,10 @@
       "longName": "runtime-framework-version",
       "shortName": "fv",
       "isHidden": "true"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/.template.config/template.json
@@ -34,6 +34,12 @@
       ],
       "replaces": "netcoreapp2.0",
       "defaultValue": "netcoreapp2.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
     }
   },
   "primaryOutputs": [ { "path": "Company.TestProject1.csproj" } ]

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -4,7 +4,8 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-beta-001507</RuntimeFrameworkVersion>
 
-    <IsPackable>false</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-beta-001507</RuntimeFrameworkVersion>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/.template.config/dotnetcli.host.json
@@ -7,6 +7,10 @@
       "longName": "runtime-framework-version",
       "shortName": "fv",
       "isHidden": "true"
+    },
+    "EnablePack": {
+      "shortName": "p",
+      "longName": "enable-pack"
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/.template.config/template.json
@@ -34,6 +34,12 @@
       ],
       "replaces": "netcoreapp2.0",
       "defaultValue": "netcoreapp2.0"
+    },
+    "EnablePack": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to enable packaging (via (\"dotnet pack\") for the project."
     }
   },
   "primaryOutputs": [ { "path": "Company.TestProject1.fsproj" } ]

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -4,7 +4,8 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-beta-001507</RuntimeFrameworkVersion>
 
-    <IsPackable>false</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
+    <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-beta-001507</RuntimeFrameworkVersion>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi :)

I'm opening this PR so there's something a little more concrete to discuss for dotnet/templating#376.

To summarise the discussion so far:

* The rationale for this is that creating NuGet packages from tests is probably not the more-common use case and so by default these project should not participate when "dotnet pack" is run at the solution level.
* Some users _do_ want to create packages for their tests, and this change doesn't prevent them from doing so if they explicitly opt into it.

Open questions:

- [ ] Should this be configurable via a template parameter (e.g. `--packable` or `--enable-packaging`)?
- [ ] Er, sorry, GitHub's saying that every line in those files has changed, but as far as I can tell that's not the case (I only changed the `IsPackable` line). I'm on a Mac, so perhaps it's a CR/LF issue? If so, could someone using Windows let me know and I'll fiddle with Git's autocrlf and try again.