### PR TITLE
Add Process.Start post-action, update localizable strings, re-add no-emit flavor of flags

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -11,7 +11,8 @@
 namespace Microsoft.TemplateEngine.Cli {
     using System;
     using System.Reflection;
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -174,6 +175,34 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string CommandDescription {
             get {
                 return ResourceManager.GetString("CommandDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Command failed..
+        /// </summary>
+        internal static string CommandFailed {
+            get {
+                return ResourceManager.GetString("CommandFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output from command:
+        ///{0}.
+        /// </summary>
+        internal static string CommandOutput {
+            get {
+                return ResourceManager.GetString("CommandOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Command succeeded..
+        /// </summary>
+        internal static string CommandSucceeded {
+            get {
+                return ResourceManager.GetString("CommandSucceeded", resourceCulture);
             }
         }
         
@@ -532,6 +561,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No Primary Outputs to restore..
+        /// </summary>
+        internal static string NoPrimaryOutputsToRestore {
+            get {
+                return ResourceManager.GetString("NoPrimaryOutputsToRestore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No templates matched the input template name: [{0}]..
         /// </summary>
         internal static string NoTemplatesMatchName {
@@ -649,11 +687,47 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Restore failed..
+        /// </summary>
+        internal static string RestoreFailed {
+            get {
+                return ResourceManager.GetString("RestoreFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Restore succeeded..
+        /// </summary>
+        internal static string RestoreSucceeded {
+            get {
+                return ResourceManager.GetString("RestoreSucceeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Run dotnet {0} --help for usage information..
         /// </summary>
         internal static string RunHelpForInformationAboutAcceptedParameters {
             get {
                 return ResourceManager.GetString("RunHelpForInformationAboutAcceptedParameters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Running command &apos;{0}&apos;....
+        /// </summary>
+        internal static string RunningCommand {
+            get {
+                return ResourceManager.GetString("RunningCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Running &apos;dotnet restore&apos; on {0}....
+        /// </summary>
+        internal static string RunningDotnetRestoreOn {
+            get {
+                return ResourceManager.GetString("RunningDotnetRestoreOn", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -363,4 +363,29 @@
   <data name="WillCreateTemplate" xml:space="preserve">
     <value>About to create: </value>
   </data>
+  <data name="NoPrimaryOutputsToRestore" xml:space="preserve">
+    <value>No Primary Outputs to restore.</value>
+  </data>
+  <data name="CommandFailed" xml:space="preserve">
+    <value>Command failed.</value>
+  </data>
+  <data name="CommandOutput" xml:space="preserve">
+    <value>Output from command:
+{0}</value>
+  </data>
+  <data name="CommandSucceeded" xml:space="preserve">
+    <value>Command succeeded.</value>
+  </data>
+  <data name="RestoreFailed" xml:space="preserve">
+    <value>Restore failed.</value>
+  </data>
+  <data name="RestoreSucceeded" xml:space="preserve">
+    <value>Restore succeeded.</value>
+  </data>
+  <data name="RunningDotnetRestoreOn" xml:space="preserve">
+    <value>Running 'dotnet restore' on {0}...</value>
+  </data>
+  <data name="RunningCommand" xml:space="preserve">
+    <value>Running command '{0}'...</value>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -406,7 +406,7 @@ namespace Microsoft.TemplateEngine.Cli
                 return;
             }
 
-            PostActionDispatcher postActionDispatcher = new PostActionDispatcher(creationResult, EnvironmentSettings.SettingsLoader.Components);
+            PostActionDispatcher postActionDispatcher = new PostActionDispatcher(EnvironmentSettings, creationResult);
             postActionDispatcher.Process();
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
@@ -7,13 +7,13 @@ namespace Microsoft.TemplateEngine.Cli
 {
     public class PostActionDispatcher
     {
-        private TemplateCreationResult _creationResult;
-        private IComponentManager _components;
+        private readonly TemplateCreationResult _creationResult;
+        private readonly IEngineEnvironmentSettings _settings;
 
-        public PostActionDispatcher(TemplateCreationResult creationResult, IComponentManager components)
+        public PostActionDispatcher(IEngineEnvironmentSettings settings, TemplateCreationResult creationResult)
         {
+            _settings = settings;
             _creationResult = creationResult;
-            _components = components;
         }
 
         public void Process()
@@ -28,12 +28,12 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 IPostActionProcessor actionProcessor = null;
 
-                if (action.ActionId == null || !_components.TryGetComponent(action.ActionId, out actionProcessor))
+                if (action.ActionId == null || !_settings.SettingsLoader.Components.TryGetComponent(action.ActionId, out actionProcessor) || actionProcessor == null)
                 {
                     actionProcessor = new InstructionDisplayPostActionProcessor();
                 }
 
-                bool result = actionProcessor.Process(action, _creationResult.ResultInfo, _creationResult.OutputBaseDirectory);
+                bool result = actionProcessor.Process(_settings, action, _creationResult.ResultInfo, _creationResult.OutputBaseDirectory);
 
                 if (!result && !action.ContinueOnError)
                 {   

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/DotnetRestorePostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/DotnetRestorePostActionProcessor.cs
@@ -15,11 +15,11 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
         {
         }
 
-        public bool Process(IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath)
+        public bool Process(IEngineEnvironmentSettings settings, IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath)
         {
             if (templateCreationResult.PrimaryOutputs.Count == 0)
             {
-                Reporter.Output.WriteLine("No Primary Outputs to restore");
+                settings.Host.LogMessage(LocalizableStrings.NoPrimaryOutputsToRestore);
                 return true;
             }
 
@@ -32,16 +32,19 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
                 restoreCommand.CaptureStdOut();
                 restoreCommand.CaptureStdErr();
 
-                Reporter.Output.WriteLine($"Running 'dotnet restore' on {pathToRestore}");
+                settings.Host.LogMessage(string.Format(LocalizableStrings.RunningDotnetRestoreOn, pathToRestore));
                 CommandResult commandResult = restoreCommand.Execute();
-                Reporter.Output.WriteLine(commandResult.StdOut);
 
                 if (commandResult.ExitCode != 0)
                 {
-                    Reporter.Output.WriteLine("restore failed:");
-                    Reporter.Output.WriteLine($"StdErr: {commandResult.StdErr}");
-                    Reporter.Output.WriteLine();
+                    settings.Host.LogMessage(LocalizableStrings.RestoreFailed);
+                    settings.Host.LogMessage(string.Format(LocalizableStrings.CommandOutput, commandResult.StdErr));
+                    settings.Host.LogMessage(string.Empty);
                     allSucceeded = false;
+                }
+                else
+                {
+                    settings.Host.LogMessage(LocalizableStrings.RestoreSucceeded);
                 }
             }
 

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/IPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/IPostActionProcessor.cs
@@ -4,6 +4,6 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 {
     public interface IPostActionProcessor : IIdentifiedComponent
     {
-        bool Process(IPostAction action, ICreationResult templateCreationResult, string outputBasePath);
+        bool Process(IEngineEnvironmentSettings settings, IPostAction action, ICreationResult templateCreationResult, string outputBasePath);
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/InstructionDisplayPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/InstructionDisplayPostActionProcessor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
         {
         }
 
-        public bool Process(IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath)
+        public bool Process(IEngineEnvironmentSettings settings, IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath)
         {
             Reporter.Output.WriteLine(actionConfig.Description);
             Reporter.Output.WriteLine(actionConfig.ManualInstructions);

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/ProcessStartPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/ProcessStartPostActionProcessor.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
+{
+    public class ProcessStartPostActionProcessor : IPostActionProcessor
+    {
+        private static readonly Guid ActionProcessorId = new Guid("3A7C4B45-1F5D-4A30-959A-51B88E82B5D2");
+
+        public Guid Id => ActionProcessorId;
+
+        public bool Process(IEngineEnvironmentSettings settings, IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath)
+        {
+            bool allSucceeded = true;
+
+            settings.Host.LogMessage(string.Format(LocalizableStrings.RunningCommand, actionConfig.Args["executable"] + " " + actionConfig.Args["args"]));
+            System.Diagnostics.Process commandResult = System.Diagnostics.Process.Start(new ProcessStartInfo
+            {
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = false,
+                WorkingDirectory = outputBasePath,
+                FileName = actionConfig.Args["executable"],
+                Arguments = actionConfig.Args["args"]
+            });
+
+            commandResult.WaitForExit();
+
+            if (commandResult.ExitCode != 0)
+            {
+                string error = commandResult.StandardError.ReadToEnd();
+                settings.Host.LogMessage(LocalizableStrings.CommandFailed);
+                settings.Host.LogMessage(string.Format(LocalizableStrings.CommandOutput, error));
+                settings.Host.LogMessage(string.Empty);
+                allSucceeded = false;
+            }
+            else
+            {
+                settings.Host.LogMessage(LocalizableStrings.CommandSucceeded);
+            }
+
+            return allSucceeded;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/FlagsConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/FlagsConfig.cs
@@ -33,6 +33,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
             yield return new SetFlag(flag, on.TokenConfig(), off.TokenConfig(), onNoEmit.TokenConfig(), offNoEmit.TokenConfig(), id, @default);
         }
 
+        private static readonly string NoEmitSuffix = ":noEmit";
         private static readonly string FlagConditionalSuffix = ":cnd";
         private static readonly string FlagReplacementSuffix = ":replacements";
         private static readonly string FlagExpandVariablesSuffix = ":vars";
@@ -45,23 +46,23 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
             List<IOperationProvider> flagOperations = new List<IOperationProvider>();
             string on = string.Format("{0}+{1}", switchPrefix, FlagConditionalSuffix);
             string off = string.Format("{0}-{1}", switchPrefix, FlagConditionalSuffix);
-            flagOperations.Add(new SetFlag(Conditional.OperationName, on.TokenConfig(), off.TokenConfig(), string.Empty.TokenConfig(), string.Empty.TokenConfig(), null));
+            flagOperations.Add(new SetFlag(Conditional.OperationName, on.TokenConfig(), off.TokenConfig(), (on + NoEmitSuffix).TokenConfig(), (off + NoEmitSuffix).TokenConfig(), null));
 
             on = string.Format("{0}+{1}", switchPrefix, FlagReplacementSuffix);
             off = string.Format("{0}-{1}", switchPrefix, FlagReplacementSuffix);
-            flagOperations.Add(new SetFlag(Replacement.OperationName, on.TokenConfig(), off.TokenConfig(), string.Empty.TokenConfig(), string.Empty.TokenConfig(), null));
+            flagOperations.Add(new SetFlag(Replacement.OperationName, on.TokenConfig(), off.TokenConfig(), (on + NoEmitSuffix).TokenConfig(), (off + NoEmitSuffix).TokenConfig(), null));
 
             on = string.Format("{0}+{1}", switchPrefix, FlagExpandVariablesSuffix);
             off = string.Format("{0}-{1}", switchPrefix, FlagExpandVariablesSuffix);
-            flagOperations.Add(new SetFlag(ExpandVariables.OperationName, on.TokenConfig(), off.TokenConfig(), string.Empty.TokenConfig(), string.Empty.TokenConfig(), null));
+            flagOperations.Add(new SetFlag(ExpandVariables.OperationName, on.TokenConfig(), off.TokenConfig(), (on + NoEmitSuffix).TokenConfig(), (off + NoEmitSuffix).TokenConfig(), null));
 
             on = string.Format("{0}+{1}", switchPrefix, FlagIncludeSuffix);
             off = string.Format("{0}-{1}", switchPrefix, FlagIncludeSuffix);
-            flagOperations.Add(new SetFlag(Include.OperationName, on.TokenConfig(), off.TokenConfig(), string.Empty.TokenConfig(), string.Empty.TokenConfig(), null));
+            flagOperations.Add(new SetFlag(Include.OperationName, on.TokenConfig(), off.TokenConfig(), (on + NoEmitSuffix).TokenConfig(), (off + NoEmitSuffix).TokenConfig(), null));
 
             // no off for the flag-flag
             on = string.Format("{0}+{1}", switchPrefix, FlagFlagsSuffix);
-            flagOperations.Add(new SetFlag(SetFlag.OperationName, on.TokenConfig(), off.TokenConfig(), string.Empty.TokenConfig(), string.Empty.TokenConfig(), null));
+            flagOperations.Add(new SetFlag(SetFlag.OperationName, on.TokenConfig(), string.Empty.TokenConfig(), (on + NoEmitSuffix).TokenConfig(), string.Empty.TokenConfig(), null));
 
             return flagOperations;
         }


### PR DESCRIPTION
Add Post-action for doing Process.Start, add missed strings to localizable strings, fix missed 'no-emit' flavor flags in default configs, update post-action interface to take the environment settings to promote host specialized logging/error reporting