### PR TITLE
Remove all UTF-8 BOMs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ indent_size = 4
 tab_width = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
+charset = utf-8
 
 [**/*.json]
 indent_size = 2


### PR DESCRIPTION
Adds `charset = utf-8` to .editorconfig

Fixes #445 