### PR TITLE
Add diagnostic message logging

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs
@@ -31,6 +31,8 @@ namespace Microsoft.TemplateEngine.Abstractions
 
         void OnSymbolUsed(string symbol, object value);
 
+        void LogDiagnosticMessage(string message, string category, params string[] details);
+
         void OnTimingCompleted(string label, TimeSpan timing);
 
         bool TryGetHostParamDefault(string paramName, out string value);

--- a/src/Microsoft.TemplateEngine.Cli/ExtendedTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Cli/ExtendedTemplateEngineHost.cs
@@ -115,6 +115,11 @@ namespace Microsoft.TemplateEngine.Cli
             return true;
         }
 
+        public void LogDiagnosticMessage(string message, string category, params string[] details)
+        {
+            _baseHost.LogDiagnosticMessage(message, category, details);
+        }
+
         private bool GlobalJsonFileExistsInPath
         {
             get

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ReplacementConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ReplacementConfig.cs
@@ -25,7 +25,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
             }
             else
             {
-                environmentSettings.Host.LogMessage($"Couldn't find a parameter called {tokens.VariableName}");
+                environmentSettings.Host.LogDiagnosticMessage($"Couldn't find a parameter called {tokens.VariableName}", "Initialization", "ReplacementConfig.Setup");
                 return null;
             }
         }

--- a/src/Microsoft.TemplateEngine.Utils/DefaultTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Utils/DefaultTemplateEngineHost.cs
@@ -116,5 +116,9 @@ namespace Microsoft.TemplateEngine.Utils
         {
             return true;
         }
+
+        public void LogDiagnosticMessage(string message, string category, params string[] details)
+        {
+        }
     }
 }

--- a/test/Microsoft.TemplateEngine.TestHelper/TestHost.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/TestHost.cs
@@ -101,5 +101,14 @@ namespace Microsoft.TemplateEngine.TestHelper
         {
             return true;
         }
+
+        public void LogDiagnosticMessage(string message, string category, params string[] details)
+        {
+            Console.WriteLine("Diag: " + message + " (" + category + ")");
+            foreach (string detail in details)
+            {
+                Console.WriteLine("      " + detail);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix message logging when parameters used by replacements are not valid but are being collected for usage help

Fixes #539