### PR TITLE
Template usage examples. Some bug fixes

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-CSharp/.template.config/dotnetcli.host.json
@@ -10,5 +10,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp1.0"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-CSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp1.0"
+    "--framework netcoreapp1.1"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ConsoleApplication-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ConsoleApplication-CSharp/.template.config/dotnetcli.host.json
@@ -10,5 +10,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp1.0"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ConsoleApplication-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ConsoleApplication-CSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp1.0"
+    "--framework netcoreapp1.1"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ConsoleApplication-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ConsoleApplication-FSharp/.template.config/dotnetcli.host.json
@@ -10,5 +10,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp1.0"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ConsoleApplication-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ConsoleApplication-FSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp1.0"
+    "--framework netcoreapp1.1"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-CSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,6 @@
     }
   },
   "UsageExamples": [
-    "--framework netcoreapp2.0 --auth Individual"
+    "--framework netcoreapp2.0"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-CSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp2.0 --skip-restore"
+    "--framework netcoreapp2.0 --auth Individual"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-CSharp/.template.config/dotnetcli.host.json
@@ -10,5 +10,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp2.0 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-FSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,6 @@
     }
   },
   "UsageExamples": [
-    "--framework netcoreapp2.0 --auth Individual"
+    "--framework netcoreapp2.0"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-FSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp2.0 --skip-restore"
+    "--framework netcoreapp2.0 --auth Individual"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-FSharp/.template.config/dotnetcli.host.json
@@ -10,5 +10,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp2.0 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ConsoleApplication-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ConsoleApplication-CSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp2.0 --skip-restore"
+    "--framework netcoreapp2.0"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ConsoleApplication-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ConsoleApplication-CSharp/.template.config/dotnetcli.host.json
@@ -10,5 +10,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp2.0 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ConsoleApplication-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ConsoleApplication-FSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp2.0 --skip-restore"
+    "--framework netcoreapp2.0"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ConsoleApplication-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ConsoleApplication-FSharp/.template.config/dotnetcli.host.json
@@ -10,5 +10,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp2.0 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -14,5 +14,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp1.0"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -16,6 +16,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp1.0"
+    "--framework netcoreapp1.1"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/.template.config/dotnetcli.host.json
@@ -14,5 +14,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp1.0"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/.template.config/dotnetcli.host.json
@@ -16,6 +16,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp1.0"
+    "--framework netcoreapp1.1"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/.template.config/dotnetcli.host.json
@@ -14,5 +14,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp1.0"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/.template.config/dotnetcli.host.json
@@ -16,6 +16,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp1.0"
+    "--framework netcoreapp1.1"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/.template.config/dotnetcli.host.json
@@ -14,5 +14,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp1.0"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/.template.config/dotnetcli.host.json
@@ -16,6 +16,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp1.0"
+    "--framework netcoreapp1.1"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -16,6 +16,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp2.0 --skip-restore"
+    "--framework netcoreapp2.0"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/.template.config/dotnetcli.host.json
@@ -14,5 +14,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp2.0 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
@@ -16,6 +16,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp2.0 --skip-restore"
+    "--framework netcoreapp2.0"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/.template.config/dotnetcli.host.json
@@ -14,5 +14,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp2.0 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/.template.config/dotnetcli.host.json
@@ -16,6 +16,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp2.0 --skip-restore"
+    "--framework netcoreapp2.0"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/.template.config/dotnetcli.host.json
@@ -14,5 +14,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp2.0 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/.template.config/dotnetcli.host.json
@@ -16,6 +16,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp2.0 --skip-restore"
+    "--framework netcoreapp2.0"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/.template.config/dotnetcli.host.json
@@ -14,5 +14,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp2.0 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
@@ -15,6 +15,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp1.1 --skip-restore"
+    "--framework netcoreapp1.1"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
@@ -13,5 +13,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp1.1 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -42,6 +42,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp1.1 --skip-restore"
+    "--framework netcoreapp1.1 --auth Individual"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -40,5 +40,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp1.1 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp1.1 --skip-restore"
+    "--framework netcoreapp1.1"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
@@ -10,5 +10,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp1.1 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/WebApi-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/WebApi-CSharp/.template.config/dotnetcli.host.json
@@ -37,5 +37,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp1.1 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/WebApi-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/WebApi-CSharp/.template.config/dotnetcli.host.json
@@ -39,6 +39,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp1.1 --skip-restore"
+    "--framework netcoreapp1.1"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
@@ -13,5 +13,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp2.0 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-CSharp/.template.config/dotnetcli.host.json
@@ -15,6 +15,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp2.0 --skip-restore"
+    "--framework netcoreapp2.0"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -40,5 +40,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp2.0 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -42,6 +42,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp2.0 --skip-restore"
+    "--framework netcoreapp2.0 --auth Individual"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
@@ -12,6 +12,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp2.0 --skip-restore"
+    "--framework netcoreapp2.0"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
@@ -10,5 +10,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp2.0 --skip-restore"
+  ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-CSharp/.template.config/dotnetcli.host.json
@@ -39,6 +39,6 @@
     }
   },
   "UsageExamples": [
-    "-f netcoreapp2.0 --skip-restore"
+    "--framework netcoreapp2.0"
   ]
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-CSharp/.template.config/dotnetcli.host.json
@@ -37,5 +37,8 @@
       "longName": "skip-restore",
       "shortName": ""
     }
-  }
+  },
+  "UsageExamples": [
+    "-f netcoreapp2.0 --skip-restore"
+  ]
 }


### PR DESCRIPTION
Bug fixes for:
- Malformed host file dumped a call stack
- Invalid input params displayed multiple times for merged template detailed help (same group identity)
- Input params displayed as invalid if they were invalid for any template in the group having the help merged. Now they must be invalid for all templates in the help merge group.