### PR TITLE
New CommandLine Parser version that preserves the number of dashes in the help display

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="0.1.0-alpha-138" />
+    <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="0.1.0-alpha-140" />
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" Version="1.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>


### PR DESCRIPTION
E.g.: so '-lang' isn't displayed as '--lang'