### PR TITLE
Aliases now refer to part of a command string instead of a template name

### DIFF
--- a/Microsoft.TemplateEngine.sln
+++ b/Microsoft.TemplateEngine.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26214.0
+VisualStudioVersion = 15.0.26312.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7DAC892E-ADAE-4CEB-8A0C-EDC452A5826A}"
 EndProject

--- a/src/Microsoft.TemplateEngine.Cli/AliasSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/AliasSupport.cs
@@ -1,0 +1,97 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.Edge.Template;
+
+namespace Microsoft.TemplateEngine.Cli
+{
+    public static class AliasSupport
+    {
+        public static AliasExpansionStatus TryExpandAliases(INewCommandInput commandInput, AliasRegistry aliasRegistry)
+        {
+            List<string> inputTokens = commandInput.Tokens.ToList();
+            inputTokens.RemoveAt(0);    // remove the command name
+
+            if (aliasRegistry.TryExpandCommandAliases(inputTokens, out IReadOnlyList<string> expandedTokens))
+            {
+                if (!expandedTokens.SequenceEqual(inputTokens))
+                {
+                    commandInput.ResetArgs(expandedTokens.ToArray());
+                    return AliasExpansionStatus.Expanded;
+                }
+
+                return AliasExpansionStatus.NoChange;
+            }
+
+            return AliasExpansionStatus.ExpansionError;
+        }
+
+        public static CreationResultStatus ManipulateAliasValue(INewCommandInput commandInput, AliasRegistry aliasRegistry)
+        {
+            List<string> inputTokens = commandInput.Tokens.ToList();
+            inputTokens.RemoveAt(0);    // remove the command name
+            AliasManipulationResult result = aliasRegistry.TryCreateOrRemoveAlias(inputTokens);
+            CreationResultStatus returnStatus = CreationResultStatus.OperationNotSpecified;
+
+            switch (result.Status)
+            {
+                case AliasManipulationStatus.Created:
+                    Reporter.Output.WriteLine(string.Format("Successfully created alias named '{0}' with value '{1}'", result.AliasName, result.AliasValue));
+                    returnStatus = CreationResultStatus.Success;
+                    break;
+                case AliasManipulationStatus.Removed:
+                    Reporter.Output.WriteLine(string.Format("Successfully removed alias named '{0}' whose value was '{1}'", result.AliasName, result.AliasValue));
+                    returnStatus = CreationResultStatus.Success;
+                    break;
+                case AliasManipulationStatus.Updated:
+                    Reporter.Output.WriteLine(string.Format("Successfully updated alias named '{0}' to value '{1}'", result.AliasName, result.AliasValue));
+                    returnStatus = CreationResultStatus.Success;
+                    break;
+                case AliasManipulationStatus.WouldCreateCycle:
+                    Reporter.Output.WriteLine(string.Format("Alias not created. It would have created an alias cycle, resulting in infinite expansion."));
+                    returnStatus = CreationResultStatus.CreateFailed;
+                    break;
+                case AliasManipulationStatus.InvalidInput:
+                    Reporter.Output.WriteLine(string.Format("Alias not created. The input was invalid"));
+                    returnStatus = CreationResultStatus.InvalidParamValues;
+                    break;
+            }
+
+            return returnStatus;
+        }
+
+        public static CreationResultStatus DisplayAliasValues(IEngineEnvironmentSettings environment, INewCommandInput commandInput, AliasRegistry aliasRegistry)
+        {
+            IReadOnlyDictionary<string, string> aliasesToShow;
+
+            if (!string.IsNullOrEmpty(commandInput.ShowAliasesAliasName))
+            {
+                if (aliasRegistry.AllAliases.TryGetValue(commandInput.ShowAliasesAliasName, out string aliasValue))
+                {
+                    aliasesToShow = new Dictionary<string, string>()
+                    {
+                        { commandInput.ShowAliasesAliasName, aliasValue }
+                    };
+                }
+                else
+                {
+                    Reporter.Output.WriteLine(string.Format("Unknown alias name '{0}'\nRun 'dotnet --show-aliases' with no args to show all aliases.", commandInput.ShowAliasesAliasName));
+                    return CreationResultStatus.InvalidParamValues;
+                }
+            }
+            else
+            {
+                aliasesToShow = aliasRegistry.AllAliases;
+                Reporter.Output.WriteLine("All Aliases:");
+            }
+
+            HelpFormatter<KeyValuePair<string, string>> formatter = new HelpFormatter<KeyValuePair<string, string>>(environment, aliasesToShow, 2, '-', false)
+                            .DefineColumn(t => t.Key, LocalizableStrings.AliasName)
+                            .DefineColumn(t => t.Value, LocalizableStrings.AliasValue);
+            Reporter.Output.WriteLine(formatter.Layout());
+            return CreationResultStatus.Success;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -137,7 +137,11 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             {
                 return new[]
                 {
+                    //Create.Option("-a|--alias", LocalizableStrings.AliasHelp, Accept.ExactlyOneArgument()),
+                    //Create.Option("--show-alias", LocalizableStrings.ShowAliasesHelp, Accept.ZeroOrOneArgument()),
+                    // When these are un-hidden, be sure to set their help values like above.
                     Create.Option("-a|--alias", string.Empty, Accept.ExactlyOneArgument()),
+                    Create.Option("--show-alias", string.Empty, Accept.ZeroOrOneArgument()),
                     Create.Option("-x|--extra-args", string.Empty, Accept.OneOrMoreArguments()),
                     Create.Option("--locale", string.Empty, Accept.ExactlyOneArgument()),
                     Create.Option("--quiet", string.Empty, Accept.NoArguments()),

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
@@ -10,7 +10,13 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
     {
         string TemplateName { get; }
 
+        IReadOnlyList<string> Tokens { get; }
+
         string Alias { get; }
+
+        bool ShowAliasesSpecified { get; }
+
+        string ShowAliasesAliasName { get; }
 
         IList<string> ExtraArgsFileNames { get; }
 
@@ -69,5 +75,9 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         void OnExecute(Func<Task<CreationResultStatus>> invoke);
 
         bool HasParseError { get; }
+
+        void ResetArgs(params string[] args);
+
+        bool ExpandedExtraArgsFiles { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -163,11 +163,30 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specified alias &quot;{0}&quot; already exists. Please specify a different alias..
+        ///   Looks up a localized string similar to Alias names cannot begin with dashes (&apos;-&apos;)..
         /// </summary>
-        public static string AliasAlreadyExists {
+        public static string AliasCannotBeginWithDashes {
             get {
-                return ResourceManager.GetString("AliasAlreadyExists", resourceCulture);
+                return ResourceManager.GetString("AliasCannotBeginWithDashes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Alias &apos;{0}&apos; is a template short name, and therefore cannot be aliased..
+        /// </summary>
+        public static string AliasCannotBeShortName {
+            get {
+                return ResourceManager.GetString("AliasCannotBeShortName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to After expanding aliases, the command is:
+        ///    dotnet {0}.
+        /// </summary>
+        public static string AliasCommandAfterExpansion {
+            get {
+                return ResourceManager.GetString("AliasCommandAfterExpansion", resourceCulture);
             }
         }
         
@@ -177,6 +196,51 @@ namespace Microsoft.TemplateEngine.Cli {
         public static string AliasCreated {
             get {
                 return ResourceManager.GetString("AliasCreated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Command is invalid after expanding aliases..
+        /// </summary>
+        public static string AliasExpandedCommandParseError {
+            get {
+                return ResourceManager.GetString("AliasExpandedCommandParseError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error expanding aliases on input params..
+        /// </summary>
+        public static string AliasExpansionError {
+            get {
+                return ResourceManager.GetString("AliasExpansionError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Creates, updates, or deletes the named alias. The alias value is the remainder of the command. If extra args files are specified, the alias value includes their expansions..
+        /// </summary>
+        public static string AliasHelp {
+            get {
+                return ResourceManager.GetString("AliasHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Alias Name.
+        /// </summary>
+        public static string AliasName {
+            get {
+                return ResourceManager.GetString("AliasName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Alias Value.
+        /// </summary>
+        public static string AliasValue {
+            get {
+                return ResourceManager.GetString("AliasValue", resourceCulture);
             }
         }
         
@@ -440,6 +504,16 @@ namespace Microsoft.TemplateEngine.Cli {
         public static string DisplaysHelp {
             get {
                 return ResourceManager.GetString("DisplaysHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to After expanding the extra args files, the command is:
+        ///    dotnet {0}.
+        /// </summary>
+        public static string ExtraArgsCommandAfterExpansion {
+            get {
+                return ResourceManager.GetString("ExtraArgsCommandAfterExpansion", resourceCulture);
             }
         }
         
@@ -947,6 +1021,15 @@ namespace Microsoft.TemplateEngine.Cli {
         public static string ShortName {
             get {
                 return ResourceManager.GetString("ShortName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Displays the value of the named alias, or all aliases if no name is specified..
+        /// </summary>
+        public static string ShowAliasesHelp {
+            get {
+                return ResourceManager.GetString("ShowAliasesHelp", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -163,15 +163,6 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Alias names cannot begin with dashes (&apos;-&apos;)..
-        /// </summary>
-        public static string AliasCannotBeginWithDashes {
-            get {
-                return ResourceManager.GetString("AliasCannotBeginWithDashes", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Alias &apos;{0}&apos; is a template short name, and therefore cannot be aliased..
         /// </summary>
         public static string AliasCannotBeShortName {
@@ -191,11 +182,20 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Alias creation successful..
+        ///   Looks up a localized string similar to Successfully created alias named &apos;{0}&apos; with value &apos;{1}&apos;.
         /// </summary>
         public static string AliasCreated {
             get {
                 return ResourceManager.GetString("AliasCreated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Alias not created. It would have created an alias cycle, resulting in infinite expansion..
+        /// </summary>
+        public static string AliasCycleError {
+            get {
+                return ResourceManager.GetString("AliasCycleError", resourceCulture);
             }
         }
         
@@ -236,11 +236,84 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Alias names can only contain letters, numbers, underscores, and periods..
+        /// </summary>
+        public static string AliasNameContainsInvalidCharacters {
+            get {
+                return ResourceManager.GetString("AliasNameContainsInvalidCharacters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Alias not created. The input was invalid..
+        /// </summary>
+        public static string AliasNotCreatedInvalidInput {
+            get {
+                return ResourceManager.GetString("AliasNotCreatedInvalidInput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully removed alias named &apos;{0}&apos; whose value was &apos;{1}&apos;..
+        /// </summary>
+        public static string AliasRemoved {
+            get {
+                return ResourceManager.GetString("AliasRemoved", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to remove alias &apos;{0}&apos;. It did not exist..
+        /// </summary>
+        public static string AliasRemoveNonExistentFailed {
+            get {
+                return ResourceManager.GetString("AliasRemoveNonExistentFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All Aliases:.
+        /// </summary>
+        public static string AliasShowAllAliasesHeader {
+            get {
+                return ResourceManager.GetString("AliasShowAllAliasesHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unknown alias name &apos;{0}&apos;.
+        ///Run &apos;dotnet --show-aliases&apos; with no args to show all aliases..
+        /// </summary>
+        public static string AliasShowErrorUnknownAlias {
+            get {
+                return ResourceManager.GetString("AliasShowErrorUnknownAlias", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Successfully updated alias named &apos;{0}&apos; to value &apos;{1}&apos;..
+        /// </summary>
+        public static string AliasUpdated {
+            get {
+                return ResourceManager.GetString("AliasUpdated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Alias Value.
         /// </summary>
         public static string AliasValue {
             get {
                 return ResourceManager.GetString("AliasValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to First argument of an alias value must be a letter or digit..
+        /// </summary>
+        public static string AliasValueFirstArgError {
+            get {
+                return ResourceManager.GetString("AliasValueFirstArgError", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -121,7 +121,7 @@
     <value>Alias</value>
   </data>
   <data name="AliasCreated" xml:space="preserve">
-    <value>Alias creation successful.</value>
+    <value>Successfully created alias named '{0}' with value '{1}'</value>
   </data>
   <data name="AmbiguousInputTemplateName" xml:space="preserve">
     <value>Unable to determine the desired template from the input template name: {0}.</value>
@@ -478,8 +478,8 @@
   <data name="ShowAliasesHelp" xml:space="preserve">
     <value>Displays the value of the named alias, or all aliases if no name is specified.</value>
   </data>
-  <data name="AliasCannotBeginWithDashes" xml:space="preserve">
-    <value>Alias names cannot begin with dashes ('-').</value>
+  <data name="AliasNameContainsInvalidCharacters" xml:space="preserve">
+    <value>Alias names can only contain letters, numbers, underscores, and periods.</value>
   </data>
   <data name="AliasCannotBeShortName" xml:space="preserve">
     <value>Alias '{0}' is a template short name, and therefore cannot be aliased.</value>
@@ -497,5 +497,30 @@
   <data name="ExtraArgsCommandAfterExpansion" xml:space="preserve">
     <value>After expanding the extra args files, the command is:
     dotnet {0}</value>
+  </data>
+  <data name="AliasCycleError" xml:space="preserve">
+    <value>Alias not created. It would have created an alias cycle, resulting in infinite expansion.</value>
+  </data>
+  <data name="AliasNotCreatedInvalidInput" xml:space="preserve">
+    <value>Alias not created. The input was invalid.</value>
+  </data>
+  <data name="AliasRemoved" xml:space="preserve">
+    <value>Successfully removed alias named '{0}' whose value was '{1}'.</value>
+  </data>
+  <data name="AliasShowAllAliasesHeader" xml:space="preserve">
+    <value>All Aliases:</value>
+  </data>
+  <data name="AliasShowErrorUnknownAlias" xml:space="preserve">
+    <value>Unknown alias name '{0}'.
+Run 'dotnet --show-aliases' with no args to show all aliases.</value>
+  </data>
+  <data name="AliasUpdated" xml:space="preserve">
+    <value>Successfully updated alias named '{0}' to value '{1}'.</value>
+  </data>
+  <data name="AliasValueFirstArgError" xml:space="preserve">
+    <value>First argument of an alias value must be a letter or digit.</value>
+  </data>
+  <data name="AliasRemoveNonExistentFailed" xml:space="preserve">
+    <value>Unable to remove alias '{0}'. It did not exist.</value>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -120,9 +120,6 @@
   <data name="Alias" xml:space="preserve">
     <value>Alias</value>
   </data>
-  <data name="AliasAlreadyExists" xml:space="preserve">
-    <value>Specified alias "{0}" already exists. Please specify a different alias.</value>
-  </data>
   <data name="AliasCreated" xml:space="preserve">
     <value>Alias creation successful.</value>
   </data>
@@ -468,5 +465,37 @@
   </data>
   <data name="AddRefPostActionProjFileListHeader" xml:space="preserve">
     <value>Project files found:</value>
+  </data>
+  <data name="AliasHelp" xml:space="preserve">
+    <value>Creates, updates, or deletes the named alias. The alias value is the remainder of the command. If extra args files are specified, the alias value includes their expansions.</value>
+  </data>
+  <data name="AliasName" xml:space="preserve">
+    <value>Alias Name</value>
+  </data>
+  <data name="AliasValue" xml:space="preserve">
+    <value>Alias Value</value>
+  </data>
+  <data name="ShowAliasesHelp" xml:space="preserve">
+    <value>Displays the value of the named alias, or all aliases if no name is specified.</value>
+  </data>
+  <data name="AliasCannotBeginWithDashes" xml:space="preserve">
+    <value>Alias names cannot begin with dashes ('-').</value>
+  </data>
+  <data name="AliasCannotBeShortName" xml:space="preserve">
+    <value>Alias '{0}' is a template short name, and therefore cannot be aliased.</value>
+  </data>
+  <data name="AliasCommandAfterExpansion" xml:space="preserve">
+    <value>After expanding aliases, the command is:
+    dotnet {0}</value>
+  </data>
+  <data name="AliasExpandedCommandParseError" xml:space="preserve">
+    <value>Command is invalid after expanding aliases.</value>
+  </data>
+  <data name="AliasExpansionError" xml:space="preserve">
+    <value>Error expanding aliases on input params.</value>
+  </data>
+  <data name="ExtraArgsCommandAfterExpansion" xml:space="preserve">
+    <value>After expanding the extra args files, the command is:
+    dotnet {0}</value>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -968,22 +968,8 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 if (!string.IsNullOrEmpty(_commandInput.Alias) && !_commandInput.IsHelpFlagSpecified)
                 {
-                    // Check that the alias name is not the short name of a template.
-                    if (AllTemplateShortNames.Contains(_commandInput.Alias))
-                    {
-                        Reporter.Output.WriteLine(string.Format(LocalizableStrings.AliasCannotBeShortName, _commandInput.Alias));
-                        return CreationResultStatus.CreateFailed;
-                    }
-                    else if (_commandInput.Alias.StartsWith("-"))
-                    {
-                        Reporter.Output.WriteLine(LocalizableStrings.AliasCannotBeginWithDashes);
-                        return CreationResultStatus.InvalidParamValues;
-                    }
-
-                    // create, update, or delete an alias.
-                    return AliasSupport.ManipulateAliasValue(_commandInput, _aliasRegistry);
+                    return AliasSupport.ManipulateAliasIfValid(_aliasRegistry, _commandInput.Alias, _commandInput.Tokens.ToList(), AllTemplateShortNames);
                 }
-                // TODO try expanding aliases... then redo everything except checking for alias expansion.
 
                 if (string.IsNullOrWhiteSpace(TemplateName))
                 {

--- a/src/Microsoft.TemplateEngine.Edge/Settings/AliasExpansionStatus.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/AliasExpansionStatus.cs
@@ -1,0 +1,10 @@
+﻿
+namespace Microsoft.TemplateEngine.Edge.Settings
+{
+    public enum AliasExpansionStatus
+    {
+        NoChange,
+        Expanded,
+        ExpansionError
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/AliasManipulationResult.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/AliasManipulationResult.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.TemplateEngine.Edge.Settings
+{
+    public class AliasManipulationResult
+    {
+        public AliasManipulationResult(AliasManipulationStatus status)
+            :this(status, null, null)
+        {
+        }
+
+        public AliasManipulationResult(AliasManipulationStatus status, string aliasName, string aliasValue)
+        {
+            Status = status;
+            AliasName = aliasName;
+            AliasValue = aliasValue;
+        }
+
+        public AliasManipulationStatus Status { get; }
+        public string AliasName { get; }
+        public string AliasValue { get; }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/AliasManipulationStatus.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/AliasManipulationStatus.cs
@@ -1,0 +1,12 @@
+﻿
+namespace Microsoft.TemplateEngine.Edge.Settings
+{
+    public enum AliasManipulationStatus
+    {
+        Created,
+        Removed,
+        Updated,
+        WouldCreateCycle,
+        InvalidInput
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/AliasManipulationStatus.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/AliasManipulationStatus.cs
@@ -5,6 +5,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
     {
         Created,
         Removed,
+        RemoveNonExistentFailed,    // for trying to remove an alias that didn't exist.
         Updated,
         WouldCreateCycle,
         InvalidInput

--- a/src/Microsoft.TemplateEngine.Edge/Settings/AliasModel.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/AliasModel.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Microsoft.TemplateEngine.Edge.Settings
+{
+    public class AliasModel
+    {
+        public AliasModel()
+            : this(new Dictionary<string, string>())
+        {
+        }
+
+        public AliasModel(Dictionary<string, string> commandAliases)
+        {
+            CommandAliases = new Dictionary<string, string>(commandAliases, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public void AddCommandAlias(string aliasName, string aliasValue)
+        {
+            CommandAliases.Add(aliasName, aliasValue);
+        }
+
+        public bool TryRemoveCommandAlias(string aliasName, out string aliasValue)
+        {
+            if (CommandAliases.TryGetValue(aliasName, out aliasValue))
+            {
+                CommandAliases.Remove(aliasName);
+                return true;
+            }
+
+            return false;
+        }
+
+        [JsonProperty]
+        public Dictionary<string, string> CommandAliases { get; set; }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -24,14 +24,12 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         private readonly IDictionary<string, IDictionary<string, ILocalizationLocator>> _localizationMemoryCache = new Dictionary<string, IDictionary<string, ILocalizationLocator>>();
         private readonly IEngineEnvironmentSettings _environmentSettings;
         private readonly Paths _paths;
-        private readonly AliasRegistry _aliasRegistry;
 
         public TemplateCache(IEngineEnvironmentSettings environmentSettings)
         {
             _environmentSettings = environmentSettings;
             _paths = new Paths(environmentSettings);
             TemplateInfo = new List<TemplateInfo>();
-            _aliasRegistry = new AliasRegistry(environmentSettings);
         }
 
         public TemplateCache(IEngineEnvironmentSettings environmentSettings, List<TemplateInfo> templatesInCache)
@@ -49,18 +47,17 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         [JsonProperty]
         public IReadOnlyList<TemplateInfo> TemplateInfo { get; set; }
 
-        public IReadOnlyCollection<IFilteredTemplateInfo> List(bool exactMatchesOnly, params Func<ITemplateInfo, string, MatchInfo?>[] fitlers)
+        public IReadOnlyCollection<IFilteredTemplateInfo> List(bool exactMatchesOnly, params Func<ITemplateInfo, MatchInfo?>[] filters)
         {
             HashSet<IFilteredTemplateInfo> matchingTemplates = new HashSet<IFilteredTemplateInfo>(FilteredTemplateEqualityComparer.Default);
 
             foreach (ITemplateInfo template in TemplateInfo)
             {
-                string alias = _aliasRegistry.GetAliasForTemplate(template);
                 List<MatchInfo> matchInformation = new List<MatchInfo>();
 
-                foreach (Func<ITemplateInfo, string, MatchInfo?> filter in fitlers)
+                foreach (Func<ITemplateInfo, MatchInfo?> filter in filters)
                 {
-                    MatchInfo? result = filter(template, alias);
+                    MatchInfo? result = filter(template);
 
                     if (result.HasValue)
                     {

--- a/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
@@ -6,9 +6,9 @@ namespace Microsoft.TemplateEngine.Edge.Template
 {
     public static class WellKnownSearchFilters
     {
-        public static Func<ITemplateInfo, string, MatchInfo?> NameFilter(string name)
+        public static Func<ITemplateInfo, MatchInfo?> NameFilter(string name)
         {
-            return (template, alias) =>
+            return (template) =>
             {
                 if (string.IsNullOrEmpty(name))
                 {
@@ -42,35 +42,10 @@ namespace Microsoft.TemplateEngine.Edge.Template
             };
         }
 
-        public static Func<ITemplateInfo, string, MatchInfo?> AliasFilter(string name)
-        {
-            return (template, alias) =>
-            {
-                if (string.IsNullOrEmpty(name))
-                {
-                    return null;
-                }
-
-                int index = alias?.IndexOf(name, StringComparison.OrdinalIgnoreCase) ?? -1;
-
-                if (index == 0 && string.Equals(alias, name, StringComparison.OrdinalIgnoreCase))
-                {
-                    return new MatchInfo { Location = MatchLocation.Alias, Kind = MatchKind.Exact };
-                }
-
-                if (index > -1)
-                {
-                    return new MatchInfo { Location = MatchLocation.Alias, Kind = MatchKind.Partial };
-                }
-
-                return null;
-            };
-        }
-
         // This being case-insensitive depends on the dictionaries on the cache tags being declared as case-insensitive
-        public static Func<ITemplateInfo, string, MatchInfo?> ContextFilter(string context)
+        public static Func<ITemplateInfo, MatchInfo?> ContextFilter(string context)
         {
-            return (template, alias) =>
+            return (template) =>
             {
                 if (string.IsNullOrEmpty(context))
                 {
@@ -98,9 +73,9 @@ namespace Microsoft.TemplateEngine.Edge.Template
         }
 
         // This being case-insensitive depends on the dictionaries on the cache tags being declared as case-insensitive
-        public static Func<ITemplateInfo, string, MatchInfo?> LanguageFilter(string language)
+        public static Func<ITemplateInfo, MatchInfo?> LanguageFilter(string language)
         {
-            return (template, alias) =>
+            return (template) =>
             {
                 if (string.IsNullOrEmpty(language))
                 {
@@ -123,9 +98,9 @@ namespace Microsoft.TemplateEngine.Edge.Template
             };
         }
 
-        public static Func<ITemplateInfo, string, MatchInfo?> ClassificationsFilter(string name)
+        public static Func<ITemplateInfo, MatchInfo?> ClassificationsFilter(string name)
         {
-            return (template, alias) =>
+            return (template) =>
             {
                 if (string.IsNullOrEmpty(name))
                 {

--- a/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs
+++ b/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs
@@ -79,7 +79,7 @@ namespace Microsoft.TemplateEngine.IDE
             Installer.InstallPackages(paths);
         }
 
-        public IReadOnlyCollection<IFilteredTemplateInfo> ListTemplates(bool exactMatchesOnly, params Func<ITemplateInfo, string, MatchInfo?>[] filters)
+        public IReadOnlyCollection<IFilteredTemplateInfo> ListTemplates(bool exactMatchesOnly, params Func<ITemplateInfo, MatchInfo?>[] filters)
         {
             EnsureInitialized();
             return ((SettingsLoader)EnvironmentSettings.SettingsLoader).UserTemplateCache.List(exactMatchesOnly, filters);


### PR DESCRIPTION
-a|--alias : to create / update / delete an alias
--show-alias [alias name] : to show all aliases, or just the specified one.
(these are still hidden flags)