### PR TITLE
Fix issue where mount points for install aren't getting reused

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -114,7 +114,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 return;
             }
 
-            if (_environmentSettings.SettingsLoader.TryGetMountPointFromPlace(searchTarget, out IMountPoint existingMountPoint))
+            if (_environmentSettings.SettingsLoader.TryGetMountPointFromPlace(templateDir, out IMountPoint existingMountPoint))
             {
                 ScanMountPointForTemplatesAndLangpacks(existingMountPoint, templateDir);
                 _environmentSettings.SettingsLoader.ReleaseMountPoint(existingMountPoint);
@@ -134,7 +134,8 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                             {
                                 _paths.CreateDirectory(_paths.User.Packages);
                                 _paths.Copy(templateDir, path);
-                                if(factory.TryMount(_environmentSettings, null, path, out IMountPoint mountPoint2))
+                                _environmentSettings.SettingsLoader.ReleaseMountPoint(mountPoint);
+                                if(_environmentSettings.SettingsLoader.TryGetMountPointFromPlace(path, out IMountPoint mountPoint2) || factory.TryMount(_environmentSettings, null, path, out mountPoint2))
                                 {
                                     mountPoint = mountPoint2;
                                     templateDir = path;
@@ -163,6 +164,8 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                                 }
                             }
                         }
+
+                        _environmentSettings.SettingsLoader.ReleaseMountPoint(mountPoint);
                     }
                 }
             }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -134,9 +134,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                             {
                                 _paths.CreateDirectory(_paths.User.Packages);
                                 _paths.Copy(templateDir, path);
-                                _environmentSettings.SettingsLoader.ReleaseMountPoint(mountPoint);
                                 if(_environmentSettings.SettingsLoader.TryGetMountPointFromPlace(path, out IMountPoint mountPoint2) || factory.TryMount(_environmentSettings, null, path, out mountPoint2))
                                 {
+                                    _environmentSettings.SettingsLoader.ReleaseMountPoint(mountPoint);
                                     mountPoint = mountPoint2;
                                     templateDir = path;
                                 }


### PR DESCRIPTION
Not quite sure if line 137 should go inside the `if` at the moment (fixed)