### PR TITLE
Add files for 1.x F# version of the empty web template

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/EmptyWeb-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/EmptyWeb-FSharp/.template.config/template.json
@@ -1,0 +1,74 @@
+{
+  "author": "Microsoft",
+  "classifications": ["Web", "Empty"],
+  "name": "ASP.NET Core Empty",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "Microsoft.Web.Empty",
+  "precedence": "100",
+  "identity": "Microsoft.Web.Empty.FSharp",
+  "shortName": "web",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "sourceName": "Company.WebApplication1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "IncludeApplicationInsights": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to include Application Insights in the project"
+    },
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "netcoreapp1.0",
+          "description": "Target netcoreapp1.0"
+        },
+        {
+          "choice": "netcoreapp1.1",
+          "description": "Target netcoreapp1.1"
+        }
+      ],
+      "defaultValue": "netcoreapp1.1"
+    },
+    "copyrightYear": {
+      "type": "generated",
+      "generator": "now",
+      "replaces": "1975",
+      "parameters": {
+        "format": "yyyy"
+      }
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [ { "path": "Company.WebApplication1.fsproj" } ],
+  "defaultName": "WebApplication1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        { "text": "Run 'dotnet restore'" }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/EmptyWeb-FSharp/Company.WebApplication1.fsproj
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/EmptyWeb-FSharp/Company.WebApplication1.fsproj
@@ -1,0 +1,22 @@
+<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(Framework)' != 'netcoreapp1.1' AND '$(TargetFrameworkOverride)' == ''">netcoreapp1.0</TargetFramework>
+    <TargetFramework Condition="'$(Framework)' == 'netcoreapp1.1' AND '$(TargetFrameworkOverride)' == ''">netcoreapp1.1</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Startup.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.1.*" />
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.*" Condition="'$(IncludeApplicationInsights)' == 'True'" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.0.*" Condition="'$(Framework)' != 'netcoreapp1.1'" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.*" Condition="'$(Framework)' == 'netcoreapp1.1'" />
+  </ItemGroup>
+  
+</Project>

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/EmptyWeb-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/EmptyWeb-FSharp/Program.fs
@@ -1,0 +1,25 @@
+namespace Company.WebApplication1
+
+open System
+open System.IO
+open Microsoft.AspNetCore.Hosting
+
+module Program =
+    let exitCode = 0
+
+    [<EntryPoint>]
+    let main args =
+        let host = 
+            WebHostBuilder()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseKestrel()
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+    #if (IncludeApplicationInsights)
+                .UseApplicationInsights()
+    #endif
+                .Build()
+
+        host.Run()
+
+        exitCode

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/EmptyWeb-FSharp/Startup.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/EmptyWeb-FSharp/Startup.fs
@@ -1,0 +1,22 @@
+namespace Company.WebApplication1
+
+open System
+open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Hosting
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Logging
+
+type Startup() =
+
+    member this.ConfigureServices(services: IServiceCollection) =
+        ()
+
+    member this.Configure(app: IApplicationBuilder, env: IHostingEnvironment, log: ILoggerFactory) =
+        log.AddConsole() |> ignore
+
+        if env.IsDevelopment() then app.UseDeveloperExceptionPage() |> ignore
+
+        app.Run(fun context -> context.Response.WriteAsync("Hello World!"))
+
+        ()


### PR DESCRIPTION
Hi, I created a 1.x F# version of the empty web template. 

I was able to manually test installing the template with new3 and test using the template with new3. 

I went for the 1.x version since that seemed like the more immediate need...though I suppose if it makes it's way into the tooling, it will be on the same release as the 2.0 templates. 

If this pr is acceptable, or with feedback I am able to get it to an acceptable state, I can work on the 2.0 version of the template as well as the 1.x and 2.0 version of the web api templates.