### PR TITLE
Added 'elif' as a variant of 'elseif'.

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalBlockCommentConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalBlockCommentConfig.cs
@@ -70,12 +70,39 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
         {
             ConditionEvaluator evaluator = EvaluatorSelector.Select(options.EvaluatorType);
 
+            List<ITokenConfig> endIfTokens = new List<ITokenConfig>();
+            foreach (string endIfKeyword in keywords.EndIfKeywords)
+            {
+                endIfTokens.Add($"{keywords.KeywordPrefix}{endIfKeyword}".TokenConfig());
+                endIfTokens.Add($"{startToken}{keywords.KeywordPrefix}{endIfKeyword}".TokenConfig());
+            }
+
+            List<ITokenConfig> actionableIfTokens = new List<ITokenConfig>();
+            foreach (string ifKeyword in keywords.IfKeywords)
+            {
+                actionableIfTokens.Add($"{startToken}{keywords.KeywordPrefix}{ifKeyword}".TokenConfig());
+            }
+
+            List<ITokenConfig> actionableElseTokens = new List<ITokenConfig>();
+            foreach (string elseKeyword in keywords.ElseKeywords)
+            {
+                actionableElseTokens.Add($"{keywords.KeywordPrefix}{elseKeyword}".TokenConfig());
+                actionableElseTokens.Add($"{startToken}{keywords.KeywordPrefix}{elseKeyword}".TokenConfig());
+            }
+
+            List<ITokenConfig> actionableElseIfTokens = new List<ITokenConfig>();
+            foreach (string elseIfKeyword in keywords.ElseIfKeywords)
+            {
+                actionableElseIfTokens.Add($"{keywords.KeywordPrefix}{elseIfKeyword}".TokenConfig());
+                actionableElseIfTokens.Add($"{startToken}{keywords.KeywordPrefix}{elseIfKeyword}".TokenConfig());
+            }
+
             ConditionalTokens tokens = new ConditionalTokens
             {
-                EndIfTokens = new[] { $"{keywords.KeywordPrefix}{keywords.EndIfKeyword}".TokenConfig(), $"{startToken}{keywords.KeywordPrefix}{keywords.EndIfKeyword}".TokenConfig() },
-                ActionableIfTokens = new[] { $"{startToken}{keywords.KeywordPrefix}{keywords.IfKeyword}".TokenConfig() },
-                ActionableElseTokens = new[] { $"{keywords.KeywordPrefix}{keywords.ElseKeyword}".TokenConfig(), $"{startToken}{keywords.KeywordPrefix}{keywords.ElseKeyword}".TokenConfig() },
-                ActionableElseIfTokens = new[] { $"{keywords.KeywordPrefix}{keywords.ElseIfKeyword}".TokenConfig(), $"{startToken}{keywords.KeywordPrefix}{keywords.ElseIfKeyword}".TokenConfig() },
+                EndIfTokens = endIfTokens,
+                ActionableIfTokens = actionableIfTokens,
+                ActionableElseTokens = actionableElseTokens,
+                ActionableElseIfTokens = actionableElseIfTokens
             };
 
             if (!string.IsNullOrWhiteSpace(pseudoEndToken))

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalKeywords.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalKeywords.cs
@@ -1,29 +1,34 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
 {
     public class ConditionalKeywords
     {
         private static readonly string DefaultPrefix = "#";
-        private static readonly string DefaultIfKeyword = "if";
-        private static readonly string DefaultElseIfKeyword = "elseif";
-        private static readonly string DefaultElseKeyword = "else";
-        private static readonly string DefaultEndIfKeyword = "endif";
+        private static readonly IReadOnlyList<string> DefaultIfKeywords = new[] { "if" };
+        private static readonly IReadOnlyList<string> DefaultElseIfKeywords = new[] { "elseif", "elif" };
+        private static readonly IReadOnlyList<string> DefaultElseKeywords = new[] { "else" };
+        private static readonly IReadOnlyList<string> DefaultEndIfKeywords = new[] { "endif" };
 
         public ConditionalKeywords()
         {
             KeywordPrefix = DefaultPrefix;
-            IfKeyword = DefaultIfKeyword;
-            ElseIfKeyword = DefaultElseIfKeyword;
-            ElseKeyword = DefaultElseKeyword;
-            EndIfKeyword = DefaultEndIfKeyword;
+            IfKeywords = DefaultIfKeywords;
+            ElseIfKeywords = DefaultElseIfKeywords;
+            ElseKeywords = DefaultElseKeywords;
+            EndIfKeywords = DefaultEndIfKeywords;
         }
 
         public string KeywordPrefix { get; set; }
-        public string IfKeyword { get; set; }
-        public string ElseIfKeyword { get; set; }
-        public string ElseKeyword { get; set; }
-        public string EndIfKeyword { get; set; }
+
+        public IReadOnlyList<string> IfKeywords { get; set; }
+
+        public IReadOnlyList<string> ElseIfKeywords { get; set; }
+
+        public IReadOnlyList<string> ElseKeywords { get; set; }
+
+        public IReadOnlyList<string> EndIfKeywords { get; set; }
 
         public static ConditionalKeywords FromJObject(JObject rawConfiguration)
         {
@@ -31,25 +36,25 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
             string ifKeyword = rawConfiguration.ToString("ifKeyword");
             if (!string.IsNullOrWhiteSpace(ifKeyword))
             {
-                keywords.IfKeyword = ifKeyword;
+                keywords.IfKeywords = new[] { ifKeyword };
             }
 
             string elseIfKeyword = rawConfiguration.ToString("elseIfKeyword");
             if (!string.IsNullOrWhiteSpace(elseIfKeyword))
             {
-                keywords.ElseIfKeyword = elseIfKeyword;
+                keywords.ElseIfKeywords = new[] { elseIfKeyword };
             }
 
             string elseKeyword = rawConfiguration.ToString("elseKeyword");
             if (!string.IsNullOrWhiteSpace(elseKeyword))
             {
-                keywords.ElseKeyword = elseKeyword;
+                keywords.ElseKeywords = new[] { elseKeyword };
             }
 
             string endIfKeyword = rawConfiguration.ToString("endIfKeyword");
             if (!string.IsNullOrWhiteSpace(endIfKeyword))
             {
-                keywords.EndIfKeyword = endIfKeyword;
+                keywords.EndIfKeywords = new[] { endIfKeyword };
             }
 
             return keywords;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalKeywords.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalKeywords.cs
@@ -30,6 +30,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
 
         public IReadOnlyList<string> EndIfKeywords { get; set; }
 
+        // TODO: Allow the rawConfiguration elements to be either strings (as-is) or arrays of strings.
+        // The code that consumes instances of this class is already setup to deal with multiple forms of each keyword type.
         public static ConditionalKeywords FromJObject(JObject rawConfiguration)
         {
             ConditionalKeywords keywords = new ConditionalKeywords();

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalLineCommentConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalLineCommentConfig.cs
@@ -36,15 +36,46 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
             IOperationProvider uncomment = new Replacement(token.TokenConfig(), string.Empty, uncommentOperationId, options.OnByDefault);
             IOperationProvider reduceComment = new Replacement($"{token}{token}".TokenConfig(), token, reduceCommentOperationId, options.OnByDefault);
 
+            List<ITokenConfig> ifTokens = new List<ITokenConfig>();
+            List<ITokenConfig> actionableIfTokens = new List<ITokenConfig>();
+            foreach (string ifKeyword in keywords.IfKeywords)
+            {
+                ifTokens.Add($"{token}{keywords.KeywordPrefix}{ifKeyword}".TokenConfig());
+                actionableIfTokens.Add($"{token}{token}{keywords.KeywordPrefix}{ifKeyword}".TokenConfig());
+            }
+
+            List<ITokenConfig> elseTokens = new List<ITokenConfig>();
+            List<ITokenConfig> actionableElseTokens = new List<ITokenConfig>();
+            foreach (string elseKeyword in keywords.ElseKeywords)
+            {
+                elseTokens.Add($"{token}{keywords.KeywordPrefix}{elseKeyword}".TokenConfig());
+                actionableElseTokens.Add($"{token}{token}{keywords.KeywordPrefix}{elseKeyword}".TokenConfig());
+            }
+
+            List<ITokenConfig> elseIfTokens = new List<ITokenConfig>();
+            List<ITokenConfig> actionalElseIfTokens = new List<ITokenConfig>();
+            foreach (string elseIfKeyword in keywords.ElseIfKeywords)
+            {
+                elseIfTokens.Add($"{token}{keywords.KeywordPrefix}{elseIfKeyword}".TokenConfig());
+                actionalElseIfTokens.Add($"{token}{token}{keywords.KeywordPrefix}{elseIfKeyword}".TokenConfig());
+            }
+
+            List<ITokenConfig> endIfTokens = new List<ITokenConfig>();
+            foreach (string endIfKeyword in keywords.EndIfKeywords)
+            {
+                endIfTokens.Add($"{token}{keywords.KeywordPrefix}{endIfKeyword}".TokenConfig());
+                endIfTokens.Add($"{token}{token}{keywords.KeywordPrefix}{endIfKeyword}".TokenConfig());
+            }
+
             ConditionalTokens conditionalTokens = new ConditionalTokens
             {
-                IfTokens = new[] { $"{token}{keywords.KeywordPrefix}{keywords.IfKeyword}" }.TokenConfigs(),
-                ElseTokens = new[] { $"{token}{keywords.KeywordPrefix}{keywords.ElseKeyword}" }.TokenConfigs(),
-                ElseIfTokens = new[] { $"{token}{keywords.KeywordPrefix}{keywords.ElseIfKeyword}" }.TokenConfigs(),
-                EndIfTokens = new[] { $"{token}{keywords.KeywordPrefix}{keywords.EndIfKeyword}", $"{token}{token}{keywords.KeywordPrefix}{keywords.EndIfKeyword}" }.TokenConfigs(),
-                ActionableIfTokens = new[] { $"{token}{token}{keywords.KeywordPrefix}{keywords.IfKeyword}" }.TokenConfigs(),
-                ActionableElseTokens = new[] { $"{token}{token}{keywords.KeywordPrefix}{keywords.ElseKeyword}" }.TokenConfigs(),
-                ActionableElseIfTokens = new[] { $"{token}{token}{keywords.KeywordPrefix}{keywords.ElseIfKeyword}" }.TokenConfigs(),
+                IfTokens = ifTokens,
+                ElseTokens = elseTokens,
+                ElseIfTokens = elseIfTokens,
+                EndIfTokens = endIfTokens,
+                ActionableIfTokens = actionableIfTokens,
+                ActionableElseTokens = actionableElseTokens,
+                ActionableElseIfTokens = actionalElseIfTokens,
                 ActionableOperations = new[] { uncommentOperationId, reduceCommentOperationId }
             };
 

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
@@ -250,6 +250,36 @@ There";
             Verify(Encoding.UTF8, output, changed, value, expected);
         }
 
+        [Fact(DisplayName = nameof(VerifyIfElifEndifTrueFalseCondition))]
+        public void VerifyIfElifEndifTrueFalseCondition()
+        {
+            string value = @"Hello
+    #if (VALUE)
+value
+    #elif (VALUE2)
+other
+    #endif
+There";
+            string expected = @"Hello
+value
+There";
+
+            byte[] valueBytes = Encoding.UTF8.GetBytes(value);
+            MemoryStream input = new MemoryStream(valueBytes);
+            MemoryStream output = new MemoryStream();
+
+            VariableCollection vc = new VariableCollection
+            {
+                ["VALUE"] = true,
+                ["VALUE2"] = false
+            };
+            IProcessor processor = SetupCStyleNoCommentsProcessor(vc);
+
+            //Changes should be made
+            bool changed = processor.Run(input, output, 28);
+            Verify(Encoding.UTF8, output, changed, value, expected);
+        }
+
         [Fact(DisplayName = nameof(VerifyIfElseifEndifTrueTrueCondition))]
         public void VerifyIfElseifEndifTrueTrueCondition()
         {
@@ -280,6 +310,35 @@ There";
             Verify(Encoding.UTF8, output, changed, value, expected);
         }
 
+        [Fact(DisplayName = nameof(VerifyIfElifEndifTrueTrueCondition))]
+        public void VerifyIfElifEndifTrueTrueCondition()
+        {
+            string value = @"Hello
+    #if (VALUE)
+value
+    #elif (VALUE2)
+other
+    #endif
+There";
+            string expected = @"Hello
+value
+There";
+
+            byte[] valueBytes = Encoding.UTF8.GetBytes(value);
+            MemoryStream input = new MemoryStream(valueBytes);
+            MemoryStream output = new MemoryStream();
+
+            VariableCollection vc = new VariableCollection
+            {
+                ["VALUE"] = true,
+                ["VALUE2"] = true
+            };
+            IProcessor processor = SetupCStyleNoCommentsProcessor(vc);
+
+            //Changes should be made
+            bool changed = processor.Run(input, output, 28);
+            Verify(Encoding.UTF8, output, changed, value, expected);
+        }
         [Fact(DisplayName = nameof(VerifyIfElseifEndifFalseTrueCondition))]
         public void VerifyIfElseifEndifFalseTrueCondition()
         {

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     EndIfTokens = new[] { "#endif", "<!--#endif" }.TokenConfigs(),
                     ActionableIfTokens = new[] { "<!--#if" }.TokenConfigs(),
                     ActionableElseTokens = new[] { "#else", "<!--#else" }.TokenConfigs(),
-                    ActionableElseIfTokens = new[] { "#elseif", "<!--#elseif" }.TokenConfigs(),
+                    ActionableElseIfTokens = new[] { "#elseif", "<!--#elseif", "#elif", "<!--#elif" }.TokenConfigs(),
                     ActionableOperations = new[] { commentFixingOperationId, commentFixingResetId }
                 };
 
@@ -125,7 +125,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     EndIfTokens = new[] { "#endif", "@*#endif" }.TokenConfigs(),
                     ActionableIfTokens = new[] { "@*#if" }.TokenConfigs(),
                     ActionableElseTokens = new[] { "#else", "@*#else" }.TokenConfigs(),
-                    ActionableElseIfTokens = new[] { "#elseif", "@*#elseif" }.TokenConfigs(),
+                    ActionableElseIfTokens = new[] { "#elseif", "@*#elseif", "#elif", "@*#elif" }.TokenConfigs(),
                     ActionableOperations = new[] { commentFixingOperationId, commentFixingResetId }
                 };
 
@@ -187,10 +187,10 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 {
                     IfTokens = new[] { "//#if" }.TokenConfigs(),
                     ElseTokens = new[] { "//#else" }.TokenConfigs(),
-                    ElseIfTokens = new[] { "//#elseif" }.TokenConfigs(),
+                    ElseIfTokens = new[] { "//#elseif", "//#elif" }.TokenConfigs(),
                     EndIfTokens = new[] { "//#endif", "////#endif" }.TokenConfigs(),
                     ActionableIfTokens = new[] { "////#if" }.TokenConfigs(),
-                    ActionableElseIfTokens = new[] { "////#elseif" }.TokenConfigs(),
+                    ActionableElseIfTokens = new[] { "////#elseif", "////#elif" }.TokenConfigs(),
                     ActionableElseTokens = new[] { "////#else" }.TokenConfigs(),
                     ActionableOperations = new[] { replaceOperationId, uncommentOperationId }
                 };
@@ -214,7 +214,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 {
                     IfTokens = new[] { "#if" }.TokenConfigs(),
                     ElseTokens = new[] { "#else" }.TokenConfigs(),
-                    ElseIfTokens = new[] { "#elseif" }.TokenConfigs(),
+                    ElseIfTokens = new[] { "#elseif", "#elif" }.TokenConfigs(),
                     EndIfTokens = new[] { "#endif" }.TokenConfigs()
                 };
 
@@ -238,10 +238,10 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 {
                     IfTokens = new[] { "#if" }.TokenConfigs(),
                     ElseTokens = new[] { "#else" }.TokenConfigs(),
-                    ElseIfTokens = new[] { "#elseif" }.TokenConfigs(),
+                    ElseIfTokens = new[] { "#elseif", "#elif" }.TokenConfigs(),
                     EndIfTokens = new[] { "#endif", "##endif" }.TokenConfigs(),
                     ActionableIfTokens = new[] { "##if" }.TokenConfigs(),
-                    ActionableElseIfTokens = new[] { "##elseif" }.TokenConfigs(),
+                    ActionableElseIfTokens = new[] { "##elseif", "##elif" }.TokenConfigs(),
                     ActionableElseTokens = new[] { "##else" }.TokenConfigs(),
                     ActionableOperations = new[] { replaceOperationId, uncommentOperationId }
                 };
@@ -268,10 +268,10 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 {
                     IfTokens = new[] { "rem #if" }.TokenConfigs(),
                     ElseTokens = new[] { "rem #else" }.TokenConfigs(),
-                    ElseIfTokens = new[] { "rem #elseif" }.TokenConfigs(),
+                    ElseIfTokens = new[] { "rem #elseif", "rem #elif" }.TokenConfigs(),
                     EndIfTokens = new[] { "rem #endif", "rem rem #endif" }.TokenConfigs(),
                     ActionableIfTokens = new[] { "rem rem #if" }.TokenConfigs(),
-                    ActionableElseIfTokens = new[] { "rem rem #elseif" }.TokenConfigs(),
+                    ActionableElseIfTokens = new[] { "rem rem #elseif", "rem rem #elif" }.TokenConfigs(),
                     ActionableElseTokens = new[] { "rem rem #else" }.TokenConfigs(),
                     ActionableOperations = new[] { replaceOperationId, uncommentOperationId }
                 };
@@ -298,10 +298,10 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 {
                     IfTokens = new[] { "-#if" }.TokenConfigs(),
                     ElseTokens = new[] { "-#else" }.TokenConfigs(),
-                    ElseIfTokens = new[] { "-#elseif" }.TokenConfigs(),
+                    ElseIfTokens = new[] { "-#elseif", "-#elif" }.TokenConfigs(),
                     EndIfTokens = new[] { "-#endif", "-#-#endif" }.TokenConfigs(),
                     ActionableIfTokens = new[] { "-#-#if" }.TokenConfigs(),
-                    ActionableElseIfTokens = new[] { "-#-#elseif" }.TokenConfigs(),
+                    ActionableElseIfTokens = new[] { "-#-#elseif", "-#-#elif" }.TokenConfigs(),
                     ActionableElseTokens = new[] { "-#-#else" }.TokenConfigs(),
                     ActionableOperations = new[] { uncommentOperationId, reduceCommentOperationId }
                 };
@@ -337,7 +337,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     EndIfTokens = new[] { "#endif", "{/*#endif" }.TokenConfigs(),
                     ActionableIfTokens = new[] { "{/*#if" }.TokenConfigs(),
                     ActionableElseTokens = new[] { "#else", "{/*#else" }.TokenConfigs(),
-                    ActionableElseIfTokens = new[] { "#elseif", "{/*#elseif" }.TokenConfigs(),
+                    ActionableElseIfTokens = new[] { "#elseif", "{/*#elseif", "#elif", "{/*#elif" }.TokenConfigs(),
                     ActionableOperations = new[] { commentFixingOperationId, commentFixingResetId }
                 };
 

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/CustomConditionalTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/CustomConditionalTests.cs
@@ -138,8 +138,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             Assert.Equal(1, conditionalOp.Tokens.IfTokens.Count);
             Assert.Equal("//#if", conditionalOp.Tokens.IfTokens[0].Value);
 
-            Assert.Equal(1, conditionalOp.Tokens.ElseIfTokens.Count);
-            Assert.Equal("//#elseif", conditionalOp.Tokens.ElseIfTokens[0].Value);
+            Assert.Equal(2, conditionalOp.Tokens.ElseIfTokens.Count);
+            Assert.True(conditionalOp.Tokens.ElseIfTokens.Any(x => x.Value == "//#elseif"));
+            Assert.True(conditionalOp.Tokens.ElseIfTokens.Any(x => x.Value == "//#elif"));
 
             Assert.Equal(1, conditionalOp.Tokens.ElseTokens.Count);
             Assert.Equal("//#else", conditionalOp.Tokens.ElseTokens[0].Value);
@@ -151,8 +152,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             Assert.Equal(1, conditionalOp.Tokens.ActionableIfTokens.Count);
             Assert.Equal("////#if", conditionalOp.Tokens.ActionableIfTokens[0].Value);
 
-            Assert.Equal(1, conditionalOp.Tokens.ActionableElseIfTokens.Count);
-            Assert.Equal("////#elseif", conditionalOp.Tokens.ActionableElseIfTokens[0].Value);
+            Assert.Equal(2, conditionalOp.Tokens.ActionableElseIfTokens.Count);
+            Assert.True(conditionalOp.Tokens.ActionableElseIfTokens.Any(x => x.Value == "////#elseif"));
+            Assert.True(conditionalOp.Tokens.ActionableElseIfTokens.Any(x => x.Value == "////#elif"));
 
             Assert.Equal(1, conditionalOp.Tokens.ActionableElseTokens.Count);
             Assert.Equal("////#else", conditionalOp.Tokens.ActionableElseTokens[0].Value);
@@ -194,9 +196,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             Assert.Equal(1, conditionalOp.Tokens.ActionableIfTokens.Count);
             Assert.Equal("/*#if", conditionalOp.Tokens.ActionableIfTokens[0].Value);
 
-            Assert.Equal(2, conditionalOp.Tokens.ActionableElseIfTokens.Count);
+            Assert.Equal(4, conditionalOp.Tokens.ActionableElseIfTokens.Count);
             Assert.True(conditionalOp.Tokens.ActionableElseIfTokens.Any(x => x.Value == "#elseif"));
             Assert.True(conditionalOp.Tokens.ActionableElseIfTokens.Any(x => x.Value == "/*#elseif"));
+            Assert.True(conditionalOp.Tokens.ActionableElseIfTokens.Any(x => x.Value == "#elif"));
+            Assert.True(conditionalOp.Tokens.ActionableElseIfTokens.Any(x => x.Value == "/*#elif"));
 
             Assert.Equal(2, conditionalOp.Tokens.ActionableElseTokens.Count);
             Assert.True(conditionalOp.Tokens.ActionableElseTokens.Any(x => x.Value == "#else"));


### PR DESCRIPTION
This adds more internal support for having multiple variants of each conditional keyword.
Not done: allowing template.json configurations to specify multiple forms of the same keyword in a single configuration. 