### PR TITLE
Add support for the Framework parameter from the CLI to the 1.x F# Class Library template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-FSharp/.template.config/dotnetcli.host.json
@@ -5,6 +5,9 @@
       "longName": "target-framework-override",
       "shortName": ""
     },
+    "Framework": {
+      "longName": "framework"
+    },
     "skipRestore": {
       "longName": "no-restore",
       "shortName": ""

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-FSharp/.template.config/template.json
@@ -21,6 +21,27 @@
       "datatype": "string",
       "defaultValue": ""
     },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "replaces": "netcoreapp1.1",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "netcoreapp1.0",
+          "description": "Target netcoreapp1.0"
+        },
+        {
+          "choice": "netcoreapp1.1",
+          "description": "Target netcoreapp1.1"
+        },
+        {
+          "choice": "netstandard1.6",
+          "description": "Target netstandard1.6"
+        }
+      ],
+      "defaultValue": "netcoreapp1.1"
+    },
     "skipRestore": {
       "type": "parameter",
       "datatype": "bool",


### PR DESCRIPTION
This pull request adds a Framework parameter to template.json and dotnetcli.host.json files under the 1.x ClassLibrary-FSharp template