### PR TITLE
Fix module initialization issue

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -10,7 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="**/*.fs" />
+    <Compile Include="Tests.fs" />
+    <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -10,7 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="**/*.fs" />
+    <Compile Include="Tests.fs" />
+    <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -9,7 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="**/*.fs" />
+    <Compile Include="Tests.fs" />
+    <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -9,7 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="**/*.fs" />
+    <Compile Include="Tests.fs" />
+    <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/Program.fs
@@ -1,0 +1,1 @@
+module Program = let [<EntryPoint>] main _ = 0


### PR DESCRIPTION
This pull request addresses the module initialization issue described in https://github.com/dotnet/netcorecli-fsc/issues/79 for all the existing F# test templates

- Add a Program.fs file with an entry point so that module values across the project get initialized

- Use explicit file inclusion instead of wildcard file inclusion in order to prevent compilation order issues