### PR TITLE
ICE matching is implicitly anchored to the template root

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileSourceHierarchicalPathMatcher.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileSourceHierarchicalPathMatcher.cs
@@ -146,7 +146,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 {
                     foreach (string source in fileSources)
                     {
-                        paths.Add(new GlobbingPatternMatcher(source));
+                        paths.Add(new GlobbingPatternMatcher(source, false));
                     }
                 }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
@@ -191,21 +191,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             return customOperations;
         }
 
-        private static IReadOnlyList<IPathMatcher> SetupPathInfoFromSource(IReadOnlyList<string> fileSources)
-        {
-            int expect = fileSources?.Count ?? 0;
-            List<IPathMatcher> paths = new List<IPathMatcher>(expect);
-            if (fileSources != null && expect > 0)
-            {
-                foreach (string source in fileSources)
-                {
-                    paths.Add(new GlobbingPatternMatcher(source));
-                }
-            }
-
-            return paths;
-        }
-
         internal class ProcessorState : IProcessorState
         {
             public ProcessorState(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, byte[] buffer, Encoding encoding)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobbingPatternMatcher.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobbingPatternMatcher.cs
@@ -9,10 +9,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         public string Pattern { get; }
 
-        public GlobbingPatternMatcher(string pattern)
+        public GlobbingPatternMatcher(string pattern, bool canBeNameOnlyMatch = true)
         {
             Pattern = pattern;
-            _pattern = Glob.Parse(pattern);
+            _pattern = Glob.Parse(pattern, canBeNameOnlyMatch);
         }
 
         public bool IsMatch(string path)

--- a/src/Microsoft.TemplateEngine.Utils/Glob.cs
+++ b/src/Microsoft.TemplateEngine.Utils/Glob.cs
@@ -9,12 +9,12 @@ namespace Microsoft.TemplateEngine.Utils
         private readonly IReadOnlyList<IMatcher> _matchers;
         private readonly bool _negate;
         private readonly bool _isNameOnlyMatch;
-
-        private Glob(bool negate, IReadOnlyList<IMatcher> matchers)
+        
+        private Glob(bool negate, IReadOnlyList<IMatcher> matchers, bool canBeNameOnlyMatch)
         {
             _negate = negate;
             _matchers = matchers;
-            _isNameOnlyMatch = !_matchers.Any(x => x is PathMatcher || x is ExactPathMatcher || (x as LiteralMatcher)?.Char?.FirstOrDefault() == '/');
+            _isNameOnlyMatch = canBeNameOnlyMatch && !_matchers.Any(x => x is PathMatcher || x is ExactPathMatcher || (x as LiteralMatcher)?.Char?.FirstOrDefault() == '/');
         }
 
         private interface IMatcher
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateEngine.Utils
             bool CanConsume(string test, int startAt, out int endPosition);
         }
 
-        public static Glob Parse(string pattern)
+        public static Glob Parse(string pattern, bool canBeNameOnlyMatch = true)
         {
             List<IMatcher> matchers = new List<IMatcher>();
 
@@ -117,7 +117,7 @@ namespace Microsoft.TemplateEngine.Utils
                 }
             }
 
-            return new Glob(negate, matchers);
+            return new Glob(negate, matchers, canBeNameOnlyMatch);
         }
 
         public bool IsMatch(string test)

--- a/src/Microsoft.TemplateEngine.VisualStudioWizard/TemplateEngineWizard.cs
+++ b/src/Microsoft.TemplateEngine.VisualStudioWizard/TemplateEngineWizard.cs
@@ -72,7 +72,9 @@ namespace Microsoft.TemplateEngine.VisualStudioWizard
             }
 
             ITemplateInfo info = match.Info;
-            ICreationResult result = bootstrapper.CreateAsync(info, replacementsDictionary[""], replacementsDictionary[""], ExtractParametersFromReplacementsDictionary(replacementsDictionary), SkipUpdatesCheck).Result;
+            // TODO: Determine where to get the baseline name from, as needed. baselineName is a placeholder so template engine builds. 
+            string baselineName = null;
+            ICreationResult result = bootstrapper.CreateAsync(info, replacementsDictionary[""], replacementsDictionary[""], ExtractParametersFromReplacementsDictionary(replacementsDictionary), SkipUpdatesCheck, baselineName).Result;
 
             foreach (ICreationPath path in result.PrimaryOutputs)
             {

--- a/test/Microsoft.TemplateEngine.Utils.UnitTests/GlobTests.cs
+++ b/test/Microsoft.TemplateEngine.Utils.UnitTests/GlobTests.cs
@@ -4,6 +4,23 @@ namespace Microsoft.TemplateEngine.Utils.UnitTests
 {
     public class GlobTests
     {
+        [Fact(DisplayName = nameof(VerifyLeadGlobPathSpanning))]
+        public void VerifyLeadGlobPathSpanning()
+        {
+            Glob g = Glob.Parse("**/file");
+            Assert.True(g.IsMatch("file"));
+            Assert.True(g.IsMatch("a/file"));
+            Assert.True(g.IsMatch("a/b/file"));
+            Assert.True(g.IsMatch("a/b/c/file"));
+            Assert.False(g.IsMatch("other"));
+            Assert.False(g.IsMatch("a/other"));
+            Assert.False(g.IsMatch("a/b/other"));
+            Assert.False(g.IsMatch("a/b/c/other"));
+            Assert.False(g.IsMatch("file/stuff"));
+            Assert.False(g.IsMatch("file.txt"));
+            Assert.False(g.IsMatch("thefile"));
+        }
+
         [Fact(DisplayName = nameof(VerifyGlobExactPathSpanning))]
         public void VerifyGlobExactPathSpanning()
         {


### PR DESCRIPTION
Also removed GlobalRunSpec::SetupPathFromSource() as it's not referenced from anywhere. IT got unused during the conversion to the new ice matching.

Note: ICE = Include, Copy, Exclude