### PR TITLE
Add correlation id to error page.

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/About.cshtml.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/About.cshtml.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Company.WebApplication1.Pages
 {

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Contact.cshtml.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Contact.cshtml.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Company.WebApplication1.Pages
 {

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml
@@ -7,6 +7,13 @@
 <h1 class="text-danger">Error.</h1>
 <h2 class="text-danger">An error occurred while processing your request.</h2>
 
+@if (Model.ShowCorrelationId)
+{
+    <p>
+        <strong>Correlation ID:</strong> <code>@Model.CorrelationId</code>
+    </p>
+}
+
 <h3>Development Mode</h3>
 <p>
     Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
@@ -14,9 +21,3 @@
 <p>
     <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
 </p>
-@if (Model.ShowActivityId)
-{
-    <p>
-        <strong>Correlation ID:</strong> <code>@Model.CorrelationId</code>
-    </p>
-}

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml
@@ -1,4 +1,5 @@
 ﻿@page
+@using System.Diagnostics
 @{
     ViewData["Title"] = "Error";
 }
@@ -13,3 +14,9 @@
 <p>
     <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
 </p>
+@if (Activity.Current != null)
+{
+<p>
+    <strong>Correlation ID:</strong> <code>@Activity.Current.Id</code>
+</p>
+}

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml
@@ -1,5 +1,5 @@
 ﻿@page
-@using System.Diagnostics
+@model ErrorModel
 @{
     ViewData["Title"] = "Error";
 }
@@ -14,9 +14,9 @@
 <p>
     <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
 </p>
-@if (Activity.Current != null)
+@if (Model.ShowActivityId)
 {
-<p>
-    <strong>Correlation ID:</strong> <code>@Activity.Current.Id</code>
-</p>
+    <p>
+        <strong>Correlation ID:</strong> <code>@Model.CorrelationId</code>
+    </p>
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml
@@ -7,10 +7,10 @@
 <h1 class="text-danger">Error.</h1>
 <h2 class="text-danger">An error occurred while processing your request.</h2>
 
-@if (Model.ShowCorrelationId)
+@if (Model.ShowRequestId)
 {
     <p>
-        <strong>Correlation ID:</strong> <code>@Model.CorrelationId</code>
+        <strong>Request ID:</strong> <code>@Model.RequestId</code>
     </p>
 }
 

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml.cs
@@ -15,7 +15,7 @@ namespace Company.WebApplication1.Pages
 
         public void OnGet()
         {
-            RequestId = Activity.Current?.Id;
+            RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
         }
     }
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Company.WebApplication1.Pages
+{
+    public class ErrorModel : PageModel
+    {
+        public string CorrelationId { get; set; }
+
+        public bool ShowCorrelationId => !string.IsNullOrEmpty(CorrelationId);
+
+        public void OnGet()
+        {
+            CorrelationId = Activity.Current?.Id;
+        }
+    }
+}

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Error.cshtml.cs
@@ -9,13 +9,13 @@ namespace Company.WebApplication1.Pages
 {
     public class ErrorModel : PageModel
     {
-        public string CorrelationId { get; set; }
+        public string RequestId { get; set; }
 
-        public bool ShowCorrelationId => !string.IsNullOrEmpty(CorrelationId);
+        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
         public void OnGet()
         {
-            CorrelationId = Activity.Current?.Id;
+            RequestId = Activity.Current?.Id;
         }
     }
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Index.cshtml.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/Pages/Index.cshtml.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Company.WebApplication1.Pages
 {

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Controllers/HomeController.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Controllers/HomeController.cs
@@ -40,7 +40,7 @@ namespace Company.WebApplication1.Controllers
 #endif
         public IActionResult Error()
         {
-            return View(new ErrorViewModel { CorrelationId = Activity.Current?.Id });
+            return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
         }
     }
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Controllers/HomeController.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Controllers/HomeController.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 #if (OrganizationalAuth)
 using Microsoft.AspNetCore.Authorization;
 #endif
 using Microsoft.AspNetCore.Mvc;
+using Company.WebApplication1.Models;
 
 namespace Company.WebApplication1.Controllers
 {
@@ -38,7 +40,7 @@ namespace Company.WebApplication1.Controllers
 #endif
         public IActionResult Error()
         {
-            return View();
+            return View(new ErrorViewModel { CorrelationId = Activity.Current?.Id });
         }
     }
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Models/ErrorViewModel.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Models/ErrorViewModel.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Company.WebApplication1.Models
+{
+    public class ErrorViewModel
+    {
+        public string CorrelationId { get; set; }
+
+        public bool ShowCorrelationId => !string.IsNullOrEmpty(CorrelationId);
+    }
+}

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Models/ErrorViewModel.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Models/ErrorViewModel.cs
@@ -4,8 +4,8 @@ namespace Company.WebApplication1.Models
 {
     public class ErrorViewModel
     {
-        public string CorrelationId { get; set; }
+        public string RequestId { get; set; }
 
-        public bool ShowCorrelationId => !string.IsNullOrEmpty(CorrelationId);
+        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
     }
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
@@ -1,7 +1,7 @@
-﻿@{
+﻿@using System.Diagnostics
+@{
     ViewData["Title"] = "Error";
 }
-@using System.Diagnostics
 
 <h1 class="text-danger">Error.</h1>
 <h2 class="text-danger">An error occurred while processing your request.</h2>
@@ -13,9 +13,9 @@
 <p>
     <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
 </p>
-@if(Activity.Current != null)
+@if (Activity.Current != null)
 {
 <p>
-    <strong>Correlation ID:</strong>
+    <strong>Correlation ID:</strong> @Activity.Current.Id
 </p>
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
@@ -1,6 +1,13 @@
-﻿@using System.Diagnostics
+﻿@model ErrorViewModel
 @{
     ViewData["Title"] = "Error";
+}
+
+@if (Model.ShowCorrelationId)
+{
+    <p>
+        <strong>Correlation ID:</strong> <code>@Model.CorrelationId</code>
+    </p>
 }
 
 <h1 class="text-danger">Error.</h1>
@@ -13,9 +20,3 @@
 <p>
     <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
 </p>
-@if (Activity.Current != null)
-{
-    <p>
-        <strong>Correlation ID:</strong> <code>@Activity.Current.Id</code>
-    </p>
-}

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
@@ -16,6 +16,6 @@
 @if (Activity.Current != null)
 {
 <p>
-    <strong>Correlation ID:</strong> @Activity.Current.Id
+    <strong>Correlation ID:</strong> <code>@Activity.Current.Id</code>
 </p>
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
@@ -1,6 +1,7 @@
 ﻿@{
     ViewData["Title"] = "Error";
 }
+@using System.Diagnostics
 
 <h1 class="text-danger">Error.</h1>
 <h2 class="text-danger">An error occurred while processing your request.</h2>
@@ -12,3 +13,9 @@
 <p>
     <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
 </p>
+@if(Activity.Current != null)
+{
+<p>
+    <strong>Correlation ID:</strong>
+</p>
+}

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
@@ -15,7 +15,7 @@
 </p>
 @if (Activity.Current != null)
 {
-<p>
-    <strong>Correlation ID:</strong> <code>@Activity.Current.Id</code>
-</p>
+    <p>
+        <strong>Correlation ID:</strong> <code>@Activity.Current.Id</code>
+    </p>
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
@@ -3,15 +3,15 @@
     ViewData["Title"] = "Error";
 }
 
+<h1 class="text-danger">Error.</h1>
+<h2 class="text-danger">An error occurred while processing your request.</h2>
+
 @if (Model.ShowRequestId)
 {
     <p>
         <strong>Request ID:</strong> <code>@Model.RequestId</code>
     </p>
 }
-
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
 
 <h3>Development Mode</h3>
 <p>

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Shared/Error.cshtml
@@ -3,10 +3,10 @@
     ViewData["Title"] = "Error";
 }
 
-@if (Model.ShowCorrelationId)
+@if (Model.ShowRequestId)
 {
     <p>
-        <strong>Correlation ID:</strong> <code>@Model.CorrelationId</code>
+        <strong>Request ID:</strong> <code>@Model.RequestId</code>
     </p>
 }
 

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/_ViewImports.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/_ViewImports.cshtml
@@ -1,2 +1,3 @@
 ﻿@using Company.WebApplication1
+@using Company.WebApplication1.Models
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/Error.cshtml
@@ -1,4 +1,5 @@
-﻿@{
+﻿@using System.Diagnostics
+@{
     ViewData["Title"] = "Error";
 }
 
@@ -12,3 +13,9 @@
 <p>
     <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
 </p>
+@if (Activity.Current != null)
+{
+<p>
+    <strong>Correlation ID:</strong> <code>@Activity.Current.Id</code>
+</p>
+}

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/Error.cshtml
@@ -13,9 +13,3 @@
 <p>
     <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
 </p>
-@if (Activity.Current != null)
-{
-    <p>
-        <strong>Correlation ID:</strong> <code>@Activity.Current.Id</code>
-    </p>
-}

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/Error.cshtml
@@ -15,7 +15,7 @@
 </p>
 @if (Activity.Current != null)
 {
-<p>
-    <strong>Correlation ID:</strong> <code>@Activity.Current.Id</code>
-</p>
+    <p>
+        <strong>Correlation ID:</strong> <code>@Activity.Current.Id</code>
+    </p>
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/Error.cshtml
@@ -1,5 +1,4 @@
-﻿@using System.Diagnostics
-@{
+﻿@{
     ViewData["Title"] = "Error";
 }
 


### PR DESCRIPTION
fixes #690 

I just realized this was still on my laptop and not sent. If we are ok with this as our beginning I can make the change to the other templates. I verified that I don't see the ID on my local machine but I do when I am in Azure and using hosting startup to turn on Application Insights

@DamianEdwards @lmolkova