### PR TITLE
Switch redirect type to temporary

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/urlRewrite.config
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/urlRewrite.config
@@ -7,7 +7,7 @@
         <add input="{HTTPS}" pattern="Off" />
         <add input="{HTTP_HOST}" negate="true" pattern="localhost" />
       </conditions>
-      <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" />
+      <action type="Redirect" redirectType="Temporary" url="https://{HTTP_HOST}/{R:1}" />
     </rule>
     <rule name="Redirect to https (localhost)">
       <match url="(.*)" />
@@ -15,7 +15,7 @@
         <add input="{HTTPS}" pattern="Off" />
         <add input="{HTTP_HOST}" pattern="localhost:55555" />
       </conditions>
-      <action type="Redirect" url="https://localhost:43434/{R:1}" />
+      <action type="Redirect" redirectType="Temporary" url="https://localhost:43434/{R:1}" />
     </rule>
   </rules>
 </rewrite>

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-CSharp/urlRewrite.config
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-CSharp/urlRewrite.config
@@ -7,7 +7,7 @@
         <add input="{HTTPS}" pattern="Off" />
         <add input="{HTTP_HOST}" negate="true" pattern="localhost" />
       </conditions>
-      <action type="Redirect" url="https://{HTTP_HOST}/{R:1}" />
+      <action type="Redirect" redirectType="Temporary" url="https://{HTTP_HOST}/{R:1}" />
     </rule>
     <rule name="Redirect to https (localhost)">
       <match url="(.*)" />
@@ -15,7 +15,7 @@
         <add input="{HTTPS}" pattern="Off" />
         <add input="{HTTP_HOST}" pattern="localhost:55555" />
       </conditions>
-      <action type="Redirect" url="https://localhost:43434/{R:1}" />
+      <action type="Redirect" redirectType="Temporary" url="https://localhost:43434/{R:1}" />
     </rule>
   </rules>
 </rewrite>


### PR DESCRIPTION
Currently the redirect type is defaulting to permanent, which will get cached indefinitely by browsers. This is super problematic in development. Switching to temporary.