### PR TITLE
Missing bowerrc for dotnet new razor - REBASED

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/.bowerrc
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "wwwroot/lib"
+}


### PR DESCRIPTION
Missing bowerrc for dotnet new razor