### PR TITLE
Add F# Empty Web & Web API, attempt to update for the 2.0 changes

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/.template.config/template.json
@@ -40,7 +40,7 @@
         }
       ],
       "replaces": "netcoreapp2.0",
-      "defaultValue": "netcoreapp1.1"
+      "defaultValue": "netcoreapp2.0"
     },
     "copyrightYear": {
       "type": "generated",

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/.template.config/template.json
@@ -1,0 +1,73 @@
+{
+  "author": "Microsoft",
+  "classifications": ["Web", "Empty"],
+  "name": "ASP.NET Core Empty",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "An empty project template for creating an ASP.NET Core application. This template does not have any content in it.",
+  "groupIdentity": "Microsoft.Web.Empty",
+  "precedence": "100",
+  "identity": "Microsoft.Web.Empty.FSharp",
+  "shortName": "web",
+  "thirdPartyNotices": "https://aka.ms/template-3pn",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "sourceName": "Company.WebApplication1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "IncludeApplicationInsights": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to include Application Insights in the project"
+    },
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "netcoreapp2.0",
+          "description": "Target netcoreapp2.0"
+        }
+      ],
+      "replaces": "netcoreapp2.0",
+      "defaultValue": "netcoreapp1.1"
+    },
+    "copyrightYear": {
+      "type": "generated",
+      "generator": "now",
+      "replaces": "1975",
+      "parameters": {
+        "format": "yyyy"
+      }
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [ { "path": "Company.WebApplication1.fsproj" } ],
+  "defaultName": "WebApplication1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        { "text": "Run 'dotnet restore'" }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Company.WebApplication1.fsproj
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Company.WebApplication1.fsproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.1.*" />
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25102" />
   </ItemGroup>
-  
+
 </Project>

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Company.WebApplication1.fsproj
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Company.WebApplication1.fsproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Controllers/*.fs" />
     <Compile Include="Startup.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Program.fs
@@ -1,0 +1,25 @@
+namespace Company.WebApplication1
+
+open System
+open System.IO
+open Microsoft.AspNetCore.Hosting
+
+module Program =
+    let exitCode = 0
+
+    [<EntryPoint>]
+    let main args =
+        let host = 
+            WebHostBuilder()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseKestrel()
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+    #if (IncludeApplicationInsights)
+                .UseApplicationInsights()
+    #endif
+                .Build()
+
+        host.Run()
+
+        exitCode

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Program.fs
@@ -1,25 +1,26 @@
 namespace Company.WebApplication1
 
 open System
+open System.Collections.Generic
 open System.IO
+open System.Linq
+open System.Threading.Tasks
+open Microsoft.AspNetCore
 open Microsoft.AspNetCore.Hosting
+open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.Logging
 
 module Program =
     let exitCode = 0
 
     [<EntryPoint>]
     let main args =
-        let host = 
-            WebHostBuilder()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseKestrel()
-                .UseIISIntegration()
-                .UseStartup<Startup>()
-    #if (IncludeApplicationInsights)
-                .UseApplicationInsights()
-    #endif
-                .Build()
-
-        host.Run()
+        BuildWebHost(args).Run()
 
         exitCode
+
+    let BuildWebHost args =
+        WebHost
+            .CreateDefaultBuilder(args)
+            .UseStartup<Startup>()
+            .Build()

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Program.fs
@@ -13,14 +13,14 @@ open Microsoft.Extensions.Logging
 module Program =
     let exitCode = 0
 
-    [<EntryPoint>]
-    let main args =
-        BuildWebHost(args).Run()
-
-        exitCode
-
     let BuildWebHost args =
         WebHost
             .CreateDefaultBuilder(args)
             .UseStartup<Startup>()
             .Build()
+
+    [<EntryPoint>]
+    let main args =
+        BuildWebHost(args).Run()
+
+        exitCode

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Startup.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Startup.fs
@@ -1,0 +1,22 @@
+namespace Company.WebApplication1
+
+open System
+open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Hosting
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Logging
+
+type Startup() =
+
+    member this.ConfigureServices(services: IServiceCollection) =
+        ()
+
+    member this.Configure(app: IApplicationBuilder, env: IHostingEnvironment, log: ILoggerFactory) =
+        log.AddConsole() |> ignore
+
+        if env.IsDevelopment() then app.UseDeveloperExceptionPage() |> ignore
+
+        app.Run(fun context -> context.Response.WriteAsync("Hello World!"))
+
+        ()

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Startup.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/EmptyWeb-FSharp/Startup.fs
@@ -5,14 +5,13 @@ open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.DependencyInjection
-open Microsoft.Extensions.Logging
 
 type Startup() =
 
     member this.ConfigureServices(services: IServiceCollection) =
         ()
 
-    member this.Configure(app: IApplicationBuilder, env: IHostingEnvironment, log: ILoggerFactory) =
+    member this.Configure(app: IApplicationBuilder, env: IHostingEnvironment) =
         log.AddConsole() |> ignore
 
         if env.IsDevelopment() then app.UseDeveloperExceptionPage() |> ignore

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Company.WebApplication1.fsproj
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Company.WebApplication1.fsproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Controllers/*.fs" />
+    <Compile Include="Controllers/HomeController.fs" />
     <Compile Include="Startup.fs" />
     <Compile Include="Program.fs" />
 

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Program.fs
@@ -5,20 +5,22 @@ open System.Collections.Generic
 open System.IO
 open System.Linq
 open System.Threading.Tasks
+open Microsoft.AspNetCore
 open Microsoft.AspNetCore.Hosting
+open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.Logging
 
 module Program =
+    let exitCode = 0
 
     [<EntryPoint>]
     let main args =
-        let host =
-            WebHostBuilder()
-                .UseKestrel()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseIISIntegration()
-                .UseStartup<Startup>()
-                .Build()
+        BuildWebHost(args).Run()
 
-        host.Run()
+        exitCode
 
-        0
+    let BuildWebHost args =
+        WebHost
+            .CreateDefaultBuilder(args)
+            .UseStartup<Startup>()
+            .Build()

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Program.fs
@@ -13,14 +13,14 @@ open Microsoft.Extensions.Logging
 module Program =
     let exitCode = 0
 
-    [<EntryPoint>]
-    let main args =
-        BuildWebHost(args).Run()
-
-        exitCode
-
     let BuildWebHost args =
         WebHost
             .CreateDefaultBuilder(args)
             .UseStartup<Startup>()
             .Build()
+
+    [<EntryPoint>]
+    let main args =
+        BuildWebHost(args).Run()
+
+        exitCode

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Startup.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Startup.fs
@@ -10,9 +10,7 @@ open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
 
 
-type Startup private () =
-
-    new (configuration: IConfiguration) as this =
+type Startup (configuration: IConfiguration) =
         Startup() then
         this.Configuration <- configuration
 

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Startup.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Startup.fs
@@ -8,22 +8,13 @@ open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.Extensions.Configuration
 open Microsoft.Extensions.DependencyInjection
-open Microsoft.Extensions.Logging
 
 
 type Startup private () =
 
-    new (env: IHostingEnvironment) as this =
+    new (configuration: IConfiguration) as this =
         Startup() then
-
-        let builder =
-            ConfigurationBuilder()
-                .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional = false, reloadOnChange = true)
-                .AddJsonFile((sprintf "appsettings.%s.json" (env.EnvironmentName)), optional = true)
-                .AddEnvironmentVariables()
-
-        this.Configuration <- builder.Build()
+        this.Configuration <- configuration
 
     // This method gets called by the runtime. Use this method to add services to the container.
     member this.ConfigureServices(services: IServiceCollection) =
@@ -31,10 +22,7 @@ type Startup private () =
         services.AddMvc() |> ignore
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-    member this.Configure(app: IApplicationBuilder, env: IHostingEnvironment, loggerFactory: ILoggerFactory) =
-
-        loggerFactory.AddConsole(this.Configuration.GetSection("Logging")) |> ignore
-        loggerFactory.AddDebug() |> ignore
+    member this.Configure(app: IApplicationBuilder, env: IHostingEnvironment) =
 
         if (env.IsDevelopment()) then
             app.UseDeveloperExceptionPage() |> ignore
@@ -49,4 +37,4 @@ type Startup private () =
                 template = "{controller=Home}/{action=Index}/{id?}") |> ignore
             ) |> ignore
 
-    member val Configuration : IConfigurationRoot = null with get, set
+    member val Configuration : IConfiguration = null with get, set

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/Error.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/Error.cshtml
@@ -1,9 +1,17 @@
-﻿@{
+﻿@model ErrorViewModel
+@{
     ViewData["Title"] = "Error";
 }
 
 <h1 class="text-danger">Error.</h1>
 <h2 class="text-danger">An error occurred while processing your request.</h2>
+
+@if (Model.ShowRequestId)
+{
+    <p>
+        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+    </p>
+}
 
 <h3>Development Mode</h3>
 <p>

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/_Layout.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/_Layout.cshtml
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Company.WebApplication1</title>
 
-    <environment names="Development">
+    <environment include="Development">
         <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
         <link rel="stylesheet" href="~/css/site.css" />
     </environment>
-    <environment names="Staging,Production">
+    <environment exclude="Development">
         <link rel="stylesheet" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/css/bootstrap.min.css"
               asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
               asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute" />
@@ -45,12 +45,12 @@
         </footer>
     </div>
 
-    <environment names="Development">
+    <environment include="Development">
         <script src="~/lib/jquery/dist/jquery.js"></script>
         <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
         <script src="~/js/site.js" asp-append-version="true"></script>
     </environment>
-    <environment names="Staging,Production">
+    <environment exclude="Development">
         <script src="https://ajax.aspnetcdn.com/ajax/jquery/jquery-2.2.0.min.js"
                 asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
                 asp-fallback-test="window.jQuery"

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,8 +1,8 @@
-﻿<environment names="Development">
+﻿<environment include="Development">
     <script src="~/lib/jquery-validation/dist/jquery.validate.js"></script>
     <script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js"></script>
 </environment>
-<environment names="Staging,Production">
+<environment exclude="Development">
     <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.14.0/jquery.validate.min.js"
             asp-fallback-src="~/lib/jquery-validation/dist/jquery.validate.min.js"
             asp-fallback-test="window.jQuery && window.jQuery.validator"

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/appsettings.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-FSharp/appsettings.json
@@ -1,8 +1,15 @@
 ﻿{
   "Logging": {
     "IncludeScopes": false,
-    "LogLevel": {
-      "Default": "Warning"
+    "Debug": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/.template.config/template.json
@@ -1,0 +1,73 @@
+{
+  "author": "Microsoft",
+  "classifications": ["Web", "WebAPI"],
+  "name": "ASP.NET Core Web API",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "A project template for creating an ASP.NET Core application with an example Controller for a RESTful HTTP service. This template can also be used for ASP.NET MVC Views and Controllers.",
+  "groupIdentity": "Microsoft.Web.WebApi",
+  "precedence": "200",
+  "identity": "Microsoft.Web.WebApi.FSharp",
+  "shortName": "webapi",
+  "thirdPartyNotices": "https://aka.ms/template-3pn",
+  "tags": {
+    "language": "F#",
+    "type": "project"
+  },
+  "sourceName": "Company.WebApplication1",
+  "preferNameDirectory": true,
+  "symbols": {
+    "IncludeApplicationInsights": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether or not to include Application Insights in the project"
+    },
+    "TargetFrameworkOverride": {
+      "type": "parameter",
+      "description": "Overrides the target framework",
+      "replaces": "TargetFrameworkOverride",
+      "datatype": "string",
+      "defaultValue": ""
+    },
+    "Framework": {
+      "type": "parameter",
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "netcoreapp2.0",
+          "description": "Target netcoreapp2.0"
+        }
+      ],
+      "replaces": "netcoreapp2.0",
+      "defaultValue": "netcoreapp2.0"
+    },
+    "copyrightYear": {
+      "type": "generated",
+      "generator": "now",
+      "replaces": "1975",
+      "parameters": {
+        "format": "yyyy"
+      }
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "If specified, skips the automatic restore of the project on create.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [ { "path": "Company.WebApplication1.fsproj" } ],
+  "defaultName": "WebApplication1",
+  "postActions": [
+    {
+      "condition": "(!skipRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        { "text": "Run 'dotnet restore'" }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ]
+}

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Company.WebApplication1.fsproj
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Company.WebApplication1.fsproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Controllers/*.fs" />
+    <Compile Include="Controllers/ValuesController.fs" />
     <Compile Include="Startup.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Company.WebApplication1.fsproj
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Company.WebApplication1.fsproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.1.*" />
     <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.0-preview2-25102" />
   </ItemGroup>
-  
+
 </Project>

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Company.WebApplication1.fsproj
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Company.WebApplication1.fsproj
@@ -1,0 +1,25 @@
+<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Controllers/*.fs" />
+    <Compile Include="Startup.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="4.1.*" />
+    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" Condition="'$(IncludeApplicationInsights)' == 'True'" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.0.5" Condition="'$(Framework)' != 'netcoreapp1.1'" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" Condition="'$(Framework)' == 'netcoreapp1.1'" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.2" />
+
+  </ItemGroup>
+  
+</Project>

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Controllers/ValuesController.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Controllers/ValuesController.fs
@@ -1,0 +1,31 @@
+﻿namespace Company.WebApplication1.Controllers
+
+open System
+open System.Collections.Generic
+open System.Linq
+open System.Threading.Tasks
+open Microsoft.AspNetCore.Mvc
+
+[<Route("api/[controller]")>]
+type ValuesController () =
+    inherit Controller()
+
+    [<HttpGet>]
+    member this.Get() =
+        [|"value1" , "value2"|]
+
+    [<HttpGet("{id}")>]
+    member this.Get(id:int) =
+        "value"
+
+    [<HttpPost>]
+    member this.Post([<FromBody>]value:string) =
+        ()
+
+    [<HttpPut("{id}")>]
+    member this.Put(id:int, [<FromBody>]value:string ) =
+        ()
+
+    [<HttpDelete("{id}")>]
+    member this.Delete(id:int) =
+        ()

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Program.fs
@@ -1,0 +1,25 @@
+namespace Company.WebApplication1
+
+open System
+open System.IO
+open Microsoft.AspNetCore.Hosting
+
+module Program =
+    let exitCode = 0
+
+    [<EntryPoint>]
+    let main args =
+        let host = 
+            WebHostBuilder()
+                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseKestrel()
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+    #if (IncludeApplicationInsights)
+                .UseApplicationInsights()
+    #endif
+                .Build()
+
+        host.Run()
+
+        exitCode

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Program.fs
@@ -1,25 +1,26 @@
 namespace Company.WebApplication1
 
 open System
+open System.Collections.Generic
 open System.IO
+open System.Linq
+open System.Threading.Tasks
+open Microsoft.AspNetCore
 open Microsoft.AspNetCore.Hosting
+open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.Logging
 
 module Program =
     let exitCode = 0
 
     [<EntryPoint>]
     let main args =
-        let host = 
-            WebHostBuilder()
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseKestrel()
-                .UseIISIntegration()
-                .UseStartup<Startup>()
-    #if (IncludeApplicationInsights)
-                .UseApplicationInsights()
-    #endif
-                .Build()
-
-        host.Run()
+        BuildWebHost(args).Run()
 
         exitCode
+
+    let BuildWebHost args =
+        WebHost
+            .CreateDefaultBuilder(args)
+            .UseStartup<Startup>()
+            .Build()

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Program.fs
@@ -13,14 +13,14 @@ open Microsoft.Extensions.Logging
 module Program =
     let exitCode = 0
 
-    [<EntryPoint>]
-    let main args =
-        BuildWebHost(args).Run()
-
-        exitCode
-
     let BuildWebHost args =
         WebHost
             .CreateDefaultBuilder(args)
             .UseStartup<Startup>()
             .Build()
+
+    [<EntryPoint>]
+    let main args =
+        BuildWebHost(args).Run()
+
+        exitCode

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Startup.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Startup.fs
@@ -1,0 +1,41 @@
+namespace Company.WebApplication1
+
+open System
+open System.Collections.Generic
+open System.Linq
+open System.Threading.Tasks
+open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Hosting
+open Microsoft.Extensions.Configuration
+open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Logging
+
+
+type Startup private () =
+
+    new (env: IHostingEnvironment) as this =
+        Startup() then
+
+        let builder =
+            ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional = false, reloadOnChange = true)
+                .AddJsonFile((sprintf "appsettings.%s.json" (env.EnvironmentName)), optional = true)
+                .AddEnvironmentVariables()
+
+        this.Configuration <- builder.Build()
+
+    // This method gets called by the runtime. Use this method to add services to the container.
+    member this.ConfigureServices(services: IServiceCollection) =
+        // Add framework services.
+        services.AddMvc() |> ignore
+
+    // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+    member this.Configure(app: IApplicationBuilder, env: IHostingEnvironment, loggerFactory: ILoggerFactory) =
+
+        loggerFactory.AddConsole(this.Configuration.GetSection("Logging")) |> ignore
+        loggerFactory.AddDebug() |> ignore
+
+        app.UseMvc() |> ignore
+
+    member val Configuration : IConfigurationRoot = null with get, set

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Startup.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Startup.fs
@@ -10,9 +10,7 @@ open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.DependencyInjection
 
 
-type Startup private () =
-
-    new (configuration: IConfiguration) as this =
+type Startup (configuration: IConfiguration) =
         Startup() then
         this.Configuration <- configuration
 

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Startup.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Startup.fs
@@ -6,24 +6,15 @@ open System.Linq
 open System.Threading.Tasks
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
-open Microsoft.Extensions.Configuration
+open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.DependencyInjection
-open Microsoft.Extensions.Logging
 
 
 type Startup private () =
 
-    new (env: IHostingEnvironment) as this =
+    new (configuration: IConfiguration) as this =
         Startup() then
-
-        let builder =
-            ConfigurationBuilder()
-                .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional = false, reloadOnChange = true)
-                .AddJsonFile((sprintf "appsettings.%s.json" (env.EnvironmentName)), optional = true)
-                .AddEnvironmentVariables()
-
-        this.Configuration <- builder.Build()
+        this.Configuration <- configuration
 
     // This method gets called by the runtime. Use this method to add services to the container.
     member this.ConfigureServices(services: IServiceCollection) =
@@ -31,11 +22,7 @@ type Startup private () =
         services.AddMvc() |> ignore
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-    member this.Configure(app: IApplicationBuilder, env: IHostingEnvironment, loggerFactory: ILoggerFactory) =
-
-        loggerFactory.AddConsole(this.Configuration.GetSection("Logging")) |> ignore
-        loggerFactory.AddDebug() |> ignore
-
+    member this.Configure(app: IApplicationBuilder, env: IHostingEnvironment) =
         app.UseMvc() |> ignore
 
-    member val Configuration : IConfigurationRoot = null with get, set
+    member val Configuration : IConfiguration = null with get, set

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/appsettings.Development.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/appsettings.Development.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/appsettings.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/appsettings.json
@@ -1,0 +1,8 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
This is an attempt to port the F# Empty Web and Web API from 1.x and update to the new program and startup class style (and a few other minor tweaks to make the cshtml files match). What I have here is probably not quite right (being generous), I'd love some F# experts to chime in.

@lambdakris @enricosada @KevinRansom

Fixes #251 
Fixes #252 