### PR TITLE
Constrain routes

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/WebApi-CSharp/Controllers/ValuesController.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/WebApi-CSharp/Controllers/ValuesController.cs
@@ -23,7 +23,7 @@ namespace Company.WebApplication1.Controllers
         }
 
         // GET api/values/5
-        [HttpGet("{id}")]
+        [HttpGet("{id:int}")]
         public string Get(int id)
         {
             return "value";
@@ -39,7 +39,7 @@ namespace Company.WebApplication1.Controllers
         }
 
         // PUT api/values/5
-        [HttpPut("{id}")]
+        [HttpPut("{id:int}")]
         public void Put(int id, [FromBody]string value)
         {
 #if (OrganizationalAuth || WindowsAuth)
@@ -48,7 +48,7 @@ namespace Company.WebApplication1.Controllers
         }
 
         // DELETE api/values/5
-        [HttpDelete("{id}")]
+        [HttpDelete("{id:int}")]
         public void Delete(int id)
         {
 #if (OrganizationalAuth || WindowsAuth)

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-CSharp/Controllers/ValuesController.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-CSharp/Controllers/ValuesController.cs
@@ -23,7 +23,7 @@ namespace Company.WebApplication1.Controllers
         }
 
         // GET api/values/5
-        [HttpGet("{id}")]
+        [HttpGet("{id:int}")]
         public string Get(int id)
         {
             return "value";
@@ -39,7 +39,7 @@ namespace Company.WebApplication1.Controllers
         }
 
         // PUT api/values/5
-        [HttpPut("{id}")]
+        [HttpPut("{id:int}")]
         public void Put(int id, [FromBody]string value)
         {
 #if (OrganizationalAuth || WindowsAuth)
@@ -48,7 +48,7 @@ namespace Company.WebApplication1.Controllers
         }
 
         // DELETE api/values/5
-        [HttpDelete("{id}")]
+        [HttpDelete("{id:int}")]
         public void Delete(int id)
         {
 #if (OrganizationalAuth || WindowsAuth)


### PR DESCRIPTION
Since the id paramter is a value type, and has a default value. Those actions will invoke even when the route contains a string, such as `/api/values/yo`. To the average user, its not obvious this behavior will occur. 

This also outlines an extra feature to users, that may not realize you can constrain routes on types.