### PR TITLE
Turn off literal dereference in strings in C++ expressions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,5 +13,8 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 charset = utf-8
 
+[**/*.sh]
+end_of_line = lf
+
 [**/*.json]
 indent_size = 2

--- a/src/Microsoft.TemplateEngine.Core/Expressions/Cpp2/Cpp2StyleEvaluatorDefinition.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/Cpp2/Cpp2StyleEvaluatorDefinition.cs
@@ -77,7 +77,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions.Cpp2
         public static bool Evaluate(IProcessorState processor, ref int bufferLength, ref int currentBufferPosition, out bool faulted)
         {
             ITokenTrie tokens = GetSymbols(processor);
-            ScopeBuilder<Operators, Tokens> builder = processor.ScopeBuilder(tokens, Map, true);
+            ScopeBuilder<Operators, Tokens> builder = processor.ScopeBuilder(tokens, Map, false);
             bool isFaulted = false;
             IEvaluable result = builder.Build(ref bufferLength, ref currentBufferPosition, x => isFaulted = true);
 


### PR DESCRIPTION
Fixes #789 