### PR TITLE
Added missing "AccessDenied" view for account controller in StarterWe…

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Account/AccessDenied.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Account/AccessDenied.cshtml
@@ -1,0 +1,8 @@
+﻿@{
+    ViewData["Title"] = "Access Denied";
+}
+
+<header>
+    <h1 class="text-danger">Access Denied.</h1>
+    <p class="text-danger">You do not have access to this resource.</p>
+</header>


### PR DESCRIPTION
There was missing a view for account controller. It's basicly the same view as in Areas/IdentityService/Views/Account. 
I'm not sure if those views should be shared (and how) because they belong to different areas.

