### PR TITLE
fix bug with spaces in inputs

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Microsoft.TemplateEngine.Edge/Settings/AliasManipulationResult.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/AliasManipulationResult.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -11,15 +11,15 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         {
         }
 
-        public AliasManipulationResult(AliasManipulationStatus status, string aliasName, string aliasValue)
+        public AliasManipulationResult(AliasManipulationStatus status, string aliasName, IReadOnlyList<string> aliasTokens)
         {
             Status = status;
             AliasName = aliasName;
-            AliasValue = aliasValue;
+            AliasTokens = aliasTokens;
         }
 
         public AliasManipulationStatus Status { get; }
         public string AliasName { get; }
-        public string AliasValue { get; }
+        public IReadOnlyList<string> AliasTokens { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/AliasModel.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/AliasModel.cs
@@ -1,29 +1,30 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace Microsoft.TemplateEngine.Edge.Settings
 {
     public class AliasModel
     {
         public AliasModel()
-            : this(new Dictionary<string, string>())
+            : this(new Dictionary<string, IReadOnlyList<string>>())
         {
         }
 
-        public AliasModel(Dictionary<string, string> commandAliases)
+        public AliasModel(IReadOnlyDictionary<string, IReadOnlyList<string>> commandAliases)
         {
-            CommandAliases = new Dictionary<string, string>(commandAliases, StringComparer.OrdinalIgnoreCase);
+            CommandAliases = new Dictionary<string, IReadOnlyList<string>>(commandAliases.ToDictionary(x => x.Key, x => x.Value), StringComparer.OrdinalIgnoreCase);
         }
 
-        public void AddCommandAlias(string aliasName, string aliasValue)
+        public void AddCommandAlias(string aliasName, IReadOnlyList<string> aliasTokens)
         {
-            CommandAliases.Add(aliasName, aliasValue);
+            CommandAliases.Add(aliasName, aliasTokens);
         }
 
-        public bool TryRemoveCommandAlias(string aliasName, out string aliasValue)
+        public bool TryRemoveCommandAlias(string aliasName, out IReadOnlyList<string> aliasTokens)
         {
-            if (CommandAliases.TryGetValue(aliasName, out aliasValue))
+            if (CommandAliases.TryGetValue(aliasName, out aliasTokens))
             {
                 CommandAliases.Remove(aliasName);
                 return true;
@@ -33,6 +34,6 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         }
 
         [JsonProperty]
-        public Dictionary<string, string> CommandAliases { get; set; }
+        public Dictionary<string, IReadOnlyList<string>> CommandAliases { get; set; }
     }
 }

--- a/src/Shared/JExtensions.cs
+++ b/src/Shared/JExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
@@ -207,7 +207,7 @@ namespace Microsoft.TemplateEngine
                 }
                 else if (property.Value.Type == JTokenType.Array)
                 {
-                    result[property.Name] = property.ArrayAsStrings();
+                    result[property.Name] = property.Value.ArrayAsStrings();
                 }
             }
 


### PR DESCRIPTION
The changes here revolve around working with inputs & alias expansions as lists of tokens, as opposed to single strings that get naively parsed. 

This changes the format of the aliases file, now it's like this:
```
{
  "CommandAliases": {
    "<aliasName>" : [ <array of args> ],
    "<aliasName>" : [ <array of args> ]
  }
}
```

Addresses #792 