### PR TITLE
fixes order of assignment of input param aliases. 

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/AliasAssignmentCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/AliasAssignmentCoordinator.cs
@@ -1,0 +1,181 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Cli.CommandParsing
+{
+    public class AliasAssignmentCoordinator
+    {
+        private IReadOnlyList<ITemplateParameter> _parameterDefinitions;
+        private IDictionary<string, string> _longNameOverrides;
+        private IDictionary<string, string> _shortNameOverrides;
+        private HashSet<string> _takenAliases;
+        private Dictionary<string, string> _longAssignments;
+        private Dictionary<string, string> _shortAssignments;
+        private HashSet<string> _invalidParams;
+        private bool _calculatedAssignments;
+
+        public AliasAssignmentCoordinator(IReadOnlyList<ITemplateParameter> parameterDefinitions, IDictionary<string, string> longNameOverrides, IDictionary<string, string> shortNameOverrides, HashSet<string> takenAliases)
+        {
+            _parameterDefinitions = parameterDefinitions;
+            _longNameOverrides = longNameOverrides;
+            _shortNameOverrides = shortNameOverrides;
+            _takenAliases = takenAliases;
+            _longAssignments = new Dictionary<string, string>();
+            _shortAssignments = new Dictionary<string, string>();
+            _invalidParams = new HashSet<string>();
+            _calculatedAssignments = false;
+        }
+
+        public IReadOnlyDictionary<string, string> LongNameOverrides
+        {
+            get
+            {
+                EnsureAliasAssignments();
+                return _longAssignments;
+            }
+        }
+
+        public IReadOnlyDictionary<string, string> ShortNameOverrides
+        {
+            get
+            {
+                EnsureAliasAssignments();
+                return _shortAssignments;
+            }
+        }
+
+        public HashSet<string> InvalidParams
+        {
+            get
+            {
+                EnsureAliasAssignments();
+                return _invalidParams;
+            }
+        }
+
+        public HashSet<string> TakenAliases
+        {
+            get
+            {
+                EnsureAliasAssignments();
+                return _takenAliases;
+            }
+        }
+
+        private void EnsureAliasAssignments()
+        {
+            if (_calculatedAssignments)
+            {
+                return;
+            }
+
+            Dictionary<string, KeyValuePair<string, string>> aliasAssignments = new Dictionary<string, KeyValuePair<string, string>>();
+            Dictionary<string, ITemplateParameter> paramNamesNeedingAssignment = _parameterDefinitions.Where(x => x.Priority != TemplateParameterPriority.Implicit)
+                                                                                    .ToDictionary(x => x.Name, x => x);
+
+            SetupAssignmentsFromLongOverrides(paramNamesNeedingAssignment);
+            SetupAssignmentsFromShortOverrides(paramNamesNeedingAssignment);
+            SetupAssignmentsWithoutOverrides(paramNamesNeedingAssignment);
+
+            _calculatedAssignments = true;
+        }
+
+        private void SetupAssignmentsFromLongOverrides(IReadOnlyDictionary<string, ITemplateParameter> paramNamesNeedingAssignment)
+        {
+            foreach (KeyValuePair<string, string> canonicalAndLong in _longNameOverrides.Where(x => paramNamesNeedingAssignment.ContainsKey(x.Key)))
+            {
+                string canonical = canonicalAndLong.Key;
+                string longOverride = canonicalAndLong.Value;
+                if (CommandAliasAssigner.TryAssignAliasesForParameter((x) => _takenAliases.Contains(x), canonical, longOverride, null, out IReadOnlyList<string> assignedAliases))
+                {
+                    // only deal with the long here, ignore the short for now
+                    string longParam = assignedAliases.FirstOrDefault(x => x.StartsWith("--"));
+                    if (!string.IsNullOrEmpty(longParam))
+                    {
+                        _longAssignments.Add(canonical, longParam);
+                        _takenAliases.Add(longParam);
+                    }
+                }
+                else
+                {
+                    _invalidParams.Add(canonical);
+                }
+            }
+        }
+
+        private void SetupAssignmentsFromShortOverrides(IReadOnlyDictionary<string, ITemplateParameter> paramNamesNeedingAssignment)
+        {
+            foreach (KeyValuePair<string, string> canonicalAndShort in _shortNameOverrides.Where(x => paramNamesNeedingAssignment.ContainsKey(x.Key)))
+            {
+                string canonical = canonicalAndShort.Key;
+                string shortOverride = canonicalAndShort.Value;
+
+                if (shortOverride == string.Empty)
+                {   // it was explicitly empty string in the host file. If it wasn't specified, it'll be null
+                    // this means there should be no short version
+                    continue;
+                }
+
+                if (CommandAliasAssigner.TryAssignAliasesForParameter((x) => _takenAliases.Contains(x), canonical, null, shortOverride, out IReadOnlyList<string> assignedAliases))
+                {
+                    string shortParam = assignedAliases.FirstOrDefault(x => x.StartsWith("-") && !x.StartsWith("--"));
+                    if (!string.IsNullOrEmpty(shortParam))
+                    {
+                        _shortAssignments.Add(canonical, shortParam);
+                        _takenAliases.Add(shortParam);
+                    }
+                }
+                else
+                {
+                    _invalidParams.Add(canonical);
+                }
+            }
+        }
+
+        private void SetupAssignmentsWithoutOverrides(IReadOnlyDictionary<string, ITemplateParameter> paramNamesNeedingAssignment)
+        {
+            foreach (ITemplateParameter parameterInfo in paramNamesNeedingAssignment.Values)
+            {
+                if (_longAssignments.ContainsKey(parameterInfo.Name) && _shortAssignments.ContainsKey(parameterInfo.Name))
+                {   // already fully assigned
+                    continue;
+                }
+
+                _longNameOverrides.TryGetValue(parameterInfo.Name, out string longOverride);
+                _shortNameOverrides.TryGetValue(parameterInfo.Name, out string shortOverride);
+
+                if (CommandAliasAssigner.TryAssignAliasesForParameter((x) => _takenAliases.Contains(x), parameterInfo.Name, longOverride, shortOverride, out IReadOnlyList<string> assignedAliases))
+                {
+                    if (shortOverride != string.Empty)
+                    {   // explicit empty string in the host file means there should be no short name.
+                        // but thats not the case here.
+                        if (!_shortAssignments.ContainsKey(parameterInfo.Name))
+                        {   // still needs a short version
+                            string shortParam = assignedAliases.FirstOrDefault(x => x.StartsWith("-") && !x.StartsWith("--"));
+                            if (!string.IsNullOrEmpty(shortParam))
+                            {
+                                _shortAssignments.Add(parameterInfo.Name, shortParam);
+                                _takenAliases.Add(shortParam);
+                            }
+                        }
+                    }
+
+                    if (!_longAssignments.ContainsKey(parameterInfo.Name))
+                    {   // still needs a long version
+                        string longParam = assignedAliases.FirstOrDefault(x => x.StartsWith("--"));
+                        if (!string.IsNullOrEmpty(longParam))
+                        {
+                            _longAssignments.Add(parameterInfo.Name, longParam);
+                            _takenAliases.Add(longParam);
+                        }
+                    }
+                }
+                else
+                {
+                    _invalidParams.Add(parameterInfo.Name);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/AliasAssignmentCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/AliasAssignmentCoordinator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             _calculatedAssignments = false;
         }
 
-        public IReadOnlyDictionary<string, string> LongNameOverrides
+        public IReadOnlyDictionary<string, string> LongNameAssignments
         {
             get
             {
@@ -36,7 +36,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             }
         }
 
-        public IReadOnlyDictionary<string, string> ShortNameOverrides
+        public IReadOnlyDictionary<string, string> ShortNameAssignments
         {
             get
             {

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
@@ -53,55 +53,54 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         {
             IList<Option> paramOptionList = new List<Option>();
             Option[] allBuiltInArgs = ArrayExtensions.CombineArrays(NewCommandVisibleArgs, NewCommandHiddenArgs, NewCommandReservedArgs, DebuggingCommandArgs);
-            HashSet<string> takenAliases = VariantsForOptions(allBuiltInArgs);
-            HashSet<string> invalidParams = new HashSet<string>();
+
+            HashSet<string> initiallyTakenAliases = VariantsForOptions(allBuiltInArgs);
             Dictionary<string, IReadOnlyList<string>> canonicalToVariantMap = new Dictionary<string, IReadOnlyList<string>>();
+            AliasAssignmentCoordinator assignmentCoordinator = new AliasAssignmentCoordinator(parameterDefinitions, longNameOverrides, shortNameOverrides, initiallyTakenAliases);
+
+            if (assignmentCoordinator.InvalidParams.Count > 0)
+            {
+                string unusableDisplayList = string.Join(", ", assignmentCoordinator.InvalidParams);
+                throw new Exception($"Template is malformed. The following parameter names are invalid: {unusableDisplayList}");
+            }
 
             foreach (ITemplateParameter parameter in parameterDefinitions.Where(x => x.Priority != TemplateParameterPriority.Implicit))
             {
-                string canonical = parameter.Name;
-                longNameOverrides.TryGetValue(canonical, out string longOverride);
-                shortNameOverrides.TryGetValue(canonical, out string shortOverride);
+                Option option;
+                IList<string> aliasesForParam = new List<string>();
 
-                if (CommandAliasAssigner.TryAssignAliasesForParameter((x) => takenAliases.Contains(x), canonical, longOverride, shortOverride, out IReadOnlyList<string> assignedAliases))
+                if (assignmentCoordinator.LongNameOverrides.TryGetValue(parameter.Name, out string longVersion))
                 {
-                    Option option;
+                    aliasesForParam.Add(longVersion);
+                }
 
-                    if (string.Equals(parameter.DataType, "choice", StringComparison.OrdinalIgnoreCase))
-                    {
-                        IList<string> choices = parameter.Choices.Keys.ToList();
-                        option = Create.Option(string.Join("|", assignedAliases), parameter.Documentation,
+                if (assignmentCoordinator.ShortNameOverrides.TryGetValue(parameter.Name, out string shortVersion))
+                {
+                    aliasesForParam.Add(shortVersion);
+                }
+
+                if (string.Equals(parameter.DataType, "choice", StringComparison.OrdinalIgnoreCase))
+                {
+                    option = Create.Option(string.Join("|", aliasesForParam), parameter.Documentation,
                                             Accept.ExactlyOneArgument()
                                                 //.WithSuggestionsFrom(parameter.Choices.Keys.ToArray())
                                                 .With(defaultValue: () => parameter.DefaultValue));
-                    }
-                    else if (string.Equals(parameter.DataType, "bool", StringComparison.OrdinalIgnoreCase))
-                    {
-                        option = Create.Option(string.Join("|", assignedAliases), parameter.Documentation,
-                                            Accept.ZeroOrOneArgument()
-                                                .WithSuggestionsFrom(new[] { "true", "false" }));
+                }
+                else if (string.Equals(parameter.DataType, "bool", StringComparison.OrdinalIgnoreCase))
+                {
+                    option = Create.Option(string.Join("|", aliasesForParam), parameter.Documentation,
+                                        Accept.ZeroOrOneArgument()
+                                            .WithSuggestionsFrom(new[] { "true", "false" }));
 
-                    }
-                    else
-                    {
-                        option = Create.Option(string.Join("|", assignedAliases), parameter.Documentation,
-                                            Accept.ExactlyOneArgument());
-                    }
-
-                    paramOptionList.Add(option);    // add the option
-                    canonicalToVariantMap.Add(canonical, assignedAliases.ToList());   // map the template canonical name to its aliases.
-                    takenAliases.UnionWith(assignedAliases);  // add the aliases to the taken aliases
                 }
                 else
                 {
-                    invalidParams.Add(canonical);
+                    option = Create.Option(string.Join("|", aliasesForParam), parameter.Documentation,
+                                        Accept.ExactlyOneArgument());
                 }
-            }
 
-            if (invalidParams.Count > 0)
-            {
-                string unusableDisplayList = string.Join(", ", invalidParams);
-                throw new Exception($"Template is malformed. The following parameter names are invalid: {unusableDisplayList}");
+                paramOptionList.Add(option);    // add the option
+                canonicalToVariantMap.Add(parameter.Name, aliasesForParam.ToList());   // map the template canonical name to its aliases.
             }
 
             templateParamMap = canonicalToVariantMap;

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -69,12 +69,12 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                 Option option;
                 IList<string> aliasesForParam = new List<string>();
 
-                if (assignmentCoordinator.LongNameOverrides.TryGetValue(parameter.Name, out string longVersion))
+                if (assignmentCoordinator.LongNameAssignments.TryGetValue(parameter.Name, out string longVersion))
                 {
                     aliasesForParam.Add(longVersion);
                 }
 
-                if (assignmentCoordinator.ShortNameOverrides.TryGetValue(parameter.Name, out string shortVersion))
+                if (assignmentCoordinator.ShortNameAssignments.TryGetValue(parameter.Name, out string shortVersion))
                 {
                     aliasesForParam.Add(shortVersion);
                 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/AliasAssignmentTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/AliasAssignmentTests.cs
@@ -1,0 +1,298 @@
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Mocks;
+using Microsoft.TemplateEngine.Utils;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests
+{
+    public class AliasAssignmentTests
+    {
+        // also asserts that "--param:<name>" is used if <name> is taken
+        [Fact(DisplayName = nameof(LongNameOverrideTakesPrecendence))]
+        public void LongNameOverrideTakesPrecendence()
+        {
+            IReadOnlyList<string> paramNameList = new List<string>()
+            {
+                "foo",
+                "bar",
+            };
+            IReadOnlyList<ITemplateParameter> parameters = ParameterNamesToParametersTransform(paramNameList);
+
+            IDictionary<string, string> longNameOverrides = new Dictionary<string, string>()
+            {
+                { "bar", "foo" }    // bar explicitly wants foo for its long form
+            };
+            IDictionary<string, string> shortNameOverrides = new Dictionary<string, string>();
+
+            AliasAssignmentCoordinator assignmentCoordinator = new AliasAssignmentCoordinator(parameters, longNameOverrides, shortNameOverrides, InitiallyTakenAliases);
+
+            Assert.Equal("--param:foo", assignmentCoordinator.LongNameAssignments["foo"]);
+            Assert.Equal("-f", assignmentCoordinator.ShortNameAssignments["foo"]);
+            Assert.Equal("--foo", assignmentCoordinator.LongNameAssignments["bar"]);
+            Assert.Equal("-fo", assignmentCoordinator.ShortNameAssignments["bar"]); // the short name is based on the long name override if it exists
+            Assert.Equal(0, assignmentCoordinator.InvalidParams.Count);
+
+        }
+
+        [Fact(DisplayName = nameof(ShortNameOverrideTakesPrecedence))]
+        public void ShortNameOverrideTakesPrecedence()
+        {
+            IReadOnlyList<string> paramNameList = new List<string>()
+            {
+                "foo",
+                "bar",
+            };
+            IReadOnlyList<ITemplateParameter> parameters = ParameterNamesToParametersTransform(paramNameList);
+
+            IDictionary<string, string> longNameOverrides = new Dictionary<string, string>();
+            IDictionary<string, string> shortNameOverrides = new Dictionary<string, string>()
+            {
+                { "bar", "f" }  // bar explicitly wants f for its short form
+            };
+
+            AliasAssignmentCoordinator assignmentCoordinator = new AliasAssignmentCoordinator(parameters, longNameOverrides, shortNameOverrides, InitiallyTakenAliases);
+
+            Assert.Equal("--foo", assignmentCoordinator.LongNameAssignments["foo"]);
+            Assert.Equal("-fo", assignmentCoordinator.ShortNameAssignments["foo"]);
+            Assert.Equal("--bar", assignmentCoordinator.LongNameAssignments["bar"]);
+            Assert.Equal("-f", assignmentCoordinator.ShortNameAssignments["bar"]);
+            Assert.Equal(0, assignmentCoordinator.InvalidParams.Count);
+        }
+
+        [Fact(DisplayName = nameof(ShortNameExcludedWithEmptyStringOverride))]
+        public void ShortNameExcludedWithEmptyStringOverride()
+        {
+            IReadOnlyList<string> paramNameList = new List<string>()
+            {
+                "foo",
+                "bar",
+            };
+            IReadOnlyList<ITemplateParameter> parameters = ParameterNamesToParametersTransform(paramNameList);
+
+            IDictionary<string, string> longNameOverrides = new Dictionary<string, string>();
+            IDictionary<string, string> shortNameOverrides = new Dictionary<string, string>()
+            {
+                { "bar", "" }  // bar explicitly wants f for its short form
+            };
+
+            AliasAssignmentCoordinator assignmentCoordinator = new AliasAssignmentCoordinator(parameters, longNameOverrides, shortNameOverrides, InitiallyTakenAliases);
+
+            Assert.Equal("--foo", assignmentCoordinator.LongNameAssignments["foo"]);
+            Assert.Equal("-f", assignmentCoordinator.ShortNameAssignments["foo"]);
+            Assert.Equal("--bar", assignmentCoordinator.LongNameAssignments["bar"]);
+            Assert.False(assignmentCoordinator.ShortNameAssignments.TryGetValue("bar", out string placeholder));
+            Assert.Equal(0, assignmentCoordinator.InvalidParams.Count);
+        }
+
+        [Fact(DisplayName = nameof(ParameterNameCannotContainColon))]
+        public void ParameterNameCannotContainColon()
+        {
+            IReadOnlyList<string> paramNameList = new List<string>()
+            {
+                "foo:bar",
+            };
+            IReadOnlyList<ITemplateParameter> parameters = ParameterNamesToParametersTransform(paramNameList);
+
+            IDictionary<string, string> longNameOverrides = new Dictionary<string, string>();
+            IDictionary<string, string> shortNameOverrides = new Dictionary<string, string>();
+
+            AliasAssignmentCoordinator assignmentCoordinator = new AliasAssignmentCoordinator(parameters, longNameOverrides, shortNameOverrides, InitiallyTakenAliases);
+
+            Assert.Equal(0, assignmentCoordinator.LongNameAssignments.Count);
+            Assert.Equal(0, assignmentCoordinator.ShortNameAssignments.Count);
+            Assert.Equal(1, assignmentCoordinator.InvalidParams.Count);
+            Assert.True(assignmentCoordinator.InvalidParams.Contains("foo:bar"));
+        }
+
+        [Fact(DisplayName = nameof(ShortNameGetPrependedPColonIfNeeded))]
+        public void ShortNameGetPrependedPColonIfNeeded()
+        {
+            IReadOnlyList<string> paramNameList = new List<string>()
+            {
+                "bar",
+                "f"
+            };
+            IReadOnlyList<ITemplateParameter> parameters = ParameterNamesToParametersTransform(paramNameList);
+
+            IDictionary<string, string> longNameOverrides = new Dictionary<string, string>();
+            IDictionary<string, string> shortNameOverrides = new Dictionary<string, string>()
+            {
+                { "bar", "f" }
+            };
+
+            AliasAssignmentCoordinator assignmentCoordinator = new AliasAssignmentCoordinator(parameters, longNameOverrides, shortNameOverrides, InitiallyTakenAliases);
+
+            Assert.Equal("--bar", assignmentCoordinator.LongNameAssignments["bar"]);
+            Assert.Equal("-f", assignmentCoordinator.ShortNameAssignments["bar"]);
+            Assert.Equal("--f", assignmentCoordinator.LongNameAssignments["f"]);
+            Assert.Equal("-p:f", assignmentCoordinator.ShortNameAssignments["f"]);
+        }
+
+        // This reflects the MVC 2.0 tempalte as of May 24, 2017
+        [Fact(DisplayName = nameof(CheckAliasAssignmentsMvc20))]
+        public void CheckAliasAssignmentsMvc20()
+        {
+            IReadOnlyList<string> paramNameList = new List<string>()
+            {
+                "auth",
+                "AAdB2CInstance",
+                "SignUpSignInPolicyId",
+                "ResetPasswordPolicyId",
+                "EditProfilePolicyId",
+                "AADInstance",
+                "ClientId",
+                "Domain",
+                "TenantId",
+                "CallbackPath",
+                "OrgReadAccess",
+                "UserSecretsId",
+                "IncludeLaunchSettings",
+                "HttpsPort",
+                "KestrelPort",
+                "IISExpressPort",
+                "UseLocalDB",
+                "TargetFrameworkOverride",
+                "Framework",
+                "NoTools",
+                "skipRestore",
+            };
+            IReadOnlyList<ITemplateParameter> parameters = ParameterNamesToParametersTransform(paramNameList);
+
+            IDictionary<string, string> longNameOverrides = new Dictionary<string, string>()
+            {
+                { "TargetFrameworkOverride", "target-framework-override" },
+                { "UseLocalDB", "use-local-db" },
+                { "AADInstance", "aad-instance" },
+                { "AAdB2CInstance", "aad-b2c-instance" },
+                { "SignUpSignInPolicyId", "susi-policy-id" },
+                { "ResetPasswordPolicyId", "reset-password-policy-id" },
+                { "EditProfilePolicyId", "edit-profile-policy-id" },
+                { "OrgReadAccess", "org-read-access" },
+                { "ClientId", "client-id" },
+                { "CallbackPath", "callback-path" },
+                { "Domain", "domain" },
+                { "TenantId", "tenant-id" },
+                { "Framework", "framework" },
+                { "NoTools", "no-tools" },
+                { "skipRestore", "no-restore" },
+            };
+
+            IDictionary<string, string> shortNameOverrides = new Dictionary<string, string>()
+            {
+                { "TargetFrameworkOverride", "" },
+                { "AADInstance", "" },
+                { "AAdB2CInstance", "" },
+                { "SignUpSignInPolicyId", "ssp" },
+                { "ResetPasswordPolicyId", "rp" },
+                { "EditProfilePolicyId", "ep" },
+                { "OrgReadAccess", "r" },
+                { "ClientId", "" },
+                { "CallbackPath", "" },
+                { "Domain", "" },
+                { "TenantId", "" },
+                { "skipRestore", "" },
+            };
+
+            AliasAssignmentCoordinator assignmentCoordinator = new AliasAssignmentCoordinator(parameters, longNameOverrides, shortNameOverrides, InitiallyTakenAliases);
+
+            Assert.Equal("-au", assignmentCoordinator.ShortNameAssignments["auth"]);
+            Assert.Equal("--auth", assignmentCoordinator.LongNameAssignments["auth"]);
+            Assert.False(assignmentCoordinator.ShortNameAssignments.TryGetValue("AAdB2CInstance", out string placeholder));
+            Assert.Equal("--aad-b2c-instance", assignmentCoordinator.LongNameAssignments["AAdB2CInstance"]);
+            Assert.Equal("-ssp", assignmentCoordinator.ShortNameAssignments["SignUpSignInPolicyId"]);
+            Assert.Equal("--susi-policy-id", assignmentCoordinator.LongNameAssignments["SignUpSignInPolicyId"]);
+            Assert.Equal("-rp", assignmentCoordinator.ShortNameAssignments["ResetPasswordPolicyId"]);
+            Assert.Equal("--reset-password-policy-id", assignmentCoordinator.LongNameAssignments["ResetPasswordPolicyId"]);
+            Assert.Equal("-ep", assignmentCoordinator.ShortNameAssignments["EditProfilePolicyId"]);
+            Assert.Equal("--edit-profile-policy-id", assignmentCoordinator.LongNameAssignments["EditProfilePolicyId"]);
+            Assert.False(assignmentCoordinator.ShortNameAssignments.TryGetValue("AADInstance", out placeholder));
+            Assert.Equal("--aad-instance", assignmentCoordinator.LongNameAssignments["AADInstance"]);
+            Assert.False(assignmentCoordinator.ShortNameAssignments.TryGetValue("ClientId", out placeholder));
+            Assert.Equal("--client-id", assignmentCoordinator.LongNameAssignments["ClientId"]);
+            Assert.False(assignmentCoordinator.ShortNameAssignments.TryGetValue("Domain", out placeholder));
+            Assert.Equal("--domain", assignmentCoordinator.LongNameAssignments["Domain"]);
+            Assert.False(assignmentCoordinator.ShortNameAssignments.TryGetValue("TenantId", out placeholder));
+            Assert.Equal("--tenant-id", assignmentCoordinator.LongNameAssignments["TenantId"]);
+            Assert.False(assignmentCoordinator.ShortNameAssignments.TryGetValue("CallbackPath", out placeholder));
+            Assert.Equal("--callback-path", assignmentCoordinator.LongNameAssignments["CallbackPath"]);
+            Assert.Equal("-r", assignmentCoordinator.ShortNameAssignments["OrgReadAccess"]);
+            Assert.Equal("--org-read-access", assignmentCoordinator.LongNameAssignments["OrgReadAccess"]);
+            Assert.Equal("-U", assignmentCoordinator.ShortNameAssignments["UserSecretsId"]);
+            Assert.Equal("--UserSecretsId", assignmentCoordinator.LongNameAssignments["UserSecretsId"]);
+            Assert.Equal("-I", assignmentCoordinator.ShortNameAssignments["IncludeLaunchSettings"]);
+            Assert.Equal("--IncludeLaunchSettings", assignmentCoordinator.LongNameAssignments["IncludeLaunchSettings"]);
+            Assert.Equal("-H", assignmentCoordinator.ShortNameAssignments["HttpsPort"]);
+            Assert.Equal("--HttpsPort", assignmentCoordinator.LongNameAssignments["HttpsPort"]);
+            Assert.Equal("-K", assignmentCoordinator.ShortNameAssignments["KestrelPort"]);
+            Assert.Equal("--KestrelPort", assignmentCoordinator.LongNameAssignments["KestrelPort"]);
+            Assert.Equal("-II", assignmentCoordinator.ShortNameAssignments["IISExpressPort"]);
+            Assert.Equal("--IISExpressPort", assignmentCoordinator.LongNameAssignments["IISExpressPort"]);
+            Assert.Equal("-uld", assignmentCoordinator.ShortNameAssignments["UseLocalDB"]);
+            Assert.Equal("--use-local-db", assignmentCoordinator.LongNameAssignments["UseLocalDB"]);
+            Assert.False(assignmentCoordinator.ShortNameAssignments.TryGetValue("TargetFrameworkOverride", out placeholder));
+            Assert.Equal("--target-framework-override", assignmentCoordinator.LongNameAssignments["TargetFrameworkOverride"]);
+            Assert.Equal("-f", assignmentCoordinator.ShortNameAssignments["Framework"]);
+            Assert.Equal("--framework", assignmentCoordinator.LongNameAssignments["Framework"]);
+            Assert.Equal("-nt", assignmentCoordinator.ShortNameAssignments["NoTools"]);
+            Assert.Equal("--no-tools", assignmentCoordinator.LongNameAssignments["NoTools"]);
+            Assert.False(assignmentCoordinator.ShortNameAssignments.TryGetValue("SkipRestore", out placeholder));
+            Assert.Equal("--no-restore", assignmentCoordinator.LongNameAssignments["skipRestore"]);
+            Assert.Equal(0, assignmentCoordinator.InvalidParams.Count);
+        }
+
+        // fills in enough of the parameter info for alias assignment
+        private static IReadOnlyList<ITemplateParameter> ParameterNamesToParametersTransform(IReadOnlyList<string> paramNameList)
+        {
+            List<ITemplateParameter> parameterList = new List<ITemplateParameter>();
+
+            foreach (string paramName in paramNameList)
+            {
+                ITemplateParameter parameter = new MockParameter()
+                {
+                    Name = paramName,
+                    Priority = TemplateParameterPriority.Required,
+                };
+
+                parameterList.Add(parameter);
+            }
+
+            return parameterList;
+        }
+
+        private static HashSet<string> InitiallyTakenAliases
+        {
+            get
+            {
+                HashSet<string> initiallyTakenAliases = new HashSet<string>()
+                {
+                    "-h", "--help",
+                    "-l", "--list",
+                    "-n", "--name",
+                    "-o", "--output",
+                    "-i", "--install",
+                    "-u", "--uninstall",
+                    "--type",
+                    "--force",
+                    "-lang", "--language",
+                    "-a", "--alias",
+                    "--show-alias",
+                    "-x", "--extra-args",
+                    "--locale",
+                    "--quiet",
+                    "-all", "--show-all",
+                    "--allow-scripts",
+                    "--baseline",
+                    "-up", "--update",
+                    "--skip-update-check"
+                };
+
+                return initiallyTakenAliases;
+            }
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Mocks/MockParameter.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockParameter.cs
@@ -1,0 +1,26 @@
+using Microsoft.TemplateEngine.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.TemplateEngine.Mocks
+{
+    public class MockParameter : ITemplateParameter
+    {
+        public string Documentation { get; set; }
+
+        public string Name { get; set; }
+
+        public TemplateParameterPriority Priority { get; set; }
+
+        public string Type { get; set; }
+
+        public bool IsName { get; set; }
+
+        public string DefaultValue { get; set; }
+
+        public string DataType { get; set; }
+
+        public IReadOnlyDictionary<string, string> Choices { get; set; }
+    }
+}


### PR DESCRIPTION
Hostfile specifications always take precedence.