### PR TITLE
Proof of concept for remove duplicated usings and sort usings post-actions

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/ICommonPostActionHandler.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ICommonPostActionHandler.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.TemplateEngine.Abstractions
+{
+    public interface ICommonPostActionHandler : IIdentifiedComponent
+    {
+        bool Process(IEngineEnvironmentSettings environment, IPostAction action, ICreationResult templateCreationResult, string outputBasePath);
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/RemoveDuplicateUsingsPostAction.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/RemoveDuplicateUsingsPostAction.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
+{
+    public class RemoveDuplicateUsingsPostAction : IPostActionProcessor
+    {
+        public static readonly Guid ActionProcessorId = new Guid("EE2061F3-2FAA-47C9-9B40-198A9DF51C39");
+
+        public Guid Id => ActionProcessorId;
+
+        public bool Process(IEngineEnvironmentSettings settings, IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath)
+        {
+            if (!settings.SettingsLoader.Components.TryGetComponent(new Guid("C405DDB2-4F64-4A2D-8005-1243D5C55EAD"), out ICommonPostActionHandler implementation))
+            {
+                return false;
+            }
+
+            return implementation.Process(settings, actionConfig, templateCreationResult, outputBasePath);
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/SortUsingsPostAction.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/SortUsingsPostAction.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
+{
+    public class SortUsingsPostAction : IPostActionProcessor
+    {
+        public static readonly Guid ActionProcessorId = new Guid("F65519F3-E665-467E-9734-A962AEB25FC6");
+
+        public Guid Id => ActionProcessorId;
+
+        public bool Process(IEngineEnvironmentSettings settings, IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath)
+        {
+            if (!settings.SettingsLoader.Components.TryGetComponent(new Guid("8A0FF3C4-CE1F-4958-B0AB-C94D40E36EED"), out ICommonPostActionHandler implementation))
+            {
+                return false;
+            }
+
+            return implementation.Process(settings, actionConfig, templateCreationResult, outputBasePath);
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Core/RemoveDuplicateUsingsPostAction.cs
+++ b/src/Microsoft.TemplateEngine.Core/RemoveDuplicateUsingsPostAction.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Core.Util;
+
+namespace Microsoft.TemplateEngine.Core
+{
+    public class RemoveDuplicateUsingsPostAction : ICommonPostActionHandler
+    {
+        public static readonly Guid ActionProcessorId = new Guid("C405DDB2-4F64-4A2D-8005-1243D5C55EAD");
+
+        public Guid Id => ActionProcessorId;
+
+        public bool Process(IEngineEnvironmentSettings settings, IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath)
+        {
+            foreach(string file in Directory.EnumerateFiles(outputBasePath, "*.cs", SearchOption.AllDirectories))
+            {
+                byte[] fileData = File.ReadAllBytes(file);
+                Encoding fileEncoding = EncodingUtil.Detect(fileData, fileData.Length, out byte[] bom);
+                string allText = fileEncoding.GetString(fileData.Skip(bom.Length).ToArray());
+                TokenTrie trie = new TokenTrie();
+                HashSet<int> seenUsings = new HashSet<int>();
+                int currentBufferPosition = 0;
+
+                foreach (string usingDirective in allText.Split(new[]{ '\n' }, StringSplitOptions.RemoveEmptyEntries).Where(IsUsingDirective))
+                {
+                    trie.AddToken(fileEncoding.GetBytes(usingDirective + "\n"));
+                }
+
+                using (Stream outputFile = File.Create(file))
+                {
+                    while (currentBufferPosition < fileData.Length)
+                    {
+                        if (!trie.GetOperation(fileData, fileData.Length, ref currentBufferPosition, out int token))
+                        {
+                            outputFile.WriteByte(fileData[currentBufferPosition++]);
+                        }
+                        else if(seenUsings.Add(token))
+                        {
+                            byte[] tokenBytes = trie.Tokens[token].Value;
+                            outputFile.Write(tokenBytes, 0, tokenBytes.Length);
+                        }
+                    }
+                    outputFile.Flush();
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsUsingDirective(string line)
+        {
+            string trimmed = line.Trim();
+            return trimmed.StartsWith("using ", StringComparison.Ordinal) && trimmed.EndsWith(";", StringComparison.Ordinal);
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Core/SortUsingsPostAction.cs
+++ b/src/Microsoft.TemplateEngine.Core/SortUsingsPostAction.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Core.Util;
+
+namespace Microsoft.TemplateEngine.Core
+{
+    public class SortUsingsPostAction : ICommonPostActionHandler
+    {
+        public static readonly Guid ActionProcessorId = new Guid("8A0FF3C4-CE1F-4958-B0AB-C94D40E36EED");
+
+        public Guid Id => ActionProcessorId;
+
+        public bool Process(IEngineEnvironmentSettings settings, IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath)
+        {
+            foreach(string file in Directory.EnumerateFiles(outputBasePath, "*.cs", SearchOption.AllDirectories))
+            {
+                byte[] fileData = File.ReadAllBytes(file);
+                Encoding fileEncoding = EncodingUtil.Detect(fileData, fileData.Length, out byte[] bom);
+                string allText = fileEncoding.GetString(fileData.Skip(bom.Length).ToArray());
+                TokenTrie trie = new TokenTrie();
+                HashSet<int> seenUsings = new HashSet<int>();
+                int currentBufferPosition = 0;
+
+                if(!actionConfig.Args.TryGetValue("SystemFirst", out string systemFirstString) || !bool.TryParse(systemFirstString, out bool systemFirst))
+                {
+                    systemFirst = true;
+                }
+
+                IComparer<string> usingDirectiveComparer = new UsingDirectiveComparer(systemFirst);
+
+                IReadOnlyList<string> usingDirectives = allText.Split(new[]{ '\n' }, StringSplitOptions.RemoveEmptyEntries).Where(IsUsingDirective).OrderBy(x => x, usingDirectiveComparer).ToList();
+
+                foreach (string usingDirective in usingDirectives)
+                {
+                    trie.AddToken(fileEncoding.GetBytes(usingDirective + "\n"));
+                }
+
+                bool matched = false;
+                using (Stream outputFile = File.Create(file))
+                {
+                    while (currentBufferPosition < fileData.Length)
+                    {
+                        if (!trie.GetOperation(fileData, fileData.Length, ref currentBufferPosition, out int token))
+                        {
+                            outputFile.WriteByte(fileData[currentBufferPosition++]);
+                        }
+                        else if (!matched)
+                        {
+                            matched = true;
+                            foreach (string directive in usingDirectives)
+                            {
+                                byte[] tokenBytes = fileEncoding.GetBytes(directive + "\n");
+                                outputFile.Write(tokenBytes, 0, tokenBytes.Length);
+                            }
+                        }
+                    }
+
+                    outputFile.Flush();
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsUsingDirective(string line)
+        {
+            string trimmed = line.Trim();
+            return trimmed.StartsWith("using ", StringComparison.Ordinal) && trimmed.EndsWith(";", StringComparison.Ordinal);
+        }
+
+        private class UsingDirectiveComparer : IComparer<string>
+        {
+            private bool _placeSystemDirectivesFirst;
+
+            public UsingDirectiveComparer(bool placeSystemDirectivesFirst)
+            {
+                _placeSystemDirectivesFirst = placeSystemDirectivesFirst;
+            }
+
+            public int Compare(string x, string y)
+            {
+                if (!_placeSystemDirectivesFirst)
+                {
+                    return StringComparer.Ordinal.Compare(x.Trim().TrimEnd(';'), y.Trim().TrimEnd(';'));
+                }
+
+                bool xIsSystem = x.IndexOf(" System.", StringComparison.Ordinal) > -1 || x.IndexOf(" System;", StringComparison.Ordinal) > -1;
+                bool yIsSystem = y.IndexOf(" System.", StringComparison.Ordinal) > -1 || y.IndexOf(" System;", StringComparison.Ordinal) > -1;
+
+                if (xIsSystem && !yIsSystem)
+                {
+                    return -1;
+                }
+                else if (!xIsSystem && yIsSystem)
+                {
+                    return 1;
+                }
+
+                return StringComparer.Ordinal.Compare(x.Trim().TrimEnd(';'), y.Trim().TrimEnd(';'));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related to https://github.com/dotnet/templating/issues/633

Open issues:
* This won't work at all for VB or F# in its current state
* Existing and newly created content isn't differentiated between
* There's a ton of redundancy in the operations
* Since post-actions can't currently be parameterized, niceties like flowing the environment's "place system usings first" setting into the action won't work
* The post-action processing interface isn't exposed in abstractions leading to this awkward workaround with creating a component to expose it & consuming it in the post-action processor (this also means that post-actions can't be generator specific)