### PR TITLE
Value forms for name are less special, can be overridden

### DIFF
--- a/src/Microsoft.TemplateEngine.Core/Matching/Trie.cs
+++ b/src/Microsoft.TemplateEngine.Core/Matching/Trie.cs
@@ -48,7 +48,16 @@ namespace Microsoft.TemplateEngine.Core.Matching
                         next.Terminals = new List<T>();
                     }
 
-                    next.Terminals.Add(terminal);
+                    int sameMatcherIndex = next.Terminals.FindIndex(t => t.Start == terminal.Start && t.End == terminal.End);
+
+                    if (sameMatcherIndex > -1)
+                    {   // this matching is identical to another terminal already added to the trie. Overwrite it.
+                        next.Terminals[sameMatcherIndex] = terminal;
+                    }
+                    else
+                    {
+                        next.Terminals.Add(terminal);
+                    }
                 }
 
                 current = next.NextNodes;

--- a/src/Microsoft.TemplateEngine.Core/Matching/TrieEvaluator.cs
+++ b/src/Microsoft.TemplateEngine.Core/Matching/TrieEvaluator.cs
@@ -185,7 +185,10 @@ namespace Microsoft.TemplateEngine.Core.Matching
 
                             if (start >= _lastReturnedTerminalEndSequenceNumber)
                             {
-                                if (start < minNonTerminatedPathStart && (best == null || start < minTerminalStart || start == minTerminalStart && terminal.End > best.End))
+                                // Take the terminal for the match that started first & is after the end of the previous match
+                                // If multiple matches start at the same place, take the one that ends last.
+                                // If multiple matches start and end at the same place, take the later one in the EncounteredTerminals list (last in wins)
+                                if (start < minNonTerminatedPathStart && (best == null || start < minTerminalStart || start == minTerminalStart && terminal.End >= best.End))
                                 {
                                     bestPath = i;
                                     best = terminal;

--- a/src/Microsoft.TemplateEngine.Core/Matching/TrieEvaluator.cs
+++ b/src/Microsoft.TemplateEngine.Core/Matching/TrieEvaluator.cs
@@ -185,10 +185,7 @@ namespace Microsoft.TemplateEngine.Core.Matching
 
                             if (start >= _lastReturnedTerminalEndSequenceNumber)
                             {
-                                // Take the terminal for the match that started first & is after the end of the previous match
-                                // If multiple matches start at the same place, take the one that ends last.
-                                // If multiple matches start and end at the same place, take the later one in the EncounteredTerminals list (last in wins)
-                                if (start < minNonTerminatedPathStart && (best == null || start < minTerminalStart || start == minTerminalStart && terminal.End >= best.End))
+                                if (start < minNonTerminatedPathStart && (best == null || start < minTerminalStart || start == minTerminalStart && terminal.End > best.End))
                                 {
                                     bestPath = i;
                                     best = terminal;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/ProcessValueFormMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/ProcessValueFormMacroConfig.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ProcessValueFormMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ProcessValueFormMacro.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ParameterSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ParameterSymbol.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
-using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
@@ -108,10 +108,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
             if (!jObject.TryGetValue(nameof(symbol.Forms), StringComparison.OrdinalIgnoreCase, out JToken formsToken) || !(formsToken is JObject formsObject))
             {
-                symbol.Forms = SymbolValueFormsModel.Default;   // no value forms explicitly defined, use the default ("identity")
+                // no value forms explicitly defined, use the default ("identity")
+                symbol.Forms = SymbolValueFormsModel.Default;
             }
             else
             {
+                // the config defines forms for the symbol. Use them.
                 symbol.Forms = SymbolValueFormsModel.FromJObject(formsObject);
             }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,6 +12,7 @@ using Microsoft.TemplateEngine.Core.Operations;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Localization;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
 
@@ -19,8 +20,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
     public class SimpleConfigModel : IRunnableProjectConfig
     {
+        private static readonly string NameSymbolName = "name";
         private static readonly string[] IncludePatternDefaults = new[] { "**/*" };
-        private static readonly string[] ExcludePatternDefaults = new[] 
+        private static readonly string[] ExcludePatternDefaults = new[]
         {
             "**/[Bb]in/**",
             "**/[Oo]bj/**",
@@ -43,10 +45,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         private IGlobalRunConfig _operationConfig;
         private IReadOnlyList<KeyValuePair<string, IGlobalRunConfig>> _specialOperationConfig;
         private Parameter _nameParameter;
-        private string _safeNameName;
-        private string _safeNamespaceName;
-        private string _lowerSafeNameName;
-        private string _lowerSafeNamespaceName;
 
         public IFile SourceFile { get; set; }
 
@@ -213,24 +211,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 {
                     Dictionary<string, Parameter> parameters = new Dictionary<string, Parameter>();
 
-                    if (Symbols == null)
-                    {
-                        parameters["name"] = new Parameter
-                        {
-                            IsName = true,
-                            Requirement = TemplateParameterPriority.Implicit,
-                            Name = "name",
-                            DefaultValue = DefaultName ?? SourceName
-                        };
-                    }
-                    else
+                    if (Symbols != null)
                     {
                         foreach (KeyValuePair<string, ISymbolModel> symbol in Symbols)
                         {
                             if (symbol.Value.Type == "parameter")
                             {
                                 ParameterSymbol param = (ParameterSymbol)symbol.Value;
-                                bool isName = param.Binding == "name";
+                                bool isName = param.Binding == NameSymbolName;
                                 parameters[symbol.Key] = new Parameter
                                 {
                                     DefaultValue = param.DefaultValue ?? (!param.IsRequired ? param.Replaces : null),
@@ -246,20 +234,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                                 };
                             }
                         }
-                    }
-
-                    string nameParameter = parameters.FirstOrDefault(x => x.Value.IsName).Key;
-
-                    if (nameParameter == null)
-                    {
-                        parameters["name"] = new Parameter
-                        {
-                            IsName = true,
-                            Requirement = TemplateParameterPriority.Implicit,
-                            Name = "name",
-                            DefaultValue = DefaultName ?? SourceName,
-                            IsVariable = true
-                        };
                     }
 
                     _parameters = parameters;
@@ -547,32 +521,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 macros = ProduceMacroConfig(computedMacros);
             }
 
-            if (SourceName != null)
-            {
-                if (SourceName.ToLower() != SourceName)
-                {
-                    if (SourceName.IndexOf('.') > -1)
-                    {
-                        macroGeneratedReplacements.Add(new ReplacementTokens(_lowerSafeNamespaceName, SourceName.ToLowerInvariant().TokenConfig()));
-                        macroGeneratedReplacements.Add(new ReplacementTokens(_lowerSafeNameName, SourceName.ToLowerInvariant().Replace('.', '_').TokenConfig()));
-                    }
-                    else
-                    {
-                        macroGeneratedReplacements.Add(new ReplacementTokens(_lowerSafeNameName, SourceName.ToLowerInvariant().TokenConfig()));
-                    }
-                }
-
-                if (SourceName.IndexOf('.') > -1)
-                {
-                    macroGeneratedReplacements.Add(new ReplacementTokens(_safeNamespaceName, SourceName.TokenConfig()));
-                    macroGeneratedReplacements.Add(new ReplacementTokens(_safeNameName, SourceName.Replace('.', '_').TokenConfig()));
-                }
-                else
-                {
-                    macroGeneratedReplacements.Add(new ReplacementTokens(_safeNameName, SourceName.TokenConfig()));
-                }
-            }
-
             if (Symbols != null)
             {
                 foreach (KeyValuePair<string, ISymbolModel> symbol in Symbols)
@@ -602,8 +550,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
                         if (sourceVariable != null)
                         {
-                            GenerateReplacementsForParameter(symbol, symbol.Value.Replaces, sourceVariable, macroGeneratedReplacements);
-
                             if (symbol.Value is ParameterSymbol p)
                             {
                                 foreach (string form in p.Forms.GlobalForms)
@@ -617,6 +563,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                                         macros.Add(new ProcessValueFormMacroConfig(symbol.Key, symbolName, form, Forms));
                                     }
                                 }
+                            }
+                            else
+                            {
+                                GenerateReplacementsForParameter(symbol, symbol.Value.Replaces, sourceVariable, macroGeneratedReplacements);
                             }
                         }
                     }
@@ -644,7 +594,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
             foreach (IOperationProvider p in operations.ToList())
             {
-                if(!string.IsNullOrEmpty(p.Id))
+                if (!string.IsNullOrEmpty(p.Id))
                 {
                     string prefix = (customGlobModel == null || string.IsNullOrEmpty(customGlobModel.FlagPrefix)) ? defaultModel.FlagPrefix : customGlobModel.FlagPrefix;
                     string on = $"{prefix}+:{p.Id}";
@@ -715,23 +665,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             {
                 foreach (KeyValuePair<string, ISymbolModel> symbol in Symbols)
                 {
-                    if (symbol.Value.Binding == "safe_name")
-                    {
-                        _safeNameName = symbol.Key; // save for later, to generate the safe_name regex macro
-                    }
-                    else if (symbol.Value.Binding == "lower_safe_name")
-                    {
-                        _lowerSafeNameName = symbol.Key; // save for later, to generate the safe_name regex macro
-                    }
-                    else if (symbol.Value.Binding == "safe_namespace_name")
-                    {
-                        _safeNamespaceName = symbol.Key; // save for later, to generate the safe_name regex macro
-                    }
-                    else if (symbol.Value.Binding == "lower_safe_namespace_name")
-                    {
-                        _lowerSafeNamespaceName = symbol.Key; // save for later, to generate the safe_name regex macro
-                    }
-
                     if (symbol.Value.Type == "computed")
                     {
                         string value = ((ComputedSymbol)symbol.Value).Value;
@@ -753,42 +686,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                         generatedMacroConfigs.Add(new GeneratedSymbolDeferredMacroConfig(type, variableName, configParams));
                     }
                 }
-            }
-
-            if (_safeNameName == null)
-            {
-                IList<KeyValuePair<string, string>> steps = new List<KeyValuePair<string, string>>
-                {
-                    new KeyValuePair<string, string>(@"(^\s+|\s+$)", ""),
-                    new KeyValuePair<string, string>(@"(((?<=\.)|^)(?=\d)|\W)", "_")
-                };
-
-                generatedMacroConfigs.Add(new RegexMacroConfig("safe_name", NameParameter.Name, steps));
-                _safeNameName = "safe_name";
-            }
-
-            if (_lowerSafeNameName == null)
-            {
-                generatedMacroConfigs.Add(new CaseChangeMacroConfig("lower_safe_name", _safeNameName, true));
-                _lowerSafeNameName = "lower_safe_name";
-            }
-
-            if (_safeNamespaceName == null)
-            {
-                IList<KeyValuePair<string, string>> steps = new List<KeyValuePair<string, string>>
-                {
-                    new KeyValuePair<string, string>(@"(^\s+|\s+$)", ""),
-                    new KeyValuePair<string, string>(@"(((?<=\.)|^)(?=\d)|[^\w\.])", "_")
-                };
-
-                generatedMacroConfigs.Add(new RegexMacroConfig("safe_namespace", NameParameter.Name, steps));
-                _safeNamespaceName = "safe_namespace";
-            }
-
-            if (_lowerSafeNamespaceName == null)
-            {
-                generatedMacroConfigs.Add(new CaseChangeMacroConfig("lower_safe_namespace", _safeNamespaceName, true));
-                _lowerSafeNamespaceName = "lower_safe_namespace";
             }
 
             return generatedMacroConfigs;
@@ -1017,6 +914,64 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             }
         }
 
+        private static ISymbolModel SetupDefaultNameSymbol(string sourceName)
+        {
+            StringBuilder nameSymbolConfigBuilder = new StringBuilder(512);
+
+            nameSymbolConfigBuilder.AppendLine(@"
+{
+  ""binding"": """ + NameSymbolName + @""",
+  ""type"": ""parameter"",
+  ""description"": ""The default name symbol"",
+  ""datatype"": ""string"",
+  ""forms"": {
+    ""global"": [ ""identity"", ""safe_name"", ""lower_safe_name"", ""safe_namespace"", ""lower_safe_namespace""]
+  }
+");
+
+            if (!string.IsNullOrEmpty(sourceName))
+            {
+                nameSymbolConfigBuilder.AppendLine(",");
+                nameSymbolConfigBuilder.AppendLine($"\"replaces\": \"{sourceName}\"");
+            }
+
+            nameSymbolConfigBuilder.AppendLine("}");
+
+            JObject config = JObject.Parse(nameSymbolConfigBuilder.ToString());
+            return ParameterSymbol.FromJObject(config, null, null);
+        }
+
+        private static IReadOnlyDictionary<string, IValueForm> SetupValueFormMapForTemplate(JObject source)
+        {
+            Dictionary<string, IValueForm> formMap = new Dictionary<string, IValueForm>(StringComparer.Ordinal);
+
+            // setup the built-in default forms - these are all used by the default "name" symbol setup.
+            IValueForm identityForm = new IdentityValueForm();
+            formMap[identityForm.Identifier] = identityForm;
+            IValueForm safeNameForm = new DefaultSafeNameValueFormModel();
+            formMap[safeNameForm.Identifier] = safeNameForm;
+            IValueForm lowerSafeNameForm = new DefaultLowerSafeNameValueFormModel();
+            formMap[lowerSafeNameForm.Identifier] = lowerSafeNameForm;
+            IValueForm safeNamespaceForm = new DefaultSafeNamespaceValueFormModel();
+            formMap[safeNamespaceForm.Identifier] = safeNamespaceForm;
+            IValueForm lowerSafeNamespaceForm = new DefaultLowerSafeNamespaceValueFormModel();
+            formMap[lowerSafeNamespaceForm.Identifier] = lowerSafeNamespaceForm;
+
+            // setup the forms defined by the template configuration.
+            // if any have the same name as a default, the default is overridden.
+            IReadOnlyDictionary<string, JToken> templateDefinedforms = source.ToJTokenDictionary(StringComparer.OrdinalIgnoreCase, nameof(Forms));
+
+            foreach (KeyValuePair<string, JToken> form in templateDefinedforms)
+            {
+                if (form.Value is JObject o)
+                {
+                    formMap[form.Key] = ValueFormRegistry.GetForm(form.Key, o);
+                }
+            }
+
+            return formMap;
+        }
+
         public static SimpleConfigModel FromJObject(IEngineEnvironmentSettings environmentSettings, JObject source, ISimpleConfigModifiers configModifiers = null, JObject localeSource = null)
         {
             ILocalizationModel localizationModel = LocalizationFromJObject(localeSource);
@@ -1039,18 +994,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 GeneratorVersions = source.ToString(nameof(config.GeneratorVersions))
             };
 
-            IReadOnlyDictionary<string, JToken> forms = source.ToJTokenDictionary(StringComparer.OrdinalIgnoreCase, nameof(Forms));
-            Dictionary<string, IValueForm> formMap = new Dictionary<string, IValueForm>(StringComparer.Ordinal);
-
-            foreach(KeyValuePair<string, JToken> form in forms)
-            {
-                if(form.Value is JObject o)
-                {
-                    formMap[form.Key] = ValueFormRegistry.GetForm(form.Key, o);
-                }
-            }
-
-            config.Forms = formMap;
+            config.Forms = SetupValueFormMapForTemplate(source);
 
             List <ExtendedFileSource> sources = new List<ExtendedFileSource>();
             config.Sources = sources;
@@ -1093,6 +1037,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             }
 
             Dictionary<string, ISymbolModel> symbols = new Dictionary<string, ISymbolModel>(StringComparer.Ordinal);
+            // create a name symbol. If one is explicitly defined in the template, it'll override this.
+            symbols.Add(NameSymbolName, SetupDefaultNameSymbol(config.SourceName));
 
             // tags are being deprecated from template configuration, but we still read them for backwards compatibility.
             // They're turned into symbols here, which eventually become tags.
@@ -1129,11 +1075,21 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     baseline.DefaultOverrides.TryGetValue(prop.Name, out defaultOverride);
                 }
 
-                ISymbolModel model = SymbolModelConverter.GetModelForObject(obj, symbolLocalization, defaultOverride);
+                ISymbolModel modelForSymbol = SymbolModelConverter.GetModelForObject(obj, symbolLocalization, defaultOverride);
 
-                if (model != null)
+                if (modelForSymbol != null)
                 {
-                    symbols[prop.Name] = model;
+                    // TODO: revisit whether this check should be case-insensitive.
+                    // The symbols dictionary comparer is Ordinal, making symbol names case-sensitive.
+                    if (string.Equals(prop.Name, NameSymbolName, StringComparison.Ordinal)
+                            && !symbols.TryGetValue(prop.Name, out ISymbolModel existingSymbol))
+                    {   // "name" symbol is explicitly defined above. If it's also defined in the template.json, it gets special handling here.
+                        symbols[prop.Name] = ParameterSymbol.ExplicitNameSymbolMergeWithDefaults(modelForSymbol, existingSymbol);
+                    }
+                    else
+                    {   // last in wins (in the odd case where a template.json defined a symbol multiple times)
+                        symbols[prop.Name] = modelForSymbol;
+                    }
                 }
             }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
@@ -925,7 +925,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
   ""description"": ""The default name symbol"",
   ""datatype"": ""string"",
   ""forms"": {
-    ""global"": [ ""identity"", ""safe_name"", ""lower_safe_name"", ""safe_namespace"", ""lower_safe_namespace""]
+    ""global"": [ """ + IdentityValueForm.FormName
+                    + @""", """ + DefaultSafeNameValueFormModel.FormName
+                    + @""", """ + DefaultLowerSafeNameValueFormModel.FormName
+                    + @""", """ + DefaultSafeNamespaceValueFormModel.FormName
+                    + @""", """ + DefaultLowerSafeNamespaceValueFormModel.FormName
+                    + @"""]
   }
 ");
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueFormModel.cs
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
             if (!FormLookup.TryGetValue(identifier, out IValueForm value))
             {
-                return FormLookup["identity"].FromJObject(name, obj);
+                return FormLookup[IdentityValueForm.FormName].FromJObject(name, obj);
             }
 
             return value.FromJObject(name, obj);

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueFormModel.cs
@@ -1,8 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Xml;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
@@ -22,6 +20,25 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             lookup[x.Identifier] = x;
             x = new IdentityValueForm();
             lookup[x.Identifier] = x;
+
+            x = new DefaultSafeNamespaceValueFormModel();
+            lookup[x.Identifier] = x;
+            x = new DefaultLowerSafeNameValueFormModel();
+            lookup[x.Identifier] = x;
+            x = new DefaultSafeNamespaceValueFormModel();
+            lookup[x.Identifier] = x;
+            x = new DefaultLowerSafeNamespaceValueFormModel();
+            lookup[x.Identifier] = x;
+
+            x = new LowerCaseValueFormModel();
+            lookup[x.Identifier] = x;
+            x = new LowerCaseInvariantValueFormModel();
+            lookup[x.Identifier] = x;
+            x = new UpperCaseValueFormModel();
+            lookup[x.Identifier] = x;
+            x = new UpperCaseInvariantValueFormModel();
+            lookup[x.Identifier] = x;
+
             return lookup;
         }
 
@@ -35,221 +52,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             }
 
             return value.FromJObject(name, obj);
-        }
-    }
-
-    public interface IValueForm
-    {
-        string Identifier { get; }
-
-        string Name { get; }
-
-        string Process(IReadOnlyDictionary<string, IValueForm> forms, string value);
-
-        IValueForm FromJObject(string name, JObject configuration);
-    }
-
-    public class ReplacementValueFormModel : IValueForm
-    {
-        private readonly Regex _match;
-        private readonly string _replacment;
-        
-        public ReplacementValueFormModel()
-        {
-        }
-
-        public ReplacementValueFormModel(string name, string pattern, string replacement)
-        {
-            _match = new Regex(pattern);
-            _replacment = replacement;
-            Name = name;
-        }
-
-        public string Identifier => "replace";
-
-        public string Name { get; }
-
-        public IValueForm FromJObject(string name, JObject configuration)
-        {
-            return new ReplacementValueFormModel(name, configuration.ToString("pattern"), configuration.ToString("replacement"));
-        }
-
-        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
-        {
-            return _match.Replace(value, _replacment);
-        }
-    }
-
-    public class ChainValueFormModel : IValueForm
-    {
-        private readonly IReadOnlyList<string> _steps;
-
-        public ChainValueFormModel()
-        {
-        }
-
-        public ChainValueFormModel(string name, IReadOnlyList<string> steps)
-        {
-            Name = name;
-            _steps = steps;
-        }
-
-        public string Identifier => "chain";
-
-        public string Name { get; }
-
-        public IValueForm FromJObject(string name, JObject configuration)
-        {
-            return new ChainValueFormModel(name, configuration.ArrayAsStrings("steps"));
-        }
-
-        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
-        {
-            string result = value;
-
-            foreach (string step in _steps)
-            {
-                result = forms[step].Process(forms, result);
-            }
-
-            return result;
-        }
-    }
-
-    public class XmlEncodeValueFormModel : IValueForm
-    {
-        private static readonly XmlWriterSettings Settings = new XmlWriterSettings { ConformanceLevel = ConformanceLevel.Fragment };
-
-        public string Identifier => "xmlEncode";
-
-        public string Name { get; }
-
-        public XmlEncodeValueFormModel()
-        {
-        }
-
-        public XmlEncodeValueFormModel(string name)
-        {
-            Name = name;
-        }
-
-        public IValueForm FromJObject(string name, JObject configuration)
-        {
-            return new XmlEncodeValueFormModel(name);
-        }
-
-        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
-        {
-            StringBuilder output = new StringBuilder();
-            using (XmlWriter w = XmlWriter.Create(output, Settings))
-            {
-                w.WriteString(value);
-            }
-            return output.ToString();
-        }
-    }
-
-    public class LowerCaseValueFormModel : IValueForm
-    {
-        public string Identifier => "lowerCase";
-
-        public string Name { get; }
-
-        public LowerCaseValueFormModel()
-        {
-        }
-
-        public LowerCaseValueFormModel(string name)
-        {
-            Name = name;
-        }
-
-        public IValueForm FromJObject(string name, JObject configuration)
-        {
-            return new LowerCaseValueFormModel(name);
-        }
-
-        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
-        {
-            return value.ToLower();
-        }
-    }
-
-    public class LowerCaseInvariantValueFormModel : IValueForm
-    {
-        public string Identifier => "lowerCaseInvariant";
-
-        public string Name { get; }
-
-        public LowerCaseInvariantValueFormModel()
-        {
-        }
-
-        public LowerCaseInvariantValueFormModel(string name)
-        {
-            Name = name;
-        }
-
-        public IValueForm FromJObject(string name, JObject configuration)
-        {
-            return new LowerCaseInvariantValueFormModel(name);
-        }
-
-        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
-        {
-            return value.ToLowerInvariant();
-        }
-    }
-
-    public class UpperCaseValueFormModel : IValueForm
-    {
-        public string Identifier => "upperCase";
-
-        public string Name { get; }
-
-        public UpperCaseValueFormModel()
-        {
-        }
-
-        public UpperCaseValueFormModel(string name)
-        {
-            Name = name;
-        }
-
-        public IValueForm FromJObject(string name, JObject configuration)
-        {
-            return new UpperCaseValueFormModel(name);
-        }
-
-        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
-        {
-            return value.ToUpper();
-        }
-    }
-
-    public class UpperCaseInvariantValueFormModel : IValueForm
-    {
-        public string Identifier => "upperCaseInvariant";
-
-        public string Name { get; }
-
-        public UpperCaseInvariantValueFormModel()
-        {
-        }
-
-        public UpperCaseInvariantValueFormModel(string name)
-        {
-            Name = name;
-        }
-
-        public IValueForm FromJObject(string name, JObject configuration)
-        {
-            return new UpperCaseInvariantValueFormModel(name);
-        }
-
-        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
-        {
-            return value.ToUpperInvariant();
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ChainValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ChainValueFormModel.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class ChainValueFormModel : IValueForm
+    {
+        private readonly IReadOnlyList<string> _steps;
+
+        public ChainValueFormModel()
+        {
+        }
+
+        public ChainValueFormModel(string name, IReadOnlyList<string> steps)
+        {
+            Name = name;
+            _steps = steps;
+        }
+
+        public string Identifier => "chain";
+
+        public string Name { get; }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new ChainValueFormModel(name, configuration.ArrayAsStrings("steps"));
+        }
+
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            string result = value;
+
+            foreach (string step in _steps)
+            {
+                result = forms[step].Process(forms, result);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNameValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNameValueFormModel.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class DefaultLowerSafeNameValueFormModel : DefaultSafeNameValueFormModel
+    {
+        public override string Identifier => "lower_safe_name";
+
+        public override string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            return base.Process(forms, value).ToLowerInvariant();
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNameValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNameValueFormModel.cs
@@ -4,7 +4,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     public class DefaultLowerSafeNameValueFormModel : DefaultSafeNameValueFormModel
     {
-        public override string Identifier => "lower_safe_name";
+        public new static readonly string FormName = "lower_safe_name";
+
+        public override string Identifier => FormName;
 
         public override string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
         {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNamespaceValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNamespaceValueFormModel.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class DefaultLowerSafeNamespaceValueFormModel : DefaultSafeNamespaceValueFormModel
+    {
+        public override string Identifier => "lower_safe_namespace";
+
+        public override string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            return base.Process(forms, value).ToLowerInvariant();
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNamespaceValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNamespaceValueFormModel.cs
@@ -4,7 +4,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     public class DefaultLowerSafeNamespaceValueFormModel : DefaultSafeNamespaceValueFormModel
     {
-        public override string Identifier => "lower_safe_namespace";
+        public new static readonly string FormName = "lower_safe_namespace";
+
+        public override string Identifier => FormName;
 
         public override string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
         {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNameValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNameValueFormModel.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class DefaultSafeNameValueFormModel : IValueForm
+    {
+        public DefaultSafeNameValueFormModel()
+        {
+        }
+
+        public virtual string Identifier => "safe_name";
+
+        public virtual string Name => Identifier;
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            string workingValue = Regex.Replace(value, @"(^\s+|\s+$)", "");
+            workingValue = Regex.Replace(workingValue, @"(((?<=\.)|^)(?=\d)|\W)", "_");
+
+            return workingValue;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNameValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNameValueFormModel.cs
@@ -11,7 +11,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
         {
         }
 
-        public virtual string Identifier => "safe_name";
+        public static readonly string FormName = "safe_name";
+
+        public virtual string Identifier => FormName;
 
         public virtual string Name => Identifier;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNamespaceValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNamespaceValueFormModel.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class DefaultSafeNamespaceValueFormModel : IValueForm
+    {
+        public DefaultSafeNamespaceValueFormModel()
+        {
+        }
+
+        public virtual string Identifier => "safe_namespace";
+
+        public string Name => Identifier;
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            string workingValue = Regex.Replace(value, @"(^\s+|\s+$)", "");
+            workingValue = Regex.Replace(workingValue, @"(((?<=\.)|^)(?=\d)|[^\w\.])", "_");
+
+            return workingValue;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNamespaceValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNamespaceValueFormModel.cs
@@ -11,7 +11,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
         {
         }
 
-        public virtual string Identifier => "safe_namespace";
+        public static readonly string FormName = "safe_namespace";
+
+        public virtual string Identifier => FormName;
 
         public string Name => Identifier;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IValueForm.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IValueForm.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public interface IValueForm
+    {
+        string Identifier { get; }
+
+        string Name { get; }
+
+        string Process(IReadOnlyDictionary<string, IValueForm> forms, string value);
+
+        IValueForm FromJObject(string name, JObject configuration);
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IdentityValueForm.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IdentityValueForm.cs
@@ -5,7 +5,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     public class IdentityValueForm : IValueForm
     {
-        public string Identifier => "identity";
+        public static readonly string FormName = "identity";
+
+        public string Identifier => FormName;
 
         public string Name { get; }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IdentityValueForm.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IdentityValueForm.cs
@@ -1,7 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     public class IdentityValueForm : IValueForm
     {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/LowerCaseInvariantValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/LowerCaseInvariantValueFormModel.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class LowerCaseInvariantValueFormModel : IValueForm
+    {
+        public string Identifier => "lowerCaseInvariant";
+
+        public string Name { get; }
+
+        public LowerCaseInvariantValueFormModel()
+        {
+        }
+
+        public LowerCaseInvariantValueFormModel(string name)
+        {
+            Name = name;
+        }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new LowerCaseInvariantValueFormModel(name);
+        }
+
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            return value.ToLowerInvariant();
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/LowerCaseValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/LowerCaseValueFormModel.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class LowerCaseValueFormModel : IValueForm
+    {
+        public string Identifier => "lowerCase";
+
+        public string Name { get; }
+
+        public LowerCaseValueFormModel()
+        {
+        }
+
+        public LowerCaseValueFormModel(string name)
+        {
+            Name = name;
+        }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new LowerCaseValueFormModel(name);
+        }
+
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            return value.ToLower();
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ReplacementValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ReplacementValueFormModel.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class ReplacementValueFormModel : IValueForm
+    {
+        private readonly Regex _match;
+        private readonly string _replacment;
+
+        public ReplacementValueFormModel()
+        {
+        }
+
+        public ReplacementValueFormModel(string name, string pattern, string replacement)
+        {
+            _match = new Regex(pattern);
+            _replacment = replacement;
+            Name = name;
+        }
+
+        public string Identifier => "replace";
+
+        public string Name { get; }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new ReplacementValueFormModel(name, configuration.ToString("pattern"), configuration.ToString("replacement"));
+        }
+
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            return _match.Replace(value, _replacment);
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/SymbolValueFormsModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/SymbolValueFormsModel.cs
@@ -60,7 +60,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
             {
                 // config is an object.
                 globalForms = globalConfig.ArrayAsStrings("forms").ToList();
-                addIdentity = globalConfig.ToBool("addIdentity");
+                addIdentity = globalConfig.ToBool("addIdentity", true);
             }
             else
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/SymbolValueFormsModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/SymbolValueFormsModel.cs
@@ -1,12 +1,15 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     public class SymbolValueFormsModel
     {
         public static SymbolValueFormsModel Empty { get; } = new SymbolValueFormsModel(Empty<string>.List.Value);
+
+        // by default, symbols get the "identity" value form, for a direct replacement
+        public static SymbolValueFormsModel Default { get; } = new SymbolValueFormsModel(new List<string>() { "identity" });
 
         public IReadOnlyList<string> GlobalForms { get; }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/SymbolValueFormsModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/SymbolValueFormsModel.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
 
@@ -6,10 +8,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     public class SymbolValueFormsModel
     {
+        private static readonly string IdentityValueFormName = IdentityValueForm.FormName;
+
         public static SymbolValueFormsModel Empty { get; } = new SymbolValueFormsModel(Empty<string>.List.Value);
 
         // by default, symbols get the "identity" value form, for a direct replacement
-        public static SymbolValueFormsModel Default { get; } = new SymbolValueFormsModel(new List<string>() { "identity" });
+        public static SymbolValueFormsModel Default { get; } = new SymbolValueFormsModel(new List<string>() { IdentityValueFormName });
 
         public IReadOnlyList<string> GlobalForms { get; }
 
@@ -18,9 +22,56 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
             GlobalForms = globalForms;
         }
 
-        public static SymbolValueFormsModel FromJObject(JObject obj)
+        // Sets up the value forms for a symbol, based on configuration from template.json
+        // There are two acceptable configuration formats for each forms specification.
+        //
+        // Note: in the examples below, "global" is used. But we'll be extending this to allow
+        //  conditional forms, which will have other names.
+        //  The same format will be used for other named form definitions.
+        //
+        // Simple:
+        // "forms": {
+        //   "global": [ <strings representing value form names> ]
+        // }
+        //
+        // Detailed:
+        // "forms" {
+        //   "global": {
+        //     "forms": [ <strings representing value form names> ],
+        //     "addIdentity": <bool default true>,
+        //     // other future extensions, e.g. conditionals
+        //   },
+        //
+        // If the symbol doesn't include an "identity" form and the addIdentity flag isn't false,
+        // an identity specification is added to the beginning of the symbol's value form list.
+        // If there is an identity form listed, its position remains intact irrespective of the addIdentity flag.
+        public static SymbolValueFormsModel FromJObject(JObject configJson)
         {
-            IReadOnlyList<string> globalForms = obj.ArrayAsStrings("global");
+            JToken globalConfig = configJson.Property("global").Value;
+            List<string> globalForms;
+            bool addIdentity;
+            if (globalConfig.Type == JTokenType.Array)
+            {
+                // config is just an array of form names.
+                globalForms = globalConfig.ArrayAsStrings().ToList();
+                addIdentity = true; // default value
+            }
+            else if (globalConfig.Type == JTokenType.Object)
+            {
+                // config is an object.
+                globalForms = globalConfig.ArrayAsStrings("forms").ToList();
+                addIdentity = globalConfig.ToBool("addIdentity");
+            }
+            else
+            {
+                throw new Exception("Malformed global value forms.");
+            }
+
+            if (addIdentity && !globalForms.Contains(IdentityValueFormName, StringComparer.OrdinalIgnoreCase))
+            {
+                globalForms.Insert(0, IdentityValueFormName);
+            }
+
             return new SymbolValueFormsModel(globalForms);
         }
     }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/UpperCaseInvariantValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/UpperCaseInvariantValueFormModel.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class UpperCaseInvariantValueFormModel : IValueForm
+    {
+        public string Identifier => "upperCaseInvariant";
+
+        public string Name { get; }
+
+        public UpperCaseInvariantValueFormModel()
+        {
+        }
+
+        public UpperCaseInvariantValueFormModel(string name)
+        {
+            Name = name;
+        }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new UpperCaseInvariantValueFormModel(name);
+        }
+
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            return value.ToUpperInvariant();
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/UpperCaseValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/UpperCaseValueFormModel.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class UpperCaseValueFormModel : IValueForm
+    {
+        public string Identifier => "upperCase";
+
+        public string Name { get; }
+
+        public UpperCaseValueFormModel()
+        {
+        }
+
+        public UpperCaseValueFormModel(string name)
+        {
+            Name = name;
+        }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new UpperCaseValueFormModel(name);
+        }
+
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            return value.ToUpper();
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/XmlEncodeValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/XmlEncodeValueFormModel.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Text;
+using System.Xml;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class XmlEncodeValueFormModel : IValueForm
+    {
+        private static readonly XmlWriterSettings Settings = new XmlWriterSettings { ConformanceLevel = ConformanceLevel.Fragment };
+
+        public string Identifier => "xmlEncode";
+
+        public string Name { get; }
+
+        public XmlEncodeValueFormModel()
+        {
+        }
+
+        public XmlEncodeValueFormModel(string name)
+        {
+            Name = name;
+        }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new XmlEncodeValueFormModel(name);
+        }
+
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            StringBuilder output = new StringBuilder();
+            using (XmlWriter w = XmlWriter.Create(output, Settings))
+            {
+                w.WriteString(value);
+            }
+            return output.ToString();
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/OperationTrieTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/OperationTrieTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.TemplateEngine.Core.Contracts;
@@ -94,6 +94,29 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             Assert.NotNull(match);
             Assert.Equal("Test2", match.Id);
             Assert.Equal(0, token);
+            Assert.Equal(buffer.Length, currentBufferPosition);
+        }
+
+        [Fact(DisplayName = nameof(VerifyLastInWinsForIdenticalMatching))]
+        public void VerifyLastInWinsForIdenticalMatching()
+        {
+            OperationTrie trie = OperationTrie.Create(new IOperation[]
+            {
+                new MockOperation("TestOp1", null, true, TokenConfig.LiteralToken(new byte[] { 5, 5, 5 })),
+                new MockOperation("TestOp2", null, true, TokenConfig.LiteralToken(new byte[] { 2, 3, 4, 5 })),
+                new MockOperation("TestOp3", null, true, TokenConfig.LiteralToken(new byte[] { 7, 7, 7 })),
+                new MockOperation("TestOp4", null, true, TokenConfig.LiteralToken(new byte[] { 9, 9, 9, 9 }),
+                                                        TokenConfig.LiteralToken(new byte[] { 2, 3, 4, 5 })
+                ),
+            });
+
+            byte[] buffer = { 9, 8, 9, 8, 7, 2, 3, 4, 5 };
+            int currentBufferPosition = 0;
+            IOperation match = trie.GetOperation(buffer, buffer.Length, ref currentBufferPosition, out int token);
+
+            Assert.NotNull(match);
+            Assert.Equal("TestOp4", match.Id);
+            Assert.Equal(1, token);
             Assert.Equal(buffer.Length, currentBufferPosition);
         }
 

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithValueForms/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithValueForms/.template.config/template.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Test Asset",
   "classifications": [ "Test Asset" ],
   "name": "TemplateWithValueForms",
@@ -14,7 +14,7 @@
       "replaces": "test.value1",
       "fileRename": "bar.2",
       "forms": {
-        "global": [ "chained", "chained2", "dotToUnderscore" ]
+        "global": [ "identity", "chained", "chained2", "dotToUnderscore" ]
       }
     }
   },

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/SplitConfigurationTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/SplitConfigurationTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
@@ -68,7 +68,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             generator.TryGetTemplateFromConfigInfo(templateConfigFileInfo, out ITemplate template, null, null);
 
             IDictionary<string, ITemplateParameter> parameters = template.Parameters.ToDictionary(p => p.Name, p => p);
-            Assert.Equal(5, parameters.Count);
+            Assert.Equal(6, parameters.Count);  // 5 in the configs + 1 for 'name' (implicit)
             Assert.True(parameters.ContainsKey("type"));
             Assert.True(parameters.ContainsKey("language"));
             Assert.True(parameters.ContainsKey("RuntimeFrameworkVersion"));

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/SymbolConfigTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/SymbolConfigTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
         [Fact(DisplayName = nameof(NameSymbolGetsAddedWithDefaultValueForms))]
         public void NameSymbolGetsAddedWithDefaultValueForms()
         {
-            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ConfigForSymbolWithFormsButNotIdentity);
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ArrayConfigForSymbolWithFormsButNotIdentity);
             Assert.True(configModel.Symbols.ContainsKey("name"));
 
             ISymbolModel symbolInfo = configModel.Symbols["name"];
@@ -35,7 +35,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
         [Fact(DisplayName = nameof(ParameterSymbolWithoutIdentityValueFormGetsIdentityAddedAsFirst))]
         public void ParameterSymbolWithoutIdentityValueFormGetsIdentityAddedAsFirst()
         {
-            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ConfigForSymbolWithFormsButNotIdentity);
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ArrayConfigForSymbolWithFormsButNotIdentity);
             Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
 
             ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             Assert.Equal(0, paramSymbol.Forms.GlobalForms.ToList().IndexOf(IdentityValueForm.FormName));
         }
 
-        private static JObject ConfigForSymbolWithFormsButNotIdentity
+        private static JObject ArrayConfigForSymbolWithFormsButNotIdentity
         {
             get
             {
@@ -78,10 +78,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
 
         // Tests that a name symbol with explicitly defined value forms but no identity form
         // gets the identity form added as the first form.
-        [Fact(DisplayName = nameof(ConfigDefinedNameSymbolWithoutIdentityFormGetsIdentityFormAddedAsFirst))]
-        public void ConfigDefinedNameSymbolWithoutIdentityFormGetsIdentityFormAddedAsFirst()
+        [Fact(DisplayName = nameof(ArrayConfigNameSymbolWithoutIdentityFormGetsIdentityFormAddedAsFirst))]
+        public void ArrayConfigNameSymbolWithoutIdentityFormGetsIdentityFormAddedAsFirst()
         {
-            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ConfigWithNameSymbolAndValueFormsButNotIdentity);
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ArrayConfigWithNameSymbolAndValueFormsButNotIdentity);
             Assert.True(configModel.Symbols.ContainsKey("name"));
 
             ISymbolModel symbolInfo = configModel.Symbols["name"];
@@ -96,7 +96,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             Assert.Equal("baz", configuredValueFormNames[3]);
         }
 
-        private static JObject ConfigWithNameSymbolAndValueFormsButNotIdentity
+        private static JObject ArrayConfigWithNameSymbolAndValueFormsButNotIdentity
         {
             get
             {
@@ -124,19 +124,17 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             }
         }
 
-        // Test that when a symbol explicitly includes the "identity" value form, the value forms for the symbol remain unmodified.
-        [Fact(DisplayName = nameof(ParameterSymbolWithIdentityValueFormRetainsFormsUnmodified))]
-        public void ParameterSymbolWithIdentityValueFormRetainsFormsUnmodified()
+        [Fact(DisplayName = nameof(ArrayConfigNameSymbolWithIdentityFormRetainsConfiguredFormsExactly))]
+        public void ArrayConfigNameSymbolWithIdentityFormRetainsConfiguredFormsExactly()
         {
-            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ConfigForSymbolWithValueFormsIncludingIdentity);
-            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ArrayConfigWithNameSymbolAndValueFormsWithIdentity);
+            Assert.True(configModel.Symbols.ContainsKey("name"));
 
-            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
+            ISymbolModel symbolInfo = configModel.Symbols["name"];
             Assert.True(symbolInfo is ParameterSymbol);
 
-            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
-            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
-
+            ParameterSymbol nameSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = nameSymbol.Forms.GlobalForms.ToList();
             Assert.Equal(4, configuredValueFormNames.Count);
             Assert.Equal("foo", configuredValueFormNames[0]);
             Assert.Equal("bar", configuredValueFormNames[1]);
@@ -144,7 +142,133 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[3]);
         }
 
-        private static JObject ConfigForSymbolWithValueFormsIncludingIdentity
+        private static JObject ArrayConfigWithNameSymbolAndValueFormsWithIdentity
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""name"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": [ ""foo"", ""bar"", ""baz"", ""identity"" ]
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(ObjectConfigNameSymbolWithIdentityFormAndAddIdentityFalseRetainsConfiguredFormsExactly))]
+        public void ObjectConfigNameSymbolWithIdentityFormAndAddIdentityFalseRetainsConfiguredFormsExactly()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ObjectConfigNameSymbolWithIdentityFormAndAddIdentityFalse);
+            Assert.True(configModel.Symbols.ContainsKey("name"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["name"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol nameSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = nameSymbol.Forms.GlobalForms.ToList();
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal("foo", configuredValueFormNames[0]);
+            Assert.Equal("bar", configuredValueFormNames[1]);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[2]);
+            Assert.Equal("baz", configuredValueFormNames[3]);
+        }
+
+        private static JObject ObjectConfigNameSymbolWithIdentityFormAndAddIdentityFalse
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""name"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""identity"", ""baz"" ],
+            ""addIdentity"": ""false""
+        }
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(ObjectConfigNameSymbolWithIdentityFormAndAddIdentityTrueRetainsConfiguredFormsExactly))]
+        public void ObjectConfigNameSymbolWithIdentityFormAndAddIdentityTrueRetainsConfiguredFormsExactly()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ObjectConfigNameSymbolWithIdentityFormAndAddIdentityTrue);
+            Assert.True(configModel.Symbols.ContainsKey("name"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["name"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol nameSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = nameSymbol.Forms.GlobalForms.ToList();
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal("foo", configuredValueFormNames[0]);
+            Assert.Equal("bar", configuredValueFormNames[1]);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[2]);
+            Assert.Equal("baz", configuredValueFormNames[3]);
+        }
+
+        private static JObject ObjectConfigNameSymbolWithIdentityFormAndAddIdentityTrue
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""name"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""identity"", ""baz"" ],
+            ""addIdentity"": ""true""
+        }
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        private static JObject ConfigWithObjectValueFormDefinitionAddIdentityFalse
         {
             get
             {
@@ -163,7 +287,207 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
       ""type"": ""parameter"",
       ""dataType"": ""string"",
       ""forms"": {
-        ""global"": [ ""foo"", ""bar"", ""baz"", ""identity"" ]
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""baz"" ],
+            ""addIdentity"": ""false""
+        }
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(NameSymbolObjectValueFormDefinitionRespectsAddIdentityTrue))]
+        public void NameSymbolObjectValueFormDefinitionRespectsAddIdentityTrue()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, NameConfigWithObjectValueFormDefinitionAddIdentityTrue);
+            Assert.True(configModel.Symbols.ContainsKey("name"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["name"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[0]);
+            Assert.Equal("foo", configuredValueFormNames[1]);
+            Assert.Equal("bar", configuredValueFormNames[2]);
+            Assert.Equal("baz", configuredValueFormNames[3]);
+        }
+
+        private static JObject NameConfigWithObjectValueFormDefinitionAddIdentityTrue
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""name"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""baz"" ],
+            ""addIdentity"": ""true""
+        }
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(NameSymbolObjectValueFormDefinitionRespectsAddIdentityFalse))]
+        public void NameSymbolObjectValueFormDefinitionRespectsAddIdentityFalse()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, NameConfigWithObjectValueFormDefinitionAddIdentityFalse);
+            Assert.True(configModel.Symbols.ContainsKey("name"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["name"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(3, configuredValueFormNames.Count);
+            Assert.Equal("foo", configuredValueFormNames[0]);
+            Assert.Equal("bar", configuredValueFormNames[1]);
+            Assert.Equal("baz", configuredValueFormNames[2]);
+        }
+
+        private static JObject NameConfigWithObjectValueFormDefinitionAddIdentityFalse
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""name"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""baz"" ],
+            ""addIdentity"": ""false""
+        }
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(NameSymbolObjectValueFormDefinitionInfersAddIdentityTrue))]
+        public void NameSymbolObjectValueFormDefinitionInfersAddIdentityTrue()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, NameConfigObjectValueFormWithoutIdentityAndAddIdentityUnspecified);
+            Assert.True(configModel.Symbols.ContainsKey("name"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["name"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[0]);
+            Assert.Equal("foo", configuredValueFormNames[1]);
+            Assert.Equal("bar", configuredValueFormNames[2]);
+            Assert.Equal("baz", configuredValueFormNames[3]);
+        }
+
+        private static JObject NameConfigObjectValueFormWithoutIdentityAndAddIdentityUnspecified
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""name"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""baz"" ],
+        }
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(NameSymbolObjectValueFormWithIdentityWithoutAddIdentityRetainsConfiguredForms))]
+        public void NameSymbolObjectValueFormWithIdentityWithoutAddIdentityRetainsConfiguredForms()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, NameConfigObjectValueFormWithIdentityAndAddIdentityUnspecified);
+            Assert.True(configModel.Symbols.ContainsKey("name"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["name"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal("foo", configuredValueFormNames[0]);
+            Assert.Equal("bar", configuredValueFormNames[1]);
+            Assert.Equal("baz", configuredValueFormNames[2]);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[3]);
+        }
+
+        private static JObject NameConfigObjectValueFormWithIdentityAndAddIdentityUnspecified
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""name"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""baz"", ""identity"" ],
+        }
       }
     }
   }
@@ -212,6 +536,55 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
                 return JObject.Parse(configString);
             }
         }
+
+        // Test that when a symbol explicitly includes the "identity" value form, the value forms for the symbol remain unmodified.
+        [Fact(DisplayName = nameof(ParameterSymbolWithArrayIdentityValueFormRetainsFormsUnmodified))]
+        public void ParameterSymbolWithArrayIdentityValueFormRetainsFormsUnmodified()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ArrayConfigForSymbolWithValueFormsIncludingIdentity);
+            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal("foo", configuredValueFormNames[0]);
+            Assert.Equal("bar", configuredValueFormNames[1]);
+            Assert.Equal("baz", configuredValueFormNames[2]);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[3]);
+        }
+
+        private static JObject ArrayConfigForSymbolWithValueFormsIncludingIdentity
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""testSymbol"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": [ ""foo"", ""bar"", ""baz"", ""identity"" ]
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
 
         [Fact(DisplayName = nameof(ObjectValueFormDefinitionRespectsAddIdentityTrue))]
         public void ObjectValueFormDefinitionRespectsAddIdentityTrue()
@@ -281,7 +654,26 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             Assert.Equal("baz", configuredValueFormNames[2]);
         }
 
-        private static JObject ConfigWithObjectValueFormDefinitionAddIdentityFalse
+
+        [Fact(DisplayName = nameof(ObjectConfigParameterSymbolWithIdentityFormAndAddIdentityFalseRetainsConfiguredFormsExactly))]
+        public void ObjectConfigParameterSymbolWithIdentityFormAndAddIdentityFalseRetainsConfiguredFormsExactly()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ObjectConfigParameterSymbolWithIdentityFormAndAddIdentityFalse);
+            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol nameSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = nameSymbol.Forms.GlobalForms.ToList();
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal("foo", configuredValueFormNames[0]);
+            Assert.Equal("bar", configuredValueFormNames[1]);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[2]);
+            Assert.Equal("baz", configuredValueFormNames[3]);
+        }
+
+        private static JObject ObjectConfigParameterSymbolWithIdentityFormAndAddIdentityFalse
         {
             get
             {
@@ -301,7 +693,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
       ""dataType"": ""string"",
       ""forms"": {
         ""global"": {
-            ""forms"": [ ""foo"", ""bar"", ""baz"" ],
+            ""forms"": [ ""foo"", ""bar"", ""identity"", ""baz"" ],
             ""addIdentity"": ""false""
         }
       }
@@ -312,10 +704,108 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             }
         }
 
-        [Fact(DisplayName = nameof(NameSymbolObjectValueFormDefinitionRespectsAddIdentityTrue))]
-        public void NameSymbolObjectValueFormDefinitionRespectsAddIdentityTrue()
+        [Fact(DisplayName = nameof(ObjectConfigParameterSymbolWithIdentityFormAndAddIdentityTrueRetainsConfiguredFormsExactly))]
+        public void ObjectConfigParameterSymbolWithIdentityFormAndAddIdentityTrueRetainsConfiguredFormsExactly()
         {
-            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, NameConfigWithObjectValueFormDefinitionAddIdentityTrue);
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ObjectConfigParameterSymbolWithIdentityFormAndAddIdentityTrue);
+            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol nameSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = nameSymbol.Forms.GlobalForms.ToList();
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal("foo", configuredValueFormNames[0]);
+            Assert.Equal("bar", configuredValueFormNames[1]);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[2]);
+            Assert.Equal("baz", configuredValueFormNames[3]);
+        }
+
+        private static JObject ObjectConfigParameterSymbolWithIdentityFormAndAddIdentityTrue
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""testSymbol"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""identity"", ""baz"" ],
+            ""addIdentity"": ""true""
+        }
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(ParameterSymbolObjectValueFormWithIdentityWithoutAddIdentityRetainsConfiguredForms))]
+        public void ParameterSymbolObjectValueFormWithIdentityWithoutAddIdentityRetainsConfiguredForms()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ParameterConfigObjectValueFormWithIdentityAndAddIdentityUnspecified);
+            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal("foo", configuredValueFormNames[0]);
+            Assert.Equal("bar", configuredValueFormNames[1]);
+            Assert.Equal("baz", configuredValueFormNames[2]);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[3]);
+        }
+
+        private static JObject ParameterConfigObjectValueFormWithIdentityAndAddIdentityUnspecified
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""testSymbol"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""baz"", ""identity"" ],
+        }
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(ParameterSymbolObjectValueFormDefinitionInfersAddIdentityTrue))]
+        public void ParameterSymbolObjectValueFormDefinitionInfersAddIdentityTrue()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ParameterConfigObjectValueFormWithoutIdentityAndAddIdentityUnspecified);
             Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
 
             ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
@@ -331,7 +821,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             Assert.Equal("baz", configuredValueFormNames[3]);
         }
 
-        private static JObject NameConfigWithObjectValueFormDefinitionAddIdentityTrue
+        private static JObject ParameterConfigObjectValueFormWithoutIdentityAndAddIdentityUnspecified
         {
             get
             {
@@ -352,7 +842,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
       ""forms"": {
         ""global"": {
             ""forms"": [ ""foo"", ""bar"", ""baz"" ],
-            ""addIdentity"": ""true""
         }
       }
     }
@@ -362,53 +851,5 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             }
         }
 
-        [Fact(DisplayName = nameof(NameSymbolObjectValueFormDefinitionRespectsAddIdentityFalse))]
-        public void NameSymbolObjectValueFormDefinitionRespectsAddIdentityFalse()
-        {
-            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, NameConfigWithObjectValueFormDefinitionAddIdentityFalse);
-            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
-
-            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
-            Assert.True(symbolInfo is ParameterSymbol);
-
-            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
-            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
-
-            Assert.Equal(3, configuredValueFormNames.Count);
-            Assert.Equal("foo", configuredValueFormNames[0]);
-            Assert.Equal("bar", configuredValueFormNames[1]);
-            Assert.Equal("baz", configuredValueFormNames[2]);
-        }
-
-        private static JObject NameConfigWithObjectValueFormDefinitionAddIdentityFalse
-        {
-            get
-            {
-                string configString = @"
-{
-  ""author"": ""Test Asset"",
-  ""classifications"": [ ""Test Asset"" ],
-  ""name"": ""TemplateWithValueForms"",
-  ""generatorVersions"": ""[1.0.0.0-*)"",
-  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
-  ""precedence"": ""100"",
-  ""identity"": ""TestAssets.TemplateWithValueForms"",
-  ""shortName"": ""TestAssets.TemplateWithValueForms"",
-  ""symbols"": {
-    ""testSymbol"": {
-      ""type"": ""parameter"",
-      ""dataType"": ""string"",
-      ""forms"": {
-        ""global"": {
-            ""forms"": [ ""foo"", ""bar"", ""baz"" ],
-            ""addIdentity"": ""false""
-        }
-      }
-    }
-  }
-}";
-                return JObject.Parse(configString);
-            }
-        }
     }
 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/SymbolConfigTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/SymbolConfigTests.cs
@@ -1,0 +1,414 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
+using Microsoft.TemplateEngine.TestHelper;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.TemplateConfigTests
+{
+    public class SymbolConfigTests : TestBase
+    {
+        // Test that when a config doesn't include a name parameter, one gets added - with the proper value forms.
+        [Fact(DisplayName = nameof(NameSymbolGetsAddedWithDefaultValueForms))]
+        public void NameSymbolGetsAddedWithDefaultValueForms()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ConfigForSymbolWithFormsButNotIdentity);
+            Assert.True(configModel.Symbols.ContainsKey("name"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["name"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol nameSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = nameSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(5, configuredValueFormNames.Count);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[0]);
+            Assert.Equal(DefaultSafeNameValueFormModel.FormName, configuredValueFormNames[1]);
+            Assert.Equal(DefaultLowerSafeNameValueFormModel.FormName, configuredValueFormNames[2]);
+            Assert.Equal(DefaultSafeNamespaceValueFormModel.FormName, configuredValueFormNames[3]);
+            Assert.Equal(DefaultLowerSafeNamespaceValueFormModel.FormName, configuredValueFormNames[4]);
+        }
+
+        // Test that when a symbol doens't explicitly include the "identity" value form, it gets added as the first form.
+        [Fact(DisplayName = nameof(ParameterSymbolWithoutIdentityValueFormGetsIdentityAddedAsFirst))]
+        public void ParameterSymbolWithoutIdentityValueFormGetsIdentityAddedAsFirst()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ConfigForSymbolWithFormsButNotIdentity);
+            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            Assert.Equal(1, paramSymbol.Forms.GlobalForms.ToList()
+                                                .Where(x => string.Equals(x, IdentityValueForm.FormName, StringComparison.OrdinalIgnoreCase))
+                                                .Count());
+            Assert.Equal(0, paramSymbol.Forms.GlobalForms.ToList().IndexOf(IdentityValueForm.FormName));
+        }
+
+        private static JObject ConfigForSymbolWithFormsButNotIdentity
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""testSymbol"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": [ ""foo"", ""bar"", ""baz"" ]
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        // Tests that a name symbol with explicitly defined value forms but no identity form
+        // gets the identity form added as the first form.
+        [Fact(DisplayName = nameof(ConfigDefinedNameSymbolWithoutIdentityFormGetsIdentityFormAddedAsFirst))]
+        public void ConfigDefinedNameSymbolWithoutIdentityFormGetsIdentityFormAddedAsFirst()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ConfigWithNameSymbolAndValueFormsButNotIdentity);
+            Assert.True(configModel.Symbols.ContainsKey("name"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["name"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol nameSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = nameSymbol.Forms.GlobalForms.ToList();
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[0]);
+            Assert.Equal("foo", configuredValueFormNames[1]);
+            Assert.Equal("bar", configuredValueFormNames[2]);
+            Assert.Equal("baz", configuredValueFormNames[3]);
+        }
+
+        private static JObject ConfigWithNameSymbolAndValueFormsButNotIdentity
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""name"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": [ ""foo"", ""bar"", ""baz"" ]
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        // Test that when a symbol explicitly includes the "identity" value form, the value forms for the symbol remain unmodified.
+        [Fact(DisplayName = nameof(ParameterSymbolWithIdentityValueFormRetainsFormsUnmodified))]
+        public void ParameterSymbolWithIdentityValueFormRetainsFormsUnmodified()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ConfigForSymbolWithValueFormsIncludingIdentity);
+            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal("foo", configuredValueFormNames[0]);
+            Assert.Equal("bar", configuredValueFormNames[1]);
+            Assert.Equal("baz", configuredValueFormNames[2]);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[3]);
+        }
+
+        private static JObject ConfigForSymbolWithValueFormsIncludingIdentity
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""testSymbol"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": [ ""foo"", ""bar"", ""baz"", ""identity"" ]
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(ParameterSymbolWithNoValueFormsGetsIdentityFormAdded))]
+        public void ParameterSymbolWithNoValueFormsGetsIdentityFormAdded()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ConfigForSymbolWithoutValueForms);
+            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(1, configuredValueFormNames.Count);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[0]);
+        }
+
+        private static JObject ConfigForSymbolWithoutValueForms
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""testSymbol"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string""
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(ObjectValueFormDefinitionRespectsAddIdentityTrue))]
+        public void ObjectValueFormDefinitionRespectsAddIdentityTrue()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ConfigWithObjectValueFormDefinitionAddIdentityTrue);
+            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[0]);
+            Assert.Equal("foo", configuredValueFormNames[1]);
+            Assert.Equal("bar", configuredValueFormNames[2]);
+            Assert.Equal("baz", configuredValueFormNames[3]);
+        }
+
+        private static JObject ConfigWithObjectValueFormDefinitionAddIdentityTrue
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""testSymbol"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""baz"" ],
+            ""addIdentity"": ""true""
+        }
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(ObjectValueFormDefinitionRespectsAddIdentityFalse))]
+        public void ObjectValueFormDefinitionRespectsAddIdentityFalse()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, ConfigWithObjectValueFormDefinitionAddIdentityFalse);
+            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(3, configuredValueFormNames.Count);
+            Assert.Equal("foo", configuredValueFormNames[0]);
+            Assert.Equal("bar", configuredValueFormNames[1]);
+            Assert.Equal("baz", configuredValueFormNames[2]);
+        }
+
+        private static JObject ConfigWithObjectValueFormDefinitionAddIdentityFalse
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""testSymbol"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""baz"" ],
+            ""addIdentity"": ""false""
+        }
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(NameSymbolObjectValueFormDefinitionRespectsAddIdentityTrue))]
+        public void NameSymbolObjectValueFormDefinitionRespectsAddIdentityTrue()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, NameConfigWithObjectValueFormDefinitionAddIdentityTrue);
+            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(4, configuredValueFormNames.Count);
+            Assert.Equal(IdentityValueForm.FormName, configuredValueFormNames[0]);
+            Assert.Equal("foo", configuredValueFormNames[1]);
+            Assert.Equal("bar", configuredValueFormNames[2]);
+            Assert.Equal("baz", configuredValueFormNames[3]);
+        }
+
+        private static JObject NameConfigWithObjectValueFormDefinitionAddIdentityTrue
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""testSymbol"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""baz"" ],
+            ""addIdentity"": ""true""
+        }
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+
+        [Fact(DisplayName = nameof(NameSymbolObjectValueFormDefinitionRespectsAddIdentityFalse))]
+        public void NameSymbolObjectValueFormDefinitionRespectsAddIdentityFalse()
+        {
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(EngineEnvironmentSettings, NameConfigWithObjectValueFormDefinitionAddIdentityFalse);
+            Assert.True(configModel.Symbols.ContainsKey("testSymbol"));
+
+            ISymbolModel symbolInfo = configModel.Symbols["testSymbol"];
+            Assert.True(symbolInfo is ParameterSymbol);
+
+            ParameterSymbol paramSymbol = symbolInfo as ParameterSymbol;
+            IList<string> configuredValueFormNames = paramSymbol.Forms.GlobalForms.ToList();
+
+            Assert.Equal(3, configuredValueFormNames.Count);
+            Assert.Equal("foo", configuredValueFormNames[0]);
+            Assert.Equal("bar", configuredValueFormNames[1]);
+            Assert.Equal("baz", configuredValueFormNames[2]);
+        }
+
+        private static JObject NameConfigWithObjectValueFormDefinitionAddIdentityFalse
+        {
+            get
+            {
+                string configString = @"
+{
+  ""author"": ""Test Asset"",
+  ""classifications"": [ ""Test Asset"" ],
+  ""name"": ""TemplateWithValueForms"",
+  ""generatorVersions"": ""[1.0.0.0-*)"",
+  ""groupIdentity"": ""TestAssets.TemplateWithValueForms"",
+  ""precedence"": ""100"",
+  ""identity"": ""TestAssets.TemplateWithValueForms"",
+  ""shortName"": ""TestAssets.TemplateWithValueForms"",
+  ""symbols"": {
+    ""testSymbol"": {
+      ""type"": ""parameter"",
+      ""dataType"": ""string"",
+      ""forms"": {
+        ""global"": {
+            ""forms"": [ ""foo"", ""bar"", ""baz"" ],
+            ""addIdentity"": ""false""
+        }
+      }
+    }
+  }
+}";
+                return JObject.Parse(configString);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Primary changes:
1) The default name is setup as a symbol in SimpleConfigModel.FromJObject(), and used unless explicitly overridden from template configuration. If the template config provides name symbol configuration, without value forms, the default name forms are used. But if the explicitly defined name symbol defines values forms, those are used exclusively for name.
2) Direct ParameterSymbol replacements are now setup via the identity value form (internal to SimpleConfigModel).
3) Parameters with value forms explicitly defined in the template are not given an identity replacement. This is a break from past behavior, in which a direct replacement was setup, in addition to any explicitly defined value forms.

Ancillary changes:
1) Fixed a bug in TrieEvaluator.cs so that if multiple terminals exist as matches to the same pattern, the effective terminal is the last-in, instead of the first in.
2) Modified a unit test to deal with the fact that parameters with value forms explicitly defined no longer get an identity replacement.
3) Modified TemplateCreator.InstantiateAsync so that separate IParameterSets are used for GetCreationEffects() and CreateAsync(). Using the same set was causing duplication of macros produced.