### PR TITLE
Allow other operators to process unhandled condition expressions

### DIFF
--- a/src/Microsoft.TemplateEngine.Core.Contracts/IProcessorState.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IProcessorState.cs
@@ -33,6 +33,6 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 
         void SeekBackWhile(ITokenTrie match);
 
-        void Inject(Stream staged, int sequenceNumberEffect);
+        void Inject(Stream staged);
     }
 }

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IProcessorState.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IProcessorState.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Text;
 
 namespace Microsoft.TemplateEngine.Core.Contracts
@@ -31,5 +32,7 @@ namespace Microsoft.TemplateEngine.Core.Contracts
         void SeekBackUntil(ITokenTrie match, bool consume);
 
         void SeekBackWhile(ITokenTrie match);
+
+        void Inject(Stream staged, int sequenceNumberEffect);
     }
 }

--- a/src/Microsoft.TemplateEngine.Core/Operations/InlineMarkupConditional.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/InlineMarkupConditional.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -115,9 +115,14 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 if (faulted)
                 {
                     target.Write(Tokens[0].Value, Tokens[0].Start, Tokens[0].Length);
-                    target.Write(condition, 0, condition.Length);
-                    target.Write(_closeConditionTrie.Tokens[0].Value, _closeConditionTrie.Tokens[0].Start, _closeConditionTrie.Tokens[0].Length);
-                    int written = Tokens[0].Length + condition.Length + _closeConditionTrie.Tokens[0].Length;
+                    MemoryStream fragment = new MemoryStream();
+                    fragment.Write(condition, 0, condition.Length);
+                    fragment.Write(_closeConditionTrie.Tokens[0].Value, _closeConditionTrie.Tokens[0].Start, _closeConditionTrie.Tokens[0].Length);
+                    fragment.Write(processor.CurrentBuffer, currentBufferPosition, bufferLength - currentBufferPosition);
+                    fragment.Position = 0;
+                    processor.Inject(fragment, 0);
+                    currentBufferPosition = processor.CurrentBufferPosition;
+                    int written = Tokens[0].Length;
                     return written;
                 }
 

--- a/src/Microsoft.TemplateEngine.Core/Operations/InlineMarkupConditional.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/InlineMarkupConditional.cs
@@ -120,7 +120,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                     fragment.Write(_closeConditionTrie.Tokens[0].Value, _closeConditionTrie.Tokens[0].Start, _closeConditionTrie.Tokens[0].Length);
                     fragment.Write(processor.CurrentBuffer, currentBufferPosition, bufferLength - currentBufferPosition);
                     fragment.Position = 0;
-                    processor.Inject(fragment, 0);
+                    processor.Inject(fragment);
                     currentBufferPosition = processor.CurrentBufferPosition;
                     int written = Tokens[0].Length;
                     return written;

--- a/src/Microsoft.TemplateEngine.Core/Util/CombinedStream.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/CombinedStream.cs
@@ -3,13 +3,13 @@ using System.IO;
 
 namespace Microsoft.TemplateEngine.Core.Util
 {
-    internal class MultiStream : Stream
+    internal class CombinedStream : Stream
     {
         private readonly Stream _stream1;
         private readonly Stream _stream2;
         private bool _isStream1Depleted;
 
-        public MultiStream(Stream stream1, Stream stream2)
+        public CombinedStream(Stream stream1, Stream stream2)
         {
             _stream1 = stream1;
             _stream2 = stream2;

--- a/src/Microsoft.TemplateEngine.Core/Util/MultiStream.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/MultiStream.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+
+namespace Microsoft.TemplateEngine.Core.Util
+{
+    internal class MultiStream : Stream
+    {
+        private readonly Stream _stream1;
+        private readonly Stream _stream2;
+        private bool _isStream1Depleted;
+
+        public MultiStream(Stream stream1, Stream stream2)
+        {
+            _stream1 = stream1;
+            _stream2 = stream2;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotImplementedException();
+
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+        public override void Flush()
+        {
+            throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int read = 0;
+            if (!_isStream1Depleted)
+            {
+                read = _stream1.Read(buffer, offset, count);
+
+                if(read == count)
+                {
+                    return read;
+                }
+
+                count -= read;
+                offset += read;
+                _isStream1Depleted = true;
+            }
+
+            read += _stream2.Read(buffer, offset, count);
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            _stream1.Dispose();
+            _stream2.Dispose();
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Core/Util/ProcessorState.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/ProcessorState.cs
@@ -518,7 +518,7 @@ namespace Microsoft.TemplateEngine.Core.Util
 
         public void Inject(Stream staged)
         {
-            _source = new CombinedStream(staged, _source);
+            _source = new CombinedStream(staged, _source, inner => _source = inner);
             CurrentBufferLength = _source.Read(CurrentBuffer, 0, CurrentBufferLength);
             CurrentBufferPosition = 0;
         }

--- a/src/Microsoft.TemplateEngine.Core/Util/ProcessorState.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/ProcessorState.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TemplateEngine.Core.Util
 {
     public class ProcessorState : IProcessorState
     {
-        private readonly Stream _source;
+        private Stream _source;
         private readonly Stream _target;
         private readonly TrieEvaluator<OperationTerminal> _trie;
         private Encoding _encoding;
@@ -514,6 +514,14 @@ namespace Microsoft.TemplateEngine.Core.Util
 
             //Ran out of places to check and haven't reached the actual match, consume all the way to the end
             currentBufferPosition = bufferLength;
+        }
+
+        public void Inject(Stream staged, int sequenceNumberEffect)
+        {
+            CurrentSequenceNumber += sequenceNumberEffect;
+            _source = new MultiStream(staged, _source);
+            CurrentBufferLength = _source.Read(CurrentBuffer, 0, CurrentBufferLength);
+            CurrentBufferPosition = 0;
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Core/Util/ProcessorState.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/ProcessorState.cs
@@ -516,10 +516,9 @@ namespace Microsoft.TemplateEngine.Core.Util
             currentBufferPosition = bufferLength;
         }
 
-        public void Inject(Stream staged, int sequenceNumberEffect)
+        public void Inject(Stream staged)
         {
-            CurrentSequenceNumber += sequenceNumberEffect;
-            _source = new MultiStream(staged, _source);
+            _source = new CombinedStream(staged, _source);
             CurrentBufferLength = _source.Read(CurrentBuffer, 0, CurrentBufferLength);
             CurrentBufferPosition = 0;
         }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
@@ -251,6 +252,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             }
 
             public void SeekForwardWhile(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Inject(Stream staged, int sequenceNumberEffect)
             {
                 throw new NotImplementedException();
             }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
@@ -256,7 +256,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 throw new NotImplementedException();
             }
 
-            public void Inject(Stream staged, int sequenceNumberEffect)
+            public void Inject(Stream staged)
             {
                 throw new NotImplementedException();
             }

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.InlineMarkup.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.InlineMarkup.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Expressions.MSBuild;
 using Microsoft.TemplateEngine.Core.Operations;
 using Microsoft.TemplateEngine.Core.Util;
-using Microsoft.TemplateEngine.TestHelper;
 using Xunit;
 
 namespace Microsoft.TemplateEngine.Core.UnitTests
@@ -21,6 +20,20 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 null,
                 true
             ));
+        }
+
+        private IProcessor SetupXmlPlusMsBuildProcessorAndReplacement(IVariableCollection vc)
+        {
+            EngineConfig cfg = new EngineConfig(EnvironmentSettings, vc, "$({0})");
+            return Processor.Create(cfg, new InlineMarkupConditional(
+                new MarkupTokens("<".TokenConfig(), "</".TokenConfig(), ">".TokenConfig(), "/>".TokenConfig(), "Condition=\"".TokenConfig(), "\"".TokenConfig()),
+                true,
+                true,
+                MSBuildStyleEvaluatorDefinition.Evaluate,
+                "$({0})",
+                null,
+                true
+            ), new Replacement("ReplaceMe".TokenConfig(), "I've been replaced", null, true));
         }
 
         [Fact(DisplayName = nameof(VerifyInlineMarkupTrue))]
@@ -270,6 +283,21 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             expectedValue = @"<root>
 </root>";
 
+            RunAndVerify(originalValue, expectedValue, processor, 9999);
+        }
+
+        [Fact(DisplayName = nameof(VerifyInlineMarkupRejectGetsProcessed))]
+        public void VerifyInlineMarkupRejectGetsProcessed()
+        {
+            string originalValue = @"<root>
+    <element Condition=""Exists(ReplaceMe)"" />
+</root>";
+
+            string expectedValue = @"<root>
+    <element Condition=""Exists(I've been replaced)"" />
+</root>";
+            VariableCollection vc = new VariableCollection { };
+            IProcessor processor = SetupXmlPlusMsBuildProcessorAndReplacement(vc);
             RunAndVerify(originalValue, expectedValue, processor, 9999);
         }
     }


### PR DESCRIPTION
Fixes #952 

The current behavior for "rejected"/"failed" (not evaluated to false - but things like encountering unknown symbols) situations for conditions simply takes the bytes that were collected in gathering the condition contents and emits them directly.

With this change, the collected condition byte are "injected" as a chunk just prior to the current position of the source stream. Since the source stream shouldn't be considered to be mutable, a stream that combines streams has been added to allow reading the chunk the condition had read from the buffer/combined from one or more portions of buffers before continuing to read from the original source stream.

Currently, after the combined stream is applied, it's never removed - meaning that if there were multiple conditions rejected, there'd be one combining stream for each rejected condition (and associated MemoryStreams holding the chunk to be read) - this should be changed such that after a read that moves `_source1` to the depleted state, the combining stream is removed and the original source stream (`_source2`) is restored on the caller.