### PR TITLE
fix return value

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Controllers/ValuesController.fs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/WebApi-FSharp/Controllers/ValuesController.fs
@@ -12,7 +12,7 @@ type ValuesController () =
 
     [<HttpGet>]
     member this.Get() =
-        [|"value1" , "value2"|]
+        [|"value1"; "value2"|]
 
     [<HttpGet("{id}")>]
     member this.Get(id:int) =


### PR DESCRIPTION
in F# the item separator in array is `;` not `,` (used for tuples)