### PR TITLE
Clarify password reset sentence in ForgotPassword view

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/Views/Account/ForgotPassword.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/Views/Account/ForgotPassword.cshtml
@@ -5,7 +5,7 @@
 
 <h2>@ViewData["Title"]</h2>
 <p>
-    For more information on how to enable reset password please see this <a href="https://go.microsoft.com/fwlink/?LinkID=532713">article</a>.
+    For more information on how to enable password reset, please see this <a href="https://go.microsoft.com/fwlink/?LinkID=532713">article</a>.
 </p>
 
 @*<form asp-controller="Account" asp-action="ForgotPassword" method="post" class="form-horizontal">

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Account/ForgotPassword.cshtml
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/Views/Account/ForgotPassword.cshtml
@@ -5,7 +5,7 @@
 
 <h2>@ViewData["Title"]</h2>
 <p>
-    For more information on how to enable reset password please see this <a href="https://go.microsoft.com/fwlink/?LinkID=532713">article</a>.
+    For more information on how to enable password reset, please see this <a href="https://go.microsoft.com/fwlink/?LinkID=532713">article</a>.
 </p>
 
 @*<form asp-controller="Account" asp-action="ForgotPassword" method="post" class="form-horizontal">


### PR DESCRIPTION
The `ForgotPassword.cshtml` view (in the 1.x and 2.0 templates) includes a sentence which was missing a comma and reversed the words "reset" and "password".