### PR TITLE
Make B2C issuer update logic more robust

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/AzureAdB2C/AzureAdB2CAuthenticationBuilderExtensions.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/RazorPagesWeb-CSharp/AzureAdB2C/AzureAdB2CAuthenticationBuilderExtensions.cs
@@ -59,7 +59,8 @@ namespace Microsoft.AspNetCore.Authentication.Extensions
                 {
                     context.ProtocolMessage.Scope = OpenIdConnectScope.OpenIdProfile;
                     context.ProtocolMessage.ResponseType = OpenIdConnectResponseType.IdToken;
-                    context.ProtocolMessage.IssuerAddress = context.ProtocolMessage.IssuerAddress.ToLower().Replace(defaultPolicy.ToLower(), policy.ToLower());
+                    context.ProtocolMessage.IssuerAddress = context.ProtocolMessage.IssuerAddress.ToLower()
+                        .Replace($"/{defaultPolicy.ToLower()}/", $"/{policy.ToLower()}/");
                     context.Properties.Items.Remove(AzureAdB2COptions.PolicyAuthenticationProperty);
                 }
                 return Task.FromResult(0);

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/AzureAdB2C/AzureAdB2CAuthenticationBuilderExtensions.cs
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.2.0/content/StarterWeb-CSharp/AzureAdB2C/AzureAdB2CAuthenticationBuilderExtensions.cs
@@ -59,7 +59,8 @@ namespace Microsoft.AspNetCore.Authentication.Extensions
                 {
                     context.ProtocolMessage.Scope = OpenIdConnectScope.OpenIdProfile;
                     context.ProtocolMessage.ResponseType = OpenIdConnectResponseType.IdToken;
-                    context.ProtocolMessage.IssuerAddress = context.ProtocolMessage.IssuerAddress.ToLower().Replace(defaultPolicy.ToLower(), policy.ToLower());
+                    context.ProtocolMessage.IssuerAddress = context.ProtocolMessage.IssuerAddress.ToLower()
+                        .Replace($"/{defaultPolicy.ToLower()}/", $"/{policy.ToLower()}/");
                     context.Properties.Items.Remove(AzureAdB2COptions.PolicyAuthenticationProperty);
                 }
                 return Task.FromResult(0);


### PR DESCRIPTION
In the future B2C will support allowing the user to control the domain in the issuer, so we need to make the issuer update logic more robust.