### PR TITLE
changed browser-link to browserlink in a couple templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-CSharp/.template.config/dotnetcli.host.json
@@ -59,7 +59,7 @@
       "isHidden": true
     },
     "UseBrowserLink": {
-      "longName": "use-browser-link",
+      "longName": "use-browserlink",
       "shortName": ""
     }
   },

--- a/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Web.ProjectTemplates.1.x/content/StarterWeb-FSharp/.template.config/dotnetcli.host.json
@@ -14,7 +14,7 @@
       "shortName": ""
     },
     "UseBrowserLink": {
-      "longName": "use-browser-link",
+      "longName": "use-browserlink",
       "shortName": ""
     }
   },


### PR DESCRIPTION
I went with "browserlink" since the majority of templates already use that form.