### PR TITLE
allowing port generation to specify ranges

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GeneratePortNumberConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GeneratePortNumberConfig.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.TemplateEngine.Core.Contracts;
@@ -15,35 +16,95 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         public int Port { get; }
 
-        public GeneratePortNumberConfig(string variableName, int fallback)
+        public int Low { get; }
+
+        public int High { get; }
+
+        private static readonly HashSet<int> UnsafePorts = new HashSet<int>() {
+                    2049, // nfs
+                    3659, // apple-sasl / PasswordServer
+                    4045, // lockd
+                    6000, // X11
+                    6665, // Alternate IRC [Apple addition]
+                    6666, // Alternate IRC [Apple addition]
+                    6667, // Standard IRC [Apple addition]
+                    6668, // Alternate IRC [Apple addition]
+                    6669, // Alternate IRC [Apple addition]
+        };
+
+        public GeneratePortNumberConfig(string variableName, int fallback, int low, int high)
         {
             VariableName = variableName;
+            Random rand = new Random();
+            int startPort = rand.Next(low, high);
+
+            for (int testPort = startPort; testPort <= high; testPort++)
+            {
+                if (TryAllocatePort(testPort, out Socket testSocket))
+                {
+                    Socket = testSocket;
+                    Port = ((IPEndPoint)Socket.LocalEndPoint).Port;
+                    return;
+                }
+            }
+
+            for (int testPort = low; testPort < startPort; testPort++)
+            {
+                if (TryAllocatePort(testPort, out Socket testSocket))
+                {
+                    Socket = testSocket;
+                    Port = ((IPEndPoint)Socket.LocalEndPoint).Port;
+                    return;
+                }
+            }
+
+            Port = fallback;
+        }
+
+        private bool TryAllocatePort(int testPort, out Socket testSocket)
+        {
+            testSocket = null;
+
+            if (UnsafePorts.Contains(testPort))
+            {
+                return false;
+            }
 
             try
             {
                 if (Socket.OSSupportsIPv4)
                 {
-                    Socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+                    testSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
                 }
                 else if (Socket.OSSupportsIPv6)
                 {
-                    Socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
+                    testSocket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp);
                 }
             }
             catch
             {
+                testSocket?.Dispose();
+                return false;
             }
 
-            if (Socket != null)
+            if (testSocket != null)
             {
-                IPEndPoint endPoint = new IPEndPoint(Socket.AddressFamily == AddressFamily.InterNetworkV6 ? IPAddress.IPv6Any : IPAddress.Any, 0);
-                Socket.Bind(endPoint);
-                Port = ((IPEndPoint)Socket.LocalEndPoint).Port;
+                IPEndPoint endPoint = new IPEndPoint(testSocket.AddressFamily == AddressFamily.InterNetworkV6 ? IPAddress.IPv6Any : IPAddress.Any, testPort);
+
+                try
+                {
+                    testSocket.Bind(endPoint);
+                    return true;
+                }
+                catch
+                {
+                    testSocket?.Dispose();
+                    return false;
+                }
             }
-            else
-            {
-                Port = fallback;
-            }
+
+            testSocket = null;
+            return false;
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GeneratePortNumberMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GeneratePortNumberMacro.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Text;
+using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
-using Microsoft.TemplateEngine.Core.Operations;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config;
 using Newtonsoft.Json.Linq;
 
@@ -13,6 +11,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
         public Guid Id => new Guid("D49B3690-B1E5-410F-A260-E1D7E873D8B2");
 
         public string Type => "port";
+
+        private static readonly int LowPortDefault = 1024;
+        private static readonly int HighPortDefault = 65535;
 
         public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
@@ -44,13 +45,40 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
                 throw new InvalidCastException("Couldn't cast the rawConfig as a GeneratedSymbolDeferredMacroConfig");
             }
 
+            int low;
+            int high;
+
+            if (!deferredConfig.Parameters.TryGetValue("low", out JToken lowToken))
+            {
+                low = LowPortDefault;
+            }
+            else
+            {
+                low = lowToken.Value<int>();
+            }
+
+            if (!deferredConfig.Parameters.TryGetValue("high", out JToken highToken))
+            {
+                high = HighPortDefault;
+            }
+            else
+            {
+                high = highToken.Value<int>();
+            }
+
+            if (low > high)
+            {
+                low = LowPortDefault;
+                high = HighPortDefault;
+            }
+
             int fallback = 0;
             if(deferredConfig.Parameters.TryGetValue("fallback", out JToken fallbackToken) && fallbackToken.Type == JTokenType.Integer)
             {
                 fallback = fallbackToken.ToInt32();
             }
 
-            IMacroConfig realConfig = new GeneratePortNumberConfig(deferredConfig.VariableName, fallback);
+            IMacroConfig realConfig = new GeneratePortNumberConfig(deferredConfig.VariableName, fallback, low, high);
             return realConfig;
         }
     }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GeneratePortNumberMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GeneratePortNumberMacro.cs
@@ -48,22 +48,30 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             int low;
             int high;
 
-            if (!deferredConfig.Parameters.TryGetValue("low", out JToken lowToken))
+            if (!deferredConfig.Parameters.TryGetValue("low", out JToken lowToken) || lowToken.Type != JTokenType.Integer)
             {
                 low = LowPortDefault;
             }
             else
             {
                 low = lowToken.Value<int>();
+                if (low < LowPortDefault)
+                {
+                    low = LowPortDefault;
+                }
             }
 
-            if (!deferredConfig.Parameters.TryGetValue("high", out JToken highToken))
+            if (!deferredConfig.Parameters.TryGetValue("high", out JToken highToken) || highToken.Type != JTokenType.Integer)
             {
                 high = HighPortDefault;
             }
             else
             {
                 high = highToken.Value<int>();
+                if (high > HighPortDefault)
+                {
+                    high = HighPortDefault;
+                }
             }
 
             if (low > high)


### PR DESCRIPTION
The syntax for template.json is like this:
```
    "HttpsPortGenerated": {
      "type": "generated",
      "generator": "port",
      "parameters": {
        "low": 2222,
        "high": 3333
      }
    },
```

`low` and `high` are both optional, their defaults are 1024 & 65535, respectively.

If low > high, both values are reset to the defaults.