### PR TITLE
Changed the test for Extensions directory for Mvc individual template

### DIFF
--- a/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/MvcIndividual.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/MvcIndividual.json
@@ -19,7 +19,7 @@
     {
       "handler": "directoryInspect",
       "directory": "Extensions",
-      "assertion": "does_not_exist"
+      "assertion": "exists"
     },
     {
       "handler": "fileInspect",


### PR DESCRIPTION
When the MVC 2.0 template files were reorganized, the test for non-existence of the Extensions directory in MvcIndividual.json became incorrect. Individual auth now drops 2 files in the Extensions directory.