### PR TITLE
Support for derived symbols

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/BaseValueSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/BaseValueSymbol.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
+{
+    public abstract class BaseValueSymbol : ISymbolModel
+    {
+        public string Binding { get; set; }
+
+        public string DefaultValue { get; set; }
+
+        public string Description { get; set; }
+
+        public SymbolValueFormsModel Forms { get; set; }
+
+        public bool IsRequired { get; set; }
+
+        public string Type { get; protected set; }
+
+        public string Replaces { get; set; }
+
+        public string DataType { get; set; }
+
+        public string FileRename { get; set; }
+
+        public IReadOnlyList<IReplacementContext> ReplacementContexts { get; set; }
+
+        protected static void FromJObject(BaseValueSymbol symbol, JObject jObject, IParameterSymbolLocalizationModel localization, string defaultOverride)
+        {
+            symbol.Binding = jObject.ToString(nameof(Binding));
+            symbol.DefaultValue = defaultOverride ?? jObject.ToString(nameof(DefaultValue));
+            symbol.Description = localization?.Description ?? jObject.ToString(nameof(Description)) ?? string.Empty;
+            symbol.FileRename = jObject.ToString(nameof(FileRename));
+            symbol.IsRequired = jObject.ToBool(nameof(IsRequired));
+            symbol.Type = jObject.ToString(nameof(Type));
+            symbol.Replaces = jObject.ToString(nameof(Replaces));
+            symbol.DataType = jObject.ToString(nameof(DataType));
+            symbol.ReplacementContexts = SymbolModelConverter.ReadReplacementContexts(jObject);
+
+            if (!jObject.TryGetValue(nameof(symbol.Forms), StringComparison.OrdinalIgnoreCase, out JToken formsToken) || !(formsToken is JObject formsObject))
+            {
+                // no value forms explicitly defined, use the default ("identity")
+                symbol.Forms = SymbolValueFormsModel.Default;
+            }
+            else
+            {
+                // the config defines forms for the symbol. Use them.
+                symbol.Forms = SymbolValueFormsModel.FromJObject(formsObject);
+            }
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ComputedSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ComputedSymbol.cs
@@ -6,6 +6,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
     public class ComputedSymbol : ISymbolModel
     {
+        public const string TypeName = "computed";
+
         public string Value { get; internal set; }
 
         public string Type { get; private set; }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/DerivedSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/DerivedSymbol.cs
@@ -1,0 +1,25 @@
+using Microsoft.TemplateEngine.Abstractions;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
+{
+    public class DerivedSymbol : BaseValueSymbol
+    {
+        public const string TypeName = "derived";
+
+        public string ValueTransform { get; set; }
+
+        public string ValueSource { get; set; }
+
+        public static ISymbolModel FromJObject(JObject jObject, IParameterSymbolLocalizationModel localization, string defaultOverride)
+        {
+            DerivedSymbol symbol = new DerivedSymbol();
+            FromJObject(symbol, jObject, localization, defaultOverride);
+
+            symbol.ValueTransform = jObject.ToString(nameof(ValueTransform));
+            symbol.ValueSource = jObject.ToString(nameof(ValueSource));
+
+            return symbol;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GeneratedSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GeneratedSymbol.cs
@@ -1,16 +1,15 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
     public class GeneratedSymbol : ISymbolModel
     {
-        // NOTE (scp 2016-09-16): Not used (i think). Only here to satisfy the interface
+        public const string TypeName = "generated";
+
         public string Binding { get; set; }
 
-        // NOTE (scp 2016-09-16): Not used (i think). Only here to satisfy the interface
         public string Replaces { get; set; }
 
         // Refers to the Type property value of a concrete IMacro
@@ -31,37 +30,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 Parameters = jObject.ToJTokenDictionary(StringComparer.Ordinal, nameof(Parameters)),
                 Type = jObject.ToString(nameof(Type)),
                 Replaces = jObject.ToString(nameof(Replaces)),
-                ReplacementContexts = ReadReplacementContexts(jObject)
+                ReplacementContexts = SymbolModelConverter.ReadReplacementContexts(jObject)
             };
 
             return sym;
-        }
-
-        private static IReadOnlyList<IReplacementContext> ReadReplacementContexts(JObject jObject)
-        {
-            JArray onlyIf = jObject.Get<JArray>("onlyIf");
-
-            if (onlyIf != null)
-            {
-                List<IReplacementContext> contexts = new List<IReplacementContext>();
-                foreach (JToken entry in onlyIf.Children())
-                {
-                    if (!(entry is JObject x))
-                    {
-                        continue;
-                    }
-
-                    string before = entry.ToString("before");
-                    string after = entry.ToString("after");
-                    contexts.Add(new ReplacementContext(before, after));
-                }
-
-                return contexts;
-            }
-            else
-            {
-                return Empty<IReplacementContext>.List.Value;
-            }
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ProcessValueFormMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ProcessValueFormMacro.cs
@@ -43,11 +43,21 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             {
                 value = form.Process(realConfig.Forms, value);
 
-                Parameter p = new Parameter
+                Parameter p;
+
+                if (parameters.TryGetParameterDefinition(config.VariableName, out ITemplateParameter existingParam))
+                {   // Derived parameters already have a definition, but need value form processing.
+                    // When the param already exists, use its definition.
+                    p = (Parameter)existingParam;
+                }
+                else
                 {
-                    IsVariable = true,
-                    Name = config.VariableName
-                };
+                    p = new Parameter
+                    {
+                        IsVariable = true,
+                        Name = config.VariableName
+                    };
+                }
 
                 vars[config.VariableName] = value;
                 setter(p, value);

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ParameterSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ParameterSymbol.cs
@@ -1,19 +1,18 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
-    public class ParameterSymbol : ISymbolModel
+    public class ParameterSymbol : BaseValueSymbol
     {
+        public const string TypeName = "parameter";
+
         // Used when the template explicitly defines the symbol "name".
         // The template definition is used exclusively, except for the case where it doesn't define any value forms.
         // When that is the case, the default value forms are used.
-        //
-        // When we add file-specific forms, this'll need some work.
         public static ParameterSymbol ExplicitNameSymbolMergeWithDefaults(ISymbolModel templateDefinedName, ISymbolModel defaultDefinedName)
         {
             if (!(templateDefinedName is ParameterSymbol templateSymbol))
@@ -51,24 +50,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             return mergedSymbol;
         }
 
-        public string Binding { get; set; }
-
-        public string DefaultValue { get; set; }
-
-        public string Description { get; set; }
-
-        public SymbolValueFormsModel Forms { get; set; }
-
-        public bool IsRequired { get; set; }
-
-        public string Type { get; private set; }
-
-        public string Replaces { get; set; }
-
-        public string DataType { get; set; }
-
-        public string FileRename { get; set; }
-
         // only relevant for choice datatype
         public bool IsTag { get; set; }
 
@@ -89,34 +70,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             }
         }
 
-        public IReadOnlyList<IReplacementContext> ReplacementContexts { get; set; }
-
         public static ISymbolModel FromJObject(JObject jObject, IParameterSymbolLocalizationModel localization, string defaultOverride)
         {
-            ParameterSymbol symbol = new ParameterSymbol
-            {
-                Binding = jObject.ToString(nameof(Binding)),
-                DefaultValue = defaultOverride ?? jObject.ToString(nameof(DefaultValue)),
-                Description = localization?.Description ?? jObject.ToString(nameof(Description)) ?? string.Empty,
-                FileRename = jObject.ToString(nameof(FileRename)),
-                IsRequired = jObject.ToBool(nameof(IsRequired)),
-                Type = jObject.ToString(nameof(Type)),
-                Replaces = jObject.ToString(nameof(Replaces)),
-                DataType = jObject.ToString(nameof(DataType)),
-                ReplacementContexts = ReadReplacementContexts(jObject),
-            };
-
-            if (!jObject.TryGetValue(nameof(symbol.Forms), StringComparison.OrdinalIgnoreCase, out JToken formsToken) || !(formsToken is JObject formsObject))
-            {
-                // no value forms explicitly defined, use the default ("identity")
-                symbol.Forms = SymbolValueFormsModel.Default;
-            }
-            else
-            {
-                // the config defines forms for the symbol. Use them.
-                symbol.Forms = SymbolValueFormsModel.FromJObject(formsObject);
-            }
-
+            ParameterSymbol symbol = new ParameterSymbol();
+            FromJObject(symbol, jObject, localization, defaultOverride);
             Dictionary<string, string> choicesAndDescriptions = new Dictionary<string, string>();
 
             if (symbol.DataType == "choice")
@@ -147,40 +104,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             ParameterSymbol symbol = new ParameterSymbol
             {
                 DefaultValue = value,
-                Type = "parameter",
+                Type = TypeName,
                 DataType = "choice",
                 IsTag = true,
                 Choices = new Dictionary<string, string>() { { value, string.Empty } },
             };
 
             return symbol;
-        }
-
-        private static IReadOnlyList<IReplacementContext> ReadReplacementContexts(JObject jObject)
-        {
-            JArray onlyIf = jObject.Get<JArray>("onlyIf");
-
-            if (onlyIf != null)
-            {
-                List<IReplacementContext> contexts = new List<IReplacementContext>();
-                foreach (JToken entry in onlyIf.Children())
-                {
-                    if (!(entry is JObject x))
-                    {
-                        continue;
-                    }
-
-                    string before = entry.ToString("before");
-                    string after = entry.ToString("after");
-                    contexts.Add(new ReplacementContext(before, after));
-                }
-
-                return contexts;
-            }
-            else
-            {
-                return Empty<IReplacementContext>.List.Value;
-            }
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SymbolModelConverter.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SymbolModelConverter.cs
@@ -1,25 +1,58 @@
+using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
     internal class SymbolModelConverter
     {
+        public const string BindSymbolTypeName = "bind";
+
         // Note: Only ParameterSymbol has a Description property, this it's the only one that gets localization
         // TODO: change how localization gets merged in, don't do it here.
         public static ISymbolModel GetModelForObject(JObject jObject, IParameterSymbolLocalizationModel localization, string defaultOverride)
         {
             switch (jObject.ToString(nameof(ISymbolModel.Type)))
             {
-                case "parameter":
+                case ParameterSymbol.TypeName:
                     return ParameterSymbol.FromJObject(jObject, localization, defaultOverride);
-                case "computed":
+                case DerivedSymbol.TypeName:
+                    return DerivedSymbol.FromJObject(jObject, localization, defaultOverride);
+                case ComputedSymbol.TypeName:
                     return ComputedSymbol.FromJObject(jObject);
-                case "bind":
-                case "generated":
+                case BindSymbolTypeName:
+                case GeneratedSymbol.TypeName:
                     return GeneratedSymbol.FromJObject(jObject);
                 default:
                     return null;
+            }
+        }
+
+        internal static IReadOnlyList<IReplacementContext> ReadReplacementContexts(JObject jObject)
+        {
+            JArray onlyIf = jObject.Get<JArray>("onlyIf");
+
+            if (onlyIf != null)
+            {
+                List<IReplacementContext> contexts = new List<IReplacementContext>();
+                foreach (JToken entry in onlyIf.Children())
+                {
+                    if (!(entry is JObject x))
+                    {
+                        continue;
+                    }
+
+                    string before = entry.ToString("before");
+                    string after = entry.ToString("after");
+                    contexts.Add(new ReplacementContext(before, after));
+                }
+
+                return contexts;
+            }
+            else
+            {
+                return Empty<IReplacementContext>.List.Value;
             }
         }
     }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/DerivedSymbolFileRenameTest.json
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/DerivedSymbolFileRenameTest.json
@@ -1,0 +1,10 @@
+[
+  {
+    "kind": "file_exists",
+    "path": "Rename.cs"
+  },
+  {
+    "kind": "file_does_not_exist",
+    "path": "Application1.cs"
+  }
+]

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/FileRenameTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/FileRenameTests.cs
@@ -1,4 +1,4 @@
-﻿using Xunit;
+using Xunit;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests
 {
@@ -8,6 +8,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [InlineData("TestAssets.TemplateWithRenames --foo baz", "FileRenamesTest.json")]
         [InlineData("TestAssets.TemplateWithSourceName --name baz", "FileRenamesTest.json")]
         [InlineData("TestAssets.TemplateWithUnspecifiedSourceName --name baz", "NegativeFileRenamesTest.json")]
+        [InlineData("TestAssets.TemplateWithDerivedSymbolFileRename --name Last.Part.Is.For.Rename", "DerivedSymbolFileRenameTest.json")]
         public void VerifyTemplateContentRenames(string args, params string[] scripts)
         {
             Run(args, scripts);

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithDerivedSymbolFileRename/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithDerivedSymbolFileRename/.template.config/template.json
@@ -1,0 +1,27 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "TemplateWithDerivedSymbolFileRename",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateWithDerivedSymbolFileRename",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateWithDerivedSymbolFileRename",
+  "shortName": "TestAssets.TemplateWithDerivedSymbolFileRename",
+  "sourceName": "Company.Web.Application1",
+  "symbols": {
+    "DerivedRename": {
+      "description": "The final part of a multi-dotted name",
+      "FileRename": "Application1",
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "AfterLastDot"
+    }
+  },
+  "Forms": {
+    "AfterLastDot": {
+      "identifier": "replace",
+      "pattern": "^.*\\.(?=[^\\.]+$)", // match everything up to and including the final "."
+      "replacement": ""
+    }
+  }
+}


### PR DESCRIPTION
Derived symbols work like parameter symbols in most regards. The difference is that value of a derived symbol is based on the value of an existing parameter symbol, transformed by a value form.