### PR TITLE
More template resolution rework

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
@@ -52,7 +52,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         bool HasDebuggingFlag(string flag);
 
-        IReadOnlyDictionary<string, string> AllTemplateParams { get; }
+        IReadOnlyDictionary<string, string> InputTemplateParams { get; }
 
         string TemplateParamInputFormat(string canonical);
 

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -257,7 +257,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             return _parseResult.HasAppliedOption(new[] { _commandName, flag });
         }
 
-        public IReadOnlyDictionary<string, string> AllTemplateParams
+        public IReadOnlyDictionary<string, string> InputTemplateParams
         {
             get
             {
@@ -357,12 +357,12 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         public bool TemplateParamHasValue(string paramName)
         {
-            return AllTemplateParams.ContainsKey(paramName);
+            return InputTemplateParams.ContainsKey(paramName);
         }
 
         public string TemplateParamValue(string paramName)
         {
-            AllTemplateParams.TryGetValue(paramName, out string value);
+            InputTemplateParams.TryGetValue(paramName, out string value);
             return value;
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpForTemplateResolution.cs
@@ -1,0 +1,147 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.TemplateEngine.Edge.Template;
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Cli
+{
+    internal static class HelpForTemplateResolution
+    {
+        public static void DisplayInvalidParameters(IReadOnlyList<string> invalidParams)
+        {
+            if (invalidParams.Count > 0)
+            {
+                Reporter.Error.WriteLine(LocalizableStrings.InvalidInputSwitch.Bold().Red());
+                foreach (string flag in invalidParams)
+                {
+                    Reporter.Error.WriteLine($"  {flag}".Bold().Red());
+                }
+            }
+        }
+
+        public static void DisplayParametersInvalidForSomeTemplates(IReadOnlyList<string> invalidParams)
+        {
+            if (invalidParams.Count > 0)
+            {
+                Reporter.Error.WriteLine(LocalizableStrings.PartialTemplateMatchSwitchesNotValidForAllMatches.Bold().Red());
+                foreach (string flag in invalidParams)
+                {
+                    Reporter.Error.WriteLine($"  {flag}".Bold().Red());
+                }
+            }
+        }
+
+        // get a better name for this, it's unclear what it's doing.
+        public static bool ShowTemplateNameMismatchHelp(string templateName, string context, TemplateListResolutionResult templateResolutionResult)
+        {
+            GetContextBasedAndOtherPartialMatches(templateResolutionResult, out IReadOnlyList<IReadOnlyList<IFilteredTemplateInfo>> contextProblemMatchGroups, out IReadOnlyList<IReadOnlyList<IFilteredTemplateInfo>> remainingPartialMatchGroups);
+            return DisplayPartialNameMatchAndContextProblems(templateName, context, contextProblemMatchGroups, remainingPartialMatchGroups);
+        }
+
+        private static void GetContextBasedAndOtherPartialMatches(TemplateListResolutionResult templateResolutionResult, out IReadOnlyList<IReadOnlyList<IFilteredTemplateInfo>> contextProblemMatchGroups, out IReadOnlyList<IReadOnlyList<IFilteredTemplateInfo>> remainingPartialMatchGroups)
+        {
+            Dictionary<string, List<IFilteredTemplateInfo>> contextProblemMatches = new Dictionary<string, List<IFilteredTemplateInfo>>();
+            Dictionary<string, List<IFilteredTemplateInfo>> remainingPartialMatches = new Dictionary<string, List<IFilteredTemplateInfo>>();
+
+            // this filtering / grouping ignores language differences.
+            foreach (IFilteredTemplateInfo template in templateResolutionResult.CoreMatchedTemplates)
+            {
+                if (template.MatchDisposition.Any(x => x.Location == MatchLocation.Context && x.Kind != MatchKind.Exact))
+                {
+                    if (!contextProblemMatches.TryGetValue(template.Info.GroupIdentity, out List<IFilteredTemplateInfo> templateGroup))
+                    {
+                        templateGroup = new List<IFilteredTemplateInfo>();
+                        contextProblemMatches.Add(template.Info.GroupIdentity, templateGroup);
+                    }
+
+                    templateGroup.Add(template);
+                }
+                else if (template.MatchDisposition.Any(t => t.Location != MatchLocation.Context && t.Kind != MatchKind.Mismatch && t.Kind != MatchKind.Unspecified))
+                {
+                    if (!remainingPartialMatches.TryGetValue(template.Info.GroupIdentity, out List<IFilteredTemplateInfo> templateGroup))
+                    {
+                        templateGroup = new List<IFilteredTemplateInfo>();
+                        remainingPartialMatches.Add(template.Info.GroupIdentity, templateGroup);
+                    }
+
+                    templateGroup.Add(template);
+                }
+            }
+
+            contextProblemMatchGroups = contextProblemMatches.Values.ToList();
+            remainingPartialMatchGroups = remainingPartialMatches.Values.ToList();
+        }
+
+        private static bool DisplayPartialNameMatchAndContextProblems(string templateName, string context, IReadOnlyList<IReadOnlyList<IFilteredTemplateInfo>> contextProblemMatchGroups, IReadOnlyList<IReadOnlyList<IFilteredTemplateInfo>> remainingPartialMatchGroups)
+        {
+            bool anythingReported = false;
+            if (contextProblemMatchGroups.Count + remainingPartialMatchGroups.Count > 1)
+            {
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.AmbiguousInputTemplateName, templateName));
+                anythingReported = true;
+            }
+            else if (contextProblemMatchGroups.Count + remainingPartialMatchGroups.Count == 0)
+            {
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.NoTemplatesMatchName, templateName));
+                Reporter.Error.WriteLine();
+                return true;
+            }
+
+            // scp (2017-08-28): not certain anything in this loop can happen anymore, due to the way filtering occurs.
+            foreach (IReadOnlyList<IFilteredTemplateInfo> templateGroup in contextProblemMatchGroups)
+            {
+                // all templates in a group should have the same context & name
+                if (templateGroup[0].Info.Tags != null && templateGroup[0].Info.Tags.TryGetValue("type", out ICacheTag typeTag))
+                {
+                    MatchInfo? matchInfo = WellKnownSearchFilters.ContextFilter(context)(templateGroup[0].Info);
+                    if ((matchInfo?.Kind ?? MatchKind.Mismatch) == MatchKind.Mismatch)
+                    {
+                        Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplateNotValidGivenTheSpecifiedFilter, templateGroup[0].Info.Name).Bold().Red());
+                        anythingReported = true;
+                    }
+                }
+                else
+                {   // this really shouldn't ever happen. But better to have a generic error than quietly ignore the partial match.
+                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.GenericPlaceholderTemplateContextError, templateGroup[0].Info.Name).Bold().Red());
+                    anythingReported = true;
+                }
+            }
+
+            if (remainingPartialMatchGroups.Count > 0)
+            {
+                Reporter.Error.WriteLine(LocalizableStrings.TemplateMultiplePartialNameMatches.Bold().Red());
+                anythingReported = true;
+            }
+
+            Reporter.Error.WriteLine();
+            return anythingReported;
+        }
+
+        // Returns a list of the parameter names that are invalid for every template in the input group.
+        public static void GetParametersInvalidForTemplatesInList(IReadOnlyList<IFilteredTemplateInfo> templateList, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates)
+        {
+            IDictionary<string, int> invalidCounts = new Dictionary<string, int>();
+
+            foreach (IFilteredTemplateInfo template in templateList)
+            {
+                foreach (string paramName in template.InvalidParameterNames)
+                {
+                    if (!invalidCounts.ContainsKey(paramName))
+                    {
+                        invalidCounts[paramName] = 1;
+                    }
+                    else
+                    {
+                        invalidCounts[paramName]++;
+                    }
+                }
+            }
+
+            invalidForAllTemplates = invalidCounts.Where(x => x.Value == templateList.Count).Select(x => x.Key).ToList();
+            invalidForSomeTemplates = invalidCounts.Where(x => x.Value != templateList.Count).Select(x => x.Key).ToList();
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1019,6 +1019,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Some partially matched templates may not support these input switches:.
+        /// </summary>
+        public static string PartialTemplateMatchSwitchesNotValidForAllMatches {
+            get {
+                return ResourceManager.GetString("PartialTemplateMatchSwitchesNotValidForAllMatches", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Actual command: {0}.
         /// </summary>
         public static string PostActionCommand {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -550,4 +550,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="UnableToSetPermissions" xml:space="preserve">
     <value>Unable to apply permissions {0} to "{1}".</value>
   </data>
+  <data name="PartialTemplateMatchSwitchesNotValidForAllMatches" xml:space="preserve">
+    <value>Some partially matched templates may not support these input switches:</value>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -617,7 +617,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             foreach (IFilteredTemplateInfo templateInfo in unambiguousTemplateGroup)
             {
-                if (templateInfo.InvalidParameterNames.Count > 0)
+                if (templateInfo.InvalidParameterNames.Count == 0)
                 {
                     anyValid = true;
                     break;
@@ -626,6 +626,8 @@ namespace Microsoft.TemplateEngine.Cli
 
             if (!anyValid)
             {
+                // There were no templates in the group that all parameters were valid for.
+                // Display an appropriate error message.
                 IFilteredTemplateInfo highestPrecedenceTemplate = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(unambiguousTemplateGroup);
 
                 if (highestPrecedenceTemplate != null)

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -487,7 +487,7 @@ namespace Microsoft.TemplateEngine.Cli
             // handling when there are parameter mismatches. There may be other issues too.
             IReadOnlyList<ITemplateMatchInfo> templatesForDisplay = GetTemplatesToDisplayInfoAbout(templateResolutionResult);
             HelpForTemplateResolution.GetParametersInvalidForTemplatesInList(templatesForDisplay, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
-            if (invalidForAllTemplates.Any() || invalidForSomeTemplates.Any())
+            if (invalidForAllTemplates.Count > 0 || invalidForSomeTemplates.Count > 0)
             {
                 HelpForTemplateResolution.DisplayInvalidParameters(invalidForAllTemplates);
                 HelpForTemplateResolution.DisplayParametersInvalidForSomeTemplates(invalidForSomeTemplates);

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -156,9 +156,9 @@ namespace Microsoft.TemplateEngine.Cli
 
         // Attempts to invoke the template.
         // Warning: The _commandInput cannot be assumed to be in a state that is parsed for the template being invoked.
-        //      So be sure to only get template-agnostic information from it. Anything specific to the template must be gotten from the IFilteredTemplateInfo
+        //      So be sure to only get template-agnostic information from it. Anything specific to the template must be gotten from the ITemplateMatchInfo
         //      Or do a reparse if necessary (currently occurs in one error case).
-        private async Task<CreationResultStatus> CreateTemplateAsync(IFilteredTemplateInfo templateMatchDetails)
+        private async Task<CreationResultStatus> CreateTemplateAsync(ITemplateMatchInfo templateMatchDetails)
         {
             ITemplateInfo template = templateMatchDetails.Info;
 
@@ -173,7 +173,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             try
             {
-                instantiateResult = await _templateCreator.InstantiateAsync(template, _commandInput.Name, fallbackName, _commandInput.OutputPath, templateMatchDetails.ValidTemplateParameters, _commandInput.SkipUpdateCheck, _commandInput.IsForceFlagSpecified, _commandInput.BaselineName).ConfigureAwait(false);
+                instantiateResult = await _templateCreator.InstantiateAsync(template, _commandInput.Name, fallbackName, _commandInput.OutputPath, templateMatchDetails.GetValidTemplateParameters(), _commandInput.SkipUpdateCheck, _commandInput.IsForceFlagSpecified, _commandInput.BaselineName).ConfigureAwait(false);
             }
             catch (ContentGenerationException cx)
             {
@@ -216,7 +216,7 @@ namespace Microsoft.TemplateEngine.Cli
                     else
                     {
                         // TODO: rework to avoid having to reparse.
-                        // The canonical info could be in the IFilteredTemplateInfo, but currently isn't.
+                        // The canonical info could be in the ITemplateMatchInfo, but currently isn't.
                         TemplateListResolver.ParseTemplateArgs(template, _hostDataLoader, _commandInput);
 
                         IReadOnlyList<string> missingParamNamesCanonical = instantiateResult.Message.Split(new[] { ',' })
@@ -370,7 +370,7 @@ namespace Microsoft.TemplateEngine.Cli
         // Otherwise retun an empty list.
         private IEnumerable<ITemplateInfo> GetTemplateGroupToShowDetailedHelpAbout(TemplateListResolutionResult templateResolutionResult)
         {
-            IReadOnlyList<IFilteredTemplateInfo> candidateTemplates = GetTemplatesToDisplayInfoAbout(templateResolutionResult);
+            IReadOnlyList<ITemplateMatchInfo> candidateTemplates = GetTemplatesToDisplayInfoAbout(templateResolutionResult);
 
             if (TemplateListResolver.AreAllTemplatesSameGroupIdentity(candidateTemplates))
             {
@@ -383,15 +383,15 @@ namespace Microsoft.TemplateEngine.Cli
         // If there are secondary matches, return them
         // Else if there are primary matches, return them
         // Otherwise return all templates in the current context
-        private IReadOnlyList<IFilteredTemplateInfo> GetTemplatesToDisplayInfoAbout(TemplateListResolutionResult templateResolutionResult)
+        private IReadOnlyList<ITemplateMatchInfo> GetTemplatesToDisplayInfoAbout(TemplateListResolutionResult templateResolutionResult)
         {
-            IEnumerable<IFilteredTemplateInfo> templateList;
+            IEnumerable<ITemplateMatchInfo> templateList;
 
-            if (templateResolutionResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousList))
+            if (templateResolutionResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousList))
             {
                 templateList = unambiguousList;
             }
-            else if (!string.IsNullOrEmpty(TemplateName) && templateResolutionResult.TryGetAllInvokableTemplates(out IReadOnlyList<IFilteredTemplateInfo> invokableTemplates))
+            else if (!string.IsNullOrEmpty(TemplateName) && templateResolutionResult.TryGetAllInvokableTemplates(out IReadOnlyList<ITemplateMatchInfo> invokableTemplates))
             {
                 templateList = invokableTemplates;
             }
@@ -414,17 +414,17 @@ namespace Microsoft.TemplateEngine.Cli
 
         private void DisplayTemplateList(TemplateListResolutionResult templateResolutionResult)
         {
-            IReadOnlyList<IFilteredTemplateInfo> results = GetTemplatesToDisplayInfoAbout(templateResolutionResult);
-            IEnumerable<IGrouping<string, IFilteredTemplateInfo>> grouped = results.GroupBy(x => x.Info.GroupIdentity, x => !string.IsNullOrEmpty(x.Info.GroupIdentity));
+            IReadOnlyList<ITemplateMatchInfo> results = GetTemplatesToDisplayInfoAbout(templateResolutionResult);
+            IEnumerable<IGrouping<string, ITemplateMatchInfo>> grouped = results.GroupBy(x => x.Info.GroupIdentity, x => !string.IsNullOrEmpty(x.Info.GroupIdentity));
             Dictionary<ITemplateInfo, string> templatesVersusLanguages = new Dictionary<ITemplateInfo, string>();
 
-            foreach (IGrouping<string, IFilteredTemplateInfo> grouping in grouped)
+            foreach (IGrouping<string, ITemplateMatchInfo> grouping in grouped)
             {
                 List<string> languageForDisplay = new List<string>();
                 HashSet<string> uniqueLanguages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 string defaultLanguageDisplay = string.Empty;
 
-                foreach (IFilteredTemplateInfo template in grouping)
+                foreach (ITemplateMatchInfo template in grouping)
                 {
                     if (template.Info.Tags != null && template.Info.Tags.TryGetValue("language", out ICacheTag languageTag))
                     {
@@ -485,7 +485,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
 
             // handling when there are parameter mismatches. There may be other issues too.
-            IReadOnlyList<IFilteredTemplateInfo> templatesForDisplay = GetTemplatesToDisplayInfoAbout(templateResolutionResult);
+            IReadOnlyList<ITemplateMatchInfo> templatesForDisplay = GetTemplatesToDisplayInfoAbout(templateResolutionResult);
             HelpForTemplateResolution.GetParametersInvalidForTemplatesInList(templatesForDisplay, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
             if (invalidForAllTemplates.Any() || invalidForSomeTemplates.Any())
             {
@@ -610,14 +610,14 @@ namespace Microsoft.TemplateEngine.Cli
         {
             bool anyValid = false;
 
-            if (!templateResolutionResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousTemplateGroup))
+            if (!templateResolutionResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousTemplateGroup))
             {
-                unambiguousTemplateGroup = new List<IFilteredTemplateInfo>();
+                unambiguousTemplateGroup = new List<ITemplateMatchInfo>();
             }
 
-            foreach (IFilteredTemplateInfo templateInfo in unambiguousTemplateGroup)
+            foreach (ITemplateMatchInfo templateInfo in unambiguousTemplateGroup)
             {
-                if (templateInfo.InvalidParameterNames.Count == 0)
+                if (templateInfo.GetInvalidParameterNames().Count == 0)
                 {
                     anyValid = true;
                     break;
@@ -628,7 +628,7 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 // There were no templates in the group that all parameters were valid for.
                 // Display an appropriate error message.
-                IFilteredTemplateInfo highestPrecedenceTemplate = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(unambiguousTemplateGroup);
+                ITemplateMatchInfo highestPrecedenceTemplate = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(unambiguousTemplateGroup);
 
                 if (highestPrecedenceTemplate != null)
                 {
@@ -646,9 +646,9 @@ namespace Microsoft.TemplateEngine.Cli
             bool anyArgsErrors = false;
             ShowUsageHelp();
 
-            if (!templateResolutionResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousTemplateGroup))
+            if (!templateResolutionResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousTemplateGroup))
             {
-                unambiguousTemplateGroup = new List<IFilteredTemplateInfo>();
+                unambiguousTemplateGroup = new List<ITemplateMatchInfo>();
             }
 
             bool showImplicitlyHiddenParams = unambiguousTemplateGroup.Count > 1;
@@ -657,19 +657,19 @@ namespace Microsoft.TemplateEngine.Cli
             HashSet<string> argsInvalidForAllTemplatesInGroup = new HashSet<string>();
             bool firstTemplate = true;
 
-            foreach (IFilteredTemplateInfo templateInfo in unambiguousTemplateGroup.OrderByDescending(x => x.Info.Precedence))
+            foreach (ITemplateMatchInfo templateInfo in unambiguousTemplateGroup.OrderByDescending(x => x.Info.Precedence))
             {
                 bool argsError = false;
                 string commandParseFailureMessage = null;
 
-                if (templateInfo.HasParseError)
+                if (templateInfo.HasParseError())
                 {
-                    commandParseFailureMessage = templateInfo.ParseError;
+                    commandParseFailureMessage = templateInfo.GetParseError();
                     argsError = true;
                 }
                 else
                 {
-                    IReadOnlyList<string> invalidParamsForTemplate = templateInfo.InvalidParameterNames;
+                    IReadOnlyList<string> invalidParamsForTemplate = templateInfo.GetInvalidParameterNames();
                     argsError = invalidParamsForTemplate.Any();
 
                     if (argsError)
@@ -705,19 +705,19 @@ namespace Microsoft.TemplateEngine.Cli
             return anyArgsErrors ? CreationResultStatus.InvalidParamValues : CreationResultStatus.Success;
         }
 
-        private bool CheckForArgsError(IFilteredTemplateInfo template, out string commandParseFailureMessage)
+        private bool CheckForArgsError(ITemplateMatchInfo template, out string commandParseFailureMessage)
         {
             bool argsError;
 
-            if (template.HasParseError)
+            if (template.HasParseError())
             {
-                commandParseFailureMessage = template.ParseError;
+                commandParseFailureMessage = template.GetParseError();
                 argsError = true;
             }
             else
             {
                 commandParseFailureMessage = null;
-                IReadOnlyList<string> invalidParams = template.InvalidParameterNames;
+                IReadOnlyList<string> invalidParams = template.GetInvalidParameterNames();
 
                 if (invalidParams.Count > 0)
                 {
@@ -733,7 +733,7 @@ namespace Microsoft.TemplateEngine.Cli
             return argsError;
         }
 
-        private async Task<CreationResultStatus> EnterTemplateInvocationFlowAsync(IFilteredTemplateInfo templateToInvoke)
+        private async Task<CreationResultStatus> EnterTemplateInvocationFlowAsync(ITemplateMatchInfo templateToInvoke)
         {
             templateToInvoke.Info.Tags.TryGetValue("language", out ICacheTag language);
             _commandInput.InputTemplateParams.TryGetValue("framework", out string framework);
@@ -812,7 +812,7 @@ namespace Microsoft.TemplateEngine.Cli
             TemplateListResolutionResult templateResolutionResult = QueryForTemplateMatches();
 
             // There must be an unambiguous group to perform singular group actions.
-            if (templateResolutionResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousTemplateGroup))
+            if (templateResolutionResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousTemplateGroup))
             {
                 if (_commandInput.IsListFlagSpecified)
                 {
@@ -824,9 +824,9 @@ namespace Microsoft.TemplateEngine.Cli
                     return DisplayTemplateHelpForSingularGroup(templateResolutionResult);
                 }
 
-                if (templateResolutionResult.TryGetSingularInvokableMatch(out IFilteredTemplateInfo templateToInvoke)
-                    && !unambiguousTemplateGroup.Any(x => x.HasParameterMismatch)
-                    && !unambiguousTemplateGroup.Any(x => x.HasAmbiguousParameterValueMatch))
+                if (templateResolutionResult.TryGetSingularInvokableMatch(out ITemplateMatchInfo templateToInvoke)
+                    && !unambiguousTemplateGroup.Any(x => x.HasParameterMismatch())
+                    && !unambiguousTemplateGroup.Any(x => x.HasAmbiguousParameterValueMatch()))
                 {
                     // If any template in the group has any ambiguous params, then don't invoke.
                     // The check is for an example like:
@@ -1225,7 +1225,7 @@ namespace Microsoft.TemplateEngine.Cli
         {
             get
             {
-                IReadOnlyCollection<IFilteredTemplateInfo> allTemplates = TemplateListResolver.PerformAllTemplatesQuery(_settingsLoader.UserTemplateCache.TemplateInfo, _hostDataLoader);
+                IReadOnlyCollection<ITemplateMatchInfo> allTemplates = TemplateListResolver.PerformAllTemplatesQuery(_settingsLoader.UserTemplateCache.TemplateInfo, _hostDataLoader);
                 HashSet<string> allShortNames = new HashSet<string>(allTemplates.Select(x => x.Info.ShortName));
                 return allShortNames;
             }

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -27,7 +27,7 @@ namespace Microsoft.TemplateEngine.Cli
         private readonly SettingsLoader _settingsLoader;
         private readonly AliasRegistry _aliasRegistry;
         private readonly Paths _paths;
-        private readonly INewCommandInput _commandInput;
+        private readonly INewCommandInput _commandInput;    // It's safe to access template agnostic information anytime after the first parse. But there is never a guarantee which template the parse is in the context of.
         private readonly IHostSpecificDataLoader _hostDataLoader;
         private readonly string _defaultLanguage;
         private static readonly Regex LocaleFormatRegex = new Regex(@"
@@ -154,8 +154,14 @@ namespace Microsoft.TemplateEngine.Cli
             }
         }
 
-        private async Task<CreationResultStatus> CreateTemplateAsync(ITemplateInfo template)
+        // Attempts to invoke the template.
+        // Warning: The _commandInput cannot be assumed to be in a state that is parsed for the template being invoked.
+        //      So be sure to only get template-agnostic information from it. Anything specific to the template must be gotten from the IFilteredTemplateInfo
+        //      Or do a reparse if necessary (currently occurs in one error case).
+        private async Task<CreationResultStatus> CreateTemplateAsync(IFilteredTemplateInfo templateMatchDetails)
         {
+            ITemplateInfo template = templateMatchDetails.Info;
+
             string fallbackName = new DirectoryInfo(_commandInput.OutputPath ?? Directory.GetCurrentDirectory()).Name;
 
             if (string.IsNullOrEmpty(fallbackName) || string.Equals(fallbackName, "/", StringComparison.Ordinal))
@@ -167,7 +173,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             try
             {
-                instantiateResult = await _templateCreator.InstantiateAsync(template, _commandInput.Name, fallbackName, _commandInput.OutputPath, _commandInput.AllTemplateParams, _commandInput.SkipUpdateCheck, _commandInput.IsForceFlagSpecified, _commandInput.BaselineName).ConfigureAwait(false);
+                instantiateResult = await _templateCreator.InstantiateAsync(template, _commandInput.Name, fallbackName, _commandInput.OutputPath, templateMatchDetails.ValidTemplateParameters, _commandInput.SkipUpdateCheck, _commandInput.IsForceFlagSpecified, _commandInput.BaselineName).ConfigureAwait(false);
             }
             catch (ContentGenerationException cx)
             {
@@ -209,6 +215,10 @@ namespace Microsoft.TemplateEngine.Cli
                     }
                     else
                     {
+                        // TODO: rework to avoid having to reparse.
+                        // The canonical info could be in the IFilteredTemplateInfo, but currently isn't.
+                        TemplateListResolver.ParseTemplateArgs(template, _hostDataLoader, _commandInput);
+
                         IReadOnlyList<string> missingParamNamesCanonical = instantiateResult.Message.Split(new[] { ',' })
                             .Select(x => _commandInput.VariantsForCanonical(x.Trim())
                                                         .DefaultIfEmpty(x.Trim()).First())
@@ -232,13 +242,15 @@ namespace Microsoft.TemplateEngine.Cli
             return instantiateResult.Status;
         }
 
+        // TODO: rework this method... it's a bit of a god-method, for very specific purposes.
+        // Number of times I've deferred on reworking this method: 3
         private IReadOnlyList<InvalidParameterInfo> GetTemplateUsageInformation(ITemplateInfo templateInfo, out IParameterSet allParams, out IReadOnlyList<string> userParamsWithInvalidValues,
                                                     out IReadOnlyDictionary<string, IReadOnlyList<string>> variantsForCanonicals, out HashSet<string> userParamsWithDefaultValues, out bool hasPostActionScriptRunner)
         {
             ITemplate template = EnvironmentSettings.SettingsLoader.LoadTemplate(templateInfo, _commandInput.BaselineName);
-            ParseTemplateArgs(templateInfo);
+            TemplateListResolver.ParseTemplateArgs(templateInfo, _hostDataLoader, _commandInput);
             allParams = _templateCreator.SetupDefaultParamValuesFromTemplateAndHost(template, template.DefaultName ?? "testName", out IReadOnlyList<string> defaultParamsWithInvalidValues);
-            _templateCreator.ResolveUserParameters(template, allParams, _commandInput.AllTemplateParams, out userParamsWithInvalidValues);
+            _templateCreator.ResolveUserParameters(template, allParams, _commandInput.InputTemplateParams, out userParamsWithInvalidValues);
             hasPostActionScriptRunner = CheckIfTemplateHasScriptRunningPostActions(template);
             _templateCreator.ReleaseMountPoints(template);
 
@@ -249,14 +261,14 @@ namespace Microsoft.TemplateEngine.Cli
                 // Lookup the input param formats - userParamsWithInvalidValues has canonical.
                 foreach (string canonical in userParamsWithInvalidValues)
                 {
-                    _commandInput.AllTemplateParams.TryGetValue(canonical, out string specifiedValue);
+                    _commandInput.InputTemplateParams.TryGetValue(canonical, out string specifiedValue);
                     string inputFormat = _commandInput.TemplateParamInputFormat(canonical);
                     InvalidParameterInfo invalidParam = new InvalidParameterInfo(inputFormat, specifiedValue, canonical);
                     invalidParameters.Add(invalidParam);
                 }
             }
 
-            if (_templateCreator.AnyParametersWithInvalidDefaultsUnresolved(defaultParamsWithInvalidValues, userParamsWithInvalidValues, _commandInput.AllTemplateParams, out IReadOnlyList<string> defaultsWithUnresolvedInvalidValues))
+            if (_templateCreator.AnyParametersWithInvalidDefaultsUnresolved(defaultParamsWithInvalidValues, userParamsWithInvalidValues, _commandInput.InputTemplateParams, out IReadOnlyList<string> defaultsWithUnresolvedInvalidValues))
             {
                 IParameterSet templateParams = template.Generator.GetParametersForTemplate(EnvironmentSettings, template);
 
@@ -301,7 +313,7 @@ namespace Microsoft.TemplateEngine.Cli
             // use a throwaway set of params for getting the creation effects - it makes changes to them.
             string targetDir = _commandInput.OutputPath ?? EnvironmentSettings.Host.FileSystem.GetCurrentDirectory();
             IParameterSet paramsForCreationEffects = _templateCreator.SetupDefaultParamValuesFromTemplateAndHost(template, template.DefaultName ?? "testName", out IReadOnlyList<string> throwaway);
-            _templateCreator.ResolveUserParameters(template, paramsForCreationEffects, _commandInput.AllTemplateParams, out IReadOnlyList<string> userParamsWithInvalidValues);
+            _templateCreator.ResolveUserParameters(template, paramsForCreationEffects, _commandInput.InputTemplateParams, out IReadOnlyList<string> userParamsWithInvalidValues);
             ICreationEffects creationEffects = template.Generator.GetCreationEffects(EnvironmentSettings, template, paramsForCreationEffects, EnvironmentSettings.SettingsLoader.Components, targetDir);
             return creationEffects.CreationResult.PostActions.Any(x => x.ActionId == ProcessStartPostActionProcessor.ActionProcessorId);
         }
@@ -356,14 +368,13 @@ namespace Microsoft.TemplateEngine.Cli
         // Checks the result of TemplatesToDisplayInfoAbout()
         // If they all have the same group identity, return them.
         // Otherwise retun an empty list.
-        private IEnumerable<ITemplateInfo> GetTemplatesToShowDetailedHelpAbout(TemplateListResolutionResult templateResolutionResult)
+        private IEnumerable<ITemplateInfo> GetTemplateGroupToShowDetailedHelpAbout(TemplateListResolutionResult templateResolutionResult)
         {
-            IReadOnlyList<ITemplateInfo> candidateTemplates = GetTemplatesToDisplayInfoAbout(templateResolutionResult);
-            Func<ITemplateInfo, string> groupIdentitySelector = (x) => x.GroupIdentity;
+            IReadOnlyList<IFilteredTemplateInfo> candidateTemplates = GetTemplatesToDisplayInfoAbout(templateResolutionResult);
 
-            if (candidateTemplates.AllAreTheSame(groupIdentitySelector, StringComparer.OrdinalIgnoreCase))
+            if (TemplateListResolver.AreAllTemplatesSameGroupIdentity(candidateTemplates))
             {
-                return candidateTemplates;
+                return candidateTemplates.Select(x => x.Info);
             }
 
             return new List<ITemplateInfo>();
@@ -372,30 +383,30 @@ namespace Microsoft.TemplateEngine.Cli
         // If there are secondary matches, return them
         // Else if there are primary matches, return them
         // Otherwise return all templates in the current context
-        private IReadOnlyList<ITemplateInfo> GetTemplatesToDisplayInfoAbout(TemplateListResolutionResult templateResolutionResult)
+        private IReadOnlyList<IFilteredTemplateInfo> GetTemplatesToDisplayInfoAbout(TemplateListResolutionResult templateResolutionResult)
         {
-            IEnumerable<ITemplateInfo> templateList;
+            IEnumerable<IFilteredTemplateInfo> templateList;
 
-            if (templateResolutionResult.HasUnambiguousTemplateGroupToUse)
+            if (templateResolutionResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousList))
             {
-                templateList = templateResolutionResult.UnambiguousTemplateGroupToUse.Select(x => x.Info);
+                templateList = unambiguousList;
             }
-            else if (!string.IsNullOrEmpty(TemplateName) && templateResolutionResult.HasMatchedTemplatesWithSecondaryMatchInfo)
-            {   // without template name, it's not reasonable to do secondary matching
-                templateList = templateResolutionResult.MatchedTemplatesWithSecondaryMatchInfo.Select(x => x.Info);
+            else if (!string.IsNullOrEmpty(TemplateName) && templateResolutionResult.TryGetAllInvokableTemplates(out IReadOnlyList<IFilteredTemplateInfo> invokableTemplates))
+            {
+                templateList = invokableTemplates;
             }
             else if (templateResolutionResult.HasCoreMatchedTemplatesWithDisposition(x => x.IsMatch))
             {
-                templateList = templateResolutionResult.CoreMatchedTemplates.Where(x => x.IsMatch).Select(x => x.Info);
+                templateList = templateResolutionResult.CoreMatchedTemplates.Where(x => x.IsMatch);
             }
             else if (templateResolutionResult.HasCoreMatchedTemplatesWithDisposition(x => x.IsPartialMatch))
             {
-                templateList = templateResolutionResult.CoreMatchedTemplates.Where(x => x.IsPartialMatch).Select(x => x.Info);
+                templateList = templateResolutionResult.CoreMatchedTemplates.Where(x => x.IsPartialMatch);
             }
             else
             {
                 templateList = TemplateListResolver.PerformAllTemplatesInContextQuery(_settingsLoader.UserTemplateCache.TemplateInfo, _hostDataLoader, _commandInput.TypeFilter?.ToLowerInvariant())
-                                                                    .Where(x => x.IsMatch).Select(x => x.Info);
+                                                                    .Where(x => x.IsMatch);
             }
 
             return templateList.ToList();
@@ -403,19 +414,19 @@ namespace Microsoft.TemplateEngine.Cli
 
         private void DisplayTemplateList(TemplateListResolutionResult templateResolutionResult)
         {
-            IReadOnlyList<ITemplateInfo> results = GetTemplatesToDisplayInfoAbout(templateResolutionResult);
-            IEnumerable<IGrouping<string, ITemplateInfo>> grouped = results.GroupBy(x => x.GroupIdentity, x => !string.IsNullOrEmpty(x.GroupIdentity));
+            IReadOnlyList<IFilteredTemplateInfo> results = GetTemplatesToDisplayInfoAbout(templateResolutionResult);
+            IEnumerable<IGrouping<string, IFilteredTemplateInfo>> grouped = results.GroupBy(x => x.Info.GroupIdentity, x => !string.IsNullOrEmpty(x.Info.GroupIdentity));
             Dictionary<ITemplateInfo, string> templatesVersusLanguages = new Dictionary<ITemplateInfo, string>();
 
-            foreach (IGrouping<string, ITemplateInfo> grouping in grouped)
+            foreach (IGrouping<string, IFilteredTemplateInfo> grouping in grouped)
             {
                 List<string> languageForDisplay = new List<string>();
                 HashSet<string> uniqueLanguages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 string defaultLanguageDisplay = string.Empty;
 
-                foreach (ITemplateInfo info in grouping)
+                foreach (IFilteredTemplateInfo template in grouping)
                 {
-                    if (info.Tags != null && info.Tags.TryGetValue("language", out ICacheTag languageTag))
+                    if (template.Info.Tags != null && template.Info.Tags.TryGetValue("language", out ICacheTag languageTag))
                     {
                         foreach (string lang in languageTag.ChoicesAndDescriptions.Keys)
                         {
@@ -440,7 +451,7 @@ namespace Microsoft.TemplateEngine.Cli
                     languageForDisplay.Insert(0, defaultLanguageDisplay);
                 }
 
-                templatesVersusLanguages[grouping.First()] = string.Join(", ", languageForDisplay);
+                templatesVersusLanguages[grouping.First().Info] = string.Join(", ", languageForDisplay);
             }
 
             HelpFormatter<KeyValuePair<ITemplateInfo, string>> formatter = HelpFormatter.For(EnvironmentSettings, templatesVersusLanguages, 6, '-', false)
@@ -456,7 +467,7 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 Reporter.Output.WriteLine();
                 ShowInvocationExamples(templateResolutionResult);
-                IList<ITemplateInfo> templatesToShow = GetTemplatesToShowDetailedHelpAbout(templateResolutionResult).ToList();
+                IList<ITemplateInfo> templatesToShow = GetTemplateGroupToShowDetailedHelpAbout(templateResolutionResult).ToList();
                 ShowTemplateGroupHelp(templatesToShow);
             }
         }
@@ -473,13 +484,30 @@ namespace Microsoft.TemplateEngine.Cli
                 return CreationResultStatus.NotFound;
             }
 
-            if (!TemplateListResolver.ValidateRemainingParameters(_commandInput, out IReadOnlyList<string> invalidParams) || (!_commandInput.IsListFlagSpecified && !string.IsNullOrEmpty(TemplateName)))
+            // handling when there are parameter mismatches. There may be other issues too.
+            IReadOnlyList<IFilteredTemplateInfo> templatesForDisplay = GetTemplatesToDisplayInfoAbout(templateResolutionResult);
+            HelpForTemplateResolution.GetParametersInvalidForTemplatesInList(templatesForDisplay, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
+            if (invalidForAllTemplates.Any() || invalidForSomeTemplates.Any())
             {
-                DisplayInvalidParameters(invalidParams);
-                bool anyPartialMatchesDisplayed = ShowTemplateNameMismatchHelp(templateResolutionResult);
+                HelpForTemplateResolution.DisplayInvalidParameters(invalidForAllTemplates);
+                HelpForTemplateResolution.DisplayParametersInvalidForSomeTemplates(invalidForSomeTemplates);
+                HelpForTemplateResolution.ShowTemplateNameMismatchHelp(TemplateName, DetermineTemplateContext(), templateResolutionResult);
                 DisplayTemplateList(templateResolutionResult);
                 return CreationResultStatus.NotFound;
             }
+
+            // handling when there are context problems
+            //
+            // This isn't quite right. We'll need some rework for context mismatches in the core query before this can be correct.
+            // Currently, context mismatches are not part of the core matches.
+            //
+            // Without this, we're closer to parity with the state of things prior to the template matching rework (August 2017).
+            //
+            //if (HelpForTemplateResolution.ShowTemplateNameMismatchHelp(TemplateName, DetermineTemplateContext(), templateResolutionResult))
+            //{
+            //    DisplayTemplateList(templateResolutionResult);
+            //    return CreationResultStatus.NotFound;
+            //}
 
             if (!string.IsNullOrWhiteSpace(_commandInput.Alias))
             {
@@ -526,7 +554,7 @@ namespace Microsoft.TemplateEngine.Cli
         {
             if (!TemplateListResolver.ValidateRemainingParameters(_commandInput, out IReadOnlyList<string> invalidParams))
             {
-                DisplayInvalidParameters(invalidParams);
+                HelpForTemplateResolution.DisplayInvalidParameters(invalidParams);
                 if (_commandInput.IsHelpFlagSpecified)
                 {
                     _telemetryLogger.TrackEvent(CommandName + "-Help");
@@ -577,15 +605,19 @@ namespace Microsoft.TemplateEngine.Cli
             return CreationResultStatus.Success;
         }
 
+        // Used when the inputs resolve to a single template group, and the list flag is specified.
         private CreationResultStatus SingularGroupDisplayTemplateListIfAnyAreValid(TemplateListResolutionResult templateResolutionResult)
         {
             bool anyValid = false;
 
-            foreach (IFilteredTemplateInfo templateInfo in templateResolutionResult.UnambiguousTemplateGroupToUse)
+            if (!templateResolutionResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousTemplateGroup))
             {
-                ParseTemplateArgs(templateInfo.Info);
+                unambiguousTemplateGroup = new List<IFilteredTemplateInfo>();
+            }
 
-                if (!TemplateListResolver.AnyRemainingParameters(_commandInput))
+            foreach (IFilteredTemplateInfo templateInfo in unambiguousTemplateGroup)
+            {
+                if (templateInfo.InvalidParameterNames.Count > 0)
                 {
                     anyValid = true;
                     break;
@@ -594,11 +626,10 @@ namespace Microsoft.TemplateEngine.Cli
 
             if (!anyValid)
             {
-                IFilteredTemplateInfo highestPrecedenceTemplate = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(templateResolutionResult.UnambiguousTemplateGroupToUse);
+                IFilteredTemplateInfo highestPrecedenceTemplate = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(unambiguousTemplateGroup);
 
                 if (highestPrecedenceTemplate != null)
                 {
-                    ParseTemplateArgs(highestPrecedenceTemplate.Info);
                     Reporter.Error.WriteLine(string.Format(LocalizableStrings.RunHelpForInformationAboutAcceptedParameters, CommandName).Bold().Red());
                     return CreationResultStatus.InvalidParamValues;
                 }
@@ -612,30 +643,33 @@ namespace Microsoft.TemplateEngine.Cli
         {
             bool anyArgsErrors = false;
             ShowUsageHelp();
-            bool showImplicitlyHiddenParams = templateResolutionResult.UnambiguousTemplateGroupToUse.Count > 1;
+
+            if (!templateResolutionResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousTemplateGroup))
+            {
+                unambiguousTemplateGroup = new List<IFilteredTemplateInfo>();
+            }
+
+            bool showImplicitlyHiddenParams = unambiguousTemplateGroup.Count > 1;
 
             IList<ITemplateInfo> templatesToShowHelpOn = new List<ITemplateInfo>();
             HashSet<string> argsInvalidForAllTemplatesInGroup = new HashSet<string>();
             bool firstTemplate = true;
 
-            foreach (IFilteredTemplateInfo templateInfo in templateResolutionResult.UnambiguousTemplateGroupToUse.OrderByDescending(x => x.Info.Precedence))
+            foreach (IFilteredTemplateInfo templateInfo in unambiguousTemplateGroup.OrderByDescending(x => x.Info.Precedence))
             {
                 bool argsError = false;
                 string commandParseFailureMessage = null;
 
-                try
+                if (templateInfo.HasParseError)
                 {
-                    ParseTemplateArgs(templateInfo.Info);
-                }
-                catch (CommandParserException ex)
-                {
-                    commandParseFailureMessage = ex.Message;
+                    commandParseFailureMessage = templateInfo.ParseError;
                     argsError = true;
                 }
-
-                if (!argsError)
+                else
                 {
-                    argsError = !TemplateListResolver.ValidateRemainingParameters(_commandInput, out IReadOnlyList<string> invalidParamsForTemplate);
+                    IReadOnlyList<string> invalidParamsForTemplate = templateInfo.InvalidParameterNames;
+                    argsError = invalidParamsForTemplate.Any();
+
                     if (argsError)
                     {
                         if (firstTemplate)
@@ -661,7 +695,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             if (argsInvalidForAllTemplatesInGroup.Count > 0)
             {
-                DisplayInvalidParameters(argsInvalidForAllTemplatesInGroup.ToList());
+                HelpForTemplateResolution.DisplayInvalidParameters(argsInvalidForAllTemplatesInGroup.ToList());
             }
 
             ShowTemplateGroupHelp(templatesToShowHelpOn, showImplicitlyHiddenParams);
@@ -669,36 +703,23 @@ namespace Microsoft.TemplateEngine.Cli
             return anyArgsErrors ? CreationResultStatus.InvalidParamValues : CreationResultStatus.Success;
         }
 
-        private async Task<CreationResultStatus> EnterSingularTemplateManipulationFlowAsync(TemplateListResolutionResult templateResolutionResult)
+        private bool CheckForArgsError(IFilteredTemplateInfo template, out string commandParseFailureMessage)
         {
-            if (_commandInput.IsListFlagSpecified)
-            {
-                return SingularGroupDisplayTemplateListIfAnyAreValid(templateResolutionResult);
-            }
-            else if (_commandInput.IsHelpFlagSpecified)
-            {
-                _telemetryLogger.TrackEvent(CommandName + "-Help");
-                return DisplayTemplateHelpForSingularGroup(templateResolutionResult);
-            }
+            bool argsError;
 
-            bool argsError = false;
-            string commandParseFailureMessage = null;
-            IFilteredTemplateInfo highestPrecedenceTemplate = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(templateResolutionResult.UnambiguousTemplateGroupToUse);
-            try
+            if (template.HasParseError)
             {
-                ParseTemplateArgs(highestPrecedenceTemplate.Info);
-            }
-            catch (CommandParserException ex)
-            {
-                commandParseFailureMessage = ex.Message;
+                commandParseFailureMessage = template.ParseError;
                 argsError = true;
             }
-
-            if (!argsError)
+            else
             {
-                if (!TemplateListResolver.ValidateRemainingParameters(_commandInput, out IReadOnlyList<string> invalidParams))
+                commandParseFailureMessage = null;
+                IReadOnlyList<string> invalidParams = template.InvalidParameterNames;
+
+                if (invalidParams.Count > 0)
                 {
-                    DisplayInvalidParameters(invalidParams);
+                    HelpForTemplateResolution.DisplayInvalidParameters(invalidParams);
                     argsError = true;
                 }
                 else
@@ -707,17 +728,23 @@ namespace Microsoft.TemplateEngine.Cli
                 }
             }
 
-            highestPrecedenceTemplate.Info.Tags.TryGetValue("language", out ICacheTag language);
-            _commandInput.AllTemplateParams.TryGetValue("framework", out string framework);
-            _commandInput.AllTemplateParams.TryGetValue("auth", out string auth);
-            bool isMicrosoftAuthored = string.Equals(highestPrecedenceTemplate.Info.Author, "Microsoft", StringComparison.OrdinalIgnoreCase);
-            string templateName = isMicrosoftAuthored ? highestPrecedenceTemplate.Info.Identity : "(3rd Party)";
+            return argsError;
+        }
+
+        private async Task<CreationResultStatus> EnterTemplateInvocationFlowAsync(IFilteredTemplateInfo templateToInvoke)
+        {
+            templateToInvoke.Info.Tags.TryGetValue("language", out ICacheTag language);
+            _commandInput.InputTemplateParams.TryGetValue("framework", out string framework);
+            _commandInput.InputTemplateParams.TryGetValue("auth", out string auth);
+            bool isMicrosoftAuthored = string.Equals(templateToInvoke.Info.Author, "Microsoft", StringComparison.OrdinalIgnoreCase);
+            string templateName = isMicrosoftAuthored ? templateToInvoke.Info.Identity : "(3rd Party)";
 
             if (!isMicrosoftAuthored)
             {
                 auth = null;
             }
 
+            bool argsError = CheckForArgsError(templateToInvoke, out string commandParseFailureMessage);
             if (argsError)
             {
                 _telemetryLogger.TrackEvent(CommandName + "CreateTemplate", new Dictionary<string, string>
@@ -743,7 +770,7 @@ namespace Microsoft.TemplateEngine.Cli
 
                 try
                 {
-                    return await CreateTemplateAsync(highestPrecedenceTemplate.Info).ConfigureAwait(false);
+                    return await CreateTemplateAsync(templateToInvoke).ConfigureAwait(false);
                 }
                 catch (ContentGenerationException cx)
                 {
@@ -782,22 +809,41 @@ namespace Microsoft.TemplateEngine.Cli
         {
             TemplateListResolutionResult templateResolutionResult = QueryForTemplateMatches();
 
-            if (templateResolutionResult.HasUnambiguousTemplateGroupToUse
-                && !templateResolutionResult.UnambiguousTemplateGroupToUse.Any(x => x.HasAmbiguousParameterMatch))
+            // There must be an unambiguous group to perform singular group actions.
+            if (templateResolutionResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousTemplateGroup))
             {
-                // unambiguous templates should all have the same dispositions
-                if (templateResolutionResult.UnambiguousTemplateGroupToUse[0].MatchDisposition.Any(x => x.Kind == MatchKind.Exact && x.Location != MatchLocation.Context && x.Location != MatchLocation.Language))
+                if (_commandInput.IsListFlagSpecified)
                 {
-                    return await EnterSingularTemplateManipulationFlowAsync(templateResolutionResult).ConfigureAwait(false);
+                    return SingularGroupDisplayTemplateListIfAnyAreValid(templateResolutionResult);
                 }
-                else if(EnvironmentSettings.Host.OnConfirmPartialMatch(templateResolutionResult.UnambiguousTemplateGroupToUse[0].Info.Name))
-                {   // unambiguous templates will all have the same name
-                    return await EnterSingularTemplateManipulationFlowAsync(templateResolutionResult).ConfigureAwait(false);
+                else if (_commandInput.IsHelpFlagSpecified)
+                {
+                    _telemetryLogger.TrackEvent(CommandName + "-Help");
+                    return DisplayTemplateHelpForSingularGroup(templateResolutionResult);
+                }
+
+                if (templateResolutionResult.TryGetSingularInvokableMatch(out IFilteredTemplateInfo templateToInvoke)
+                    && !unambiguousTemplateGroup.Any(x => x.HasParameterMismatch)
+                    && !unambiguousTemplateGroup.Any(x => x.HasAmbiguousParameterValueMatch))
+                {
+                    // If any template in the group has any ambiguous params, then don't invoke.
+                    // The check is for an example like:
+                    // "dotnet new mvc -f netcore"
+                    //      - '-f netcore' is ambiguous in the 1.x version (2 begins-with matches)
+                    //      - '-f netcore' is not ambiguous in the 2.x version (1 begins-with match)
+                    return await EnterTemplateInvocationFlowAsync(templateToInvoke).ConfigureAwait(false);
                 }
                 else
                 {
-                    return CreationResultStatus.Cancelled;
+                    _telemetryLogger.TrackEvent(CommandName + "-Help");
+                    return DisplayTemplateHelpForSingularGroup(templateResolutionResult);
                 }
+                // There used to be code for allowing an interactive verification, but we've never used it.
+                // The verification call was stubbed to return true, and masked other resolution issues.
+                // Its only param is a template name, and if we already know the name, we could invoke it.
+                // ... or it's uninvokable for other reasons - in which case the confirmation wouldn't help.
+                // The use cases what flowed through interactive verification would always cause invocation errors.
+                // Those types of errors are now handled without having to invoke.
             }
 
             return EnterAmbiguousTemplateManipulationFlow(templateResolutionResult);
@@ -883,7 +929,7 @@ namespace Microsoft.TemplateEngine.Cli
         private CreationResultStatus HandleParseError()
         {
             TemplateListResolver.ValidateRemainingParameters(_commandInput, out IReadOnlyList<string> invalidParams);
-            DisplayInvalidParameters(invalidParams);
+            HelpForTemplateResolution.DisplayInvalidParameters(invalidParams);
 
             // TODO: get a meaningful error message from the parser
             if (_commandInput.IsHelpFlagSpecified)
@@ -1168,12 +1214,6 @@ namespace Microsoft.TemplateEngine.Cli
             }
         }
 
-        private void ParseTemplateArgs(ITemplateInfo templateInfo)
-        {
-            HostSpecificTemplateData hostSpecificTemplateData = _hostDataLoader.ReadHostSpecificTemplateData(templateInfo);
-            _commandInput.ReparseForTemplate(templateInfo, hostSpecificTemplateData);
-        }
-
         private string DetermineTemplateContext()
         {
             return _commandInput.TypeFilter?.ToLowerInvariant();
@@ -1377,85 +1417,14 @@ namespace Microsoft.TemplateEngine.Cli
             IParameterSet allGroupParameters = new TemplateGroupParameterSet(parameterSetsForAllTemplatesInGroup);
             string parameterErrors = InvalidParameterInfo.InvalidParameterListToString(invalidParametersForGroup.Values.ToList());
             HashSet<string> parametersToHide = new HashSet<string>(parameterHidingDisposition.Where(x => x.Value).Select(x => x.Key), StringComparer.Ordinal);
-            ShowParameterHelp(_commandInput.AllTemplateParams, allGroupParameters, parameterErrors, groupUserParamsWithInvalidValues.ToList(), parametersToHide, groupVariantsForCanonicals, groupUserParamsWithDefaultValues, showImplicitlyHiddenParams, groupHasPostActionScriptRunner);
-        }
-
-        // Returns true if any partial matches were displayed, false otherwise
-        private bool ShowTemplateNameMismatchHelp(TemplateListResolutionResult templateResolutionResult)
-        {
-            IDictionary<string, IFilteredTemplateInfo> contextProblemMatches = new Dictionary<string, IFilteredTemplateInfo>();
-            IDictionary<string, IFilteredTemplateInfo> remainingPartialMatches = new Dictionary<string, IFilteredTemplateInfo>();
-
-            // this filtering / grouping ignores language differences.
-            foreach (IFilteredTemplateInfo template in templateResolutionResult.CoreMatchedTemplates)
-            {
-                if (contextProblemMatches.ContainsKey(template.Info.Name) || remainingPartialMatches.ContainsKey(template.Info.Name))
-                {
-                    continue;
-                }
-
-                if (template.MatchDisposition.Any(x => x.Location == MatchLocation.Context && x.Kind != MatchKind.Exact))
-                {
-                    contextProblemMatches.Add(template.Info.Name, template);
-                }
-                else if(template.MatchDisposition.Any(t => t.Location != MatchLocation.Context && t.Kind != MatchKind.Mismatch && t.Kind != MatchKind.Unspecified))
-                {
-                    remainingPartialMatches.Add(template.Info.Name, template);
-                }
-            }
-
-            if (contextProblemMatches.Keys.Count + remainingPartialMatches.Keys.Count > 1)
-            {
-                Reporter.Error.WriteLine(string.Format(LocalizableStrings.AmbiguousInputTemplateName, TemplateName));
-            }
-            else if (contextProblemMatches.Keys.Count + remainingPartialMatches.Keys.Count == 0)
-            {
-                Reporter.Error.WriteLine(string.Format(LocalizableStrings.NoTemplatesMatchName, TemplateName));
-                Reporter.Error.WriteLine();
-                return false;
-            }
-
-            foreach (IFilteredTemplateInfo template in contextProblemMatches.Values)
-            {
-                if (template.Info.Tags != null && template.Info.Tags.TryGetValue("type", out ICacheTag typeTag))
-                {
-                    MatchInfo? matchInfo = WellKnownSearchFilters.ContextFilter(DetermineTemplateContext())(template.Info);
-                    if ((matchInfo?.Kind ?? MatchKind.Mismatch) == MatchKind.Mismatch)
-                    {
-                        Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplateNotValidGivenTheSpecifiedFilter, template.Info.Name).Bold().Red());
-                    }
-                }
-                else
-                {   // this really shouldn't ever happen. But better to have a generic error than quietly ignore the partial match.
-                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.GenericPlaceholderTemplateContextError, template.Info.Name).Bold().Red());
-                }
-            }
-
-            if (remainingPartialMatches.Keys.Count > 0)
-            {
-                Reporter.Error.WriteLine(LocalizableStrings.TemplateMultiplePartialNameMatches.Bold().Red());
-            }
-
-            Reporter.Error.WriteLine();
-            return true;
+            ShowParameterHelp(_commandInput.InputTemplateParams, allGroupParameters, parameterErrors, groupUserParamsWithInvalidValues.ToList(), parametersToHide, groupVariantsForCanonicals,
+                                groupUserParamsWithDefaultValues, showImplicitlyHiddenParams, groupHasPostActionScriptRunner);
         }
 
         private void ShowUsageHelp()
         {
             Reporter.Output.WriteLine(_commandInput.HelpText);
             Reporter.Output.WriteLine();
-        }
-
-        private void DisplayInvalidParameters(IReadOnlyList<string> invalidParams)
-        {
-            if (invalidParams.Count > 0)
-            {
-                Reporter.Error.WriteLine(LocalizableStrings.InvalidInputSwitch.Bold().Red());
-                foreach (string flag in invalidParams)
-                {
-                    Reporter.Error.WriteLine($"  {flag}".Bold().Red());
-                }
-            }
         }
 
         private static bool ValidateLocaleFormat(string localeToCheck)

--- a/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
@@ -10,11 +10,14 @@ namespace Microsoft.TemplateEngine.Cli
 {
     public class TemplateListResolutionResult
     {
+        public TemplateListResolutionResult(bool hasUserInputLanguage)
+        {
+            _hasUserInputLanguage = hasUserInputLanguage;
+        }
+
+        private readonly bool _hasUserInputLanguage;
+
         public IReadOnlyList<IFilteredTemplateInfo> CoreMatchedTemplates { get; set; }
-
-        public IReadOnlyList<IFilteredTemplateInfo> UnambiguousTemplateGroupToUse { get; set; }
-
-        public IReadOnlyList<IFilteredTemplateInfo> MatchedTemplatesWithSecondaryMatchInfo { get; set; }
 
         public bool HasCoreMatchedTemplatesWithDisposition(Func<IFilteredTemplateInfo, bool> filter)
         {
@@ -22,22 +25,91 @@ namespace Microsoft.TemplateEngine.Cli
                     && CoreMatchedTemplates.Any(filter);
         }
 
-        public bool HasUnambiguousTemplateGroupToUse
+        public bool TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousTemplateGroup)
         {
-            get
+            if (CoreMatchedTemplates.Count == 0)
             {
-                return UnambiguousTemplateGroupToUse != null
-                        && UnambiguousTemplateGroupToUse.Count > 0;
+                unambiguousTemplateGroup = null;
+                return false;
             }
+
+            if (CoreMatchedTemplates.Count == 1)
+            {
+                unambiguousTemplateGroup = new List<IFilteredTemplateInfo>(CoreMatchedTemplates);
+                return true;
+            }
+
+            if (!_hasUserInputLanguage)
+            {
+                // only consider default language match dispositions if the user did not specify a language.
+                List<IFilteredTemplateInfo> defaultLanguageMatchedTemplates = CoreMatchedTemplates.Where(x => x.DispositionOfDefaults
+                                                                            .Any(y => y.Location == MatchLocation.DefaultLanguage && y.Kind == MatchKind.Exact))
+                                                                            .ToList();
+
+                if (TemplateListResolver.AreAllTemplatesSameGroupIdentity(defaultLanguageMatchedTemplates))
+                {
+                    if (defaultLanguageMatchedTemplates.Any(x => !x.HasParameterMismatch))
+                    {
+                        unambiguousTemplateGroup = defaultLanguageMatchedTemplates.Where(x => !x.HasParameterMismatch).ToList();
+                        return true;
+                    }
+                    else
+                    {
+                        unambiguousTemplateGroup = defaultLanguageMatchedTemplates;
+                        return true;
+                    }
+                }
+            }
+
+            List<IFilteredTemplateInfo> paramFiltered = CoreMatchedTemplates.Where(x => !x.HasParameterMismatch).ToList();
+            if (TemplateListResolver.AreAllTemplatesSameGroupIdentity(paramFiltered))
+            {
+                unambiguousTemplateGroup = paramFiltered;
+                return true;
+            }
+
+            if (TemplateListResolver.AreAllTemplatesSameGroupIdentity(CoreMatchedTemplates))
+            {
+                unambiguousTemplateGroup = new List<IFilteredTemplateInfo>(CoreMatchedTemplates);
+                return true;
+            }
+
+            unambiguousTemplateGroup = null;
+            return false;
         }
 
-        public bool HasMatchedTemplatesWithSecondaryMatchInfo
+        public bool TryGetAllInvokableTemplates(out IReadOnlyList<IFilteredTemplateInfo> invokableTemplates)
         {
-            get
+            IEnumerable<IFilteredTemplateInfo> invokableMatches = CoreMatchedTemplates.Where(x => x.IsInvokableMatch);
+
+            if (invokableMatches.Any())
             {
-                return MatchedTemplatesWithSecondaryMatchInfo != null
-                        && MatchedTemplatesWithSecondaryMatchInfo.Count > 0;
+                invokableTemplates = invokableMatches.ToList();
+                return true;
             }
+
+            invokableTemplates = null;
+            return false;
+        }
+
+        public bool TryGetSingularInvokableMatch(out IFilteredTemplateInfo template)
+        {
+            IReadOnlyList<IFilteredTemplateInfo> invokableMatches = CoreMatchedTemplates.Where(x => x.IsInvokableMatch).ToList();
+            if (invokableMatches.Count() == 1)
+            {
+                template = invokableMatches.First();
+                return true;
+            }
+
+            IFilteredTemplateInfo highestInGroupIfSingleGroup = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(invokableMatches);
+            if (highestInGroupIfSingleGroup != null)
+            {
+                template = highestInGroupIfSingleGroup;
+                return true;
+            }
+
+            template = null;
+            return false;
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
@@ -104,6 +104,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
 
             ITemplateMatchInfo highestInGroupIfSingleGroup = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(invokableMatches);
+
             if (highestInGroupIfSingleGroup != null)
             {
                 template = highestInGroupIfSingleGroup;

--- a/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
@@ -17,15 +17,15 @@ namespace Microsoft.TemplateEngine.Cli
 
         private readonly bool _hasUserInputLanguage;
 
-        public IReadOnlyList<IFilteredTemplateInfo> CoreMatchedTemplates { get; set; }
+        public IReadOnlyList<ITemplateMatchInfo> CoreMatchedTemplates { get; set; }
 
-        public bool HasCoreMatchedTemplatesWithDisposition(Func<IFilteredTemplateInfo, bool> filter)
+        public bool HasCoreMatchedTemplatesWithDisposition(Func<ITemplateMatchInfo, bool> filter)
         {
             return CoreMatchedTemplates != null
                     && CoreMatchedTemplates.Any(filter);
         }
 
-        public bool TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousTemplateGroup)
+        public bool TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousTemplateGroup)
         {
             if (CoreMatchedTemplates.Count == 0)
             {
@@ -35,22 +35,22 @@ namespace Microsoft.TemplateEngine.Cli
 
             if (CoreMatchedTemplates.Count == 1)
             {
-                unambiguousTemplateGroup = new List<IFilteredTemplateInfo>(CoreMatchedTemplates);
+                unambiguousTemplateGroup = new List<ITemplateMatchInfo>(CoreMatchedTemplates);
                 return true;
             }
 
             if (!_hasUserInputLanguage)
             {
                 // only consider default language match dispositions if the user did not specify a language.
-                List<IFilteredTemplateInfo> defaultLanguageMatchedTemplates = CoreMatchedTemplates.Where(x => x.DispositionOfDefaults
+                List<ITemplateMatchInfo> defaultLanguageMatchedTemplates = CoreMatchedTemplates.Where(x => x.DispositionOfDefaults
                                                                             .Any(y => y.Location == MatchLocation.DefaultLanguage && y.Kind == MatchKind.Exact))
                                                                             .ToList();
 
                 if (TemplateListResolver.AreAllTemplatesSameGroupIdentity(defaultLanguageMatchedTemplates))
                 {
-                    if (defaultLanguageMatchedTemplates.Any(x => !x.HasParameterMismatch))
+                    if (defaultLanguageMatchedTemplates.Any(x => !x.HasParameterMismatch()))
                     {
-                        unambiguousTemplateGroup = defaultLanguageMatchedTemplates.Where(x => !x.HasParameterMismatch).ToList();
+                        unambiguousTemplateGroup = defaultLanguageMatchedTemplates.Where(x => !x.HasParameterMismatch()).ToList();
                         return true;
                     }
                     else
@@ -61,7 +61,7 @@ namespace Microsoft.TemplateEngine.Cli
                 }
             }
 
-            List<IFilteredTemplateInfo> paramFiltered = CoreMatchedTemplates.Where(x => !x.HasParameterMismatch).ToList();
+            List<ITemplateMatchInfo> paramFiltered = CoreMatchedTemplates.Where(x => !x.HasParameterMismatch()).ToList();
             if (TemplateListResolver.AreAllTemplatesSameGroupIdentity(paramFiltered))
             {
                 unambiguousTemplateGroup = paramFiltered;
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             if (TemplateListResolver.AreAllTemplatesSameGroupIdentity(CoreMatchedTemplates))
             {
-                unambiguousTemplateGroup = new List<IFilteredTemplateInfo>(CoreMatchedTemplates);
+                unambiguousTemplateGroup = new List<ITemplateMatchInfo>(CoreMatchedTemplates);
                 return true;
             }
 
@@ -78,9 +78,9 @@ namespace Microsoft.TemplateEngine.Cli
             return false;
         }
 
-        public bool TryGetAllInvokableTemplates(out IReadOnlyList<IFilteredTemplateInfo> invokableTemplates)
+        public bool TryGetAllInvokableTemplates(out IReadOnlyList<ITemplateMatchInfo> invokableTemplates)
         {
-            IEnumerable<IFilteredTemplateInfo> invokableMatches = CoreMatchedTemplates.Where(x => x.IsInvokableMatch);
+            IEnumerable<ITemplateMatchInfo> invokableMatches = CoreMatchedTemplates.Where(x => x.IsInvokableMatch());
 
             if (invokableMatches.Any())
             {
@@ -92,16 +92,16 @@ namespace Microsoft.TemplateEngine.Cli
             return false;
         }
 
-        public bool TryGetSingularInvokableMatch(out IFilteredTemplateInfo template)
+        public bool TryGetSingularInvokableMatch(out ITemplateMatchInfo template)
         {
-            IReadOnlyList<IFilteredTemplateInfo> invokableMatches = CoreMatchedTemplates.Where(x => x.IsInvokableMatch).ToList();
+            IReadOnlyList<ITemplateMatchInfo> invokableMatches = CoreMatchedTemplates.Where(x => x.IsInvokableMatch()).ToList();
             if (invokableMatches.Count() == 1)
             {
                 template = invokableMatches.First();
                 return true;
             }
 
-            IFilteredTemplateInfo highestInGroupIfSingleGroup = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(invokableMatches);
+            ITemplateMatchInfo highestInGroupIfSingleGroup = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(invokableMatches);
             if (highestInGroupIfSingleGroup != null)
             {
                 template = highestInGroupIfSingleGroup;

--- a/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
@@ -62,6 +62,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
 
             List<ITemplateMatchInfo> paramFiltered = CoreMatchedTemplates.Where(x => !x.HasParameterMismatch()).ToList();
+
             if (TemplateListResolver.AreAllTemplatesSameGroupIdentity(paramFiltered))
             {
                 unambiguousTemplateGroup = paramFiltered;

--- a/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
@@ -95,9 +95,9 @@ namespace Microsoft.TemplateEngine.Cli
         public bool TryGetSingularInvokableMatch(out ITemplateMatchInfo template)
         {
             IReadOnlyList<ITemplateMatchInfo> invokableMatches = CoreMatchedTemplates.Where(x => x.IsInvokableMatch()).ToList();
-            if (invokableMatches.Count() == 1)
+            if (invokableMatches.Count == 1)
             {
-                template = invokableMatches.First();
+                template = invokableMatches[0];
                 return true;
             }
 

--- a/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
@@ -89,6 +89,7 @@ namespace Microsoft.TemplateEngine.Cli
                 return true;
             }
 
+
             invokableTemplates = null;
             return false;
         }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListResolutionResult.cs
@@ -104,7 +104,6 @@ namespace Microsoft.TemplateEngine.Cli
             }
 
             ITemplateMatchInfo highestInGroupIfSingleGroup = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(invokableMatches);
-
             if (highestInGroupIfSingleGroup != null)
             {
                 template = highestInGroupIfSingleGroup;

--- a/src/Microsoft.TemplateEngine.Cli/TemplateListResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListResolver.cs
@@ -273,6 +273,10 @@ namespace Microsoft.TemplateEngine.Cli
                 {   // if we do actually throw, add a non-match
                     template.AddDisposition(new MatchInfo { Location = MatchLocation.Unspecified, Kind = MatchKind.Unspecified, AdditionalInformation = ex.Message });
                 }
+                catch (Exception ex)
+                {
+                    template.AddDisposition(new MatchInfo { Location = MatchLocation.Unspecified, Kind = MatchKind.Unspecified, AdditionalInformation = $"Unexpected error: {ex.Message}" });
+                }
             }
         }
     }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateMatchInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateMatchInfoExtensions.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.TemplateEngine.Edge.Template;
+
+namespace Microsoft.TemplateEngine.Cli
+{
+    public static class TemplateMatchInfoExtensions
+    {
+        public static bool HasParameterMismatch(this ITemplateMatchInfo templateMatchInfo)
+        {
+            return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter
+                                       && (x.Kind != MatchKind.Exact && x.Kind != MatchKind.AmbiguousParameterValue));
+        }
+
+        public static bool HasAmbiguousParameterValueMatch(this ITemplateMatchInfo templateMatchInfo)
+        {
+            return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.AmbiguousParameterValue);
+        }
+
+        public static bool IsInvokableMatch(this ITemplateMatchInfo templateMatchInfo)
+        {
+            return templateMatchInfo.MatchDisposition.Count > 0
+                            && templateMatchInfo.MatchDisposition.All(x =>
+                                x.Kind == MatchKind.Exact
+                                ||
+                                (   // these locations can have partial or exact matches.
+                                    x.Kind == MatchKind.Partial
+                                    && (x.Location == MatchLocation.Name || x.Location == MatchLocation.ShortName || x.Location == MatchLocation.Classification)
+                                )
+                            );
+        }
+
+        public static IReadOnlyList<string> GetInvalidParameterNames(this ITemplateMatchInfo templateMatchInfo)
+        {
+            return templateMatchInfo.MatchDisposition.Where(x => x.Kind == MatchKind.InvalidParameterName)
+                                                   .Select(x => x.ChoiceIfLocationIsOtherChoice).ToList();
+        }
+
+        public static bool HasParseError(this ITemplateMatchInfo templateMatchInfo)
+        {
+            return templateMatchInfo.MatchDisposition.Any(x => x.Kind == MatchKind.Unspecified);
+        }
+
+        public static string GetParseError(this ITemplateMatchInfo templateMatchInfo)
+        {
+            return templateMatchInfo.MatchDisposition.Where(x => x.Kind == MatchKind.Unspecified).Select(x => x.AdditionalInformation).FirstOrDefault();
+        }
+
+        // This is analogous to INewCommandInput.InputTemplateParams
+        public static IReadOnlyDictionary<string, string> GetValidTemplateParameters(this ITemplateMatchInfo templateMatchInfo)
+        { 
+            return templateMatchInfo.MatchDisposition.Where(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.Exact)
+                                    .ToDictionary(x => x.ChoiceIfLocationIsOtherChoice, x => x.ParameterValue);
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/FilteredTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/FilteredTemplateInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Edge.Template;
@@ -10,27 +13,88 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         public FilteredTemplateInfo(ITemplateInfo info, IReadOnlyList<MatchInfo> matchDisposition)
         {
             Info = info;
-            MatchDisposition = matchDisposition;
+            if (matchDisposition != null)
+            {
+                _matchDisposition = matchDisposition.ToList();
+            }
+            else
+            {
+                _matchDisposition = new List<MatchInfo>();
+            }
+
+            _dispositionOfDefaults = new List<MatchInfo>();
         }
 
         public ITemplateInfo Info { get; }
 
-        public IReadOnlyList<MatchInfo> MatchDisposition { get; set; }
+        public IReadOnlyList<MatchInfo> MatchDisposition
+        {
+            get
+            {
+                return _matchDisposition.ToList();
+            }
+        }
+        private IList<MatchInfo> _matchDisposition;
 
+        // Stores match info relative to default settings.
+        // These don't have to match for the template to be a match, but they can be used to filter matches
+        // in appropriate situations.
+        // For example, matching or non-matching on the default language should only be used as a final disambiguator.
+        // It shouldn't unconditionally disqualify a match.
+        public IReadOnlyList<MatchInfo> DispositionOfDefaults
+        {
+            get
+            {
+                return _dispositionOfDefaults.ToList();
+            }
+        }
+        private IList<MatchInfo> _dispositionOfDefaults;
+
+        public void AddDisposition(MatchInfo newDisposition)
+        {
+            _matchDisposition.Add(newDisposition);
+        }
+
+        public void AddDefaultDisposition(MatchInfo newDisposition)
+        {
+            _dispositionOfDefaults.Add(newDisposition);
+        }
+
+        // TODO: get rid of, or rename this. "IsMatch" has become a misnomer as the system has evolved.
         public bool IsMatch => MatchDisposition.Count > 0 && !MatchDisposition.Any(x => x.Kind == MatchKind.Mismatch);
 
         public bool IsPartialMatch => MatchDisposition.Any(x => x.Kind != MatchKind.Mismatch)
             && MatchDisposition.All(x => x.Location != MatchLocation.Context
                                 || (x.Location == MatchLocation.Context && x.Kind == MatchKind.Exact));
 
-        // All parameter matches are exact (or there are no parameter matches)
-        public bool HasParameterMismatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind != MatchKind.Exact);
+        // There is a parameter with a match kind other than: exact or ambiguous
+        public bool HasParameterMismatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter
+                                                                && (x.Kind != MatchKind.Exact && x.Kind != MatchKind.AmbiguousParameterValue));
 
-        // There is at least one parameter match And all parameter matches are exact
-        public bool IsParameterMatch => !HasParameterMismatch && MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter);
+        // For choice parameters - when the value provided is the start of multiple choice values.
+        public bool HasAmbiguousParameterValueMatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.AmbiguousParameterValue);
 
-        public bool HasInvalidParameterValue => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.InvalidParameterValue);
+        public bool IsInvokableMatch => MatchDisposition.Count > 0
+                                    && MatchDisposition.All(x =>
+                                        x.Kind == MatchKind.Exact
+                                        ||
+                                        (   // these locations can have partial or exact matches.
+                                            x.Kind == MatchKind.Partial
+                                            && (x.Location == MatchLocation.Name || x.Location == MatchLocation.ShortName || x.Location == MatchLocation.Classification)
+                                        )
+                                    );
 
-        public bool HasAmbiguousParameterMatch => !HasInvalidParameterValue && MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.AmbiguousParameterValue);
+        // a list of the invalid parameter names for the template, if any.
+        // analogous to INewCommandInput.RemainingArguments
+        public IReadOnlyList<string> InvalidParameterNames => MatchDisposition.Where(x => x.Kind == MatchKind.InvalidParameterName)
+                                                                            .Select(x => x.ChoiceIfLocationIsOtherChoice).ToList();
+
+        public bool HasParseError => MatchDisposition.Any(x => x.Kind == MatchKind.Unspecified);
+
+        public string ParseError => MatchDisposition.Where(x => x.Kind == MatchKind.Unspecified).Select(x => x.AdditionalInformation).FirstOrDefault();
+
+        public IReadOnlyDictionary<string, string> ValidTemplateParameters
+                    => MatchDisposition.Where(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.Exact)
+                        .ToDictionary(x => x.ChoiceIfLocationIsOtherChoice, x => x.ParameterValue);
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/FilteredTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/FilteredTemplateInfo.cs
@@ -13,88 +13,26 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         public FilteredTemplateInfo(ITemplateInfo info, IReadOnlyList<MatchInfo> matchDisposition)
         {
             Info = info;
-            if (matchDisposition != null)
-            {
-                _matchDisposition = matchDisposition.ToList();
-            }
-            else
-            {
-                _matchDisposition = new List<MatchInfo>();
-            }
-
-            _dispositionOfDefaults = new List<MatchInfo>();
+            MatchDisposition = matchDisposition;
         }
 
         public ITemplateInfo Info { get; }
 
-        public IReadOnlyList<MatchInfo> MatchDisposition
-        {
-            get
-            {
-                return _matchDisposition.ToList();
-            }
-        }
-        private IList<MatchInfo> _matchDisposition;
+        public IReadOnlyList<MatchInfo> MatchDisposition { get; set; }
 
-        // Stores match info relative to default settings.
-        // These don't have to match for the template to be a match, but they can be used to filter matches
-        // in appropriate situations.
-        // For example, matching or non-matching on the default language should only be used as a final disambiguator.
-        // It shouldn't unconditionally disqualify a match.
-        public IReadOnlyList<MatchInfo> DispositionOfDefaults
-        {
-            get
-            {
-                return _dispositionOfDefaults.ToList();
-            }
-        }
-        private IList<MatchInfo> _dispositionOfDefaults;
-
-        public void AddDisposition(MatchInfo newDisposition)
-        {
-            _matchDisposition.Add(newDisposition);
-        }
-
-        public void AddDefaultDisposition(MatchInfo newDisposition)
-        {
-            _dispositionOfDefaults.Add(newDisposition);
-        }
-
-        // TODO: get rid of, or rename this. "IsMatch" has become a misnomer as the system has evolved.
         public bool IsMatch => MatchDisposition.Count > 0 && !MatchDisposition.Any(x => x.Kind == MatchKind.Mismatch);
 
         public bool IsPartialMatch => MatchDisposition.Any(x => x.Kind != MatchKind.Mismatch)
             && MatchDisposition.All(x => x.Location != MatchLocation.Context
                                 || (x.Location == MatchLocation.Context && x.Kind == MatchKind.Exact));
 
-        // There is a parameter with a match kind other than: exact or ambiguous
-        public bool HasParameterMismatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter
-                                                                && (x.Kind != MatchKind.Exact && x.Kind != MatchKind.AmbiguousParameterValue));
-
-        // For choice parameters - when the value provided is the start of multiple choice values.
-        public bool HasAmbiguousParameterValueMatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.AmbiguousParameterValue);
-
-        public bool IsInvokableMatch => MatchDisposition.Count > 0
-                                    && MatchDisposition.All(x =>
-                                        x.Kind == MatchKind.Exact
-                                        ||
-                                        (   // these locations can have partial or exact matches.
-                                            x.Kind == MatchKind.Partial
-                                            && (x.Location == MatchLocation.Name || x.Location == MatchLocation.ShortName || x.Location == MatchLocation.Classification)
-                                        )
-                                    );
-
-        // a list of the invalid parameter names for the template, if any.
-        // analogous to INewCommandInput.RemainingArguments
-        public IReadOnlyList<string> InvalidParameterNames => MatchDisposition.Where(x => x.Kind == MatchKind.InvalidParameterName)
-                                                                            .Select(x => x.ChoiceIfLocationIsOtherChoice).ToList();
+        // All parameter matches are exact (or there are no parameter matches)
+        public bool HasParameterMismatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind != MatchKind.Exact);
 
         public bool IsParameterMatch => !HasParameterMismatch && MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter);
 
-        public string ParseError => MatchDisposition.Where(x => x.Kind == MatchKind.Unspecified).Select(x => x.AdditionalInformation).FirstOrDefault();
+        public bool HasInvalidParameterValue => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.InvalidParameterValue);
 
-        public IReadOnlyDictionary<string, string> ValidTemplateParameters
-                    => MatchDisposition.Where(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.Exact)
-                        .ToDictionary(x => x.ChoiceIfLocationIsOtherChoice, x => x.ParameterValue);
+        public bool HasAmbiguousParameterMatch => !HasInvalidParameterValue && MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.AmbiguousParameterValue);
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/FilteredTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/FilteredTemplateInfo.cs
@@ -13,88 +13,26 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         public FilteredTemplateInfo(ITemplateInfo info, IReadOnlyList<MatchInfo> matchDisposition)
         {
             Info = info;
-            if (matchDisposition != null)
-            {
-                _matchDisposition = matchDisposition.ToList();
-            }
-            else
-            {
-                _matchDisposition = new List<MatchInfo>();
-            }
-
-            _dispositionOfDefaults = new List<MatchInfo>();
+            MatchDisposition = matchDisposition;
         }
 
         public ITemplateInfo Info { get; }
 
-        public IReadOnlyList<MatchInfo> MatchDisposition
-        {
-            get
-            {
-                return _matchDisposition.ToList();
-            }
-        }
-        private IList<MatchInfo> _matchDisposition;
+        public IReadOnlyList<MatchInfo> MatchDisposition { get; set; }
 
-        // Stores match info relative to default settings.
-        // These don't have to match for the template to be a match, but they can be used to filter matches
-        // in appropriate situations.
-        // For example, matching or non-matching on the default language should only be used as a final disambiguator.
-        // It shouldn't unconditionally disqualify a match.
-        public IReadOnlyList<MatchInfo> DispositionOfDefaults
-        {
-            get
-            {
-                return _dispositionOfDefaults.ToList();
-            }
-        }
-        private IList<MatchInfo> _dispositionOfDefaults;
-
-        public void AddDisposition(MatchInfo newDisposition)
-        {
-            _matchDisposition.Add(newDisposition);
-        }
-
-        public void AddDefaultDisposition(MatchInfo newDisposition)
-        {
-            _dispositionOfDefaults.Add(newDisposition);
-        }
-
-        // TODO: get rid of, or rename this. "IsMatch" has become a misnomer as the system has evolved.
         public bool IsMatch => MatchDisposition.Count > 0 && !MatchDisposition.Any(x => x.Kind == MatchKind.Mismatch);
 
         public bool IsPartialMatch => MatchDisposition.Any(x => x.Kind != MatchKind.Mismatch)
             && MatchDisposition.All(x => x.Location != MatchLocation.Context
                                 || (x.Location == MatchLocation.Context && x.Kind == MatchKind.Exact));
 
-        // There is a parameter with a match kind other than: exact or ambiguous
-        public bool HasParameterMismatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter
-                                                                && (x.Kind != MatchKind.Exact && x.Kind != MatchKind.AmbiguousParameterValue));
+        // All parameter matches are exact (or there are no parameter matches)
+        public bool HasParameterMismatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind != MatchKind.Exact);
 
-        // For choice parameters - when the value provided is the start of multiple choice values.
-        public bool HasAmbiguousParameterValueMatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.AmbiguousParameterValue);
+        public bool IsParameterMatch => !HasParameterMismatch && MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter);
 
-        public bool IsInvokableMatch => MatchDisposition.Count > 0
-                                    && MatchDisposition.All(x =>
-                                        x.Kind == MatchKind.Exact
-                                        ||
-                                        (   // these locations can have partial or exact matches.
-                                            x.Kind == MatchKind.Partial
-                                            && (x.Location == MatchLocation.Name || x.Location == MatchLocation.ShortName || x.Location == MatchLocation.Classification)
-                                        )
-                                    );
+        public bool HasInvalidParameterValue => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.InvalidParameterValue);
 
-        // a list of the invalid parameter names for the template, if any.
-        // analogous to INewCommandInput.RemainingArguments
-        public IReadOnlyList<string> InvalidParameterNames => MatchDisposition.Where(x => x.Kind == MatchKind.InvalidParameterName)
-                                                                            .Select(x => x.ChoiceIfLocationIsOtherChoice).ToList();
-
-        public bool HasParseError => MatchDisposition.Any(x => x.Kind == MatchKind.Unspecified);
-
-        public string ParseError => MatchDisposition.Where(x => x.Kind == MatchKind.Unspecified).Select(x => x.AdditionalInformation).FirstOrDefault();
-
-        public IReadOnlyDictionary<string, string> ValidTemplateParameters
-                    => MatchDisposition.Where(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.Exact)
-                        .ToDictionary(x => x.ChoiceIfLocationIsOtherChoice, x => x.ParameterValue);
+        public bool HasAmbiguousParameterMatch => !HasInvalidParameterValue && MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.AmbiguousParameterValue);
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/FilteredTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/FilteredTemplateInfo.cs
@@ -13,26 +13,88 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         public FilteredTemplateInfo(ITemplateInfo info, IReadOnlyList<MatchInfo> matchDisposition)
         {
             Info = info;
-            MatchDisposition = matchDisposition;
+            if (matchDisposition != null)
+            {
+                _matchDisposition = matchDisposition.ToList();
+            }
+            else
+            {
+                _matchDisposition = new List<MatchInfo>();
+            }
+
+            _dispositionOfDefaults = new List<MatchInfo>();
         }
 
         public ITemplateInfo Info { get; }
 
-        public IReadOnlyList<MatchInfo> MatchDisposition { get; set; }
+        public IReadOnlyList<MatchInfo> MatchDisposition
+        {
+            get
+            {
+                return _matchDisposition.ToList();
+            }
+        }
+        private IList<MatchInfo> _matchDisposition;
 
+        // Stores match info relative to default settings.
+        // These don't have to match for the template to be a match, but they can be used to filter matches
+        // in appropriate situations.
+        // For example, matching or non-matching on the default language should only be used as a final disambiguator.
+        // It shouldn't unconditionally disqualify a match.
+        public IReadOnlyList<MatchInfo> DispositionOfDefaults
+        {
+            get
+            {
+                return _dispositionOfDefaults.ToList();
+            }
+        }
+        private IList<MatchInfo> _dispositionOfDefaults;
+
+        public void AddDisposition(MatchInfo newDisposition)
+        {
+            _matchDisposition.Add(newDisposition);
+        }
+
+        public void AddDefaultDisposition(MatchInfo newDisposition)
+        {
+            _dispositionOfDefaults.Add(newDisposition);
+        }
+
+        // TODO: get rid of, or rename this. "IsMatch" has become a misnomer as the system has evolved.
         public bool IsMatch => MatchDisposition.Count > 0 && !MatchDisposition.Any(x => x.Kind == MatchKind.Mismatch);
 
         public bool IsPartialMatch => MatchDisposition.Any(x => x.Kind != MatchKind.Mismatch)
             && MatchDisposition.All(x => x.Location != MatchLocation.Context
                                 || (x.Location == MatchLocation.Context && x.Kind == MatchKind.Exact));
 
-        // All parameter matches are exact (or there are no parameter matches)
-        public bool HasParameterMismatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind != MatchKind.Exact);
+        // There is a parameter with a match kind other than: exact or ambiguous
+        public bool HasParameterMismatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter
+                                                                && (x.Kind != MatchKind.Exact && x.Kind != MatchKind.AmbiguousParameterValue));
+
+        // For choice parameters - when the value provided is the start of multiple choice values.
+        public bool HasAmbiguousParameterValueMatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.AmbiguousParameterValue);
+
+        public bool IsInvokableMatch => MatchDisposition.Count > 0
+                                    && MatchDisposition.All(x =>
+                                        x.Kind == MatchKind.Exact
+                                        ||
+                                        (   // these locations can have partial or exact matches.
+                                            x.Kind == MatchKind.Partial
+                                            && (x.Location == MatchLocation.Name || x.Location == MatchLocation.ShortName || x.Location == MatchLocation.Classification)
+                                        )
+                                    );
+
+        // a list of the invalid parameter names for the template, if any.
+        // analogous to INewCommandInput.RemainingArguments
+        public IReadOnlyList<string> InvalidParameterNames => MatchDisposition.Where(x => x.Kind == MatchKind.InvalidParameterName)
+                                                                            .Select(x => x.ChoiceIfLocationIsOtherChoice).ToList();
 
         public bool IsParameterMatch => !HasParameterMismatch && MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter);
 
-        public bool HasInvalidParameterValue => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.InvalidParameterValue);
+        public string ParseError => MatchDisposition.Where(x => x.Kind == MatchKind.Unspecified).Select(x => x.AdditionalInformation).FirstOrDefault();
 
-        public bool HasAmbiguousParameterMatch => !HasInvalidParameterValue && MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.AmbiguousParameterValue);
+        public IReadOnlyDictionary<string, string> ValidTemplateParameters
+                    => MatchDisposition.Where(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.Exact)
+                        .ToDictionary(x => x.ChoiceIfLocationIsOtherChoice, x => x.ParameterValue);
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/FilteredTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/FilteredTemplateInfo.cs
@@ -13,26 +13,88 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         public FilteredTemplateInfo(ITemplateInfo info, IReadOnlyList<MatchInfo> matchDisposition)
         {
             Info = info;
-            MatchDisposition = matchDisposition;
+            if (matchDisposition != null)
+            {
+                _matchDisposition = matchDisposition.ToList();
+            }
+            else
+            {
+                _matchDisposition = new List<MatchInfo>();
+            }
+
+            _dispositionOfDefaults = new List<MatchInfo>();
         }
 
         public ITemplateInfo Info { get; }
 
-        public IReadOnlyList<MatchInfo> MatchDisposition { get; set; }
+        public IReadOnlyList<MatchInfo> MatchDisposition
+        {
+            get
+            {
+                return _matchDisposition.ToList();
+            }
+        }
+        private IList<MatchInfo> _matchDisposition;
 
+        // Stores match info relative to default settings.
+        // These don't have to match for the template to be a match, but they can be used to filter matches
+        // in appropriate situations.
+        // For example, matching or non-matching on the default language should only be used as a final disambiguator.
+        // It shouldn't unconditionally disqualify a match.
+        public IReadOnlyList<MatchInfo> DispositionOfDefaults
+        {
+            get
+            {
+                return _dispositionOfDefaults.ToList();
+            }
+        }
+        private IList<MatchInfo> _dispositionOfDefaults;
+
+        public void AddDisposition(MatchInfo newDisposition)
+        {
+            _matchDisposition.Add(newDisposition);
+        }
+
+        public void AddDefaultDisposition(MatchInfo newDisposition)
+        {
+            _dispositionOfDefaults.Add(newDisposition);
+        }
+
+        // TODO: get rid of, or rename this. "IsMatch" has become a misnomer as the system has evolved.
         public bool IsMatch => MatchDisposition.Count > 0 && !MatchDisposition.Any(x => x.Kind == MatchKind.Mismatch);
 
         public bool IsPartialMatch => MatchDisposition.Any(x => x.Kind != MatchKind.Mismatch)
             && MatchDisposition.All(x => x.Location != MatchLocation.Context
                                 || (x.Location == MatchLocation.Context && x.Kind == MatchKind.Exact));
 
-        // All parameter matches are exact (or there are no parameter matches)
-        public bool HasParameterMismatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind != MatchKind.Exact);
+        // There is a parameter with a match kind other than: exact or ambiguous
+        public bool HasParameterMismatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter
+                                                                && (x.Kind != MatchKind.Exact && x.Kind != MatchKind.AmbiguousParameterValue));
 
-        public bool IsParameterMatch => !HasParameterMismatch && MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter);
+        // For choice parameters - when the value provided is the start of multiple choice values.
+        public bool HasAmbiguousParameterValueMatch => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.AmbiguousParameterValue);
 
-        public bool HasInvalidParameterValue => MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.InvalidParameterValue);
+        public bool IsInvokableMatch => MatchDisposition.Count > 0
+                                    && MatchDisposition.All(x =>
+                                        x.Kind == MatchKind.Exact
+                                        ||
+                                        (   // these locations can have partial or exact matches.
+                                            x.Kind == MatchKind.Partial
+                                            && (x.Location == MatchLocation.Name || x.Location == MatchLocation.ShortName || x.Location == MatchLocation.Classification)
+                                        )
+                                    );
 
-        public bool HasAmbiguousParameterMatch => !HasInvalidParameterValue && MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.AmbiguousParameterValue);
+        // a list of the invalid parameter names for the template, if any.
+        // analogous to INewCommandInput.RemainingArguments
+        public IReadOnlyList<string> InvalidParameterNames => MatchDisposition.Where(x => x.Kind == MatchKind.InvalidParameterName)
+                                                                            .Select(x => x.ChoiceIfLocationIsOtherChoice).ToList();
+
+        public bool HasParseError => MatchDisposition.Any(x => x.Kind == MatchKind.Unspecified);
+
+        public string ParseError => MatchDisposition.Where(x => x.Kind == MatchKind.Unspecified).Select(x => x.AdditionalInformation).FirstOrDefault();
+
+        public IReadOnlyDictionary<string, string> ValidTemplateParameters
+                    => MatchDisposition.Where(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.Exact)
+                        .ToDictionary(x => x.ChoiceIfLocationIsOtherChoice, x => x.ParameterValue);
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateMatchInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateMatchInfo.cs
@@ -1,0 +1,75 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Edge.Template;
+
+namespace Microsoft.TemplateEngine.Edge.Settings
+{
+    public class TemplateMatchInfo : ITemplateMatchInfo
+    {
+        public TemplateMatchInfo(ITemplateInfo info, IReadOnlyList<MatchInfo> matchDispositions)
+            : this(info)
+        {
+            if (matchDispositions != null)
+            {
+                foreach (MatchInfo disposition in matchDispositions)
+                {
+                    AddDisposition(disposition);
+                }
+            }
+        }
+
+        public TemplateMatchInfo(ITemplateInfo info)
+        {
+            Info = info;
+            _matchDisposition = new List<MatchInfo>();
+            _dispositionOfDefaults = new List<MatchInfo>();
+        }
+
+        public ITemplateInfo Info { get; }
+
+        public IReadOnlyList<MatchInfo> MatchDisposition
+        {
+            get
+            {
+                return _matchDisposition.ToList();
+            }
+        }
+        private IList<MatchInfo> _matchDisposition;
+
+        // Stores match info relative to default settings.
+        // These don't have to match for the template to be a match, but they can be used to filter matches
+        // in appropriate situations.
+        // For example, matching or non-matching on the default language should only be used as a final disambiguator.
+        // It shouldn't unconditionally disqualify a match.
+        public IReadOnlyList<MatchInfo> DispositionOfDefaults
+        {
+            get
+            {
+                return _dispositionOfDefaults.ToList();
+            }
+        }
+        private IList<MatchInfo> _dispositionOfDefaults;
+
+        public void AddDisposition(MatchInfo newDisposition)
+        {
+            if (newDisposition.Location == MatchLocation.DefaultLanguage)
+            {
+                _dispositionOfDefaults.Add(newDisposition);
+            }
+            else
+            {
+                _matchDisposition.Add(newDisposition);
+            }
+        }
+
+        public bool IsMatch => MatchDisposition.Count > 0 && !MatchDisposition.Any(x => x.Kind == MatchKind.Mismatch);
+
+        public bool IsPartialMatch => MatchDisposition.Any(x => x.Kind != MatchKind.Mismatch)
+                                    && MatchDisposition.All(x => x.Location != MatchLocation.Context
+                                        || (x.Location == MatchLocation.Context && x.Kind == MatchKind.Exact));
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateMatchInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateMatchInfo.cs
@@ -31,13 +31,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
         public ITemplateInfo Info { get; }
 
-        public IReadOnlyList<MatchInfo> MatchDisposition
-        {
-            get
-            {
-                return _matchDisposition.ToList();
-            }
-        }
+        public IReadOnlyList<MatchInfo> MatchDisposition => _matchDisposition.ToList();
         private IList<MatchInfo> _matchDisposition;
 
         // Stores match info relative to default settings.
@@ -45,13 +39,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         // in appropriate situations.
         // For example, matching or non-matching on the default language should only be used as a final disambiguator.
         // It shouldn't unconditionally disqualify a match.
-        public IReadOnlyList<MatchInfo> DispositionOfDefaults
-        {
-            get
-            {
-                return _dispositionOfDefaults.ToList();
-            }
-        }
+        public IReadOnlyList<MatchInfo> DispositionOfDefaults => _dispositionOfDefaults.ToList();
         private IList<MatchInfo> _dispositionOfDefaults;
 
         public void AddDisposition(MatchInfo newDisposition)
@@ -66,7 +54,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
         }
 
-        public bool IsMatch => MatchDisposition.Count > 0 && !MatchDisposition.Any(x => x.Kind == MatchKind.Mismatch);
+        public bool IsMatch => MatchDisposition.Count > 0 && MatchDisposition.All(x => x.Kind != MatchKind.Mismatch);
 
         public bool IsPartialMatch => MatchDisposition.Any(x => x.Kind != MatchKind.Mismatch)
                                     && MatchDisposition.All(x => x.Location != MatchLocation.Context

--- a/src/Microsoft.TemplateEngine.Edge/Template/IFilteredTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/IFilteredTemplateInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Edge.Template
@@ -9,16 +9,29 @@ namespace Microsoft.TemplateEngine.Edge.Template
 
         IReadOnlyList<MatchInfo> MatchDisposition { get; }
 
+        IReadOnlyList<MatchInfo> DispositionOfDefaults { get; }
+
+        void AddDisposition(MatchInfo newDisposition);
+
+        void AddDefaultDisposition(MatchInfo newDisposition);
+
         bool IsMatch { get; }
 
         bool IsPartialMatch { get; }
 
         bool HasParameterMismatch { get; }
 
-        bool IsParameterMatch { get; }
+        bool IsInvokableMatch { get; }
 
-        bool HasInvalidParameterValue { get; }
+        bool HasAmbiguousParameterValueMatch { get; }
 
-        bool HasAmbiguousParameterMatch { get; }
+        IReadOnlyList<string> InvalidParameterNames { get; }
+
+        bool HasParseError { get; }
+
+        string ParseError { get; }
+
+        // This is analogous to INewCommandInput.InputTemplateParams
+        IReadOnlyDictionary<string, string> ValidTemplateParameters { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Template/IFilteredTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/IFilteredTemplateInfo.cs
@@ -9,29 +9,16 @@ namespace Microsoft.TemplateEngine.Edge.Template
 
         IReadOnlyList<MatchInfo> MatchDisposition { get; }
 
-        IReadOnlyList<MatchInfo> DispositionOfDefaults { get; }
-
-        void AddDisposition(MatchInfo newDisposition);
-
-        void AddDefaultDisposition(MatchInfo newDisposition);
-
         bool IsMatch { get; }
 
         bool IsPartialMatch { get; }
 
         bool HasParameterMismatch { get; }
 
-        bool IsInvokableMatch { get; }
+        bool IsParameterMatch { get; }
 
-        bool HasAmbiguousParameterValueMatch { get; }
+        bool HasInvalidParameterValue { get; }
 
-        IReadOnlyList<string> InvalidParameterNames { get; }
-
-        bool HasParseError { get; }
-
-        string ParseError { get; }
-
-        // This is analogous to INewCommandInput.InputTemplateParams
-        IReadOnlyDictionary<string, string> ValidTemplateParameters { get; }
+        bool HasAmbiguousParameterMatch { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Template/IFilteredTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/IFilteredTemplateInfo.cs
@@ -9,16 +9,29 @@ namespace Microsoft.TemplateEngine.Edge.Template
 
         IReadOnlyList<MatchInfo> MatchDisposition { get; }
 
+        IReadOnlyList<MatchInfo> DispositionOfDefaults { get; }
+
+        void AddDisposition(MatchInfo newDisposition);
+
+        void AddDefaultDisposition(MatchInfo newDisposition);
+
         bool IsMatch { get; }
 
         bool IsPartialMatch { get; }
 
         bool HasParameterMismatch { get; }
 
-        bool IsParameterMatch { get; }
+        bool IsInvokableMatch { get; }
 
-        bool HasInvalidParameterValue { get; }
+        bool HasAmbiguousParameterValueMatch { get; }
 
-        bool HasAmbiguousParameterMatch { get; }
+        IReadOnlyList<string> InvalidParameterNames { get; }
+
+        bool HasParseError { get; }
+
+        string ParseError { get; }
+
+        // This is analogous to INewCommandInput.InputTemplateParams
+        IReadOnlyDictionary<string, string> ValidTemplateParameters { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Template/ITemplateMatchInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/ITemplateMatchInfo.cs
@@ -1,0 +1,23 @@
+using Microsoft.TemplateEngine.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.TemplateEngine.Edge.Template
+{
+    // Replacement for IFilteredTemplateInfo
+    public interface ITemplateMatchInfo
+    {
+        ITemplateInfo Info { get; }
+
+        IReadOnlyList<MatchInfo> MatchDisposition { get; }
+
+        IReadOnlyList<MatchInfo> DispositionOfDefaults { get; }
+
+        void AddDisposition(MatchInfo newDisposition);
+
+        bool IsMatch { get; }
+
+        bool IsPartialMatch { get; }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Template/ITemplateMatchInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/ITemplateMatchInfo.cs
@@ -1,7 +1,5 @@
-using Microsoft.TemplateEngine.Abstractions;
-using System;
 using System.Collections.Generic;
-using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Edge.Template
 {

--- a/src/Microsoft.TemplateEngine.Edge/Template/MatchInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/MatchInfo.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.TemplateEngine.Edge.Template
+namespace Microsoft.TemplateEngine.Edge.Template
 {
     public struct MatchInfo
     {
@@ -6,6 +6,14 @@
 
         public MatchKind Kind;
 
+        // TODO: Rename - this always represents the input parameter name.
+        // This is an outward facing assembly, so we will have to wait for a major version release to change it.
+        // If we can, should be "InputParameterName"
         public string ChoiceIfLocationIsOtherChoice;
+
+        public string ParameterValue;
+
+        // Stores the exception message if there is an args parse error.
+        public string AdditionalInformation;
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Template/MatchInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/MatchInfo.cs
@@ -1,5 +1,8 @@
+using System.Runtime.InteropServices;
+
 namespace Microsoft.TemplateEngine.Edge.Template
 {
+    [StructLayout(LayoutKind.Sequential)]
     public struct MatchInfo
     {
         public MatchLocation Location;

--- a/src/Microsoft.TemplateEngine.Edge/Template/MatchKind.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/MatchKind.cs
@@ -1,9 +1,9 @@
-﻿namespace Microsoft.TemplateEngine.Edge.Template
+namespace Microsoft.TemplateEngine.Edge.Template
 {
 
     public enum MatchKind
     {
-        Unspecified,
+        Unspecified,    // TODO: rename to "ParseError". Will have to be done for a major version release.
         Exact,
         Partial,
         AmbiguousParameterValue,

--- a/src/Microsoft.TemplateEngine.Edge/Template/MatchLocation.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/MatchLocation.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.TemplateEngine.Edge.Template
+namespace Microsoft.TemplateEngine.Edge.Template
 {
 
     public enum MatchLocation
@@ -8,9 +8,10 @@
         ShortName,
         Alias,
         Classification,
-        Language,
+        Language,   // this is meant for the input language
         Context,
         OtherParameter,
-        Baseline
+        Baseline,
+        DefaultLanguage
     }    
 }

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateMatchInfoEqualityComparer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateMatchInfoEqualityComparer.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.TemplateEngine.Edge.Template
+{
+    public class TemplateMatchInfoEqualityComparer : IEqualityComparer<ITemplateMatchInfo>
+    {
+        public static IEqualityComparer<ITemplateMatchInfo> Default { get; } = new TemplateMatchInfoEqualityComparer();
+
+        public bool Equals(ITemplateMatchInfo x, ITemplateMatchInfo y)
+        {
+            return ReferenceEquals(x.Info, y.Info) || (x != null && y != null && x.Info != null && y.Info != null && string.Equals(x.Info.Identity, y.Info.Identity, StringComparison.Ordinal));
+        }
+
+        public int GetHashCode(ITemplateMatchInfo obj)
+        {
+            return obj?.Info?.Identity?.GetHashCode() ?? 0;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateMatchInfoEqualityComparer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateMatchInfoEqualityComparer.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
 
         public bool Equals(ITemplateMatchInfo x, ITemplateMatchInfo y)
         {
-            return ReferenceEquals(x.Info, y.Info) || (x != null && y != null && x.Info != null && y.Info != null && string.Equals(x.Info.Identity, y.Info.Identity, StringComparison.Ordinal));
+            return ReferenceEquals(x?.Info, y?.Info) || (x != null && y != null && x?.Info != null && y?.Info != null && string.Equals(x?.Info?.Identity, y?.Info?.Identity, StringComparison.Ordinal));
         }
 
         public int GetHashCode(ITemplateMatchInfo obj)

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -19,10 +19,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
         {
             _rawParameterInputs = rawParameterInputs;
 
-            AllTemplateParams = new Dictionary<string, string>();
+            InputTemplateParams = new Dictionary<string, string>();
             RemainingParameters = new Dictionary<string, IList<string>>();
             RemainingArguments = new List<string>();
+            _allParametersForTemplate = new List<string>();
         }
+
+        // a list of all the parameters defined by the template
+        private IReadOnlyList<string> _allParametersForTemplate;
 
         private IReadOnlyDictionary<string, string> _rawParameterInputs;
 
@@ -68,7 +72,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 
         public string AllowScriptsToRun { get; set; }
 
-        public IReadOnlyDictionary<string, string> AllTemplateParams { get; set; }
+        public IReadOnlyDictionary<string, string> InputTemplateParams { get; set; }
 
         public List<string> RemainingArguments { get; set; }
 
@@ -119,9 +123,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
                 }
             }
 
-            AllTemplateParams = templateParamValues;
+            InputTemplateParams = templateParamValues;
             RemainingParameters = remainingParams;
             RemainingArguments = remainingParams.Keys.ToList();
+
+            _allParametersForTemplate = templateInfo.Parameters.Select(x => x.Name).ToList();
         }
 
         public void ResetArgs(params string[] args)
@@ -145,11 +151,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
         }
 
         // Note: This doesn't really deal with variants.
-        // If the input "variant" is in the inputs, return true with the canonical set to the variant.
+        // If the input "variant" is a parameter for the template, return true with the canonical set to the variant.
         // Otherwise return false with the canonical as null.
         public bool TryGetCanonicalNameForVariant(string variant, out string canonical)
         {
-            if (_rawParameterInputs.ContainsKey(variant))
+            if (_allParametersForTemplate.Contains(variant))
             {
                 canonical = variant;
                 return true;

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/HelpForTemplateResolutionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/HelpForTemplateResolutionTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.Edge.Template;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
+{
+    public class HelpForTemplateResolutionTests
+    {
+        [Fact(DisplayName = nameof(GetParametersInvalidForTemplatesInListTest))]
+        public void GetParametersInvalidForTemplatesInListTest()
+        {
+            List<ITemplateMatchInfo> matchInfo = new List<ITemplateMatchInfo>();
+
+            // template one
+            List<MatchInfo> templateOneDispositions = new List<MatchInfo>();
+            templateOneDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, ChoiceIfLocationIsOtherChoice = "foo" });
+            templateOneDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, ChoiceIfLocationIsOtherChoice = "bar" });
+            ITemplateMatchInfo templateOneMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateOneDispositions);
+            matchInfo.Add(templateOneMatchInfo);
+
+            // template two
+            List<MatchInfo> templateTwoDispositions = new List<MatchInfo>();
+            templateTwoDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, ChoiceIfLocationIsOtherChoice = "foo" });
+            ITemplateMatchInfo templateTwoMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateTwoDispositions);
+            matchInfo.Add(templateTwoMatchInfo);
+
+            // template three
+            List<MatchInfo> templateThreeDispositions = new List<MatchInfo>();
+            templateThreeDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, ChoiceIfLocationIsOtherChoice = "foo" });
+            templateThreeDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, ChoiceIfLocationIsOtherChoice = "baz" });
+            ITemplateMatchInfo templateThreeMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateThreeDispositions);
+            matchInfo.Add(templateThreeMatchInfo);
+
+            HelpForTemplateResolution.GetParametersInvalidForTemplatesInList(matchInfo, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
+
+            Assert.Equal(1, invalidForAllTemplates.Count);
+            Assert.True(invalidForAllTemplates.Contains("foo"));
+
+            Assert.Equal(2, invalidForSomeTemplates.Count);
+            Assert.True(invalidForSomeTemplates.Contains("bar"));
+            Assert.True(invalidForSomeTemplates.Contains("baz"));
+        }
+
+        [Fact(DisplayName = nameof(GetParametersInvalidForTemplatesInList_NoneForAllTest))]
+        public void GetParametersInvalidForTemplatesInList_NoneForAllTest()
+        {
+            List<ITemplateMatchInfo> matchInfo = new List<ITemplateMatchInfo>();
+
+            // template one
+            List<MatchInfo> templateOneDispositions = new List<MatchInfo>();
+            templateOneDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, ChoiceIfLocationIsOtherChoice = "foo" });
+            templateOneDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, ChoiceIfLocationIsOtherChoice = "bar" });
+            ITemplateMatchInfo templateOneMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateOneDispositions);
+            matchInfo.Add(templateOneMatchInfo);
+
+            // template two
+            List<MatchInfo> templateTwoDispositions = new List<MatchInfo>();
+            ITemplateMatchInfo templateTwoMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateTwoDispositions);
+            matchInfo.Add(templateTwoMatchInfo);
+
+            HelpForTemplateResolution.GetParametersInvalidForTemplatesInList(matchInfo, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
+
+            Assert.Equal(0, invalidForAllTemplates.Count);
+
+            Assert.Equal(2, invalidForSomeTemplates.Count);
+            Assert.True(invalidForSomeTemplates.Contains("foo"));
+            Assert.True(invalidForSomeTemplates.Contains("bar"));
+        }
+
+        [Fact(DisplayName = nameof(GetParametersInvalidForTemplatesInList_NoneForSomeTest))]
+        public void GetParametersInvalidForTemplatesInList_NoneForSomeTest()
+        {
+            List<ITemplateMatchInfo> matchInfo = new List<ITemplateMatchInfo>();
+
+            // template one
+            List<MatchInfo> templateOneDispositions = new List<MatchInfo>();
+            templateOneDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, ChoiceIfLocationIsOtherChoice = "foo" });
+            ITemplateMatchInfo templateOneMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateOneDispositions);
+            matchInfo.Add(templateOneMatchInfo);
+
+            // template two
+            List<MatchInfo> templateTwoDispositions = new List<MatchInfo>();
+            templateTwoDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, ChoiceIfLocationIsOtherChoice = "foo" });
+            ITemplateMatchInfo templateTwoMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateTwoDispositions);
+            matchInfo.Add(templateTwoMatchInfo);
+
+            HelpForTemplateResolution.GetParametersInvalidForTemplatesInList(matchInfo, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
+
+            Assert.Equal(1, invalidForAllTemplates.Count);
+            Assert.True(invalidForAllTemplates.Contains("foo"));
+
+            Assert.Equal(0, invalidForSomeTemplates.Count);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateListResolverTests.cs
@@ -160,12 +160,16 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 ShortName = "Template1",
                 Name = "Long name of Template1",
                 Identity = "Template1",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+                Tags = new Dictionary<string, ICacheTag>()
             });
             templatesToSearch.Add(new TemplateInfo()
             {
                 ShortName = "Template2",
                 Name = "Long name of Template2",
                 Identity = "Template2",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+                Tags = new Dictionary<string, ICacheTag>()
             });
 
             INewCommandInput userInputs = new MockNewCommandInput()
@@ -174,11 +178,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             };
 
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
-            Assert.Equal(null, matchResult.MatchedTemplatesWithSecondaryMatchInfo);
+
             Assert.Equal(1, matchResult.CoreMatchedTemplates.Count);
-            Assert.Equal(1, matchResult.UnambiguousTemplateGroupToUse.Count);
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.Equal(1, unambiguousGroup.Count);
             Assert.Equal("Template2", matchResult.CoreMatchedTemplates[0].Info.Identity);
-            Assert.Equal("Template2", matchResult.UnambiguousTemplateGroupToUse[0].Info.Identity);
+            Assert.Equal("Template2", unambiguousGroup[0].Info.Identity);
         }
 
         [Fact(DisplayName = nameof(TestPerformCoreTemplateQuery_DefaultLanguageDisambiguates))]
@@ -194,7 +199,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "language", CreateTestCacheTag("Perl") }
-                }
+                },
+                CacheParameters = new Dictionary<string, ICacheParameter>()
             });
             templatesToSearch.Add(new TemplateInfo()
             {
@@ -205,7 +211,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "language", CreateTestCacheTag("LISP") }
-                }
+                },
+                CacheParameters = new Dictionary<string, ICacheParameter>()
             });
 
             INewCommandInput userInputs = new MockNewCommandInput()
@@ -214,10 +221,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             };
 
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "Perl");
-            Assert.Equal(null, matchResult.MatchedTemplatesWithSecondaryMatchInfo);
             Assert.Equal(2, matchResult.CoreMatchedTemplates.Count);    // they both match the initial query. Default language is secondary
-            Assert.Equal(1, matchResult.UnambiguousTemplateGroupToUse.Count);
-            Assert.Equal("foo.test.Perl", matchResult.UnambiguousTemplateGroupToUse[0].Info.Identity);
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.Equal(1, unambiguousGroup.Count);
+            Assert.Equal("foo.test.Perl", unambiguousGroup[0].Info.Identity);
         }
 
         [Fact(DisplayName = nameof(TestPerformCoreTemplateQuery_InputLanguageIsPreferredOverDefault))]
@@ -233,7 +240,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "language", CreateTestCacheTag("Perl") }
-                }
+                },
+                CacheParameters = new Dictionary<string, ICacheParameter>()
             });
             templatesToSearch.Add(new TemplateInfo()
             {
@@ -244,7 +252,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "language", CreateTestCacheTag("LISP") }
-                }
+                },
+                CacheParameters = new Dictionary<string, ICacheParameter>()
             });
 
             INewCommandInput userInputs = new MockNewCommandInput()
@@ -254,10 +263,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             };
 
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "Perl");
-            Assert.Equal(null, matchResult.MatchedTemplatesWithSecondaryMatchInfo);
+
             Assert.Equal(1, matchResult.CoreMatchedTemplates.Count);    // Input language is part of the initial checks.
-            Assert.Equal(1, matchResult.UnambiguousTemplateGroupToUse.Count);
-            Assert.Equal("foo.test.Lisp", matchResult.UnambiguousTemplateGroupToUse[0].Info.Identity);
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.Equal(1, unambiguousGroup.Count);
+            Assert.Equal("foo.test.Lisp", unambiguousGroup[0].Info.Identity);
         }
 
         [Fact(DisplayName = nameof(TestPerformCoreTemplateQuery_GroupIsFound))]
@@ -270,7 +280,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Name = "Foo template old",
                 Identity = "foo.test.old",
                 GroupIdentity = "foo.test.template",
-                Precedence = 100
+                Precedence = 100,
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+                Tags = new Dictionary<string, ICacheTag>()
             });
             templatesToSearch.Add(new TemplateInfo()
             {
@@ -278,7 +290,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Name = "Foo template new",
                 Identity = "foo.test.new",
                 GroupIdentity = "foo.test.template",
-                Precedence = 200
+                Precedence = 200,
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+                Tags = new Dictionary<string, ICacheTag>()
             });
             templatesToSearch.Add(new TemplateInfo()
             {
@@ -286,7 +300,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Name = "Bar template",
                 Identity = "bar.test",
                 GroupIdentity = "bar.test.template",
-                Precedence = 100
+                Precedence = 100,
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+                Tags = new Dictionary<string, ICacheTag>()
             });
 
             INewCommandInput userInputs = new MockNewCommandInput()
@@ -295,11 +311,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             };
 
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
-            Assert.Equal(2, matchResult.MatchedTemplatesWithSecondaryMatchInfo.Count);
             Assert.Equal(2, matchResult.CoreMatchedTemplates.Count);
-            Assert.Equal(2, matchResult.UnambiguousTemplateGroupToUse.Count);
-            Assert.True(matchResult.UnambiguousTemplateGroupToUse.Any(x => string.Equals(x.Info.Identity, "foo.test.old")));
-            Assert.True(matchResult.UnambiguousTemplateGroupToUse.Any(x => string.Equals(x.Info.Identity, "foo.test.new")));
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.Equal(2, unambiguousGroup.Count);
+            Assert.True(unambiguousGroup.Any(x => string.Equals(x.Info.Identity, "foo.test.old")));
+            Assert.True(unambiguousGroup.Any(x => string.Equals(x.Info.Identity, "foo.test.new")));
         }
 
         [Fact(DisplayName = nameof(TestPerformCoreTemplateQuery_ParameterNameDisambiguates))]
@@ -342,9 +358,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             };
 
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
-            Assert.Equal(2, matchResult.MatchedTemplatesWithSecondaryMatchInfo.Count);
-            Assert.Equal(1, matchResult.UnambiguousTemplateGroupToUse.Count);
-            Assert.Equal("foo.test.new", matchResult.UnambiguousTemplateGroupToUse[0].Info.Identity);
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.Equal(1, unambiguousGroup.Count);
+            Assert.Equal("foo.test.new", unambiguousGroup[0].Info.Identity);
         }
 
         [Fact(DisplayName = nameof(TestPerformCoreTemplateQuery_ParameterValueDisambiguates))]
@@ -389,9 +405,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             };
 
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
-            Assert.Equal(2, matchResult.MatchedTemplatesWithSecondaryMatchInfo.Count);
-            Assert.Equal(1, matchResult.UnambiguousTemplateGroupToUse.Count);
-            Assert.Equal("foo.test.old", matchResult.UnambiguousTemplateGroupToUse[0].Info.Identity);
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.Equal(1, unambiguousGroup.Count);
+            Assert.Equal("foo.test.old", unambiguousGroup[0].Info.Identity);
         }
 
         [Fact(DisplayName = nameof(TestPerformCoreTemplateQuery_UnknownParameterNameInvalidatesMatch))]
@@ -425,18 +441,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
 
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, hostSpecificDataLoader, userInputs, null);
-            Assert.Equal(null, matchResult.MatchedTemplatesWithSecondaryMatchInfo);
-            Assert.Equal(1, matchResult.UnambiguousTemplateGroupToUse.Count);
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.Equal(1, unambiguousGroup.Count);
 
-            // TODO:
-            // These 2 lines are the analogues of what happens in New3Command.EnterSingularTemplateManipulationFlowAsync()
-            //      as a final verification for the template.
-            // This is really a shortcoming of the resolver, this check should get factored into it.
-            // But we'll need to add a new match category so we know that the unambiguous template "matched", except the extra user parameters.
-            HostSpecificTemplateData hostTemplateData = hostSpecificDataLoader.ReadHostSpecificTemplateData(matchResult.UnambiguousTemplateGroupToUse[0].Info);
-            userInputs.ReparseForTemplate(matchResult.UnambiguousTemplateGroupToUse[0].Info, hostTemplateData);
-
-            Assert.False(TemplateListResolver.ValidateRemainingParameters(userInputs, out IReadOnlyList<string> invalidParams));
+            Assert.False(TemplateListResolver.ValidateRemainingParameters(unambiguousGroup[0], out IReadOnlyList<string> invalidParams));
             Assert.Equal(1, invalidParams.Count);
             Assert.Equal("baz", invalidParams[0]);
         }
@@ -483,14 +491,13 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             };
 
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
-
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, hostSpecificDataLoader, userInputs, null);
-            Assert.Equal(2, matchResult.MatchedTemplatesWithSecondaryMatchInfo.Count);
-            Assert.Equal(2, matchResult.UnambiguousTemplateGroupToUse.Count);
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.Equal(2, unambiguousGroup.Count);
             Assert.Equal(2, matchResult.CoreMatchedTemplates.Count);
 
-            Assert.True(matchResult.UnambiguousTemplateGroupToUse[0].MatchDisposition.Any(x => x.Kind == MatchKind.InvalidParameterValue));
-            Assert.True(matchResult.UnambiguousTemplateGroupToUse[1].MatchDisposition.Any(x => x.Kind == MatchKind.InvalidParameterValue));
+            Assert.True(unambiguousGroup[0].MatchDisposition.Any(x => x.Kind == MatchKind.InvalidParameterValue));
+            Assert.True(unambiguousGroup[1].MatchDisposition.Any(x => x.Kind == MatchKind.InvalidParameterValue));
         }
 
         private static ICacheTag CreateTestCacheTag(string choice, string description = null, string defaultValue = null)

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateListResolverTests.cs
@@ -23,8 +23,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(TestFindHighestPrecedenceTemplateIfAllSameGroupIdentity))]
         public void TestFindHighestPrecedenceTemplateIfAllSameGroupIdentity()
         {
-            List<IFilteredTemplateInfo> templatesToCheck = new List<IFilteredTemplateInfo>();
-            templatesToCheck.Add(new FilteredTemplateInfo(
+            List<ITemplateMatchInfo> templatesToCheck = new List<ITemplateMatchInfo>();
+            templatesToCheck.Add(new TemplateMatchInfo(
                 new TemplateInfo()
                 {
                     Precedence = 10,
@@ -33,7 +33,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                     GroupIdentity = "TestGroup"
                 }
                 , null));
-            templatesToCheck.Add(new FilteredTemplateInfo(
+            templatesToCheck.Add(new TemplateMatchInfo(
                 new TemplateInfo()
                 {
                     Precedence = 20,
@@ -42,7 +42,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                     GroupIdentity = "TestGroup"
                 }
                 , null));
-            templatesToCheck.Add(new FilteredTemplateInfo(
+            templatesToCheck.Add(new TemplateMatchInfo(
                 new TemplateInfo()
                 {
                     Precedence = 0,
@@ -52,7 +52,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 }
                 , null));
 
-            IFilteredTemplateInfo highestPrecedenceTemplate = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(templatesToCheck);
+            ITemplateMatchInfo highestPrecedenceTemplate = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(templatesToCheck);
             Assert.NotNull(highestPrecedenceTemplate);
             Assert.Equal("Template2", highestPrecedenceTemplate.Info.Identity);
             Assert.Equal(20, highestPrecedenceTemplate.Info.Precedence);
@@ -61,8 +61,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(TestFindHighestPrecedenceTemplateIfAllSameGroupIdentity_ReturnsNullIfGroupsAreDifferent))]
         public void TestFindHighestPrecedenceTemplateIfAllSameGroupIdentity_ReturnsNullIfGroupsAreDifferent()
         {
-            List<IFilteredTemplateInfo> templatesToCheck = new List<IFilteredTemplateInfo>();
-            templatesToCheck.Add(new FilteredTemplateInfo(
+            List<ITemplateMatchInfo> templatesToCheck = new List<ITemplateMatchInfo>();
+            templatesToCheck.Add(new TemplateMatchInfo(
                 new TemplateInfo()
                 {
                     Precedence = 10,
@@ -71,7 +71,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                     GroupIdentity = "TestGroup"
                 }
                 , null));
-            templatesToCheck.Add(new FilteredTemplateInfo(
+            templatesToCheck.Add(new TemplateMatchInfo(
                 new TemplateInfo()
                 {
                     Precedence = 20,
@@ -80,7 +80,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                     GroupIdentity = "RealGroup"
                 }
                 , null));
-            IFilteredTemplateInfo highestPrecedenceTemplate = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(templatesToCheck);
+            ITemplateMatchInfo highestPrecedenceTemplate = TemplateListResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(templatesToCheck);
             Assert.Null(highestPrecedenceTemplate);
         }
 
@@ -136,17 +136,17 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
 
             IHostSpecificDataLoader hostDataLoader = new MockHostSpecificDataLoader();
 
-            IReadOnlyCollection<IFilteredTemplateInfo> projectTemplates = TemplateListResolver.PerformAllTemplatesInContextQuery(templatesToSearch, hostDataLoader, "project");
+            IReadOnlyCollection<ITemplateMatchInfo> projectTemplates = TemplateListResolver.PerformAllTemplatesInContextQuery(templatesToSearch, hostDataLoader, "project");
             Assert.Equal(3, projectTemplates.Count);
             Assert.True(projectTemplates.Where(x => string.Equals(x.Info.Identity, "Template1", StringComparison.Ordinal)).Any());
             Assert.True(projectTemplates.Where(x => string.Equals(x.Info.Identity, "Template4", StringComparison.Ordinal)).Any());
             Assert.True(projectTemplates.Where(x => string.Equals(x.Info.Identity, "Template5", StringComparison.Ordinal)).Any());
 
-            IReadOnlyCollection<IFilteredTemplateInfo> itemTemplates = TemplateListResolver.PerformAllTemplatesInContextQuery(templatesToSearch, hostDataLoader, "item");
+            IReadOnlyCollection<ITemplateMatchInfo> itemTemplates = TemplateListResolver.PerformAllTemplatesInContextQuery(templatesToSearch, hostDataLoader, "item");
             Assert.Equal(1, itemTemplates.Count);
             Assert.True(itemTemplates.Where(x => string.Equals(x.Info.Identity, "Template2", StringComparison.Ordinal)).Any());
 
-            IReadOnlyCollection<IFilteredTemplateInfo> otherTemplates = TemplateListResolver.PerformAllTemplatesInContextQuery(templatesToSearch, hostDataLoader, "other");
+            IReadOnlyCollection<ITemplateMatchInfo> otherTemplates = TemplateListResolver.PerformAllTemplatesInContextQuery(templatesToSearch, hostDataLoader, "other");
             Assert.Equal(1, otherTemplates.Count);
             Assert.True(otherTemplates.Where(x => string.Equals(x.Info.Identity, "Template3", StringComparison.Ordinal)).Any());
         }
@@ -180,7 +180,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
 
             Assert.Equal(1, matchResult.CoreMatchedTemplates.Count);
-            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
             Assert.Equal(1, unambiguousGroup.Count);
             Assert.Equal("Template2", matchResult.CoreMatchedTemplates[0].Info.Identity);
             Assert.Equal("Template2", unambiguousGroup[0].Info.Identity);
@@ -222,7 +222,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
 
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "Perl");
             Assert.Equal(2, matchResult.CoreMatchedTemplates.Count);    // they both match the initial query. Default language is secondary
-            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
             Assert.Equal(1, unambiguousGroup.Count);
             Assert.Equal("foo.test.Perl", unambiguousGroup[0].Info.Identity);
         }
@@ -265,7 +265,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "Perl");
 
             Assert.Equal(1, matchResult.CoreMatchedTemplates.Count);    // Input language is part of the initial checks.
-            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
             Assert.Equal(1, unambiguousGroup.Count);
             Assert.Equal("foo.test.Lisp", unambiguousGroup[0].Info.Identity);
         }
@@ -312,7 +312,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
 
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.Equal(2, matchResult.CoreMatchedTemplates.Count);
-            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
             Assert.Equal(2, unambiguousGroup.Count);
             Assert.True(unambiguousGroup.Any(x => string.Equals(x.Info.Identity, "foo.test.old")));
             Assert.True(unambiguousGroup.Any(x => string.Equals(x.Info.Identity, "foo.test.new")));
@@ -358,7 +358,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             };
 
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
-            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
             Assert.Equal(1, unambiguousGroup.Count);
             Assert.Equal("foo.test.new", unambiguousGroup[0].Info.Identity);
         }
@@ -405,7 +405,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             };
 
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
-            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
             Assert.Equal(1, unambiguousGroup.Count);
             Assert.Equal("foo.test.old", unambiguousGroup[0].Info.Identity);
         }
@@ -441,7 +441,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
 
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, hostSpecificDataLoader, userInputs, null);
-            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
             Assert.Equal(1, unambiguousGroup.Count);
 
             Assert.False(TemplateListResolver.ValidateRemainingParameters(unambiguousGroup[0], out IReadOnlyList<string> invalidParams));
@@ -492,7 +492,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
 
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
             TemplateListResolutionResult matchResult = TemplateListResolver.PerformCoreTemplateQuery(templatesToSearch, hostSpecificDataLoader, userInputs, null);
-            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<IFilteredTemplateInfo> unambiguousGroup));
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
             Assert.Equal(2, unambiguousGroup.Count);
             Assert.Equal(2, matchResult.CoreMatchedTemplates.Count);
 

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Common/Console.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Common/Console.json
@@ -1,6 +1,6 @@
-﻿{
-  "create": "console --no-restore",
-  "name": "Console (default framework)",
+{
+  "create": "console -f netcoreapp2.0 --no-restore",
+  "name": "Console (2.0 framework)",
   "tasks": [
     {
       "handler": "execute",

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/Mvc.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/Mvc.json
@@ -1,6 +1,6 @@
 {
-  "create": "mvc --no-restore",
-  "name": "MVC (C#, default framework, default auth)",
+  "create": "mvc -f netcoreapp2.0 --no-restore",
+  "name": "MVC (C#, 2.0 framework, default auth)",
   "tasks": [
     {
       "handler": "execute",

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/MvcIndividual.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/MvcIndividual.json
@@ -1,6 +1,6 @@
 {
-  "create": "mvc -au Individual --KestrelPort 5000 --no-restore",
-  "name": "MVC (C#, default framework, local individual auth)",
+  "create": "mvc -f netcoreapp2.0 -au Individual --KestrelPort 5000 --no-restore",
+  "name": "MVC (C#, 2.0 framework, local individual auth)",
   "tasks": [
     {
       "handler": "execute",

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/RazorPages.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/RazorPages.json
@@ -1,6 +1,6 @@
 {
-  "create": "razor --no-restore",
-  "name": "Razor Pages (C#, default framework, default auth)",
+  "create": "razor -f netcoreapp2.0 --no-restore",
+  "name": "Razor Pages (C#, 2.0 framework, default auth)",
   "tasks": [
     {
       "handler": "execute",

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/Web.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/Web.json
@@ -1,6 +1,6 @@
 {
-  "create": "web --no-restore",
-  "name": "Empty Web (C#, default framework, default auth)",
+  "create": "web -f netcoreapp2.0 --no-restore",
+  "name": "Empty Web (C#, 2.0 framework, default auth)",
   "tasks": [
     {
       "handler": "execute",

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/WebApi.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/WebApi.json
@@ -1,6 +1,6 @@
 {
-  "create": "api --no-restore",
-  "name": "WebAPI (C#, default framework, default auth)",
+  "create": "api -f netcoreapp2.0 --no-restore",
+  "name": "WebAPI (C#, 2.0 framework, default auth)",
   "tasks": [
     {
       "handler": "execute",

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/FSharp/Defaults/Common/Console.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/FSharp/Defaults/Common/Console.json
@@ -1,6 +1,6 @@
-﻿{
-  "create": "console --language F# --no-restore",
-  "name": "Console (F#, default framework)",
+{
+  "create": "console -f netcoreapp2.0 --language F# --no-restore",
+  "name": "Console (F#, 2.0 framework)",
   "tasks": [
     {
       "handler": "execute",

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/FSharp/Defaults/Web/Mvc.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/FSharp/Defaults/Web/Mvc.json
@@ -1,6 +1,6 @@
-﻿{
-  "create": "mvc --language F# --no-restore",
-  "name": "MVC (F#, default framework, default auth)",
+{
+  "create": "mvc -f netcoreapp2.0 --language F# --no-restore",
+  "name": "MVC (F#, 2.0 framework, default auth)",
   "tasks": [
     {
       "handler": "execute",


### PR DESCRIPTION
1) Greatly simplifies the template resolution code, much easier to understand.
2) IFilteredTemplateInfo now stores more information about command parse results in the context of the template it's for. This avoids the need to reparse, and also avoids having to rely on the command input object to be in the state of a particular template.
3) Invocations that would cause errors are now prevented by checking for the same errors pre-invocation.
4) Some reworking of help / error output when not invoking templates, just enough to deal with the resolution changes. There is still considerable help rework to be done, but the scope on this PR is already creeping.
5) Changes to project test runner tests - to explicitly invoke the 2.0 templates, instead of the default (which is now 2.1)