### PR TITLE
Skipping the F# Mvc test runner test

### DIFF
--- a/tools/ProjectTestRunner/TestCases/BuiltIn/FSharp/Defaults/Web/Mvc.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/FSharp/Defaults/Web/Mvc.json
@@ -1,4 +1,5 @@
 {
+  "skip": true,
   "create": "mvc -f netcoreapp2.0 --language F# --no-restore",
   "name": "MVC (F#, 2.0 framework, default auth)",
   "tasks": [


### PR DESCRIPTION
All other asp.net template tests in project test runner got set to "skip" when those templates got moved to the aspnet/templating repo.