### PR TITLE
fixed a bug with installs that dumped a stack

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Installer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Installer.cs
@@ -210,8 +210,11 @@ namespace Microsoft.TemplateEngine.Cli
                 if (wildcardIndex > -1)
                 {
                     int lastSlashBeforeWildcard = pkg.LastIndexOfAny(new[] { '\\', '/' });
-                    pattern = pkg.Substring(lastSlashBeforeWildcard + 1);
-                    pkg = pkg.Substring(0, lastSlashBeforeWildcard);
+                    if (lastSlashBeforeWildcard >= 0)
+                    {
+                        pattern = pkg.Substring(lastSlashBeforeWildcard + 1);
+                        pkg = pkg.Substring(0, lastSlashBeforeWildcard);
+                    }
                 }
 
                 try


### PR DESCRIPTION
Wildcards in local package specifications was causing installation to throw.