### PR TITLE
fixes: template dir with dll was getting deleted if no content found

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -257,7 +257,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     }
                 }
 
-                if (!anythingFound)
+                if (!anythingFound && !isInOriginalInstallLocation)
                 {
                     try
                     {


### PR DESCRIPTION
Fixing the issue reported in #1280. If a directory being installed contains a .dll but isn't a component, the install directory was getting deleted.