### PR TITLE
Choice param switches with a user provided value no longer get assigned the default value.

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -98,9 +98,10 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                 if (string.Equals(parameter.DataType, "choice", StringComparison.OrdinalIgnoreCase))
                 {
                     option = Create.Option(string.Join("|", aliasesForParam), parameter.Documentation,
-                                            Accept.ExactlyOneArgument()
+                                            Accept.ExactlyOneArgument());
                                                 //.WithSuggestionsFrom(parameter.Choices.Keys.ToArray())
-                                                .With(defaultValue: () => parameter.DefaultValue));
+                                                // Don't give this a default value, otherwise the switch without a value is valid (gets set to the default)
+                                                // User should have to give a value, or not specify the switch - which causes the default to be applied.
                 }
                 else if (string.Equals(parameter.DataType, "bool", StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Microsoft.TemplateEngine.Cli/TemplateListResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListResolver.cs
@@ -257,7 +257,11 @@ namespace Microsoft.TemplateEngine.Cli
                         if (template.Info.Tags.TryGetValue(paramName, out ICacheTag paramDetails))
                         {
                             // key is the value user should provide, value is description
-                            if (paramDetails.ChoicesAndDescriptions.ContainsKey(paramValue))
+                            if (string.IsNullOrEmpty(paramValue))
+                            {
+                                template.AddDisposition(new MatchInfo { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterValue, ChoiceIfLocationIsOtherChoice = paramName, ParameterValue = paramValue });
+                            }
+                            else if (paramDetails.ChoicesAndDescriptions.ContainsKey(paramValue))
                             {
                                 template.AddDisposition(new MatchInfo { Location = MatchLocation.OtherParameter, Kind = MatchKind.Exact, ChoiceIfLocationIsOtherChoice = paramName, ParameterValue = paramValue });
                             }


### PR DESCRIPTION
Instead, they result in an "invalid parameter(s)" error message.