### PR TITLE
Fix #1288

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Dotnet.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Dotnet.cs
@@ -13,6 +13,7 @@ namespace Microsoft.TemplateEngine.Cli
         private StringBuilder _stderr;
         private StringBuilder _stdout;
         private DataReceivedEventHandler _outputDataReceived;
+        private bool _anyNonEmptyStderrWritten;
 
         public static Dotnet Restore(params string[] args)
         {
@@ -109,6 +110,16 @@ namespace Microsoft.TemplateEngine.Cli
 
         private void ForwardStreamStdErr(object sender, DataReceivedEventArgs e)
         {
+            if (!_anyNonEmptyStderrWritten)
+            {
+                if (string.IsNullOrWhiteSpace(e.Data))
+                {
+                    return;
+                }
+
+                _anyNonEmptyStderrWritten = true;
+            }
+
             Console.Error.WriteLine(e.Data);
         }
 


### PR DESCRIPTION
Skips passing blank lines through to stderr from child processes unless a non-blank line has already been written to it.

Fixes #1288