### PR TITLE
A few minor changes

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -67,6 +67,7 @@ namespace Microsoft.TemplateEngine
 {
     internal static class GitInfo
     {
+        public static string PackageVersion { get%3B } = "$(PackageVersion)"%3B
         public static string CommitCount { get%3B } = "$(GitInfoCommitCount)"%3B
         public static string CommitHash { get%3B } = "$(GitInfoCommitHash)"%3B
     }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -135,7 +135,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                     Create.Option("-n|--name", LocalizableStrings.NameOfOutput, Accept.ExactlyOneArgument()),
                     Create.Option("-o|--output", LocalizableStrings.OutputPath, Accept.ExactlyOneArgument()),
                     Create.Option("-i|--install", LocalizableStrings.InstallHelp, Accept.OneOrMoreArguments()),
-                    Create.Option("-u|--uninstall", LocalizableStrings.UninstallHelp, Accept.OneOrMoreArguments()),
+                    Create.Option("-u|--uninstall", LocalizableStrings.UninstallHelp, Accept.ZeroOrMoreArguments()),
                     Create.Option("--type", LocalizableStrings.ShowsFilteredTemplates, Accept.ExactlyOneArgument()),
                     Create.Option("--force", LocalizableStrings.ForcesTemplateCreation, Accept.NoArguments()),
                     Create.Option("-lang|--language", LocalizableStrings.LanguageParameter,
@@ -195,6 +195,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                     Create.Option("--debug:emit-timings", string.Empty, Accept.NoArguments()),
                     Create.Option("--debug:emit-telemetry", string.Empty, Accept.NoArguments()),
                     Create.Option("--debug:custom-hive", string.Empty, Accept.ExactlyOneArgument()),
+                    Create.Option("--debug:version", string.Empty, Accept.NoArguments()),
 
                     Create.Option("--trace:authoring", string.Empty, Accept.NoArguments()),
                     Create.Option("--trace:install", string.Empty, Accept.NoArguments()),

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Edge.Template;
+using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli.CommandParsing
 {
@@ -121,7 +122,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             _parseResult = parser.Parse(argsWithCommand.ToArray());
             _templateParamCanonicalToVariantMap = null;
 
-            IList<string> templateNameList = _parseResult.GetArgumentListAtPath(new[] { _commandName }).ToList();
+            IReadOnlyList<string> templateNameList = _parseResult.GetArgumentListAtPath(new[] { _commandName })?.ToList() ?? Empty<string>.List.Value;
             if ((templateNameList.Count > 0) &&
                 !templateNameList[0].StartsWith("-", StringComparison.Ordinal)
                 && (_parseResult.Tokens.Count >= 2)
@@ -213,11 +214,11 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         public string BaselineName => _parseResult.GetArgumentValueAtPath(new[] { _commandName, "baseline" });
 
-        public IList<string> ExtraArgsFileNames => _parseResult.GetArgumentListAtPath(new[] { _commandName, "extra-args" }).ToList();
+        public IList<string> ExtraArgsFileNames => _parseResult.GetArgumentListAtPath(new[] { _commandName, "extra-args" })?.ToList();
 
-        public IList<string> ToInstallList => _parseResult.GetArgumentListAtPath(new[] { _commandName, "install" }).ToList();
+        public IList<string> ToInstallList => _parseResult.GetArgumentListAtPath(new[] { _commandName, "install" })?.ToList();
 
-        public IList<string> ToUninstallList => _parseResult.GetArgumentListAtPath(new[] { _commandName, "uninstall" }).ToList();
+        public IList<string> ToUninstallList => _parseResult.GetArgumentListAtPath(new[] { _commandName, "uninstall" })?.ToList();
 
         public bool IsForceFlagSpecified => _parseResult.HasAppliedOption(new[] { _commandName, "force" });
 

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/ParseResultExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/ParseResultExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 
@@ -74,7 +74,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                 return option.Arguments;
             }
 
-            return new List<string>();
+            return null;
         }
 
         private static bool TryTraversePath(this ParseResult parseResult, out AppliedOption option, params string[] optionPath)

--- a/src/Microsoft.TemplateEngine.Cli/Installer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Installer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.TemplateEngine.Cli
                 //If the request string doesn't have any wild cards or probable path indicators,
                 //  and doesn't have a "::" delimiter either, try to convert it to "latest package"
                 //  form
-                if (req.IndexOfAny(new[] { '*', '?', '/', '\\' }) < 0 && req.IndexOf("::", StringComparison.Ordinal) < 0)
+                if (OriginalRequestIsImplicitPackageVersionSyntax(request))
                 {
                     req += "::*";
                 }
@@ -67,6 +67,27 @@ namespace Microsoft.TemplateEngine.Cli
             }
 
             _environmentSettings.SettingsLoader.Save();
+        }
+
+        private bool OriginalRequestIsImplicitPackageVersionSyntax(string req)
+        {
+            if (req.IndexOfAny(new[] { '*', '?', '/', '\\' }) < 0 && req.IndexOf("::", StringComparison.Ordinal) < 0)
+            {
+                bool localFileSystemEntryExists = false;
+
+                try
+                {
+                    localFileSystemEntryExists = _environmentSettings.Host.FileSystem.FileExists(req)
+                                                 || _environmentSettings.Host.FileSystem.DirectoryExists(req);
+                }
+                catch
+                {
+                }
+
+                return !localFileSystemEntryExists;
+            }
+
+            return false;
         }
 
         public IEnumerable<string> Uninstall(IEnumerable<string> uninstallRequests)

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -537,6 +537,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to  Commit Hash: {0}.
+        /// </summary>
+        public static string CommitHash {
+            get {
+                return ResourceManager.GetString("CommitHash", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Configured Value: {0}.
         /// </summary>
         public static string ConfiguredValue {
@@ -733,6 +742,15 @@ namespace Microsoft.TemplateEngine.Cli {
         public static string Id {
             get {
                 return ResourceManager.GetString("Id", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Currently installed items:.
+        /// </summary>
+        public static string InstalledItems {
+            get {
+                return ResourceManager.GetString("InstalledItems", resourceCulture);
             }
         }
         
@@ -1403,6 +1421,15 @@ namespace Microsoft.TemplateEngine.Cli {
         public static string ValueSpecifiedForValuelessParameter {
             get {
                 return ResourceManager.GetString("ValueSpecifiedForValuelessParameter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  Version:             {0}.
+        /// </summary>
+        public static string Version {
+            get {
+                return ResourceManager.GetString("Version", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -553,6 +553,15 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="PartialTemplateMatchSwitchesNotValidForAllMatches" xml:space="preserve">
     <value>Some partially matched templates may not support these input switches:</value>
   </data>
+  <data name="CommitHash" xml:space="preserve">
+    <value> Commit Hash: {0}</value>
+  </data>
+  <data name="Version" xml:space="preserve">
+    <value> Version:             {0}</value>
+  </data>
+  <data name="InstalledItems" xml:space="preserve">
+    <value>Currently installed items:</value>
+  </data>
   <data name="AllUpdatesApplyPrompt" xml:space="preserve">
     <value>Apply updates ([A]ll|[N]one|[P]rompt)?</value>
   </data>

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -589,13 +589,4 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="SettingsReadError" xml:space="preserve">
     <value>Error reading the installed configuration, file may be corrupted. If this problem persists, try resetting with the `--debug:reinit' flag</value>
   </data>
-  <data name="CommitHash" xml:space="preserve">
-    <value> Commit Hash: {0}</value>
-  </data>
-  <data name="Version" xml:space="preserve">
-    <value> Version:             {0}</value>
-  </data>
-  <data name="InstalledItems" xml:space="preserve">
-    <value>Currently installed items:</value>
-  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -580,4 +580,13 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="SettingsReadError" xml:space="preserve">
     <value>Error reading the installed configuration, file may be corrupted. If this problem persists, try resetting with the `--debug:reinit' flag</value>
   </data>
+  <data name="CommitHash" xml:space="preserve">
+    <value> Commit Hash: {0}</value>
+  </data>
+  <data name="Version" xml:space="preserve">
+    <value> Version:             {0}</value>
+  </data>
+  <data name="InstalledItems" xml:space="preserve">
+    <value>Currently installed items:</value>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -81,6 +81,12 @@ namespace Microsoft.TemplateEngine.Cli
 
         public static int Run(string commandName, ITemplateEngineHost host, ITelemetryLogger telemetryLogger, Action<IEngineEnvironmentSettings, IInstaller> onFirstRun, string[] args, string hivePath)
         {
+            if (args.Any(x => string.Equals(x, "--debug:version", StringComparison.Ordinal)))
+            {
+                ShowVersion();
+                return 0;
+            }
+
             if (args.Any(x => string.Equals(x, "--debug:attach", StringComparison.Ordinal)))
             {
                 Console.ReadLine();
@@ -317,16 +323,32 @@ namespace Microsoft.TemplateEngine.Cli
 
             if (_commandInput.ToInstallList != null && _commandInput.ToInstallList.Count > 0 && _commandInput.ToInstallList[0] != null)
             {
-                Installer.Uninstall(_commandInput.ToInstallList.Select(x => x.Split(new[] { "::" }, StringSplitOptions.None)[0]));
+                Installer.InstallPackages(_commandInput.ToInstallList.Select(x => x.Split(new[] { "::" }, StringSplitOptions.None)[0]));
             }
 
-            if (_commandInput.ToUninstallList != null && _commandInput.ToUninstallList.Count > 0 && _commandInput.ToUninstallList[0] != null)
+            if (_commandInput.ToUninstallList != null)
             {
-                IEnumerable<string> failures = Installer.Uninstall(_commandInput.ToUninstallList);
-
-                foreach (string failure in failures)
+                if (_commandInput.ToUninstallList.Count > 0 && _commandInput.ToUninstallList[0] != null)
                 {
-                    Console.WriteLine(LocalizableStrings.CouldntUninstall, failure);
+                    IEnumerable<string> failures = Installer.Uninstall(_commandInput.ToUninstallList);
+
+                    foreach (string failure in failures)
+                    {
+                        Console.WriteLine(LocalizableStrings.CouldntUninstall, failure);
+                    }
+                }
+                else
+                {
+                    Console.WriteLine(LocalizableStrings.CommandDescription);
+                    Console.WriteLine();
+                    Console.WriteLine(LocalizableStrings.InstalledItems);
+
+                    foreach (string value in _settingsLoader.InstallUnitDescriptorCache.InstalledItems.Values)
+                    {
+                        Console.WriteLine($" {value}");
+                    }
+
+                    return CreationResultStatus.Success;
                 }
             }
 
@@ -534,7 +556,11 @@ namespace Microsoft.TemplateEngine.Cli
                 return CreationResultStatus.InvalidParamValues;
             }
 
-            Initialize();
+            if (!Initialize())
+            {
+                return CreationResultStatus.Success;
+            }
+
             bool forceCacheRebuild = _commandInput.HasDebuggingFlag("--debug:rebuildcache");
             try
             {
@@ -680,6 +706,14 @@ namespace Microsoft.TemplateEngine.Cli
                 {LocalizableStrings.Type, x => x.GetType().FullName},
                 {LocalizableStrings.Assembly, x => x.GetType().GetTypeInfo().Assembly.FullName}
             });
+        }
+
+        private static void ShowVersion()
+        {
+            Reporter.Output.WriteLine(LocalizableStrings.CommandDescription);
+            Reporter.Output.WriteLine();
+            Reporter.Output.WriteLine(string.Format(LocalizableStrings.Version, GitInfo.PackageVersion));
+            Reporter.Output.WriteLine(string.Format(LocalizableStrings.CommitHash, GitInfo.CommitHash));
         }
 
         private static bool ValidateLocaleFormat(string localeToCheck)

--- a/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/NupkgInstallUnitDescriptorFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/NupkgInstallUnitDescriptorFactory.cs
@@ -57,7 +57,7 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
             return false;
         }
 
-        private static bool TryGetPackageInfoFromNuspec(IMountPoint mountPoint, out string packageName, out string version)
+        internal static bool TryGetPackageInfoFromNuspec(IMountPoint mountPoint, out string packageName, out string version)
         {
             IList<IFile> nuspecFiles = mountPoint.Root.EnumerateFiles("*.nuspec", SearchOption.TopDirectoryOnly).ToList();
 


### PR DESCRIPTION
Shows the set of things that can be uninstalled when passing no arguments to the uninstall switch

Add a debug:version switch to show the version and commit hash

Prevent showing usage help when Initialize indicates that we should stop