### PR TITLE
reworked built-in glob configs to configure from json snippets

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalBlockCommentConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalBlockCommentConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Core;
 using Microsoft.TemplateEngine.Core.Contracts;
@@ -107,7 +107,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
 
             if (!string.IsNullOrWhiteSpace(pseudoEndToken))
             {
-                Guid operationIdGuid = new Guid();
+                Guid operationIdGuid = Guid.NewGuid();
                 string commentFixOperationId = $"Fix pseudo tokens ({pseudoEndToken} {operationIdGuid})";
                 string commentFixResetId = $"Reset pseudo token fixer ({pseudoEndToken} {operationIdGuid})";
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalBuiltinConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalBuiltinConfig.cs
@@ -1,0 +1,309 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.Utils;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
+{
+    internal static class ConditionalBuiltinConfig
+    {
+        public static List<IOperationProvider> GetConfigByType(ConditionalOperationConfigType configType)
+        {
+            JObject configObject = null;
+
+            switch (configType)
+            {
+                case ConditionalOperationConfigType.CBlockComment:
+                    configObject = CBlockCommentConfig;
+                    break;
+                case ConditionalOperationConfigType.CLineComment:
+                    configObject = CLineCommentConfig;
+                    break;
+                case ConditionalOperationConfigType.CNoComment:
+                    configObject = CNoCommentConfig;
+                    break;
+                case ConditionalOperationConfigType.HamlLineComment:
+                    configObject = HamlLineCommentConfig;
+                    break;
+                case ConditionalOperationConfigType.HashLineComment:
+                    configObject = HashLineCommentConfig;
+                    break;
+                case ConditionalOperationConfigType.JsxBlockComment:
+                    configObject = JsxBlockCommentConfig;
+                    break;
+                case ConditionalOperationConfigType.MSBuildInline:
+                    configObject = MSBuildInlineConfig;
+                    break;
+                case ConditionalOperationConfigType.None:
+                    break;
+                case ConditionalOperationConfigType.RazorBlockComment:
+                    configObject = RazorBlockCommentConfig;
+                    break;
+                case ConditionalOperationConfigType.RemLineComment:
+                    configObject = RemLineCommentConfig;
+                    break;
+                case ConditionalOperationConfigType.XmlBlockComment:
+                    configObject = XmlBlockCommentConfig;
+                    break;
+                default:
+                    throw new TemplateAuthoringException($"Template authoring error. Unhandled built in conditional configuration: {configType.ToString()}", "style");
+            }
+
+            if (configObject == null)
+            {
+                throw new TemplateAuthoringException($"Template authoring error. Unhandled built in conditional configuration: {configType.ToString()}", "style");
+            }
+
+            return ConditionalConfig.SetupFromJObject(configObject).ToList();
+        }
+
+        public static List<IOperationProvider> GetConfig(JObject rawConfig)
+        {
+            List<IOperationProvider> allOperations = new List<IOperationProvider>();
+            IReadOnlyList<string> configNames = ConfigurationNamesFromConfig(rawConfig);
+
+            if (configNames.Count == 0)
+            {
+                return allOperations;
+            }
+
+            foreach (string builtInConfigName in configNames)
+            {
+                if (!Enum.TryParse(builtInConfigName, out ConditionalOperationConfigType configType))
+                {
+                    throw new TemplateAuthoringException($"Template authoring error. Invalid built in conditional configuration: {builtInConfigName}", "style");
+                }
+
+                IEnumerable<IOperationProvider> configOperations = GetConfigByType(configType);
+                allOperations.AddRange(configOperations);
+            }
+
+            return allOperations;
+        }
+
+        private static IReadOnlyList<string> ConfigurationNamesFromConfig(JObject rawConfig)
+        {
+            // "configuration" could be a single string value, or an array of strings.
+            JToken builtInConfigsToken = rawConfig.Get<JToken>("configuration");
+            if (builtInConfigsToken == null)
+            {
+                return new List<string>();
+            }
+
+            IReadOnlyList<string> configNames;
+            if (builtInConfigsToken.Type == JTokenType.String)
+            {
+                configNames = new List<string>()
+                {
+                    builtInConfigsToken.ToString()
+                };
+            }
+            else
+            {
+                configNames = builtInConfigsToken.ArrayAsStrings();
+            }
+
+            return configNames;
+        }
+
+        private static JObject CBlockCommentConfig
+        {
+            get
+            {
+                string config = @"
+{
+  ""Style"": ""block"",
+  ""StartToken"": ""/*"",
+  ""EndToken"": ""*/"",
+  ""PseudoEndToken"": ""* /"",
+  ""KeywordPrefix"": ""#"",
+  ""Evaluator"": ""C++"",
+  ""WholeLine"": true,
+  ""TrimWhitespace"": true,
+}";
+                return JObject.Parse(config);
+            }
+        }
+
+        private static JObject CLineCommentConfig
+        {
+            get
+            {
+                string config = @"
+{
+  ""Style"": ""line"",
+  ""Token"": ""//"",
+  ""KeywordPrefix"": ""#"",
+  ""Evaluator"": ""C++"",
+  ""WholeLine"": true,
+  ""TrimWhitespace"": true,
+  ""Id"": null,
+}";
+                return JObject.Parse(config);
+            }
+        }
+
+    private static JObject CNoCommentConfig
+        {
+            get
+            {
+                string config = @"
+{
+  ""If"": [
+    ""#if""
+  ],
+  ""Else"": [
+    ""#else""
+  ],
+  ""ElseIf"": [
+    ""#elseif"",
+    ""#elif""
+  ],
+  ""EndIf"": [
+    ""#endif""
+  ],
+  ""Trim"": true,
+  ""WholeLine"": true,
+  ""Evaluator"": ""C++""
+}";
+                return JObject.Parse(config);
+            }
+        }
+
+        private static JObject HamlLineCommentConfig
+        {
+            get
+            {
+                string config = @"
+{
+  ""Style"": ""line"",
+  ""Token"": ""-#"",
+  ""KeywordPrefix"": ""#"",
+  ""Evaluator"": ""C++"",
+  ""WholeLine"": true,
+  ""TrimWhitespace"": true,
+  ""Id"": null,
+}";
+                return JObject.Parse(config);
+            }
+        }
+
+        private static JObject HashLineCommentConfig
+        {
+            get
+            {
+                string config = @"
+{
+  ""Style"": ""line"",
+  ""Token"": ""#"",
+  ""KeywordPrefix"": """",
+  ""Evaluator"": ""C++"",
+  ""WholeLine"": true,
+  ""TrimWhitespace"": true,
+  ""Id"": null,
+}";
+                return JObject.Parse(config);
+            }
+        }
+
+        private static JObject JsxBlockCommentConfig
+        {
+            get
+            {
+                string config = @"
+{
+  ""Style"": ""block"",
+  ""StartToken"": ""{/*"",
+  ""EndToken"": ""*/}"",
+  ""PseudoEndToken"": ""* /}"",
+  ""KeywordPrefix"": ""#"",
+  ""Evaluator"": ""C++"",
+  ""WholeLine"": true,
+  ""TrimWhitespace"": true,
+}";
+                return JObject.Parse(config);
+            }
+        }
+
+        private static JObject MSBuildInlineConfig
+        {
+            get
+            {
+                string config = @"
+{
+  ""Style"": ""msbuild"",
+  ""OpenOpenToken"": ""<"",
+  ""OpenCloseToken"": ""</"",
+  ""CloseToken"": "">"",
+  ""SelfClosingEndToken"": ""/>"",
+  ""ConditionOpenExpression"": ""Condition=\"""",
+  ""ConditionCloseExpression"": ""\"""",
+  ""VariableFormat"": ""$({0})"",
+  ""Id"": ""msbuild-conditional"",
+  ""Trim"": true,
+  ""WholeLine"": true,
+  ""Evaluator"": ""MSBUILD""
+}";
+                return JObject.Parse(config);
+            }
+        }
+
+        private static JObject RazorBlockCommentConfig
+        {
+            get
+            {
+                string config = @"
+{
+  ""Style"": ""block"",
+  ""StartToken"": ""@*"",
+  ""EndToken"": ""*@"",
+  ""PseudoEndToken"": ""* @"",
+  ""KeywordPrefix"": ""#"",
+  ""Evaluator"": ""C++"",
+  ""WholeLine"": true,
+  ""TrimWhitespace"": true,
+}";
+                return JObject.Parse(config);
+            }
+        }
+
+        private static JObject RemLineCommentConfig
+        {
+            get
+            {
+                string config = @"
+{
+  ""Style"": ""line"",
+  ""Token"": ""rem "",
+  ""KeywordPrefix"": ""#"",
+  ""Evaluator"": ""C++"",
+  ""WholeLine"": true,
+  ""TrimWhitespace"": true,
+  ""Id"": null,
+}";
+                return JObject.Parse(config);
+            }
+        }
+
+        private static JObject XmlBlockCommentConfig
+        {
+            get
+            {
+                string config = @"
+{
+  ""Style"": ""block"",
+  ""StartToken"": ""<!--"",
+  ""EndToken"": ""-->"",
+  ""PseudoEndToken"": ""-- >"",
+  ""KeywordPrefix"": ""#"",
+  ""Evaluator"": ""C++"",
+  ""WholeLine"": true,
+  ""TrimWhitespace"": true,
+}";
+                return JObject.Parse(config);
+            }
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalBuiltinConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Config/ConditionalBuiltinConfig.cs
@@ -62,7 +62,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
         public static List<IOperationProvider> GetConfig(JObject rawConfig)
         {
             List<IOperationProvider> allOperations = new List<IOperationProvider>();
-            IReadOnlyList<string> configNames = ConfigurationNamesFromConfig(rawConfig);
+            IReadOnlyList<string> configNames = BuiltinConfigurationNamesFromConfig(rawConfig);
 
             if (configNames.Count == 0)
             {
@@ -73,7 +73,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
             {
                 if (!Enum.TryParse(builtInConfigName, out ConditionalOperationConfigType configType))
                 {
-                    throw new TemplateAuthoringException($"Template authoring error. Invalid built in conditional configuration: {builtInConfigName}", "style");
+                    throw new TemplateAuthoringException($"Template authoring error. Invalid built in conditional configuration name: {builtInConfigName}", "style");
                 }
 
                 IEnumerable<IOperationProvider> configOperations = GetConfigByType(configType);
@@ -83,10 +83,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
             return allOperations;
         }
 
-        private static IReadOnlyList<string> ConfigurationNamesFromConfig(JObject rawConfig)
+        private static IReadOnlyList<string> BuiltinConfigurationNamesFromConfig(JObject rawConfig)
         {
-            // "configuration" could be a single string value, or an array of strings.
-            JToken builtInConfigsToken = rawConfig.Get<JToken>("configuration");
+            // "name" could be a single string value, or an array of strings.
+            JToken builtInConfigsToken = rawConfig.Get<JToken>("name");
             if (builtInConfigsToken == null)
             {
                 return new List<string>();
@@ -145,7 +145,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config
             }
         }
 
-    private static JObject CNoCommentConfig
+        private static JObject CNoCommentConfig
         {
             get
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CustomFileGlobModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CustomFileGlobModel.cs
@@ -11,8 +11,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         public IReadOnlyList<ICustomOperationModel> Operations { get; set; }
 
-        // TODO: reference to built-in conditional config ???
-
         public IVariableConfig VariableFormat { get; set; }
 
         public string FlagPrefix { get; set; }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileGlobOperationConfigParameters.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileGlobOperationConfigParameters.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
+{
+    internal enum ConditionalOperationConfigType
+    {
+        None,
+        CBlockComment,
+        CLineComment,
+        CNoComment,
+        HamlLineComment,
+        HashLineComment,
+        JsxBlockComment,
+        MSBuildInline,
+        RazorBlockComment,
+        RemLineComment,
+        XmlBlockComment
+    };
+
+    internal class FileGlobOperationConfigParameters
+    {
+        public FileGlobOperationConfigParameters(string glob, string flagPrefix, params ConditionalOperationConfigType[] conditionalConfigs)
+        {
+            Glob = glob;
+            FlagPrefix = flagPrefix;
+            ConditionalConfigs = conditionalConfigs;
+        }
+
+        public string Glob { get; }
+
+        public string FlagPrefix { get; }
+
+        public IReadOnlyList<ConditionalOperationConfigType> ConditionalConfigs { get; }
+
+        private static readonly FileGlobOperationConfigParameters _Defaults = new FileGlobOperationConfigParameters(string.Empty, string.Empty, ConditionalOperationConfigType.None);
+
+        public static FileGlobOperationConfigParameters Defaults => _Defaults;
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileGlobOperationConfigParameters.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileGlobOperationConfigParameters.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
@@ -483,6 +483,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             {
                 foreach (ConditionalOperationConfigType configType in defaultModel.ConditionalConfigs)
                 {
+                    if (configType == ConditionalOperationConfigType.None)
+                    {
+                        continue;
+                    }
+
                     operations.AddRange(ConditionalBuiltinConfig.GetConfigByType(configType));
                 }
             }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ConditionalConfigurationTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ConditionalConfigurationTests.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests
+{
+    public class ConditionalConfigurationTests : EndToEndTestBase
+    {
+        [Theory(DisplayName = nameof(VerifyConditionalConfiguration))]
+        [InlineData("TestAssets.TemplateWithCustomGlobReferencingBuiltin --Extra true", "CustomGlobReferencingBuiltinConditionalTest.json")]
+        [InlineData("TestAssets.TemplateWithBlockCommentConditionalConfiguration --Extra true", "CustomBlockCommentConditionalTests.json")]
+        [InlineData("TestAssets.TemplateWithLineCommentConditionalConfiguration --Extra true", "CustomLineCommentConditionalTests.json")]
+        [InlineData("TestAssets.TemplateWithMultipleBuiltInConditionalsOnOneGlob --Extra true", "MultipleBuiltInConditionalsTests.json")]
+        public void VerifyConditionalConfiguration(string args, params string[] scripts)
+        {
+            Run(args, scripts);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CustomBlockCommentConditionalTests.json
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CustomBlockCommentConditionalTests.json
@@ -1,0 +1,57 @@
+[
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "Random text."
+    },
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "Extra content."
+    },
+    {
+        "kind": "file_does_not_contain",
+        "path": "Test.abc",
+        "text": "Wrong content."
+    },
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "#if (Extra)"
+    },
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "Invalid conditional."
+    },
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "Also invalid."
+    },
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "OuterContent"
+    },
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "InnerContent"
+    },
+    {
+        "kind": "file_does_not_contain",
+        "path": "Test.abc",
+        "text": "&--"
+    },
+    {
+        "kind": "file_does_not_contain",
+        "path": "Test.abc",
+        "text": "--&"
+    },
+    {
+        "kind": "file_does_not_contain",
+        "path": "Test.abc",
+        "text": "-- &"
+    }
+]

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CustomGlobReferencingBuiltinConditionalTest.json
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CustomGlobReferencingBuiltinConditionalTest.json
@@ -1,0 +1,32 @@
+[
+  {
+    "kind": "file_contains",
+    "path": "Test.abc",
+    "text": "Random text."
+  },
+  {
+    "kind": "file_contains",
+    "path": "Test.abc",
+    "text": "Extra content."
+  },
+  {
+    "kind": "file_does_not_contain",
+    "path": "Test.abc",
+    "text": "Wrong content."
+  },
+  {
+    "kind": "file_contains",
+    "path": "Test.abc",
+    "text": "#if (Extra)"
+  },
+  {
+    "kind": "file_contains",
+    "path": "Test.abc",
+    "text": "Invalid conditional."
+  },
+  {
+    "kind": "file_contains",
+    "path": "Test.abc",
+    "text": "Also invalid."
+  }
+]

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CustomLineCommentConditionalTests.json
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CustomLineCommentConditionalTests.json
@@ -1,0 +1,42 @@
+[
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "Random text."
+    },
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "Extra content."
+    },
+    {
+        "kind": "file_does_not_contain",
+        "path": "Test.abc",
+        "text": "Wrong content."
+    },
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "#if (Extra)"
+    },
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "Invalid conditional."
+    },
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "Also invalid."
+    },
+    {
+        "kind": "file_contains",
+        "path": "Test.abc",
+        "text": "    Remove Comments"
+    },
+    {
+        "kind": "file_does_not_contain",
+        "path": "Test.abc",
+        "text": "$$    Remove Comments"
+    }
+]

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/MultipleBuiltInConditionalsTests.json
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/MultipleBuiltInConditionalsTests.json
@@ -1,0 +1,27 @@
+[
+  {
+    "kind": "file_contains",
+    "path": "Test.abc",
+    "text": "Random text."
+  },
+  {
+    "kind": "file_contains",
+    "path": "Test.abc",
+    "text": "XML Extra content."
+  },
+  {
+    "kind": "file_does_not_contain",
+    "path": "Test.abc",
+    "text": "XML Wrong content."
+  },
+  {
+    "kind": "file_contains",
+    "path": "Test.abc",
+    "text": "Hash Extra content."
+  },
+  {
+    "kind": "file_does_not_contain",
+    "path": "Test.abc",
+    "text": "Hash Wrong content."
+  }
+]

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithBlockCommentConditionalConfiguration/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithBlockCommentConditionalConfiguration/.template.config/template.json
@@ -1,0 +1,36 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "TemplateWithBlockCommentConditionalConfiguration",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateWithBlockCommentConditionalConfiguration",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateWithBlockCommentConditionalConfiguration",
+  "shortName": "TestAssets.TemplateWithBlockCommentConditionalConfiguration",
+  "sourceName": "Company.Web.Application1",
+  "description": "Testing specifying a block comment conditional",
+  "SpecialCustomOperations": {
+    "**/*.abc": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "style": "block",
+            "startToken": "&--",
+            "endToken": "--&",
+            "pseudoEndToken": "-- &",
+            "keywordPrefix": "#"
+          }
+        }
+      ]
+    }
+  },
+  "Symbols": {
+    "Extra": {
+      "type": "parameter",
+      "description": "Controls extra content",
+      "datatype": "bool",
+      "defaultValue": "false"
+    }
+  }
+}

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithBlockCommentConditionalConfiguration/Test.abc
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithBlockCommentConditionalConfiguration/Test.abc
@@ -1,0 +1,19 @@
+Random text.
+&--#if (Extra) --&
+    Extra content.
+&--#else --&
+    Wrong content.
+&--#endif --&
+
+&--#if (true)
+    OuterContent
+    &--#if (Extra) -- &
+        InnerContent
+    #endif
+#endif-- & --&
+
+#if (Extra)
+    Invalid conditional.
+#else
+    Also invalid.
+#endif

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithCustomGlobReferencingBuiltin/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithCustomGlobReferencingBuiltin/.template.config/template.json
@@ -1,0 +1,33 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "TemplateWithCustomGlobReferencingBuiltin",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateWithCustomGlobReferencingBuiltin",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateWithCustomGlobReferencingBuiltin",
+  "shortName": "TestAssets.TemplateWithCustomGlobReferencingBuiltin",
+  "sourceName": "Company.Web.Application1",
+  "description": "Testing specifying a built-in conditional",
+  "SpecialCustomOperations": {
+    "**/*.abc": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "style": "builtin",
+            "name": "XmlBlockComment"
+          }
+        }
+      ]
+    }
+  },
+  "Symbols": {
+    "Extra": {
+      "type": "parameter",
+      "description": "Controls extra content",
+      "datatype": "bool",
+      "defaultValue": "false"
+    }
+  }
+}

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithCustomGlobReferencingBuiltin/Test.abc
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithCustomGlobReferencingBuiltin/Test.abc
@@ -1,0 +1,12 @@
+Random text.
+<!--#if (Extra) -->
+    Extra content.
+<!--#else -->
+    Wrong content.
+<!--#endif-->
+
+#if (Extra)
+    Invalid conditional.
+#else
+    Also invalid.
+#endif

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithLineCommentConditionalConfiguration/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithLineCommentConditionalConfiguration/.template.config/template.json
@@ -1,0 +1,34 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "TemplateWithLineCommentConditionalConfiguration",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateWithLineCommentConditionalConfiguration",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateWithLineCommentConditionalConfiguration",
+  "shortName": "TestAssets.TemplateWithLineCommentConditionalConfiguration",
+  "sourceName": "Company.Web.Application1",
+  "description": "Testing specifying a line comment conditional",
+  "SpecialCustomOperations": {
+    "**/*.abc": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "style": "line",
+            "token": "$$",
+            "keywordPrefix": "@"
+          }
+        }
+      ]
+    }
+  },
+  "Symbols": {
+    "Extra": {
+      "type": "parameter",
+      "description": "Controls extra content",
+      "datatype": "bool",
+      "defaultValue": "false"
+    }
+  }
+}

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithLineCommentConditionalConfiguration/Test.abc
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithLineCommentConditionalConfiguration/Test.abc
@@ -1,0 +1,17 @@
+Random text.
+$$@if (Extra) $$
+    Extra content.
+$$@else $$
+    Wrong content.
+$$@endif $$
+
+$$$$@if (true) $$
+$$    Remove Comments
+$$$$    Reduce Comments
+$$@endif
+
+#if (Extra)
+    Invalid conditional.
+#else
+    Also invalid.
+#endif

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithMultipleBuiltInConditionalsOnOneGlob/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithMultipleBuiltInConditionalsOnOneGlob/.template.config/template.json
@@ -1,0 +1,33 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "TemplateWithMultipleBuiltInConditionalsOnOneGlob",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateWithMultipleBuiltInConditionalsOnOneGlob",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateWithMultipleBuiltInConditionalsOnOneGlob",
+  "shortName": "TestAssets.TemplateWithMultipleBuiltInConditionalsOnOneGlob",
+  "sourceName": "Company.Web.Application1",
+  "description": "Testing specifying multiple built-in conditionals",
+  "SpecialCustomOperations": {
+    "**/*.abc": {
+      "operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "style": "builtin",
+            "name": [ "XmlBlockComment", "HashLineComment" ]
+          }
+        }
+      ]
+    }
+  },
+  "Symbols": {
+    "Extra": {
+      "type": "parameter",
+      "description": "Controls extra content",
+      "datatype": "bool",
+      "defaultValue": "false"
+    }
+  }
+}

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithMultipleBuiltInConditionalsOnOneGlob/Test.abc
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithMultipleBuiltInConditionalsOnOneGlob/Test.abc
@@ -1,0 +1,12 @@
+Random text.
+<!--#if (Extra) -->
+    XML Extra content.
+<!--#else -->
+    XML Wrong content.
+<!--#endif-->
+
+#if (Extra)
+    Hash Extra content.
+#else
+    Hash Wrong content.
+#endif


### PR DESCRIPTION
Regarding performance differences from before and after this change, I did some nominal testing and didn't see any real differences. I ran the mvc1.1 template 4 times against the code before and after my changes, with negligible timing differences:

New way:
 Content generation time 1158.7476
 Content generation time 976.8154
 Content generation time 1069.5988
 Content generation time 1022.9127
   
Old way
Content generation time 957.0962
Content generation time 1107.2132
Content generation time 975.9659
Content generation time 1142.1048

