### PR TITLE
fix for multiple templates with choice param with single starts with matches

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -79,9 +79,10 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 
             GetParametersInvalidForTemplatesInList(unambiguousTemplateGroup, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
 
-            if (invalidForAllTemplates.Count > 0)
+            if (invalidForAllTemplates.Count > 0 || invalidForSomeTemplates.Count > 0)
             {
                 DisplayInvalidParameters(invalidForAllTemplates);
+                DisplayParametersInvalidForSomeTemplates(invalidForSomeTemplates, LocalizableStrings.SingleTemplateGroupPartialMatchSwitchesNotValidForAllMatches);
             }
 
             bool showImplicitlyHiddenParams = unambiguousTemplateGroup.Count > 1;
@@ -122,7 +123,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             {
                 hasInvalidParameters = true;
                 DisplayInvalidParameters(invalidForAllTemplates);
-                DisplayParametersInvalidForSomeTemplates(invalidForSomeTemplates);
+                DisplayParametersInvalidForSomeTemplates(invalidForSomeTemplates, LocalizableStrings.PartialTemplateMatchSwitchesNotValidForAllMatches);
             }
 
             if (commandInput.IsHelpFlagSpecified)
@@ -255,11 +256,11 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             }
         }
 
-        private static void DisplayParametersInvalidForSomeTemplates(IReadOnlyList<string> invalidParams)
+        private static void DisplayParametersInvalidForSomeTemplates(IReadOnlyList<string> invalidParams, string messageHeader)
         {
             if (invalidParams.Count > 0)
             {
-                Reporter.Error.WriteLine(LocalizableStrings.PartialTemplateMatchSwitchesNotValidForAllMatches.Bold().Red());
+                Reporter.Error.WriteLine(messageHeader.Bold().Red());
                 foreach (string flag in invalidParams)
                 {
                     Reporter.Error.WriteLine($"  {flag}".Bold().Red());

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1254,6 +1254,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The following parameter(s) or their value(s) are not valid in combination with other supplied parameters or their values:.
+        /// </summary>
+        public static string SingleTemplateGroupPartialMatchSwitchesNotValidForAllMatches {
+            get {
+                return ResourceManager.GetString("SingleTemplateGroupPartialMatchSwitchesNotValidForAllMatches", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} : update ([Y]es|[N]o)?.
         /// </summary>
         public static string SingleUpdateApplyPrompt {
@@ -1425,7 +1434,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to  Version:             {0}.
+        ///   Looks up a localized string similar to  Version:     {0}.
         /// </summary>
         public static string Version {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -557,7 +557,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
     <value> Commit Hash: {0}</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value> Version:             {0}</value>
+    <value> Version:     {0}</value>
   </data>
   <data name="InstalledItems" xml:space="preserve">
     <value>Currently installed items:</value>
@@ -588,5 +588,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   </data>
   <data name="SettingsReadError" xml:space="preserve">
     <value>Error reading the installed configuration, file may be corrupted. If this problem persists, try resetting with the `--debug:reinit' flag</value>
+  </data>
+  <data name="SingleTemplateGroupPartialMatchSwitchesNotValidForAllMatches" xml:space="preserve">
+    <value>The following parameter(s) or their value(s) are not valid in combination with other supplied parameters or their values:</value>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/TemplateListResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListResolver.cs
@@ -275,7 +275,7 @@ namespace Microsoft.TemplateEngine.Cli
                                 int startsWithCount = paramDetails.ChoicesAndDescriptions.Count(x => x.Key.StartsWith(paramValue, StringComparison.OrdinalIgnoreCase));
                                 if (startsWithCount == 1)
                                 {
-                                    template.AddDisposition(new MatchInfo { Location = MatchLocation.OtherParameter, Kind = MatchKind.Exact, ChoiceIfLocationIsOtherChoice = paramName, ParameterValue = paramValue });
+                                    template.AddDisposition(new MatchInfo { Location = MatchLocation.OtherParameter, Kind = MatchKind.SingleStartsWith, ChoiceIfLocationIsOtherChoice = paramName, ParameterValue = paramValue });
                                 }
                                 else if (startsWithCount > 1)
                                 {

--- a/src/Microsoft.TemplateEngine.Cli/TemplateMatchInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateMatchInfoExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.TemplateEngine.Cli
         public static bool HasParameterMismatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter
-                                       && (x.Kind != MatchKind.Exact && x.Kind != MatchKind.AmbiguousParameterValue));
+                                       && (x.Kind != MatchKind.Exact && x.Kind != MatchKind.AmbiguousParameterValue && x.Kind != MatchKind.SingleStartsWith));
         }
 
         public static bool HasContextMismatch(this ITemplateMatchInfo templateMatchInfo)
@@ -38,6 +38,10 @@ namespace Microsoft.TemplateEngine.Cli
                                 (   // these locations can have partial or exact matches.
                                     x.Kind == MatchKind.Partial
                                     && (x.Location == MatchLocation.Name || x.Location == MatchLocation.ShortName || x.Location == MatchLocation.Classification)
+                                )
+                                ||
+                                (
+                                    x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.SingleStartsWith
                                 )
                             );
         }
@@ -61,7 +65,7 @@ namespace Microsoft.TemplateEngine.Cli
         // This is analogous to INewCommandInput.InputTemplateParams
         public static IReadOnlyDictionary<string, string> GetValidTemplateParameters(this ITemplateMatchInfo templateMatchInfo)
         { 
-            return templateMatchInfo.MatchDisposition.Where(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.Exact)
+            return templateMatchInfo.MatchDisposition.Where(x => x.Location == MatchLocation.OtherParameter && (x.Kind == MatchKind.Exact || x.Kind == MatchKind.SingleStartsWith))
                                     .ToDictionary(x => x.ChoiceIfLocationIsOtherChoice, x => x.ParameterValue);
         }
 

--- a/src/Microsoft.TemplateEngine.Edge/Template/MatchKind.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/MatchKind.cs
@@ -9,6 +9,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
         AmbiguousParameterValue,
         InvalidParameterName,
         InvalidParameterValue,
-        Mismatch
+        Mismatch,
+        SingleStartsWith
     }
 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ResolutionTestHelper.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ResolutionTestHelper.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Utils;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
+{
+    internal static class ResolutionTestHelper
+    {
+        public static ICacheTag CreateTestCacheTag(string choice, string description = null, string defaultValue = null)
+        {
+            return new CacheTag(null,
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { choice, description }
+                },
+                defaultValue);
+        }
+
+        public static ICacheTag CreateTestCacheTag(IReadOnlyList<string> choiceList, string description = null, string defaultValue = null)
+        {
+            Dictionary<string, string> choicesDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string choice in choiceList)
+            {
+                choicesDict.Add(choice, null);
+            };
+
+            return new CacheTag(null, choicesDict, defaultValue);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/SingularInvokableMatchTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/SingularInvokableMatchTests.cs
@@ -1,0 +1,226 @@
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.Edge.Template;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
+{
+    public class SingularInvokableMatchTests
+    {
+        [Fact(DisplayName = nameof(MultipleTemplatesInGroupHavingSingleStartsWithOnSameParamIsAmbiguous))]
+        public void MultipleTemplatesInGroupHavingSingleStartsWithOnSameParamIsAmbiguous()
+        {
+            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "foo",
+                Name = "Foo template",
+                Identity = "foo.test_1",
+                GroupIdentity = "foo.test.template",
+                Precedence = 100,
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_1"}) }
+                },
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+            });
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "foo",
+                Name = "Foo template",
+                Identity = "foo.test_2",
+                GroupIdentity = "foo.test.template",
+                Precedence = 200,
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_2"}) }
+                },
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+            });
+
+            INewCommandInput userInputs = new MockNewCommandInput(
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "MyChoice", "value_" }
+                }
+            )
+            {
+                TemplateName = "foo"
+            };
+
+            IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
+            TemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResult(templatesToSearch, hostSpecificDataLoader, userInputs, null);
+            // make sure there's an unambiguous group, otherwise the singular match check is meaningless
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
+            Assert.Equal(2, unambiguousGroup.Count);
+            Assert.Equal(2, matchResult.GetBestTemplateMatchList().Count);
+
+            Assert.False(matchResult.TryGetSingularInvokableMatch(out ITemplateMatchInfo singularInvokableMatch));
+            Assert.Null(singularInvokableMatch);
+        }
+
+        [Fact(DisplayName = nameof(MultipleTemplatesInGroupParamPartiaMatch_TheOneHavingSingleStartsWithIsTheSingularInvokableMatch))]
+        public void MultipleTemplatesInGroupParamPartiaMatch_TheOneHavingSingleStartsWithIsTheSingularInvokableMatch()
+        {
+            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "foo",
+                Name = "Foo template",
+                Identity = "foo.test_1",
+                GroupIdentity = "foo.test.template",
+                Precedence = 100,
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_1"}) }
+                },
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+            });
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "foo",
+                Name = "Foo template",
+                Identity = "foo.test_2",
+                GroupIdentity = "foo.test.template",
+                Precedence = 200,
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_2", "value_3"}) }
+                },
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+            });
+
+            INewCommandInput userInputs = new MockNewCommandInput(
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "MyChoice", "value_" }
+                }
+            )
+            {
+                TemplateName = "foo"
+            };
+
+            IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
+            TemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResult(templatesToSearch, hostSpecificDataLoader, userInputs, null);
+            // make sure there's an unambiguous group, otherwise the singular match check is meaningless
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
+            Assert.Equal(2, unambiguousGroup.Count);
+            Assert.Equal(2, matchResult.GetBestTemplateMatchList().Count);
+
+            Assert.True(matchResult.TryGetSingularInvokableMatch(out ITemplateMatchInfo singularInvokableMatch));
+            Assert.Equal("foo.test_1", singularInvokableMatch.Info.Identity);
+        }
+
+        [Fact(DisplayName = nameof(MultipleTemplatesInGroupHavingAmbiguousParamMatchOnSameParamIsAmbiguous))]
+        public void MultipleTemplatesInGroupHavingAmbiguousParamMatchOnSameParamIsAmbiguous()
+        {
+            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "foo",
+                Name = "Foo template",
+                Identity = "foo.test_1",
+                GroupIdentity = "foo.test.template",
+                Precedence = 100,
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_1", "value_2"}) }
+                },
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+            });
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "foo",
+                Name = "Foo template",
+                Identity = "foo.test_2",
+                GroupIdentity = "foo.test.template",
+                Precedence = 200,
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_3", "value_4"}) }
+                },
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+            });
+
+            INewCommandInput userInputs = new MockNewCommandInput(
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "MyChoice", "value_" }
+                }
+            )
+            {
+                TemplateName = "foo"
+            };
+
+            IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
+            TemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResult(templatesToSearch, hostSpecificDataLoader, userInputs, null);
+            // make sure there's an unambiguous group, otherwise the singular match check is meaningless
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
+            Assert.Equal(2, unambiguousGroup.Count);
+            Assert.Equal(2, matchResult.GetBestTemplateMatchList().Count);
+
+            Assert.False(matchResult.TryGetSingularInvokableMatch(out ITemplateMatchInfo singularInvokableMatch));
+            Assert.Null(singularInvokableMatch);
+        }
+
+        [Fact(DisplayName = nameof(MultipleTemplatesInGroupHavingSingularStartMatchesOnDifferentParams_HighPrecedenceIsChosen))]
+        public void MultipleTemplatesInGroupHavingSingularStartMatchesOnDifferentParams_HighPrecedenceIsChosen()
+        {
+            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "foo",
+                Name = "Foo template",
+                Identity = "foo.test_1",
+                GroupIdentity = "foo.test.template",
+                Precedence = 100,
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_1", "other_value"}) },    // single starts with
+                    { "OtherChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "foo_" }) }          // exact
+                },
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+            });
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "foo",
+                Name = "Foo template",
+                Identity = "foo.test_2",
+                GroupIdentity = "foo.test.template",
+                Precedence = 200,
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_" }) },    // exact
+                    { "OtherChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "foo_", "bar_1"}) }      // single starts with
+                },
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+            });
+
+            INewCommandInput userInputs = new MockNewCommandInput(
+                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "MyChoice", "value_" },
+                    { "OtherChoice", "foo_" }
+                }
+            )
+            {
+                TemplateName = "foo"
+            };
+
+            IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
+            TemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResult(templatesToSearch, hostSpecificDataLoader, userInputs, null);
+            // make sure there's an unambiguous group, otherwise the singular match check is meaningless
+            Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
+            Assert.Equal(2, unambiguousGroup.Count);
+            Assert.Equal(2, matchResult.GetBestTemplateMatchList().Count);
+
+            Assert.True(matchResult.TryGetSingularInvokableMatch(out ITemplateMatchInfo singularInvokableMatch));
+            Assert.Equal("foo.test_2", singularInvokableMatch.Info.Identity);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateListResolverTests.cs
@@ -12,7 +12,7 @@ using Microsoft.TemplateEngine.Edge.Template;
 using Microsoft.TemplateEngine.Utils;
 using Xunit;
 
-namespace Microsoft.TemplateEngine.Cli.UnitTests
+namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 {
     // Implementation notes:
     // If a test is going to hit the secondary matching in the resolver, make sure to initialize the Tags & CacheParameters,
@@ -94,7 +94,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Identity = "Template1",
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "type", CreateTestCacheTag("project") }
+                    { "type", ResolutionTestHelper.CreateTestCacheTag("project") }
                 }
             });
             templatesToSearch.Add(new TemplateInfo()
@@ -103,7 +103,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Identity = "Template2",
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "type", CreateTestCacheTag("item") }
+                    { "type", ResolutionTestHelper.CreateTestCacheTag("item") }
                 }
             });
             templatesToSearch.Add(new TemplateInfo()
@@ -112,7 +112,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Identity = "Template3",
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "type", CreateTestCacheTag("myType") }
+                    { "type", ResolutionTestHelper.CreateTestCacheTag("myType") }
                 }
             });
             templatesToSearch.Add(new TemplateInfo()
@@ -121,7 +121,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Identity = "Template4",
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "type", CreateTestCacheTag("project") }
+                    { "type",ResolutionTestHelper.CreateTestCacheTag("project") }
                 }
             });
             templatesToSearch.Add(new TemplateInfo()
@@ -130,7 +130,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Identity = "Template5",
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "type", CreateTestCacheTag("project") }
+                    { "type", ResolutionTestHelper.CreateTestCacheTag("project") }
                 }
             });
 
@@ -198,7 +198,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 GroupIdentity = "foo.test.template",
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "language", CreateTestCacheTag("Perl") }
+                    { "language", ResolutionTestHelper.CreateTestCacheTag("Perl") }
                 },
                 CacheParameters = new Dictionary<string, ICacheParameter>()
             });
@@ -210,7 +210,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 GroupIdentity = "foo.test.template",
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "language", CreateTestCacheTag("LISP") }
+                    { "language", ResolutionTestHelper.CreateTestCacheTag("LISP") }
                 },
                 CacheParameters = new Dictionary<string, ICacheParameter>()
             });
@@ -239,7 +239,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 GroupIdentity = "foo.test.template",
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "language", CreateTestCacheTag("Perl") }
+                    { "language", ResolutionTestHelper.CreateTestCacheTag("Perl") }
                 },
                 CacheParameters = new Dictionary<string, ICacheParameter>()
             });
@@ -251,7 +251,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 GroupIdentity = "foo.test.template",
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "language", CreateTestCacheTag("LISP") }
+                    { "language", ResolutionTestHelper.CreateTestCacheTag("LISP") }
                 },
                 CacheParameters = new Dictionary<string, ICacheParameter>()
             });
@@ -376,7 +376,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Precedence = 100,
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "framework", CreateTestCacheTag(new List<string>() { "netcoreapp1.0", "netcoreapp1.1" }) }
+                    { "framework", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "netcoreapp1.0", "netcoreapp1.1" }) }
                 },
                 CacheParameters = new Dictionary<string, ICacheParameter>()
             });
@@ -389,7 +389,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Precedence = 200,
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "framework", CreateTestCacheTag(new List<string>() { "netcoreapp2.0" }) }
+                    { "framework", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "netcoreapp2.0" }) }
                 },
                 CacheParameters = new Dictionary<string, ICacheParameter>()
             });
@@ -462,7 +462,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Precedence = 100,
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "framework", CreateTestCacheTag(new List<string>() { "netcoreapp1.0", "netcoreapp1.1" }) }
+                    { "framework", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "netcoreapp1.0", "netcoreapp1.1" }) }
                 },
                 CacheParameters = new Dictionary<string, ICacheParameter>()
             });
@@ -475,7 +475,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                 Precedence = 200,
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "framework", CreateTestCacheTag(new List<string>() { "netcoreapp2.0" }) }
+                    { "framework", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "netcoreapp2.0" }) }
                 },
                 CacheParameters = new Dictionary<string, ICacheParameter>()
             });
@@ -498,27 +498,6 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
 
             Assert.Contains(unambiguousGroup[0].MatchDisposition, x => x.Kind == MatchKind.InvalidParameterValue);
             Assert.Contains(unambiguousGroup[1].MatchDisposition, x => x.Kind == MatchKind.InvalidParameterValue);
-        }
-
-        private static ICacheTag CreateTestCacheTag(string choice, string description = null, string defaultValue = null)
-        {
-            return new CacheTag(null,
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { choice, description }
-                },
-                defaultValue);
-        }
-
-        private static ICacheTag CreateTestCacheTag(IReadOnlyList<string> choiceList, string description = null, string defaultValue = null)
-        {
-            Dictionary<string, string> choicesDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            foreach(string choice in choiceList)
-            {
-                choicesDict.Add(choice, null);
-            };
-
-            return new CacheTag(null, choicesDict, defaultValue);
         }
     }
 }


### PR DESCRIPTION
Fix for when an input parameter value is a "single starts with" choice match for multiple templates in the same group. Prevents template invocation because the match is ambiguous.

Also, a fix in HelpForTemplateResolution.cs for what's displayed when the input matches a single template group, and each input parameter is valid for at least one template in the group, but the input parameters in combination are not valid for any templates in the group. For example, with the 1.x and 2.0 web templates installed:
`c:\Github\templating>dotnet new3 web -f netcoreapp1.1 --use-launch-settings -o W1`
![image](https://user-images.githubusercontent.com/20912881/32681305-b983523e-c623-11e7-8e7c-2f039c6bc518.png)
For the 1.x web template: `-f netcoreapp1.1` is valid, but `--use-launch-settings` is not valid.
For the 2.0 web template: `-f netcoreapp1.1` is not valid (but the -f flag is), and `--use-launch-settings` is valid.