### PR TITLE
fix for scanning the install directory for components - part 1

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -198,6 +198,8 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                     Create.Option("--debug:custom-hive", string.Empty, Accept.ExactlyOneArgument()),
                     Create.Option("--debug:version", string.Empty, Accept.NoArguments()),
 
+                    Create.Option("--dev:install", string.Empty, Accept.NoArguments()),
+
                     Create.Option("--trace:authoring", string.Empty, Accept.NoArguments()),
                     Create.Option("--trace:install", string.Empty, Accept.NoArguments()),
                 };

--- a/src/Microsoft.TemplateEngine.Cli/IInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Cli/IInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
@@ -10,6 +10,8 @@ namespace Microsoft.TemplateEngine.Cli
         void InstallPackages(IEnumerable<string> installationRequests);
 
         void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources);
+
+        void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall);
 
         IEnumerable<string> Uninstall(IEnumerable<string> uninstallRequests);
     }

--- a/src/Microsoft.TemplateEngine.Cli/Installer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Installer.cs
@@ -31,10 +31,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         public void InstallPackages(IEnumerable<string> installationRequests) => InstallPackages(installationRequests, null, false);
 
-        public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources)
-        {
-            InstallPackages(installationRequests, nuGetSources, false);
-        }
+        public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources) => InstallPackages(installationRequests, nuGetSources, false);
 
         public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall)
         {

--- a/src/Microsoft.TemplateEngine.Cli/Installer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Installer.cs
@@ -29,9 +29,14 @@ namespace Microsoft.TemplateEngine.Cli
             ((SettingsLoader)(_environmentSettings.SettingsLoader)).InstallUnitDescriptorCache.TryAddDescriptorForLocation(mountPointId);
         }
 
-        public void InstallPackages(IEnumerable<string> installationRequests) => InstallPackages(installationRequests, null);
+        public void InstallPackages(IEnumerable<string> installationRequests) => InstallPackages(installationRequests, null, false);
 
         public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources)
+        {
+            InstallPackages(installationRequests, nuGetSources, false);
+        }
+
+        public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall)
         {
             List<string> localSources = new List<string>();
             List<Package> packages = new List<Package>();
@@ -60,7 +65,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             if (localSources.Count > 0)
             {
-                InstallLocalPackages(localSources);
+                InstallLocalPackages(localSources, debugAllowDevInstall);
             }
 
             if (packages.Count > 0)
@@ -232,10 +237,10 @@ namespace Microsoft.TemplateEngine.Cli
             }
 
             _paths.DeleteDirectory(_paths.User.ScratchDir);
-            InstallLocalPackages(newLocalPackages);
+            InstallLocalPackages(newLocalPackages, false);
         }
 
-        private void InstallLocalPackages(IReadOnlyList<string> packageNames)
+        private void InstallLocalPackages(IReadOnlyList<string> packageNames, bool debugAllowDevInstall)
         {
             List<string> toInstall = new List<string>();
 
@@ -268,7 +273,7 @@ namespace Microsoft.TemplateEngine.Cli
                     {
                         string fullDirectory = new DirectoryInfo(pkg).FullName;
                         string fullPathGlob = Path.Combine(fullDirectory, pattern);
-                        ((SettingsLoader)(_environmentSettings.SettingsLoader)).UserTemplateCache.Scan(fullPathGlob, out IReadOnlyList<Guid> contentMountPointIds);
+                        ((SettingsLoader)(_environmentSettings.SettingsLoader)).UserTemplateCache.Scan(fullPathGlob, out IReadOnlyList<Guid> contentMountPointIds, debugAllowDevInstall);
 
                         foreach (Guid mountPointId in contentMountPointIds)
                         {
@@ -278,7 +283,7 @@ namespace Microsoft.TemplateEngine.Cli
                     else if (_environmentSettings.Host.FileSystem.DirectoryExists(pkg) || _environmentSettings.Host.FileSystem.FileExists(pkg))
                     {
                         string packageLocation = new DirectoryInfo(pkg).FullName;
-                        ((SettingsLoader)(_environmentSettings.SettingsLoader)).UserTemplateCache.Scan(packageLocation, out IReadOnlyList<Guid> contentMountPointIds);
+                        ((SettingsLoader)(_environmentSettings.SettingsLoader)).UserTemplateCache.Scan(packageLocation, out IReadOnlyList<Guid> contentMountPointIds, debugAllowDevInstall);
 
                         foreach (Guid mountPointId in contentMountPointIds)
                         {

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -314,7 +314,6 @@ namespace Microsoft.TemplateEngine.Cli
         {
             _telemetryLogger.TrackEvent(CommandName + TelemetryConstants.InstallEventSuffix, new Dictionary<string, string> { { TelemetryConstants.ToInstallCount, _commandInput.ToInstallList.Count.ToString() } });
 
-            // new
             bool allowDevInstall = _commandInput.HasDebuggingFlag("--dev:install");
             Installer.InstallPackages(_commandInput.ToInstallList, _commandInput.InstallNuGetSourceList, allowDevInstall);
 
@@ -340,14 +339,6 @@ namespace Microsoft.TemplateEngine.Cli
                 }
 
                 return CreationResultStatus.InvalidParamValues;
-            }
-
-            // duplicate
-            if (_commandInput.ToInstallList != null && _commandInput.ToInstallList.Count > 0 && _commandInput.ToInstallList[0] != null)
-            {
-                // new
-                bool allowDevInstall = _commandInput.HasDebuggingFlag("--dev:install");
-                Installer.InstallPackages(_commandInput.ToInstallList, _commandInput.InstallNuGetSourceList, allowDevInstall);
             }
 
             if (_commandInput.ToUninstallList != null)

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -65,7 +65,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
         }
 
-        public static IInstaller Installer { get; set; }
+        internal static Installer Installer { get; set; }
 
         public string CommandName { get; }
 
@@ -314,7 +314,9 @@ namespace Microsoft.TemplateEngine.Cli
         {
             _telemetryLogger.TrackEvent(CommandName + TelemetryConstants.InstallEventSuffix, new Dictionary<string, string> { { TelemetryConstants.ToInstallCount, _commandInput.ToInstallList.Count.ToString() } });
 
-            Installer.InstallPackages(_commandInput.ToInstallList, _commandInput.InstallNuGetSourceList);
+            // new
+            bool allowDevInstall = _commandInput.HasDebuggingFlag("--dev:install");
+            Installer.InstallPackages(_commandInput.ToInstallList, _commandInput.InstallNuGetSourceList, allowDevInstall);
 
             //TODO: When an installer that directly calls into NuGet is available,
             //  return a more accurate representation of the outcome of the operation
@@ -340,9 +342,12 @@ namespace Microsoft.TemplateEngine.Cli
                 return CreationResultStatus.InvalidParamValues;
             }
 
+            // duplicate
             if (_commandInput.ToInstallList != null && _commandInput.ToInstallList.Count > 0 && _commandInput.ToInstallList[0] != null)
             {
-                Installer.InstallPackages(_commandInput.ToInstallList.Select(x => x.Split(new[] { "::" }, StringSplitOptions.None)[0]), _commandInput.InstallNuGetSourceList);
+                // new
+                bool allowDevInstall = _commandInput.HasDebuggingFlag("--dev:install");
+                Installer.InstallPackages(_commandInput.ToInstallList, _commandInput.InstallNuGetSourceList, allowDevInstall);
             }
 
             if (_commandInput.ToUninstallList != null)

--- a/src/Microsoft.TemplateEngine.Edge/Settings/ScanResult.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/ScanResult.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Edge.Settings
+{
+    public class ScanResult
+    {
+        public ScanResult()
+        {
+            _localizations = new List<ILocalizationLocator>();
+            _templates = new List<ITemplate>();
+            _installedMountPointIds = new List<Guid>();
+        }
+
+        private List<ILocalizationLocator> _localizations;
+        private List<ITemplate> _templates;
+        private List<Guid> _installedMountPointIds;
+
+        public void AddLocalization(ILocalizationLocator locater)
+        {
+            _localizations.Add(locater);
+        }
+
+        public void AddTemplate(ITemplate template)
+        {
+            _templates.Add(template);
+        }
+
+        public void AddInstalledMountPointId(Guid mountPointId)
+        {
+            _installedMountPointIds.Add(mountPointId);
+        }
+
+        public IReadOnlyList<ILocalizationLocator> Localizations => _localizations;
+
+        public IReadOnlyList<ITemplate> Templates => _templates;
+
+        public IReadOnlyList<Guid> InstalledMountPointIds => _installedMountPointIds;
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
@@ -1,0 +1,346 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.Edge.Mount.FileSystem;
+using Microsoft.TemplateEngine.Utils;
+
+namespace Microsoft.TemplateEngine.Edge.Settings
+{
+    public class Scanner
+    {
+        public Scanner(IEngineEnvironmentSettings environmentSettings)
+        {
+            _environmentSettings = environmentSettings;
+            _paths = new Paths(environmentSettings);
+        }
+
+        private readonly IEngineEnvironmentSettings _environmentSettings;
+        private readonly Paths _paths;
+
+        public ScanResult Scan(string baseDir)
+        {
+            return Scan(baseDir, false);
+        }
+
+        public ScanResult Scan(string baseDir, bool allowDevInstall)
+        {
+            IReadOnlyList<string> directoriesToScan = DetermineDirectoriesToScan(baseDir);
+            IReadOnlyList<MountPointScanSource> sourceList = SetupMountPointScanInfoForDirectories(directoriesToScan);
+
+            ScanSourcesForComponents(sourceList, allowDevInstall);
+            ScanResult scanResult = ScanSourcesForTemplatesAndLangPacks(sourceList);
+
+            foreach (MountPointScanSource source in sourceList)
+            {
+                if (source.AnythingFound)
+                {
+                    scanResult.AddInstalledMountPointId(source.MountPoint.Info.MountPointId);
+                }
+
+                if (source.MountPoint != null)
+                {   // should never be null, but just in case.
+                    _environmentSettings.SettingsLoader.ReleaseMountPoint(source.MountPoint);
+
+                    if (source.RemoveIfNothingFound && !source.AnythingFound)
+                    {
+                        _environmentSettings.SettingsLoader.RemoveMountPoints(new[] { source.MountPoint.Info.MountPointId });
+                    }
+                }
+            }
+
+            return scanResult;
+        }
+
+        private IReadOnlyList<string> DetermineDirectoriesToScan(string baseDir)
+        {
+            List<string> directoriesToScan = new List<string>();
+
+            if (baseDir[baseDir.Length - 1] == '/' || baseDir[baseDir.Length - 1] == '\\')
+            {
+                baseDir = baseDir.Substring(0, baseDir.Length - 1);
+            }
+
+            string searchTarget = Path.Combine(_environmentSettings.Host.FileSystem.GetCurrentDirectory(), baseDir.Trim());
+            List<string> matches = _environmentSettings.Host.FileSystem.EnumerateFileSystemEntries(Path.GetDirectoryName(searchTarget), Path.GetFileName(searchTarget), SearchOption.TopDirectoryOnly)
+                                                                                                .Where(x => !x.EndsWith("symbols.nupkg", StringComparison.OrdinalIgnoreCase)).ToList();
+
+            if (matches.Count == 1)
+            {
+                directoriesToScan.Add(matches[0]);
+            }
+            else
+            {
+                foreach (string match in matches)
+                {
+                    IReadOnlyList<string> subDirMatches = DetermineDirectoriesToScan(match);
+                    directoriesToScan.AddRange(subDirMatches);
+                }
+            }
+
+            return directoriesToScan;
+        }
+
+        private IReadOnlyList<MountPointScanSource> SetupMountPointScanInfoForDirectories(IReadOnlyList<string> directoriesToScan)
+        {
+            List<MountPointScanSource> locationList = new List<MountPointScanSource>();
+
+            foreach (string directory in directoriesToScan)
+            {
+                MountPointScanSource locationInfo = GetOrCreateMountPointScanInfoForDirectory(directory);
+                if (locationInfo != null)
+                {
+                    locationList.Add(locationInfo);
+                }
+            }
+
+            return locationList;
+        }
+
+        private MountPointScanSource GetOrCreateMountPointScanInfoForDirectory(string originalLocation)
+        {
+            if (_environmentSettings.SettingsLoader.TryGetMountPointFromPlace(originalLocation, out IMountPoint existingMountPoint))
+            {
+                return new MountPointScanSource()
+                {
+                    Location = originalLocation,
+                    MountPoint = existingMountPoint,
+                    RemoveIfNothingFound = false,
+                    AnythingFound = false
+                };
+            }
+            else
+            {
+                foreach (IMountPointFactory factory in _environmentSettings.SettingsLoader.Components.OfType<IMountPointFactory>().ToList())
+                {
+                    if (factory.TryMount(_environmentSettings, null, originalLocation, out IMountPoint originalLocationMountPoint))
+                    {
+                        string mountPointLocation = originalLocation;
+                        IMountPoint effectiveMountPoint = originalLocationMountPoint;
+
+                        if (originalLocationMountPoint.Info.MountPointFactoryId != FileSystemMountPointFactory.FactoryId)
+                        {
+                            string targetLocation = Path.Combine(_paths.User.Packages, Path.GetFileName(originalLocation));
+
+                            if (!string.Equals(targetLocation, originalLocation))
+                            {
+                                _paths.CreateDirectory(_paths.User.Packages);
+                                _paths.Copy(originalLocation, targetLocation);
+
+                                var attributes = _environmentSettings.Host.FileSystem.GetFileAttributes(targetLocation);
+                                if (attributes.HasFlag(FileAttributes.ReadOnly))
+                                {
+                                    attributes &= ~FileAttributes.ReadOnly;
+                                    _environmentSettings.Host.FileSystem.SetFileAttributes(targetLocation, attributes);
+                                }
+
+                                if (_environmentSettings.SettingsLoader.TryGetMountPointFromPlace(targetLocation, out IMountPoint targetLocationMountPoint)
+                                        || factory.TryMount(_environmentSettings, null, targetLocation, out targetLocationMountPoint))
+                                {
+                                    // the original location will not be used, release its MP without adding it.
+                                    _environmentSettings.SettingsLoader.ReleaseMountPoint(originalLocationMountPoint);
+                                    mountPointLocation = targetLocation;
+                                    effectiveMountPoint = targetLocationMountPoint;
+                                }
+                            }
+                        }
+
+                        // Add the effective MP.
+                        // If the original isn't being used, it got released when the target MP was created, so doesn't need a special release here.
+                        // The effective is the only one that needs action here.
+                        _environmentSettings.SettingsLoader.AddMountPoint(effectiveMountPoint);
+
+                        return new MountPointScanSource()
+                        {
+                            Location = mountPointLocation,
+                            RemoveIfNothingFound = true,
+                            AnythingFound = false,
+                            MountPoint = effectiveMountPoint,
+                        };
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        // Iterate over the sourceList, scanning for components.
+        // Track the sources that didn't find any components.
+        // If any source found components, re-try the remaining sources that didn't find any components.
+        // Repeat until all sources have found components, or none of the remaining sources find anything.
+        // This is to avoid problems with the load order - an assembly that depends on another assembly can't be loaded until the dependent assembly has been loaded.
+        private void ScanSourcesForComponents(IReadOnlyList<MountPointScanSource> sourceList, bool allowDevInstall)
+        {
+            List<MountPointScanSource> workingSet = new List<MountPointScanSource>(sourceList);
+
+            bool anythingFoundThisRound;
+            do
+            {
+                anythingFoundThisRound = false;
+                List<MountPointScanSource> unhandledSources = new List<MountPointScanSource>();
+
+                foreach (MountPointScanSource source in workingSet)
+                {
+                    IMountPoint mountPoint = source.MountPoint;
+
+                    // note: if we can't get the mount point, don't put this source in the unhandled sources - it'll never succeed.
+                    bool anythingFound = ScanForComponents(mountPoint, source.Location, allowDevInstall);
+                    source.AnythingFound |= anythingFound;
+                    anythingFoundThisRound |= anythingFound;
+
+                    if (!anythingFound)
+                    {
+                        unhandledSources.Add(source);
+                    }
+                }
+
+                workingSet = unhandledSources;
+            } while (anythingFoundThisRound && workingSet.Count > 0);
+        }
+
+        private bool ScanForComponents(IMountPoint mountPoint, string scanLocation, bool allowDevInstall)
+        {
+            bool anythingFound = false;
+            bool isInOriginalInstallLocation;
+
+            if (!mountPoint.Root.EnumerateFiles("*.dll", SearchOption.AllDirectories).Any())
+            {
+                return false;
+            }
+
+            string diskPath;
+            if (mountPoint.Info.MountPointFactoryId != FileSystemMountPointFactory.FactoryId)
+            {
+                if (!TryCopyContentForNonFileSystemBasedMountPoints(mountPoint, scanLocation, out diskPath))
+                {
+                    return false;
+                }
+
+                isInOriginalInstallLocation = false;
+            }
+            else
+            {
+                if (!allowDevInstall)
+                {
+                    // TODO: localize this message
+                    _environmentSettings.Host.LogDiagnosticMessage("Installing local .dll files is not a standard supported scenario. Either package it in a .zip or .nupkg, or install it using '--dev:install'.", "Install");
+                    // dont allow .dlls to be installed from a file unless the debugging flag is set.
+                    return false;
+                }
+
+                diskPath = scanLocation;
+                isInOriginalInstallLocation = true;
+            }
+
+            foreach (KeyValuePair<string, Assembly> asm in AssemblyLoader.LoadAllFromPath(_paths, out IEnumerable<string> failures, diskPath))
+            {
+                try
+                {
+                    IReadOnlyList<Type> typeList = asm.Value.GetTypes();
+
+                    if (typeList.Count > 0)
+                    {
+                        _environmentSettings.SettingsLoader.Components.RegisterMany(typeList);
+                        _environmentSettings.SettingsLoader.AddProbingPath(Path.GetDirectoryName(asm.Key));
+                        anythingFound = true;
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            if (!anythingFound && !isInOriginalInstallLocation)
+            {
+                try
+                {
+                    _environmentSettings.Host.FileSystem.DirectoryDelete(diskPath, true);
+                }
+                catch
+                {
+                }
+            }
+
+            return isInOriginalInstallLocation && anythingFound;
+        }
+
+        private bool TryCopyContentForNonFileSystemBasedMountPoints(IMountPoint mountPoint, string scanLocation, out string diskPath)
+        {
+            string path = Path.Combine(_paths.User.Content, Path.GetFileName(scanLocation));
+
+            try
+            {
+                mountPoint.Root.CopyTo(path);
+            }
+            catch (IOException)
+            {
+                diskPath = null;
+                return false;
+            }
+
+            try
+            {
+                if (mountPoint.Info.Place.StartsWith(_paths.User.Packages))
+                {
+                    _environmentSettings.Host.FileSystem.FileDelete(mountPoint.Info.Place);
+                }
+            }
+            catch
+            {
+            }
+
+            diskPath = path;
+            return true;
+        }
+
+        private ScanResult ScanSourcesForTemplatesAndLangPacks(IReadOnlyList<MountPointScanSource> sourceList)
+        {
+            ScanResult foundTemplatesAndLangPacks = new ScanResult();
+
+            foreach (MountPointScanSource source in sourceList)
+            {
+                IMountPoint mountPoint = source.MountPoint;
+
+                bool anythingFound = ScanMountPointForTemplatesAndLangpacks(mountPoint, source.Location, foundTemplatesAndLangPacks);
+                source.AnythingFound |= anythingFound;
+            }
+
+            return foundTemplatesAndLangPacks;
+        }
+
+        private bool ScanMountPointForTemplatesAndLangpacks(IMountPoint mountPoint, string templateDir, ScanResult foundTemplatesAndLangPacks)
+        {
+            bool anythingFound = false;
+
+            foreach (IGenerator generator in _environmentSettings.SettingsLoader.Components.OfType<IGenerator>())
+            {
+                IList<ITemplate> templateList = generator.GetTemplatesAndLangpacksFromDir(mountPoint, out IList<ILocalizationLocator> localizationInfo);
+
+                foreach (ILocalizationLocator locator in localizationInfo)
+                {
+                    foundTemplatesAndLangPacks.AddLocalization(locator);
+                }
+
+                foreach (ITemplate template in templateList)
+                {
+                    foundTemplatesAndLangPacks.AddTemplate(template);
+                }
+
+                anythingFound |= templateList.Count > 0 || localizationInfo.Count > 0;
+            }
+
+            return anythingFound;
+        }
+
+        private class MountPointScanSource
+        {
+            public string Location { get; set; }
+            public IMountPoint MountPoint { get; set; }
+            public bool RemoveIfNothingFound { get; set; }
+            public bool AnythingFound { get; set; }
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/SettingsStore.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/SettingsStore.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 using Newtonsoft.Json;
@@ -8,6 +8,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 {
     public class SettingsStore
     {
+        // NOTE: when the current version changes, a corresponding change in TemplateInfo.cs is needed, to get the correct template cache version reader to fire.
         internal static readonly string CurrentVersion = "1.0.0.0";
 
         public SettingsStore()

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -74,15 +74,15 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
         public void Scan(string templateDir, bool debugAllowDevInstall)
         {
-            Scan(templateDir, out IReadOnlyList<Guid> mountPointIds, debugAllowDevInstall);
+            Scan(templateDir, out IReadOnlyList<Guid> newMountPointIds, debugAllowDevInstall);
         }
 
-        public void Scan(string templateDir, out IReadOnlyList<Guid> mountPointIds)
+        public void Scan(string templateDir, out IReadOnlyList<Guid> newMountPointIds)
         {
-            Scan(templateDir, out mountPointIds, false);
+            Scan(templateDir, out newMountPointIds, false);
         }
 
-        public void Scan(string templateDir, out IReadOnlyList<Guid> mountPointIds, bool debugAllowDevInstall)
+        public void Scan(string templateDir, out IReadOnlyList<Guid> newMountPointIds, bool debugAllowDevInstall)
         {
             if (templateDir[templateDir.Length - 1] == '/' || templateDir[templateDir.Length - 1] == '\\')
             {
@@ -107,14 +107,14 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     storageLocations.AddRange(locationsForThisContent);
                 }
 
-                mountPointIds = storageLocations;
+                newMountPointIds = storageLocations;
                 return;
             }
 
             if (_environmentSettings.SettingsLoader.TryGetMountPointFromPlace(templateDir, out IMountPoint existingMountPoint))
             {
                 ScanMountPointForTemplatesAndLangpacks(existingMountPoint, templateDir, debugAllowDevInstall);
-                mountPointIds = new Guid[]
+                newMountPointIds = new Guid[]
                 {
                     existingMountPoint.Info.MountPointId
                 };
@@ -159,7 +159,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                         // 1) no templates, and no langpacks were found.
                         // 2) only langpacks were found, but they aren't for any existing templates - but we won't know that at this point.
                         _environmentSettings.SettingsLoader.AddMountPoint(mountPoint);
-                        if(!ScanMountPointForTemplatesAndLangpacks(mountPoint, templateDir, debugAllowDevInstall))
+                        if (!ScanMountPointForTemplatesAndLangpacks(mountPoint, templateDir, debugAllowDevInstall))
                         {
                             _environmentSettings.SettingsLoader.RemoveMountPoint(mountPoint);
 
@@ -173,12 +173,17 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                                 {
                                 }
                             }
-                        }
 
-                        mountPointIds = new Guid[]
+                            newMountPointIds = new Guid[] { };
+                        }
+                        else
                         {
-                            mountPoint.Info.MountPointId
-                        };
+                            // only add the MP to the return list if something was found under it.
+                            newMountPointIds = new Guid[]
+                            {
+                                mountPoint.Info.MountPointId
+                            };
+                        }
 
                         _environmentSettings.SettingsLoader.ReleaseMountPoint(mountPoint);
                         return;
@@ -186,7 +191,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 }
             }
 
-            mountPointIds = new Guid[] { };
+            newMountPointIds = new Guid[] { };
         }
 
         private bool ScanMountPointForTemplatesAndLangpacks(IMountPoint mountPoint, string templateDir, bool debugAllowDevInstall)

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -237,7 +237,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     diskPath = path;
                 }
 
-                foreach (KeyValuePair<string, Assembly> asm in AssemblyLoader.LoadAllAssemblies(_paths, out IEnumerable<string> failures))
+                foreach (KeyValuePair<string, Assembly> asm in AssemblyLoader.LoadAllFromPath(_paths, out IEnumerable<string> failures, diskPath))
                 {
                     try
                     {

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -9,7 +9,6 @@ using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli;
 using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects;
-using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config;
 using Microsoft.TemplateEngine.Utils;
 using Microsoft.TemplateEngine.Edge.TemplateUpdates;
 using Microsoft.TemplateEngine.Cli.PostActionProcessors;
@@ -26,11 +25,6 @@ namespace dotnet_new3
 
         public static int Main(string[] args)
         {
-            if (args.Any(x => string.Equals(x, "--debug:attach", StringComparison.OrdinalIgnoreCase)))
-            {
-                Console.ReadLine();
-            }
-
             bool emitTimings = args.Any(x => string.Equals(x, "--debug:emit-timings", StringComparison.OrdinalIgnoreCase));
             bool debugTelemetry = args.Any(x => string.Equals(x, "--debug:emit-telemetry", StringComparison.OrdinalIgnoreCase));
     

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -12,6 +12,7 @@ using Microsoft.TemplateEngine.Orchestrator.RunnableProjects;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Config;
 using Microsoft.TemplateEngine.Utils;
 using Microsoft.TemplateEngine.Edge.TemplateUpdates;
+using Microsoft.TemplateEngine.Cli.PostActionProcessors;
 
 [assembly:InternalsVisibleTo("dotnet-new3.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]
 
@@ -25,6 +26,11 @@ namespace dotnet_new3
 
         public static int Main(string[] args)
         {
+            if (args.Any(x => string.Equals(x, "--debug:attach", StringComparison.OrdinalIgnoreCase)))
+            {
+                Console.ReadLine();
+            }
+
             bool emitTimings = args.Any(x => string.Equals(x, "--debug:emit-timings", StringComparison.OrdinalIgnoreCase));
             bool debugTelemetry = args.Any(x => string.Equals(x, "--debug:emit-telemetry", StringComparison.OrdinalIgnoreCase));
     
@@ -67,7 +73,8 @@ namespace dotnet_new3
             {
                 typeof(RunnableProjectGenerator).GetTypeInfo().Assembly,
                 typeof(ConditionalConfig).GetTypeInfo().Assembly,
-                typeof(NupkgInstallUnitDescriptorFactory).GetTypeInfo().Assembly
+                typeof(NupkgInstallUnitDescriptorFactory).GetTypeInfo().Assembly,
+                typeof(DotnetRestorePostActionProcessor).GetTypeInfo().Assembly
             });
 
             DefaultTemplateEngineHost host = new DefaultTemplateEngineHost(HostIdentifier, HostVersion, CultureInfo.CurrentCulture.Name, preferences, builtIns, new[] { "dotnetcli" });

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -71,10 +71,9 @@ namespace dotnet_new3
 
             var builtIns = new AssemblyComponentCatalog(new[]
             {
-                typeof(RunnableProjectGenerator).GetTypeInfo().Assembly,
-                typeof(ConditionalConfig).GetTypeInfo().Assembly,
-                typeof(NupkgInstallUnitDescriptorFactory).GetTypeInfo().Assembly,
-                typeof(DotnetRestorePostActionProcessor).GetTypeInfo().Assembly
+                typeof(RunnableProjectGenerator).GetTypeInfo().Assembly,            // for assembly: Microsoft.TemplateEngine.Orchestrator.RunnableProjects
+                typeof(NupkgInstallUnitDescriptorFactory).GetTypeInfo().Assembly,   // for assembly: Microsoft.TemplateEngine.Edge
+                typeof(DotnetRestorePostActionProcessor).GetTypeInfo().Assembly     // for assembly: Microsoft.TemplateEngine.Cli
             });
 
             DefaultTemplateEngineHost host = new DefaultTemplateEngineHost(HostIdentifier, HostVersion, CultureInfo.CurrentCulture.Name, preferences, builtIns, new[] { "dotnetcli" });

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateUpdateTests/MockInstaller.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateUpdateTests/MockInstaller.cs
@@ -20,10 +20,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateUpdateTests
 
         public HashSet<string> Installed { get; private set; }
 
-        public void InstallPackages(IEnumerable<string> installationRequests) => InstallPackages(installationRequests, null);
+        public void InstallPackages(IEnumerable<string> installationRequests) => InstallPackages(installationRequests, null, false);
 
         // unconditionally adds the installation requests to the _installed list.
-        public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources)
+        public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources) => InstallPackages(installationRequests, nuGetSources, false);
+
+        public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall)
         {
             Installed.UnionWith(installationRequests);
         }

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
 using Microsoft.TemplateEngine.Cli;
+using Microsoft.TemplateEngine.Cli.PostActionProcessors;
 using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Edge.TemplateUpdates;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects;
@@ -205,7 +206,8 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
             {
                 typeof(RunnableProjectGenerator).GetTypeInfo().Assembly,
                 typeof(ConditionalConfig).GetTypeInfo().Assembly,
-                typeof(NupkgInstallUnitDescriptorFactory).GetTypeInfo().Assembly
+                typeof(NupkgInstallUnitDescriptorFactory).GetTypeInfo().Assembly,
+                typeof(DotnetRestorePostActionProcessor).GetTypeInfo().Assembly
             });
 
             return new DefaultTemplateEngineHost(HostIdentifier, HostVersion, CultureInfo.CurrentCulture.Name, preferences, builtIns, new[] { "dotnetcli" });

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
@@ -204,10 +204,9 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
 
             var builtIns = new AssemblyComponentCatalog(new[]
             {
-                typeof(RunnableProjectGenerator).GetTypeInfo().Assembly,
-                typeof(ConditionalConfig).GetTypeInfo().Assembly,
-                typeof(NupkgInstallUnitDescriptorFactory).GetTypeInfo().Assembly,
-                typeof(DotnetRestorePostActionProcessor).GetTypeInfo().Assembly
+                typeof(RunnableProjectGenerator).GetTypeInfo().Assembly,            // for assembly: Microsoft.TemplateEngine.Orchestrator.RunnableProjects
+                typeof(NupkgInstallUnitDescriptorFactory).GetTypeInfo().Assembly,   // for assembly: Microsoft.TemplateEngine.Edge
+                typeof(DotnetRestorePostActionProcessor).GetTypeInfo().Assembly     // for assembly: Microsoft.TemplateEngine.Cli
             });
 
             return new DefaultTemplateEngineHost(HostIdentifier, HostVersion, CultureInfo.CurrentCulture.Name, preferences, builtIns, new[] { "dotnetcli" });


### PR DESCRIPTION
This as scanning based on _paths, as opposed to the user-provided install path.