### PR TITLE
localizable string changes to support localized user prompt responses

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -401,6 +401,33 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to All.
+        /// </summary>
+        public static string AllUpdates_AllResponse {
+            get {
+                return ResourceManager.GetString("AllUpdates_AllResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to None.
+        /// </summary>
+        public static string AllUpdates_NoneResponse {
+            get {
+                return ResourceManager.GetString("AllUpdates_NoneResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prompt.
+        /// </summary>
+        public static string AllUpdates_PromptResponse {
+            get {
+                return ResourceManager.GetString("AllUpdates_PromptResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Apply updates ([A]ll|[N]one|[P]rompt)?.
         /// </summary>
         public static string AllUpdatesApplyPrompt {
@@ -1109,11 +1136,29 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid input &quot;{0}&quot;. Please enter one of (Y|N)..
+        ///   Looks up a localized string similar to Invalid input &quot;{0}&quot;. Please enter one of ([Y]es|[N]o)..
         /// </summary>
         public static string PostActionInvalidInputRePrompt {
             get {
                 return ResourceManager.GetString("PostActionInvalidInputRePrompt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No.
+        /// </summary>
+        public static string PostActionPrompt_NoResponse {
+            get {
+                return ResourceManager.GetString("PostActionPrompt_NoResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Yes.
+        /// </summary>
+        public static string PostActionPrompt_YesResponse {
+            get {
+                return ResourceManager.GetString("PostActionPrompt_YesResponse", resourceCulture);
             }
         }
         
@@ -1127,7 +1172,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do you want to run this action (Y|N)?.
+        ///   Looks up a localized string similar to Do you want to run this action ([Y]es|[N]o)?.
         /// </summary>
         public static string PostActionPromptRequest {
             get {
@@ -1250,6 +1295,24 @@ namespace Microsoft.TemplateEngine.Cli {
         public static string ShowsFilteredTemplates {
             get {
                 return ResourceManager.GetString("ShowsFilteredTemplates", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No.
+        /// </summary>
+        public static string SingleChoice_NoResponse {
+            get {
+                return ResourceManager.GetString("SingleChoice_NoResponse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Yes.
+        /// </summary>
+        public static string SingleChoice_YesResponse {
+            get {
+                return ResourceManager.GetString("SingleChoice_YesResponse", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -387,13 +387,13 @@ See https://aka.ms/dotnet-install-templates to learn how to install additional t
     <value>Running command '{0}'...</value>
   </data>
   <data name="PostActionInvalidInputRePrompt" xml:space="preserve">
-    <value>Invalid input "{0}". Please enter one of (Y|N).</value>
+    <value>Invalid input "{0}". Please enter one of ([Y]es|[N]o).</value>
   </data>
   <data name="PostActionPromptHeader" xml:space="preserve">
     <value>Template is configured to run the following action:</value>
   </data>
   <data name="PostActionPromptRequest" xml:space="preserve">
-    <value>Do you want to run this action (Y|N)?</value>
+    <value>Do you want to run this action ([Y]es|[N]o)?</value>
   </data>
   <data name="ProcessingPostActions" xml:space="preserve">
     <value>Processing post-creation actions...</value>
@@ -591,5 +591,33 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   </data>
   <data name="SingleTemplateGroupPartialMatchSwitchesNotValidForAllMatches" xml:space="preserve">
     <value>The following parameter(s) or their value(s) are not valid in combination with other supplied parameters or their values:</value>
+  </data>
+  <data name="AllUpdates_AllResponse" xml:space="preserve">
+    <value>All</value>
+    <comment>Needs to be localized the same as 'All' in AllUpdatesApplyPrompt</comment>
+  </data>
+  <data name="AllUpdates_NoneResponse" xml:space="preserve">
+    <value>None</value>
+    <comment>Needs to be localized the same as 'None' in AllUpdatesApplyPrompt</comment>
+  </data>
+  <data name="AllUpdates_PromptResponse" xml:space="preserve">
+    <value>Prompt</value>
+    <comment>Needs to be localized the same as 'Prompt' in AllUpdatesApplyPrompt</comment>
+  </data>
+  <data name="PostActionPrompt_NoResponse" xml:space="preserve">
+    <value>No</value>
+    <comment>Needs to be localized the same as 'No' in PostActionPromptRequest</comment>
+  </data>
+  <data name="PostActionPrompt_YesResponse" xml:space="preserve">
+    <value>Yes</value>
+    <comment>Needs to be localized the same as 'Yes' in PostActionPromptRequest</comment>
+  </data>
+  <data name="SingleChoice_NoResponse" xml:space="preserve">
+    <value>No</value>
+    <comment>Needs to be localized the same as 'No' in SingleUpdateApplyPrompt</comment>
+  </data>
+  <data name="SingleChoice_YesResponse" xml:space="preserve">
+    <value>Yes</value>
+    <comment>Needs to be localized the same as 'Yes' in SingleUpdateApplyPrompt</comment>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.PostActionProcessors;
 using Microsoft.TemplateEngine.Edge.Template;
@@ -118,11 +118,13 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 string input = inputGetter();
 
-                if (input.Equals("Y", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(input, LocalizableStrings.PostActionPrompt_YesResponse, StringComparison.CurrentCultureIgnoreCase)
+                        || string.Equals(input, LocalizableStrings.PostActionPrompt_YesResponse.Substring(0, 1), StringComparison.CurrentCultureIgnoreCase))
                 {
                     return true;
                 }
-                else if (input.Equals("N", StringComparison.OrdinalIgnoreCase))
+                else if (string.Equals(input, LocalizableStrings.PostActionPrompt_NoResponse, StringComparison.CurrentCultureIgnoreCase)
+                        || string.Equals(input, LocalizableStrings.PostActionPrompt_NoResponse.Substring(0, 1), StringComparison.CurrentCultureIgnoreCase))
                 {
                     return false;
                 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateUpdateCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateUpdateCoordinator.cs
@@ -113,24 +113,25 @@ namespace Microsoft.TemplateEngine.Cli
                 Reporter.Output.WriteLine(LocalizableStrings.AllUpdatesApplyPrompt.Bold().Red());
                 string userChoice = inputGetter();
 
-                switch (userChoice.ToLowerInvariant())
+                if (string.Equals(userChoice, LocalizableStrings.AllUpdates_AllResponse, StringComparison.CurrentCultureIgnoreCase)
+                        || string.Equals(userChoice, LocalizableStrings.AllUpdates_AllResponse.Substring(0, 1), StringComparison.CurrentCultureIgnoreCase))
                 {
-                    case "a":
-                    case "all":
-                        choice = ApplyUpdatesChoice.All;
-                        break;
-                    case "n":
-                    case "none":
-                        choice = ApplyUpdatesChoice.None;
-                        break;
-                    case "p":
-                    case "prompt":
-                        choice = ApplyUpdatesChoice.Prompt;
-                        break;
-                    default:
-                        choice = ApplyUpdatesChoice.InvalidChoice;
-                        Reporter.Output.Write(LocalizableStrings.ApplyUpdatesInvalidChoiceResponse.Bold().Red());
-                        break;
+                    choice = ApplyUpdatesChoice.All;
+                }
+                else if (string.Equals(userChoice, LocalizableStrings.AllUpdates_NoneResponse, StringComparison.CurrentCultureIgnoreCase)
+                        || string.Equals(userChoice, LocalizableStrings.AllUpdates_NoneResponse.Substring(0, 1), StringComparison.CurrentCultureIgnoreCase))
+                {
+                    choice = ApplyUpdatesChoice.None;
+                }
+                else if (string.Equals(userChoice, LocalizableStrings.AllUpdates_PromptResponse, StringComparison.CurrentCultureIgnoreCase)
+                        || string.Equals(userChoice, LocalizableStrings.AllUpdates_PromptResponse.Substring(0, 1), StringComparison.CurrentCultureIgnoreCase))
+                {
+                    choice = ApplyUpdatesChoice.Prompt;
+                }
+                else
+                {
+                    choice = ApplyUpdatesChoice.InvalidChoice;
+                    Reporter.Output.Write(LocalizableStrings.ApplyUpdatesInvalidChoiceResponse.Bold().Red());
                 }
             } while (choice == ApplyUpdatesChoice.InvalidChoice);
 
@@ -145,24 +146,23 @@ namespace Microsoft.TemplateEngine.Cli
             do
             {
                 Reporter.Output.WriteLine(string.Format(LocalizableStrings.SingleUpdateApplyPrompt.Bold().Red(), descriptor.UpdateDisplayInfo));
-
                 string userChoice = inputGetter();
 
-                switch (userChoice.ToLowerInvariant())
+                if (string.Equals(userChoice, LocalizableStrings.SingleChoice_YesResponse, StringComparison.CurrentCultureIgnoreCase)
+                        || string.Equals(userChoice, LocalizableStrings.SingleChoice_YesResponse.Substring(0, 1), StringComparison.CurrentCultureIgnoreCase))
                 {
-                    case "y":
-                    case "yes":
-                        installChoice = true;
-                        validChoice = true;
-                        break;
-                    case "n":
-                    case "no":
-                        installChoice = false;
-                        validChoice = true;
-                        break;
-                    default:
-                        Reporter.Output.WriteLine(LocalizableStrings.ApplyUpdatesInvalidChoiceResponse.Bold().Red());
-                        break;
+                    installChoice = true;
+                    validChoice = true;
+                }
+                else if (string.Equals(userChoice, LocalizableStrings.SingleChoice_NoResponse, StringComparison.CurrentCultureIgnoreCase)
+                        || string.Equals(userChoice, LocalizableStrings.SingleChoice_NoResponse.Substring(0, 1), StringComparison.CurrentCultureIgnoreCase))
+                {
+                    installChoice = false;
+                    validChoice = true;
+                }
+                else
+                {
+                    Reporter.Output.WriteLine(LocalizableStrings.ApplyUpdatesInvalidChoiceResponse.Bold().Red());
                 }
             } while (!validChoice);
 


### PR DESCRIPTION
Prior to this change, the strings to check against user responses for post action & template updates would not get localized. That would make the suggested localized responses invalid, and incorrectly checked for. This fixes it.

Related to: #1342 #1341 