### PR TITLE
Remove PB_SkipTests from build.ps1 input parameters

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -10,14 +10,7 @@ param(
     [bool]$SkipTests=$false,
     [bool]$TemplatesBuild=-not $CIBuild,
     [bool]$EngineBuild=-not $CIBuild,
-    [switch]$Help,
-    [string]$PB_SkipTests="false")
-
-switch ($PB_SkipTests.ToLower())
-{
-	"true" { $PB_SkipTests = "True" }
-	default { $PB_SkipTests = "False" }
-}
+    [switch]$Help)
 
 if($Help)
 {
@@ -95,5 +88,5 @@ $NoTimestampPackageVersion=$env:PACKAGE_VERSION + "-" + $env:BUILD_QUALITY
 
 $TimestampPackageVersion=$NoTimestampPackageVersion + "-" + [System.DateTime]::Now.ToString("yyyyMMdd") + "-" + $env:BUILD_NUMBER
 
-& dotnet msbuild $RepoRoot\build.proj /p:IsFullFrameworkBuildSupported=$PerformFullFrameworkBuild /p:Configuration=$Configuration /p:CIBuild=$CIBuild /p:SkipTests=$SkipTests /p:TemplatesBuild=$TemplatesBuild /p:EngineBuild=$EngineBuild /p:PB_SkipTests=$PB_SkipTests
+& dotnet msbuild $RepoRoot\build.proj /p:IsFullFrameworkBuildSupported=$PerformFullFrameworkBuild /p:Configuration=$Configuration /p:CIBuild=$CIBuild /p:SkipTests=$SkipTests /p:TemplatesBuild=$TemplatesBuild /p:EngineBuild=$EngineBuild
 & $RepoRoot\SetPath.ps1 -DevDir "$DevDir"


### PR DESCRIPTION
@seancpeters @mlorbetske 

When PB_SkipTests env variable is set, build.proj should automatically get this value from the env variable. So, passing it from build.ps1 is not required.