### PR TITLE
Make the full file name be matched when enumerating files for the in-memory file system

### DIFF
--- a/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
+++ b/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -499,7 +499,7 @@ namespace Microsoft.TemplateEngine.Utils
                 }
             }
 
-            Regex rx = new Regex(Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", "."));
+            Regex rx = new Regex("^" + Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", ".") + "$");
 
             foreach (KeyValuePair<string, FileSystemFile> entry in currentDir.Files)
             {


### PR DESCRIPTION
In some experimentation last night, I ran across a case where if an in-memory file system has a file that's subjected to scan and also contains a file name that has the original name as a substring, a stack overflow can occur.