### PR TITLE
Scan fix for template packs with dll's

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/AssemblyLoadContextHelper.cs
+++ b/src/Microsoft.TemplateEngine.Edge/AssemblyLoadContextHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -37,7 +37,8 @@ namespace Microsoft.TemplateEngine.Edge
 #if !NET45
                     if(file.IndexOf("netcoreapp", StringComparison.OrdinalIgnoreCase) > -1 || file.IndexOf("netstandard", StringComparison.OrdinalIgnoreCase) > -1)
                     {
-                        assembly = context.LoadFromStream(paths.OpenRead(file));
+                        using (Stream fileStream = paths.OpenRead(file))
+                            assembly = context.LoadFromStream(fileStream);
                     }
 #else
                     if (file.IndexOf("net4", StringComparison.OrdinalIgnoreCase) > -1)

--- a/src/Microsoft.TemplateEngine.Edge/Settings/ScanResult.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/ScanResult.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Edge.Settings
@@ -10,12 +11,12 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         {
             _localizations = new List<ILocalizationLocator>();
             _templates = new List<ITemplate>();
-            _installedMountPointIds = new List<Guid>();
+            _installedMountPointIds = new HashSet<Guid>();
         }
 
         private List<ILocalizationLocator> _localizations;
         private List<ITemplate> _templates;
-        private List<Guid> _installedMountPointIds;
+        private HashSet<Guid> _installedMountPointIds;
 
         public void AddLocalization(ILocalizationLocator locater)
         {
@@ -36,6 +37,6 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
         public IReadOnlyList<ITemplate> Templates => _templates;
 
-        public IReadOnlyList<Guid> InstalledMountPointIds => _installedMountPointIds;
+        public IReadOnlyList<Guid> InstalledMountPointIds => _installedMountPointIds.ToList();
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
@@ -280,9 +280,10 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     // Note: no mount pount was created for this copy, so no need to release it.
                     _environmentSettings.Host.FileSystem.DirectoryDelete(diskPath, true);
                 }
-                catch
+                catch (Exception ex)
                 {
                     _environmentSettings.Host.LogDiagnosticMessage($"During ScanForComponents() cleanup, couldn't delete source copied into the content dir: {diskPath}", "Install");
+                    _environmentSettings.Host.LogDiagnosticMessage($"\tError: {ex.Message}", "Install");
                 }
             }
 

--- a/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
@@ -260,6 +260,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
                     if (typeList.Count > 0)
                     {
+                        // TODO: figure out what to do with probing path registration when components are not found.
+                        // They need to be registered for dependent assemblies, not just when an assembly can be loaded.
+                        // We'll need to figure out how to know when that is.
                         _environmentSettings.SettingsLoader.Components.RegisterMany(typeList);
                         _environmentSettings.SettingsLoader.AddProbingPath(Path.GetDirectoryName(asm.Key));
                         anythingFound = true;

--- a/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/NupkgInstallUnitDescriptorFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/NupkgInstallUnitDescriptorFactory.cs
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
             descriptorList = allDescriptors;
 
             if (mountPoint.Info.Place != null
-                && File.Exists(mountPoint.Info.Place)
+                && mountPoint.EnvironmentSettings.Host.FileSystem.FileExists(mountPoint.Info.Place)
                 && TryGetPackageInfoFromNuspec(mountPoint, out string packageName, out string version))
             {
                 IInstallUnitDescriptor descriptor = new NupkgInstallUnitDescriptor(mountPoint.Info.MountPointId, packageName, version);

--- a/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/NupkgInstallUnitDescriptorFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/NupkgInstallUnitDescriptorFactory.cs
@@ -47,7 +47,9 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
             List<IInstallUnitDescriptor> allDescriptors = new List<IInstallUnitDescriptor>();
             descriptorList = allDescriptors;
 
-            if (mountPoint.Info.Place != null && File.Exists(mountPoint.Info.Place) && TryGetPackageInfoFromNuspec(mountPoint, out string packageName, out string version))
+            if (mountPoint.Info.Place != null
+                && Directory.Exists(mountPoint.Info.Place)  // nupkgs are expanded to files on install, so Directory.Exists() is more appropriate
+                && TryGetPackageInfoFromNuspec(mountPoint, out string packageName, out string version))
             {
                 IInstallUnitDescriptor descriptor = new NupkgInstallUnitDescriptor(mountPoint.Info.MountPointId, packageName, version);
                 allDescriptors.Add(descriptor);

--- a/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/NupkgInstallUnitDescriptorFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/NupkgInstallUnitDescriptorFactory.cs
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
             descriptorList = allDescriptors;
 
             if (mountPoint.Info.Place != null
-                && Directory.Exists(mountPoint.Info.Place)  // nupkgs are expanded to files on install, so Directory.Exists() is more appropriate
+                && File.Exists(mountPoint.Info.Place)
                 && TryGetPackageInfoFromNuspec(mountPoint, out string packageName, out string version))
             {
                 IInstallUnitDescriptor descriptor = new NupkgInstallUnitDescriptor(mountPoint.Info.MountPointId, packageName, version);


### PR DESCRIPTION
Fixes #1397 

High-level sketch of the lifecycle of files / archives to install:

Scanner.Scan() orchestration never deletes install candidates from their original location, as proposed to Scan(). (Installer deals with remote packages in the scratch dir, and doesn't remove local packages).

Scan()
* SetupMountPointScanInfoForDirectories()
-- GetOrCreateMountPointScanInfoForDirectory()
--- If the directory is an existing mount point, return it.
--- Otherwise: Setup a mount point for the source location. If the location is not under the ScratchDir, mark the source as ShouldStayInOriginalLocation. 

- ScanSourcesForComponents()
-- ScanForComponents()
--- For source not marked as ShouldStayInOriginalLocation, copy into Content/ then do the component scan from there. Otherwise leave it where it is.
--- After component scan, if nothing was found, and dealing with a copy in Content/ then delete the Content/ copy. For things not copied to Content/ do nothing.

- ScanSourcesForTemplatesAndLangPacks()
-- No copying or moving of sources. The original location as proposed to Scan() is dealt with.

- Cleanup at the end of Scan() for each of the proposed scan locations:
-- If it's a new MP and nothing was found:
--- Remove the mount point.
--- If GetOrCreateMountPointScanInfoForDirectory() made a copy into Packages/ then delete that copy.
