### PR TITLE
Apply 0001-Allow-explicitly-setting-PackageDateTime.patch

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -4,10 +4,11 @@
     <PackageBuildQuality>$(BUILD_QUALITY)</PackageBuildQuality>
     <PackageBuildQuality Condition=" '$(PackageBuildQuality)' == '' ">beta1</PackageBuildQuality>
     <PackageVersion>$(PackageReleaseVersion)-$(PackageBuildQuality)</PackageVersion>
+    <PackageDateTime Condition="'$(PackageDateTime)' == ''">$([System.DateTime]::Now.ToString("yyyyMMdd"))</PackageDateTime>
     <BUILD_NUMBER Condition="'$(BUILD_NUMBER)' == ''">0</BUILD_NUMBER>
     <BUILD_NUMBER Condition="'$(BUILD_NUMBER)' == '0' And '$(BUILD_BUILDNUMBER)' != ''">$(BUILD_BUILDNUMBER)</BUILD_NUMBER>
-    <AssemblyReleaseVersion>$(PackageReleaseVersion).0</AssemblyReleaseVersion>
-    <PackageVersion Condition="'$(NO_TIMESTAMP)' != 'true'">$(PackageVersion)-$([System.DateTime]::Now.ToString("yyyyMMdd"))-$(BUILD_NUMBER)</PackageVersion>
+    <AssemblyReleaseVersion>$(PackageReleaseVersion).$(BUILD_NUMBER)</AssemblyReleaseVersion>
+    <PackageVersion Condition="'$(NO_TIMESTAMP)' != 'true'">$(PackageVersion)-$(PackageDateTime)-$(BUILD_NUMBER)</PackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>Microsoft</Authors>


### PR DESCRIPTION
Part of: https://github.com/dotnet/source-build/issues/177

Patch applied: [0001-Allow-explicitly-setting-PackageDateTime.patch](https://github.com/dotnet/source-build/blob/dev/release/2.0/patches/templating/0001-Allow-explicitly-setting-PackageDateTime.patch)