### PR TITLE
Support for multiple short names in a template

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/IShortNameList.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IShortNameList.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Microsoft.TemplateEngine.Abstractions
+{
+    public interface IShortNameList
+    {
+        IReadOnlyList<string> ShortNameList { get; }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -733,7 +733,21 @@ namespace Microsoft.TemplateEngine.Cli
             get
             {
                 IReadOnlyCollection<ITemplateMatchInfo> allTemplates = TemplateListResolver.PerformAllTemplatesQuery(_settingsLoader.UserTemplateCache.TemplateInfo, _hostDataLoader);
-                HashSet<string> allShortNames = new HashSet<string>(allTemplates.Select(x => x.Info.ShortName));
+
+                HashSet<string> allShortNames = new HashSet<string>();
+
+                foreach (ITemplateMatchInfo templateMatchInfo in allTemplates)
+                {
+                    if (templateMatchInfo.Info is IShortNameList templateWithShortNameList)
+                    {
+                        allShortNames.UnionWith(templateWithShortNameList.ShortNameList);
+                    }
+                    else
+                    {
+                        allShortNames.Add(templateMatchInfo.Info.ShortName);
+                    }
+                }
+
                 return allShortNames;
             }
         }

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -734,7 +734,7 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 IReadOnlyCollection<ITemplateMatchInfo> allTemplates = TemplateListResolver.PerformAllTemplatesQuery(_settingsLoader.UserTemplateCache.TemplateInfo, _hostDataLoader);
 
-                HashSet<string> allShortNames = new HashSet<string>();
+                HashSet<string> allShortNames = new HashSet<string>(StringComparer.Ordinal);
 
                 foreach (ITemplateMatchInfo templateMatchInfo in allTemplates)
                 {

--- a/src/Microsoft.TemplateEngine.Edge/FilterableTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/FilterableTemplateInfo.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Edge
+{
+    public class FilterableTemplateInfo : ITemplateInfo, IShortNameList
+    {
+        public static FilterableTemplateInfo FromITemplateInfo(ITemplateInfo source)
+        {
+            FilterableTemplateInfo filterableTemplate = new FilterableTemplateInfo()
+            {
+                Author = source.Author,
+                Description = source.Description,
+                Classifications = source.Classifications,
+                DefaultName = source.DefaultName,
+                Identity = source.Identity,
+                GeneratorId = source.GeneratorId,
+                GroupIdentity = source.GroupIdentity,
+                Precedence = source.Precedence,
+                Name = source.Name,
+                ShortName = source.ShortName,
+                Tags = source.Tags,
+                CacheParameters = source.CacheParameters,
+                Parameters = source.Parameters,
+                ConfigMountPointId = source.ConfigMountPointId,
+                ConfigPlace = source.ConfigPlace,
+                LocaleConfigMountPointId = source.LocaleConfigMountPointId,
+                LocaleConfigPlace = source.LocaleConfigPlace,
+                HostConfigMountPointId = source.HostConfigMountPointId,
+                ThirdPartyNotices = source.ThirdPartyNotices,
+                BaselineInfo = source.BaselineInfo,
+                HasScriptRunningPostActions = source.HasScriptRunningPostActions
+            };
+
+            if (source is IShortNameList sourceWithShortNameList)
+            {
+                filterableTemplate.ShortNameList = sourceWithShortNameList.ShortNameList;
+            }
+
+            return filterableTemplate;
+        }
+
+        public string Author { get; private set; }
+
+        public string Description { get; private set; }
+
+        public IReadOnlyList<string> Classifications { get; private set; }
+
+        public string DefaultName { get; private set; }
+
+        public string Identity { get; private set; }
+
+        public Guid GeneratorId { get; private set; }
+
+        public string GroupIdentity { get; private set; }
+
+        public int Precedence { get; private set; }
+
+        public string Name { get; private set; }
+
+        public string ShortName { get; private set; }
+
+        public IReadOnlyList<string> ShortNameList { get; set; }
+
+        public IReadOnlyList<string> GroupShortNameList { get; set; }
+
+        public IReadOnlyDictionary<string, ICacheTag> Tags { get; private set; }
+
+        public IReadOnlyDictionary<string, ICacheParameter> CacheParameters { get; private set; }
+
+        public IReadOnlyList<ITemplateParameter> Parameters { get; private set; }
+
+        public Guid ConfigMountPointId { get; private set; }
+
+        public string ConfigPlace { get; private set; }
+
+        public Guid LocaleConfigMountPointId { get; private set; }
+
+        public string LocaleConfigPlace { get; private set; }
+
+        public Guid HostConfigMountPointId { get; private set; }
+
+        public string HostConfigPlace { get; private set; }
+
+        public string ThirdPartyNotices { get; private set; }
+
+        public IReadOnlyDictionary<string, IBaselineInfo> BaselineInfo { get; private set; }
+
+        public bool HasScriptRunningPostActions { get; set; }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -322,6 +322,11 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 HasScriptRunningPostActions = template.HasScriptRunningPostActions
             };
 
+            if (template is IShortNameList templateWithShortNameList)
+            {
+                localizedTemplate.ShortNameList = templateWithShortNameList.ShortNameList;
+            }
+
             return localizedTemplate;
         }
 

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
@@ -8,10 +8,11 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Edge.Settings
 {
-    public class TemplateInfo : ITemplateInfo
+    public class TemplateInfo : ITemplateInfo, IShortNameList
     {
         public TemplateInfo()
         {
+            ShortNameList = new List<string>();
         }
 
         private static readonly Func<JObject, TemplateInfo> _defaultReader;
@@ -135,7 +136,37 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         public string Name { get; set; }
 
         [JsonProperty]
-        public string ShortName { get; set; }
+        public string ShortName
+        {
+            get
+            {
+                if (ShortNameList.Count > 0)
+                {
+                    return ShortNameList[0];
+                }
+
+                return String.Empty;
+            }
+            set
+            {
+                if (ShortNameList.Count > 0)
+                {
+                    throw new Exception("Can't set the short name when the ShortNameList already has entries.");
+                }
+
+                ShortNameList = new List<string>() { value };
+            }
+        }
+
+        // ShortName should get deserialized when it exists, for backwards compat.
+        // But moving forward, ShortNameList should be the definitive source.
+        // It can still be ShortName in the template.json, but in the caches it'll be ShortNameList
+        public bool ShouldSerializeShortName()
+        {
+            return false;
+        }
+
+        public IReadOnlyList<string> ShortNameList { get; set; }
 
         [JsonProperty]
         public IReadOnlyDictionary<string, ICacheTag> Tags

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_0.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_0.cs
@@ -46,7 +46,8 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
             info.GroupIdentity = jObject.ToString(nameof(TemplateInfo.GroupIdentity));
             info.Precedence = jObject.ToInt32(nameof(TemplateInfo.Precedence));
             info.Name = jObject.ToString(nameof(TemplateInfo.Name));
-            info.ShortName = jObject.ToString(nameof(TemplateInfo.ShortName));
+
+            ReadShortNameInfo(jObject, info);
 
             info.ConfigPlace = jObject.ToString(nameof(TemplateInfo.ConfigPlace));
             info.LocaleConfigMountPointId = Guid.Parse(jObject.ToString(nameof(TemplateInfo.LocaleConfigMountPointId)));
@@ -71,6 +72,11 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
                 }
             }
             info.BaselineInfo = baselineInfo;
+        }
+
+        protected virtual void ReadShortNameInfo(JObject jObject, TemplateInfo info)
+        {
+            info.ShortName = jObject.ToString(nameof(TemplateInfo.ShortName));
         }
 
         protected virtual IReadOnlyDictionary<string, ICacheTag> ReadTags(JObject jObject)

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_2.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_2.cs
@@ -1,6 +1,7 @@
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
 {
@@ -12,6 +13,42 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
 
             TemplateInfoReaderVersion1_0_0_2 reader = new TemplateInfoReaderVersion1_0_0_2();
             return reader.Read(jObject);
+        }
+
+        protected override void ReadShortNameInfo(JObject jObject, TemplateInfo info)
+        {
+            if (info is IShortNameList)
+            {
+                JToken shortNameToken = jObject.Get<JToken>(nameof(TemplateInfo.ShortNameList));
+                info.ShortNameList = JTokenStringOrArrayToCollection(shortNameToken, new string[0]);
+
+                if (info.ShortNameList.Count == 0)
+                {
+                    // template.json stores the short name(s) in ShortName
+                    // but the cache will store it in ShortNameList
+                    base.ReadShortNameInfo(jObject, info);
+                }
+            }
+            else
+            {
+                base.ReadShortNameInfo(jObject, info);
+            }
+        }
+
+        private static IReadOnlyList<string> JTokenStringOrArrayToCollection(JToken token, string[] defaultSet)
+        {
+            if (token == null)
+            {
+                return defaultSet;
+            }
+
+            if (token.Type == JTokenType.String)
+            {
+                string tokenValue = token.ToString();
+                return new List<string>() { tokenValue };
+            }
+
+            return token.ArrayAsStrings();
         }
 
         protected override ICacheTag ReadOneTag(JProperty item)

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_2.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_2.cs
@@ -1,7 +1,7 @@
+using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
-using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
 {

--- a/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
@@ -16,16 +16,38 @@ namespace Microsoft.TemplateEngine.Edge.Template
                 }
 
                 int nameIndex = template.Name.IndexOf(name, StringComparison.OrdinalIgnoreCase);
-                int shortNameIndex = template.ShortName.IndexOf(name, StringComparison.OrdinalIgnoreCase);
 
                 if (nameIndex == 0 && string.Equals(template.Name, name, StringComparison.OrdinalIgnoreCase))
                 {
                     return new MatchInfo { Location = MatchLocation.Name, Kind = MatchKind.Exact };
                 }
 
-                if (shortNameIndex == 0 && string.Equals(template.ShortName, name, StringComparison.OrdinalIgnoreCase))
+                bool hasShortNamePartialMatch = false;
+
+                if (template is FilterableTemplateInfo filterableTemplate)
                 {
-                    return new MatchInfo { Location = MatchLocation.ShortName, Kind = MatchKind.Exact };
+                    foreach (string shortName in filterableTemplate.GroupShortNameList)
+                    {
+                        int shortNameIndex = shortName.IndexOf(name, StringComparison.OrdinalIgnoreCase);
+
+                        if (shortNameIndex == 0 && string.Equals(shortName, name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return new MatchInfo { Location = MatchLocation.ShortName, Kind = MatchKind.Exact };
+                        }
+
+                        hasShortNamePartialMatch |= shortNameIndex > -1;
+                    }
+                }
+                else
+                {
+                    int shortNameIndex = template.ShortName.IndexOf(name, StringComparison.OrdinalIgnoreCase);
+
+                    if (shortNameIndex == 0 && string.Equals(template.ShortName, name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new MatchInfo { Location = MatchLocation.ShortName, Kind = MatchKind.Exact };
+                    }
+
+                    hasShortNamePartialMatch = shortNameIndex > -1;
                 }
 
                 if (nameIndex > -1)
@@ -33,7 +55,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                     return new MatchInfo { Location = MatchLocation.Name, Kind = MatchKind.Partial };
                 }
 
-                if (shortNameIndex > -1)
+                if (hasShortNamePartialMatch)
                 {
                     return new MatchInfo { Location = MatchLocation.ShortName, Kind = MatchKind.Partial };
                 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IRunnableProjectConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IRunnableProjectConfig.cs
@@ -23,7 +23,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         string Name { get; }
 
-        string ShortName { get; }
+        IReadOnlyList<string> ShortNameList { get; }
 
         string Author { get; }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
-    public class RunnableProjectTemplate : ITemplate
+    public class RunnableProjectTemplate : ITemplate, IShortNameList
     {
         private readonly JObject _raw;
 
@@ -20,7 +20,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             DefaultName = config.DefaultName;
             Name = config.Name;
             Identity = config.Identity ?? config.Name;
-            ShortName = config.ShortName;
+
+            ShortNameList = config.ShortNameList ?? new List<string>();
+
             Author = config.Author;
             Tags = config.Tags ?? new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase);
             CacheParameters = config.CacheParameters ?? new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase);
@@ -68,7 +70,29 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         public string Name { get; }
 
-        public string ShortName { get; }
+        public string ShortName
+        {
+            get
+            {
+                if (ShortNameList.Count > 0)
+                {
+                    return ShortNameList[0];
+                }
+
+                return String.Empty;
+            }
+            set
+            {
+                if (ShortNameList.Count > 0)
+                {
+                    throw new Exception("Can't set the short name when the ShortNameList already has entries.");
+                }
+
+                ShortNameList = new List<string>() { value };
+            }
+        }
+
+        public IReadOnlyList<string> ShortNameList { get; private set; }
 
         public IMountPoint Source { get; }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
@@ -64,7 +64,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         public string Name { get; set; }
 
-        public string ShortName { get; set; }
+        public IReadOnlyList<string> ShortNameList { get; set; }
 
         public string SourceName { get; set; }
 
@@ -283,9 +283,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
                     foreach (ExtendedFileSource source in Sources)
                     {
-                        IReadOnlyList<string> includePattern = JTokenToCollection(source.Include, SourceFile, IncludePatternDefaults);
-                        IReadOnlyList<string> excludePattern = JTokenToCollection(source.Exclude, SourceFile, ExcludePatternDefaults);
-                        IReadOnlyList<string> copyOnlyPattern = JTokenToCollection(source.CopyOnly, SourceFile, CopyOnlyPatternDefaults);
+                        IReadOnlyList<string> includePattern = JTokenAsFilenameToReadOrArrayToCollection(source.Include, SourceFile, IncludePatternDefaults);
+                        IReadOnlyList<string> excludePattern = JTokenAsFilenameToReadOrArrayToCollection(source.Exclude, SourceFile, ExcludePatternDefaults);
+                        IReadOnlyList<string> copyOnlyPattern = JTokenAsFilenameToReadOrArrayToCollection(source.CopyOnly, SourceFile, CopyOnlyPatternDefaults);
                         FileSourceEvaluable topLevelEvaluable = new FileSourceEvaluable(includePattern, excludePattern, copyOnlyPattern);
                         IReadOnlyDictionary<string, string> renamePatterns = new Dictionary<string, string>(source.Rename ?? RenameDefaults, StringComparer.Ordinal);
                         FileSourceMatchInfo matchInfo = new FileSourceMatchInfo(
@@ -743,7 +743,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         //          If so, read that files content as the exclude list.
         //          Otherwise returns an array containing the string value as its only entry.
         // Otherwise, interpret the token as an array and return the content.
-        private static IReadOnlyList<string> JTokenToCollection(JToken token, IFile sourceFile, string[] defaultSet)
+        private static IReadOnlyList<string> JTokenAsFilenameToReadOrArrayToCollection(JToken token, IFile sourceFile, string[] defaultSet)
         {
             if (token == null)
             {
@@ -766,6 +766,22 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                         return reader.ReadToEnd().Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
                     }
                 }
+            }
+
+            return token.ArrayAsStrings();
+        }
+
+        private static IReadOnlyList<string> JTokenStringOrArrayToCollection(JToken token, string[] defaultSet)
+        {
+            if (token == null)
+            {
+                return defaultSet;
+            }
+
+            if (token.Type == JTokenType.String)
+            {
+                string tokenValue = token.ToString();
+                return new List<string>() { tokenValue };
             }
 
             return token.ArrayAsStrings();
@@ -841,9 +857,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     continue;
                 }
 
-                IReadOnlyList<string> topIncludePattern = JTokenToCollection(source.Include, SourceFile, IncludePatternDefaults).ToList();
-                IReadOnlyList<string> topExcludePattern = JTokenToCollection(source.Exclude, SourceFile, ExcludePatternDefaults).ToList();
-                IReadOnlyList<string> topCopyOnlyPattern = JTokenToCollection(source.CopyOnly, SourceFile, CopyOnlyPatternDefaults).ToList();
+                IReadOnlyList<string> topIncludePattern = JTokenAsFilenameToReadOrArrayToCollection(source.Include, SourceFile, IncludePatternDefaults).ToList();
+                IReadOnlyList<string> topExcludePattern = JTokenAsFilenameToReadOrArrayToCollection(source.Exclude, SourceFile, ExcludePatternDefaults).ToList();
+                IReadOnlyList<string> topCopyOnlyPattern = JTokenAsFilenameToReadOrArrayToCollection(source.CopyOnly, SourceFile, CopyOnlyPatternDefaults).ToList();
                 FileSourceEvaluable topLevelPatterns = new FileSourceEvaluable(topIncludePattern, topExcludePattern, topCopyOnlyPattern);
 
                 Dictionary<string, string> fileRenamesFromSource = new Dictionary<string, string>(source.Rename ?? RenameDefaults, StringComparer.Ordinal);
@@ -855,9 +871,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     {
                         if (string.IsNullOrEmpty(modifier.Condition) || Cpp2StyleEvaluatorDefinition.EvaluateFromString(EnvironmentSettings, modifier.Condition, rootVariableCollection))
                         {
-                            IReadOnlyList<string> modifierIncludes = JTokenToCollection(modifier.Include, SourceFile, new string[0]);
-                            IReadOnlyList<string> modifierExcludes = JTokenToCollection(modifier.Exclude, SourceFile, new string[0]);
-                            IReadOnlyList<string> modifierCopyOnly = JTokenToCollection(modifier.CopyOnly, SourceFile, new string[0]);
+                            IReadOnlyList<string> modifierIncludes = JTokenAsFilenameToReadOrArrayToCollection(modifier.Include, SourceFile, new string[0]);
+                            IReadOnlyList<string> modifierExcludes = JTokenAsFilenameToReadOrArrayToCollection(modifier.Exclude, SourceFile, new string[0]);
+                            IReadOnlyList<string> modifierCopyOnly = JTokenAsFilenameToReadOrArrayToCollection(modifier.CopyOnly, SourceFile, new string[0]);
                             FileSourceEvaluable modifierPatterns = new FileSourceEvaluable(modifierIncludes, modifierExcludes, modifierCopyOnly);
                             modifierList.Add(modifierPatterns);
 
@@ -985,12 +1001,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 Guids = source.ArrayAsGuids(nameof(config.Guids)),
                 Identity = source.ToString(nameof(config.Identity)),
                 Name = localizationModel?.Name ?? source.ToString(nameof(config.Name)),
-                ShortName = source.ToString(nameof(config.ShortName)),
+
                 SourceName = source.ToString(nameof(config.SourceName)),
                 PlaceholderFilename = source.ToString(nameof(config.PlaceholderFilename)),
                 EnvironmentSettings = environmentSettings,
                 GeneratorVersions = source.ToString(nameof(config.GeneratorVersions))
             };
+
+            JToken shortNameToken = source.Get<JToken>("ShortName");
+            config.ShortNameList = JTokenStringOrArrayToCollection(shortNameToken, new string[0]);
 
             config.Forms = SetupValueFormMapForTemplate(source);
 

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -80,11 +80,17 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 
         public string AllowScriptsToRun { get; set; }
 
-        public IReadOnlyDictionary<string, string> InputTemplateParams { get; set; }
+        // When using this mock, set the inputs using constructor input.
+        // This property gets assigned based on the constructor input and the template being worked with.
+        public IReadOnlyDictionary<string, string> InputTemplateParams { get; private set; }
 
-        public List<string> RemainingArguments { get; set; }
+        // When using this mock, set the inputs using constructor input.
+        // This property gets assigned based on the constructor input and the template being worked with.
+        public List<string> RemainingArguments { get; private set; }
 
-        public IDictionary<string, IList<string>> RemainingParameters { get; set; }
+        // When using this mock, set the inputs using constructor input.
+        // This property gets assigned based on the constructor input and the template being worked with.
+        public IDictionary<string, IList<string>> RemainingParameters { get; private set; }
 
         public string HelpText { get; set; }
 

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/MultiShortNameResolutionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/MultiShortNameResolutionTests.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.Edge.Template;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
+{
+    public class MultiShortNameResolutionTests
+    {
+        [Fact(DisplayName = nameof(AllTemplatesInGroupUseAllShortNamesForResolution))]
+        public void AllTemplatesInGroupUseAllShortNamesForResolution()
+        {
+            IReadOnlyList<string> shortNamesForGroup = new List<string>()
+            {
+                "aaa", "bbb", "ccc", "ddd", "eee", "fff"
+            };
+
+            foreach (string testShortName in shortNamesForGroup)
+            {
+                INewCommandInput userInputs = new MockNewCommandInput()
+                {
+                    TemplateName = testShortName
+                };
+
+                TemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), userInputs, "C#");
+                matchResult.TryGetCoreMatchedTemplatesWithDisposition(x => x.IsMatch, out IReadOnlyList<ITemplateMatchInfo> matchedTemplateList);
+                Assert.Equal(3, matchedTemplateList.Count);
+
+                foreach (ITemplateMatchInfo templateMatchInfo in matchedTemplateList)
+                {
+                    Assert.Equal("MultiName.Test", templateMatchInfo.Info.GroupIdentity);
+                    Assert.Equal(1, templateMatchInfo.MatchDisposition.Count);
+                    Assert.True(templateMatchInfo.MatchDisposition[0].Location == MatchLocation.ShortName && templateMatchInfo.MatchDisposition[0].Kind == MatchKind.Exact);
+                }
+            }
+        }
+
+        [Fact(DisplayName = nameof(HighestPrecedenceWinsWithMultipleShortNames))]
+        public void HighestPrecedenceWinsWithMultipleShortNames()
+        {
+            IReadOnlyList<string> shortNamesForGroup = new List<string>()
+            {
+                "aaa", "bbb", "ccc", "ddd", "eee", "fff"
+            };
+
+            foreach (string testShortName in shortNamesForGroup)
+            {
+                INewCommandInput userInputs = new MockNewCommandInput()
+                {
+                    TemplateName = testShortName
+                };
+
+                TemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), userInputs, "C#");
+                Assert.True(matchResult.TryGetSingularInvokableMatch(out ITemplateMatchInfo invokableTemplate, out TemplateListResolutionResult.SingularInvokableMatchCheckStatus resultStatus));
+                Assert.Equal(TemplateListResolutionResult.SingularInvokableMatchCheckStatus.SingleMatch, resultStatus);
+                Assert.Equal("MultiName.Test.High.CSharp", invokableTemplate.Info.Identity);
+            }
+        }
+
+        [Fact(DisplayName = nameof(ExplicitLanguageChoiceIsHonoredWithMultipleShortNames))]
+        public void ExplicitLanguageChoiceIsHonoredWithMultipleShortNames()
+        {
+            IReadOnlyList<string> shortNamesForGroup = new List<string>()
+            {
+                "aaa", "bbb", "ccc", "ddd", "eee", "fff"
+            };
+
+            foreach (string testShortName in shortNamesForGroup)
+            {
+                INewCommandInput userInputs = new MockNewCommandInput()
+                {
+                    TemplateName = testShortName,
+                    Language = "F#"
+                };
+
+                TemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), userInputs, "C#");
+                Assert.True(matchResult.TryGetSingularInvokableMatch(out ITemplateMatchInfo invokableTemplate, out TemplateListResolutionResult.SingularInvokableMatchCheckStatus resultStatus));
+                Assert.Equal(TemplateListResolutionResult.SingularInvokableMatchCheckStatus.SingleMatch, resultStatus);
+                Assert.Equal("Multiname.Test.Only.FSharp", invokableTemplate.Info.Identity);
+            }
+        }
+
+        [Theory(DisplayName = nameof(ChoiceValueDisambiguatesMatchesWithMultipleShortNames))]
+        [InlineData("aaa", "W", "MultiName.Test.High.CSharp")]  // uses a short name from the expected invokable template
+        [InlineData("fff", "W", "MultiName.Test.High.CSharp")]  // uses a short name from a different template in the group
+        [InlineData("ccc", "X", "MultiName.Test.Low.CSharp")]   // uses a short name from the expected invokable template
+        [InlineData("fff", "X", "MultiName.Test.Low.CSharp")]   // uses a short name from a different template in the group
+        [InlineData("fff", "Y", "Multiname.Test.Only.FSharp")]  // uses a short name from the expected invokable template
+        [InlineData("eee", "Y", "Multiname.Test.Only.FSharp")]  // uses a short name from a different template in the group
+        public void ChoiceValueDisambiguatesMatchesWithMultipleShortNames(string name, string fooChoice, string expectedIdentity)
+        {
+            IReadOnlyDictionary<string, string> userParams = new Dictionary<string, string>()
+            {
+                {  "foo", fooChoice }
+            };
+
+            INewCommandInput commandInput = new MockNewCommandInput(userParams)
+            {
+                TemplateName = name
+            };
+
+            TemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), commandInput, "C#");
+
+            Assert.True(matchResult.TryGetSingularInvokableMatch(out ITemplateMatchInfo invokableTemplate, out TemplateListResolutionResult.SingularInvokableMatchCheckStatus resultStatus));
+            Assert.Equal(TemplateListResolutionResult.SingularInvokableMatchCheckStatus.SingleMatch, resultStatus);
+            Assert.Equal(expectedIdentity, invokableTemplate.Info.Identity);
+        }
+
+        [Theory(DisplayName = nameof(ParameterExistenceDisambiguatesMatchesWithMultipleShortNames))]
+        [InlineData("aaa", "HighC", "someValue", "MultiName.Test.High.CSharp")] // uses a short name from the expected invokable template
+        [InlineData("fff", "HighC", "someValue", "MultiName.Test.High.CSharp")] // uses a short name from a different template in the group
+        [InlineData("ccc", "LowC", "someValue", "MultiName.Test.Low.CSharp")]   // uses a short name from the expected invokable template
+        [InlineData("fff", "LowC", "someValue", "MultiName.Test.Low.CSharp")]   // uses a short name from a different template in the group
+        [InlineData("fff", "OnlyF", "someValue", "Multiname.Test.Only.FSharp")] // uses a short name from the expected invokable template
+        [InlineData("eee", "OnlyF", "someValue", "Multiname.Test.Only.FSharp")] // uses a short name from a different template in the group
+        public void ParameterExistenceDisambiguatesMatchesWithMultipleShortNames(string name, string paramName, string paramValue, string expectedIdentity)
+        {
+            IReadOnlyDictionary<string, string> userParams = new Dictionary<string, string>()
+            {
+                { paramName, paramValue }
+            };
+
+            INewCommandInput commandInput = new MockNewCommandInput(userParams)
+            {
+                TemplateName = name
+            };
+
+            TemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), commandInput, "C#");
+
+            Assert.True(matchResult.TryGetSingularInvokableMatch(out ITemplateMatchInfo invokableTemplate, out TemplateListResolutionResult.SingularInvokableMatchCheckStatus resultStatus));
+            Assert.Equal(TemplateListResolutionResult.SingularInvokableMatchCheckStatus.SingleMatch, resultStatus);
+            Assert.Equal(expectedIdentity, invokableTemplate.Info.Identity);
+        }
+
+        private static IReadOnlyList<ITemplateInfo> MultiShortNameGroupTemplateInfo
+        {
+            get
+            {
+                if (_multiShortNameGroupTemplateInfo == null)
+                {
+                    List<ITemplateInfo> templateList = new List<ITemplateInfo>();
+
+                    templateList.Add(new TemplateInfo()
+                    {
+                        ShortNameList = new string[] { "aaa", "bbb" },
+                        Name = "High precedence C# in group",
+                        Precedence = 2000,
+                        Identity = "MultiName.Test.High.CSharp",
+                        GroupIdentity = "MultiName.Test",
+                        Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            { "language", ResolutionTestHelper.CreateTestCacheTag("C#") },
+                            { "foo", ResolutionTestHelper.CreateTestCacheTag(new string[] { "A", "W" }) }
+                        },
+                        CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            { "HighC", new CacheParameter("string", "high c", "high c description") }
+                        }
+                    });
+
+                    templateList.Add(new TemplateInfo()
+                    {
+                        ShortNameList = new string[] { "ccc", "ddd", "eee" },
+                        Name = "Low precedence C# in group",
+                        Precedence = 100,
+                        Identity = "MultiName.Test.Low.CSharp",
+                        GroupIdentity = "MultiName.Test",
+                        Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            { "language", ResolutionTestHelper.CreateTestCacheTag("C#") },
+                            { "foo", ResolutionTestHelper.CreateTestCacheTag(new string[] { "A", "X" }) }
+                        },
+                        CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            { "LowC", new CacheParameter("string", "low c", "low c description") }
+                        }
+                    });
+
+                    templateList.Add(new TemplateInfo()
+                    {
+                        ShortNameList = new string[] { "fff" },
+                        Name = "Only F# in group",
+                        Precedence = 100,
+                        Identity = "Multiname.Test.Only.FSharp",
+                        GroupIdentity = "MultiName.Test",
+                        Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            { "language", ResolutionTestHelper.CreateTestCacheTag("F#") },
+                            { "foo", ResolutionTestHelper.CreateTestCacheTag(new string[] { "A", "Y" }) }
+                        },
+                        CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            { "OnlyF", new CacheParameter("string", "only f", "only f description") }
+                        }
+                    });
+
+                    templateList.Add(new TemplateInfo()
+                    {
+                        ShortNameList = new string[] { "other" },
+                        Name = "Unrelated template",
+                        Precedence = 9999,
+                        Identity = "Unrelated.Template.CSharp",
+                        GroupIdentity = "Unrelated.Template",
+                        Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            { "language", ResolutionTestHelper.CreateTestCacheTag("C#") },
+                            { "foo", ResolutionTestHelper.CreateTestCacheTag(new string[] { "A", "Z" }) }
+                        },
+                        CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
+                    });
+
+                    _multiShortNameGroupTemplateInfo = templateList;
+                }
+
+                return _multiShortNameGroupTemplateInfo;
+            }
+        }
+        private static IReadOnlyList<ITemplateInfo> _multiShortNameGroupTemplateInfo;
+    }
+}

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ResolutionTestHelper.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ResolutionTestHelper.cs
@@ -1,24 +1,26 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Edge.Template;
 using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 {
     internal static class ResolutionTestHelper
     {
-        public static ICacheTag CreateTestCacheTag(string choice, string description = null, string defaultValue = null, string defaultIfOptionWithoutValue = null)
+        public static ICacheTag CreateTestCacheTag(string choice, string choiceDescription = null, string defaultValue = null, string defaultIfOptionWithoutValue = null)
         {
             return new CacheTag(null,
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { choice, description }
+                    { choice, choiceDescription }
                 },
                 defaultValue,
                 defaultIfOptionWithoutValue);
         }
 
-        public static ICacheTag CreateTestCacheTag(IReadOnlyList<string> choiceList, string description = null, string defaultValue = null, string defaultIfOptionWithoutValue = null)
+        public static ICacheTag CreateTestCacheTag(IReadOnlyList<string> choiceList, string tagDescription = null, string defaultValue = null, string defaultIfOptionWithoutValue = null)
         {
             Dictionary<string, string> choicesDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (string choice in choiceList)
@@ -26,7 +28,29 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 choicesDict.Add(choice, null);
             };
 
-            return new CacheTag(null, choicesDict, defaultValue, defaultIfOptionWithoutValue);
+            return new CacheTag(tagDescription, choicesDict, defaultValue, defaultIfOptionWithoutValue);
+        }
+
+        public static string DebugOutputForResolutionResult(TemplateListResolutionResult matchResult, Func<ITemplateMatchInfo, bool> filter)
+        {
+            if (!matchResult.TryGetCoreMatchedTemplatesWithDisposition(filter, out IReadOnlyList<ITemplateMatchInfo> matchingTemplates))
+            {
+                return "No templates matched the filter";
+            }
+
+            StringBuilder builder = new StringBuilder(512);
+            foreach (ITemplateMatchInfo templateMatchInfo in matchingTemplates)
+            {
+                builder.AppendLine($"Identity: {templateMatchInfo.Info.Identity}");
+                foreach (MatchInfo disposition in templateMatchInfo.MatchDisposition)
+                {
+                    builder.AppendLine($"\t{disposition.Location.ToString()} = {disposition.Kind.ToString()}");
+                }
+
+                builder.AppendLine();
+            }
+
+            return builder.ToString();
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateListResolverTests.cs
@@ -92,15 +92,17 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             {
                 Name = "Template1",
                 Identity = "Template1",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "type", ResolutionTestHelper.CreateTestCacheTag("project") }
-                }
+                },
             });
             templatesToSearch.Add(new TemplateInfo()
             {
                 Name = "Template2",
                 Identity = "Template2",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "type", ResolutionTestHelper.CreateTestCacheTag("item") }
@@ -110,6 +112,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             {
                 Name = "Template3",
                 Identity = "Template3",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "type", ResolutionTestHelper.CreateTestCacheTag("myType") }
@@ -119,6 +122,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             {
                 Name = "Template4",
                 Identity = "Template4",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "type",ResolutionTestHelper.CreateTestCacheTag("project") }
@@ -128,6 +132,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             {
                 Name = "Template5",
                 Identity = "Template5",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
                 Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
                 {
                     { "type", ResolutionTestHelper.CreateTestCacheTag("project") }

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithUnspecifiedSourceName/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/test_templates/TemplateWithUnspecifiedSourceName/.template.config/template.json
@@ -1,9 +1,9 @@
-﻿{
+{
   "author": "Test Asset",
   "classifications": [ "Test Asset" ],
   "name": "TemplateWithUnspecifiedSourceName",
   "generatorVersions": "[1.0.0.0-*)",
-  "groupIdentity": "TestAssets.TemplateWithSourceName",
+  "groupIdentity": "TestAssets.TemplateWithUnspecifiedSourceName",
   "precedence": "100",
   "identity": "TestAssets.TemplateWithUnspecifiedSourceName",
   "shortName": "TestAssets.TemplateWithUnspecifiedSourceName"

--- a/test/Microsoft.TemplateEngine.Mocks/MockTemplate.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockTemplate.cs
@@ -4,8 +4,13 @@ using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Mocks
 {
-    public class MockTemplate : ITemplateInfo
+    public class MockTemplate : ITemplateInfo, IShortNameList
     {
+        public MockTemplate()
+        {
+            ShortNameList = new List<string>();
+        }
+
         public string Author { get; set; }
 
         public string Description { get; set; }
@@ -24,7 +29,29 @@ namespace Microsoft.TemplateEngine.Mocks
 
         public string Name { get; set; }
 
-        public string ShortName { get; set; }
+        public string ShortName
+        {
+            get
+            {
+                if (ShortNameList.Count > 0)
+                {
+                    return ShortNameList[0];
+                }
+
+                return String.Empty;
+            }
+            set
+            {
+                if (ShortNameList.Count > 0)
+                {
+                    throw new Exception("Can't set the short name when the ShortNameList already has entries.");
+                }
+
+                ShortNameList = new List<string>() { value };
+            }
+        }
+
+        public IReadOnlyList<string> ShortNameList { get; set; }
 
         public IReadOnlyDictionary<string, ICacheTag> Tags { get; set; }
 


### PR DESCRIPTION
Also support for different short names among the templates in a group.

Short name can be either a string or an array of strings. When in array context, the first entry in the array will be the “preferred” short name for the template.

**Displaying a list of templates using dotnet new**: when there are multiple templates installed with the same group identity, those templates are coalesced into one entry in the list, using info from the template with the highest precedence when there is a need to choose among the templates (this is existing behavior). The displayed short name will be preferred short name from the highest precedence template in the group.

**Attempting to invoke a template using dotnet new**: Based on the user inputs, a search is performed on the installed templates to determine the best matched template. The first argument on the command line represents the template “name”, which is used for substring matching on the template name and short name. When there are multiple templates installed with the same group identity, all the short names for all the templates in the group will be considered as short names for every template in the group. This search behavior will be applicable when a template gets invoked because it’s the single unambiguous match. It’s also used when the match is ambiguous, causing a template list or help on a template group to be displayed; and also when the –list or –help flags are explicitly provided by the user.
