### PR TITLE
Add a sample line to NuGetConfig

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Nuget/nuget.config
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Nuget/nuget.config
@@ -3,5 +3,6 @@
  <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
  </packageSources>
 </configuration>


### PR DESCRIPTION
When using `dotnet new NuGetConfig`, I always have to look up the syntax for how to add a new URL.

Adding an example line to the template solves this.  Now I can just replace the name and URL with the feed I want to use.

@seancpeters @mlorbetske 