### PR TITLE
WIP - Making a dotnet new global tool

### DIFF
--- a/src/dotnet-new-gt/DotnetToolSettings.xml
+++ b/src/dotnet-new-gt/DotnetToolSettings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<DotNetCliTool>
+    <Commands>
+        <Command Name="dotnet-new-gt" EntryPoint="dotnet-new-gt.dll" Runner="dotnet" />
+    </Commands>
+</DotNetCliTool>

--- a/src/dotnet-new-gt/PackGlobalTool.targets
+++ b/src/dotnet-new-gt/PackGlobalTool.targets
@@ -1,0 +1,23 @@
+<Project>
+  <Target Name="PackGlobalTool" Condition="'$(PackageType)' == 'DotnetTool'" BeforeTargets="GenerateNuspec" DependsOnTargets="Publish">
+    <PropertyGroup>
+      <NuspecProperties>
+        publishDir=$(PublishDir);
+        version=1;
+		
+		<!-- TODO: get these filled in as needed -->
+        <!--licenseUrl=$(PackageLicenseUrl);
+        projectUrl=$(PackageProjectUrl);
+        iconUrl=$(PackageIconUrl);
+        serviceable=$(Serviceable);
+        copyright=$(Copyright);
+        description=$(Description);
+        repositoryUrl=$(RepositoryUrl);-->
+		
+		targetFramework=$(TargetFramework);
+        
+        MicrosoftNETCorePlatformsPackageVersion=$(MicrosoftNETCorePlatformsPackageVersion);
+      </NuspecProperties>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/dotnet-new-gt/Program.cs
+++ b/src/dotnet-new-gt/Program.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Cli;
+using Microsoft.TemplateEngine.Cli.PostActionProcessors;
+using Microsoft.TemplateEngine.Edge;
+using Microsoft.TemplateEngine.Edge.TemplateUpdates;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects;
+using Microsoft.TemplateEngine.Utils;
+
+namespace dotnet_new
+{
+    /// <summary>
+    /// apparently i need a comment here to avoid a warning
+    /// </summary>
+    public class Program
+    {
+        private const string HostIdentifier = "dotnet-new-gt";
+        private const string HostVersion = "1.0.0";
+        private const string CommandName = "new";
+
+        private static readonly string PathEnvironmentVariableName = "DNGT";    // DotnetNewGlobalTool
+
+        static int Main(string[] args)
+        {
+            if (args.Any(x => string.Equals(x, "--debug:attach", StringComparison.OrdinalIgnoreCase)))
+            {
+                Console.WriteLine($"Attach the debugger to processID: {System.Diagnostics.Process.GetCurrentProcess().Id} and hit return.");
+                Console.ReadLine();
+            }
+
+            bool emitTimings = args.Any(x => string.Equals(x, "--debug:emit-timings", StringComparison.OrdinalIgnoreCase));
+            bool debugTelemetry = args.Any(x => string.Equals(x, "--debug:emit-telemetry", StringComparison.OrdinalIgnoreCase));
+
+            DefaultTemplateEngineHost host = CreateHost(emitTimings);
+
+            bool debugAuthoring = args.Any(x => string.Equals(x, "--trace:authoring", StringComparison.OrdinalIgnoreCase));
+            bool debugInstall = args.Any(x => string.Equals(x, "--trace:install", StringComparison.OrdinalIgnoreCase));
+            if (debugAuthoring)
+            {
+                AddAuthoringLogger(host);
+                AddInstallLogger(host);
+            }
+            else if (debugInstall)
+            {
+                AddInstallLogger(host);
+            }
+
+            return New3Command.Run(CommandName, host, new TelemetryLogger(null, debugTelemetry), FirstRun, args);
+        }
+
+        private static DefaultTemplateEngineHost CreateHost(bool emitTimings)
+        {
+            var preferences = new Dictionary<string, string>
+            {
+                { "prefs:language", "C#" }
+            };
+
+            try
+            {
+                string versionString = Dotnet.Version().CaptureStdOut().Execute().StdOut;
+                if (!string.IsNullOrWhiteSpace(versionString))
+                {
+                    preferences["dotnet-cli-version"] = versionString.Trim();
+                }
+            }
+            catch
+            { }
+
+            var builtIns = new AssemblyComponentCatalog(new[]
+            {
+                typeof(RunnableProjectGenerator).GetTypeInfo().Assembly,            // for assembly: Microsoft.TemplateEngine.Orchestrator.RunnableProjects
+                typeof(NupkgInstallUnitDescriptorFactory).GetTypeInfo().Assembly,   // for assembly: Microsoft.TemplateEngine.Edge
+                typeof(DotnetRestorePostActionProcessor).GetTypeInfo().Assembly     // for assembly: Microsoft.TemplateEngine.Cli
+            });
+
+            DefaultTemplateEngineHost host = new DefaultTemplateEngineHost(HostIdentifier, HostVersion, CultureInfo.CurrentCulture.Name, preferences, builtIns, new[] { "dotnetcli" });
+
+            if (emitTimings)
+            {
+                host.OnLogTiming = (label, duration, depth) =>
+                {
+                    string indent = string.Join("", Enumerable.Repeat("  ", depth));
+                    Console.WriteLine($"{indent} {label} {duration.TotalMilliseconds}");
+                };
+            }
+
+            return host;
+        }
+
+        private static void AddAuthoringLogger(DefaultTemplateEngineHost host)
+        {
+            Action<string, string[]> authoringLogger = (message, additionalInfo) =>
+            {
+                Console.WriteLine(string.Format("Authoring: {0}", message));
+            };
+            host.RegisterDiagnosticLogger("Authoring", authoringLogger);
+        }
+
+        private static void AddInstallLogger(DefaultTemplateEngineHost host)
+        {
+            Action<string, string[]> installLogger = (message, additionalInfo) =>
+            {
+                Console.WriteLine(string.Format("Install: {0}", message));
+            };
+            host.RegisterDiagnosticLogger("Install", installLogger);
+        }
+
+        // TODO: make this appropriate for the global tool
+        private static void FirstRun(IEngineEnvironmentSettings environmentSettings, IInstaller installer)
+        {
+            string baseDir = Environment.ExpandEnvironmentVariables($"%{PathEnvironmentVariableName}%");
+
+            if (baseDir.Contains('%'))
+            {
+                Assembly a = typeof(Program).GetTypeInfo().Assembly;
+                string path = new Uri(a.CodeBase, UriKind.Absolute).LocalPath;
+                path = Path.GetDirectoryName(path);
+                Environment.SetEnvironmentVariable(PathEnvironmentVariableName, path);
+            }
+
+            List<string> toInstallList = new List<string>();
+            Paths paths = new Paths(environmentSettings);
+
+            if (paths.FileExists(paths.Global.DefaultInstallPackageList))
+            {
+                toInstallList.AddRange(paths.ReadAllText(paths.Global.DefaultInstallPackageList).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
+            }
+
+            if (paths.FileExists(paths.Global.DefaultInstallTemplateList))
+            {
+                toInstallList.AddRange(paths.ReadAllText(paths.Global.DefaultInstallTemplateList).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
+            }
+
+            if (toInstallList.Count > 0)
+            {
+                for (int i = 0; i < toInstallList.Count; i++)
+                {
+                    toInstallList[i] = toInstallList[i].Replace("\r", "")
+                                                        .Replace('\\', Path.DirectorySeparatorChar);
+                }
+
+                installer.InstallPackages(toInstallList);
+            }
+        }
+    }
+}

--- a/src/dotnet-new-gt/Program.cs
+++ b/src/dotnet-new-gt/Program.cs
@@ -15,14 +15,14 @@ using Microsoft.TemplateEngine.Utils;
 namespace dotnet_new
 {
     /// <summary>
-    /// apparently i need a comment here to avoid a warning
+    /// Entry point for dotnet new as a global tool ref.
     /// </summary>
     public class Program
     {
+        // TODO: finalize these values
         private const string HostIdentifier = "dotnet-new-gt";
         private const string HostVersion = "1.0.0";
-        private const string CommandName = "new";
-
+        private const string CommandName = "new-gt";
         private static readonly string PathEnvironmentVariableName = "DNGT";    // DotnetNewGlobalTool
 
         static int Main(string[] args)
@@ -110,7 +110,6 @@ namespace dotnet_new
             host.RegisterDiagnosticLogger("Install", installLogger);
         }
 
-        // TODO: make this appropriate for the global tool
         private static void FirstRun(IEngineEnvironmentSettings environmentSettings, IInstaller installer)
         {
             string baseDir = Environment.ExpandEnvironmentVariables($"%{PathEnvironmentVariableName}%");
@@ -125,11 +124,6 @@ namespace dotnet_new
 
             List<string> toInstallList = new List<string>();
             Paths paths = new Paths(environmentSettings);
-
-            if (paths.FileExists(paths.Global.DefaultInstallPackageList))
-            {
-                toInstallList.AddRange(paths.ReadAllText(paths.Global.DefaultInstallPackageList).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
-            }
 
             if (paths.FileExists(paths.Global.DefaultInstallTemplateList))
             {

--- a/src/dotnet-new-gt/build/dependencies.props
+++ b/src/dotnet-new-gt/build/dependencies.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup Label="Package Versions">
+    <MicrosoftNETCorePlatformsPackageVersion>2.1.0-preview2-26130-01</MicrosoftNETCorePlatformsPackageVersion>
+	<NewtonsoftJsonPackageVersion>9.0.1</NewtonsoftJsonPackageVersion>
+  </PropertyGroup>
+</Project>

--- a/src/dotnet-new-gt/defaultinstall.template.list
+++ b/src/dotnet-new-gt/defaultinstall.template.list
@@ -1,0 +1,1 @@
+%DNGT%\template_feed\

--- a/src/dotnet-new-gt/dotnet-new-gt.csproj
+++ b/src/dotnet-new-gt/dotnet-new-gt.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="PackGlobalTool.targets" />
+  <Import Project="build\dependencies.props" />
+  
+  <PropertyGroup>
+    <Description>Template generation tool for dotnet.</Description>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <PackageType>DotnetTool</PackageType>
+    <ToolCommandName>dotnet-new-gt</ToolCommandName>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <PackageBasePath>tools/any/any/</PackageBasePath>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <RootNamespace>Microsoft.TemplateEngine.Cli</RootNamespace>
+  </PropertyGroup>
+
+  <!--TODO: decide whether we want a separate template list for the global tool than for new-->
+  <ItemGroup>
+    <Content Include="defaultinstall.template.list" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\template_feed\**\*" Link="template_feed\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
+    <ProjectReference Include="..\Microsoft.TemplateEngine.Cli\Microsoft.TemplateEngine.Cli.csproj" />
+    <ProjectReference Include="..\Microsoft.TemplateEngine.Core\Microsoft.TemplateEngine.Core.csproj" />
+    <ProjectReference Include="..\Microsoft.TemplateEngine.Core.Contracts\Microsoft.TemplateEngine.Core.Contracts.csproj" />
+    <ProjectReference Include="..\Microsoft.TemplateEngine.Edge\Microsoft.TemplateEngine.Edge.csproj" />
+    <ProjectReference Include="..\Microsoft.TemplateEngine.Orchestrator.RunnableProjects\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj" />
+    <ProjectReference Include="..\Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+  </ItemGroup>
+  
+  <PropertyGroup>
+    <NuspecFile>$(MSBuildProjectDirectory)\dotnet-new-gt.nuspec</NuspecFile>
+  </PropertyGroup>
+
+  </Project>

--- a/src/dotnet-new-gt/dotnet-new-gt.nuspec
+++ b/src/dotnet-new-gt/dotnet-new-gt.nuspec
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>dotnet-new-gt</id>
+    <tags>dotnet-new-gt</tags>
+    <version>$version$</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <description>dotnet new global tool</description>
+      
+	<!-- TODO: fill these in as appropriate -->
+    <!-- <licenseUrl>$licenseUrl$</licenseUrl> -->
+    <!-- <projectUrl>$projectUrl$</projectUrl> -->
+    <!-- <iconUrl>$iconUrl$</iconUrl> -->
+    <!-- <copyright>$copyright$</copyright> -->
+    <!-- <requireLicenseAcceptance>true</requireLicenseAcceptance> -->
+    <!-- <serviceable>$serviceable$</serviceable> -->
+	<!-- <repository type="git" url="$repositoryUrl$" /> -->
+      
+    <packageTypes>
+      <packageType name="DotnetTool" />
+    </packageTypes>
+
+    <dependencies>
+    <!-- Workaround https://github.com/dotnet/cli/issues/8418 --> 
+      <dependency id="Microsoft.NETCore.Platforms" version="$MicrosoftNETCorePlatformsPackageVersion$" /> 
+    </dependencies>
+
+  </metadata>
+  <files>
+    <file src="$publishdir$" target="tools/any/any" />
+    <file src="DotnetToolSettings.xml" target="tools/any/any/DotnetToolSettings.xml" />
+  </files>
+</package>


### PR DESCRIPTION
This code will build & run directly. It can also create a nupkg via dotnet pack, and that nupkg successfully installs as a global tool via:
```dotnet install tool -g dotnet-new-gt```
assuming I have the nupkg in a location in a place referenced by my nugget.config.

TODO:
- Finalize the command name. I'm using 'new-gt' as a placeholder.
- Determine if we want to fill in the values noted by "TODO's" in the PR.
- Decide which template packs to ship.
- Ability to create the nupkg with signed packages.
