### PR TITLE
[WIP] Support for using opinions from the host on which template is best within a group

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 {
     internal static class HelpForTemplateResolution
     {
-        public static CreationResultStatus CoordinateHelpAndUsageDisplay(TemplateListResolutionResult templateResolutionResult, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, ITelemetryLogger telemetryLogger, TemplateCreator templateCreator, string defaultLanguage)
+        public static CreationResultStatus CoordinateHelpAndUsageDisplay(TemplateListResolutionResult templateResolutionResult, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, ITelemetryLogger telemetryLogger, TemplateCreator templateCreator, string defaultLanguage, bool showAll)
         {
             ShowUsageHelp(commandInput, telemetryLogger);
 

--- a/src/Microsoft.TemplateEngine.Cli/IntrinsicsFilter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/IntrinsicsFilter.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Edge.Template;
+
+namespace Microsoft.TemplateEngine.Cli
+{
+    internal static class IntrinsicsFilter
+    {
+        public static bool TryFilterSingularGroupWithIntrinsics(IEngineEnvironmentSettings environmentSettings, IReadOnlyList<ITemplateMatchInfo> unambiguousTemplateGroup, out IReadOnlyList<string> specificIdentities, out IReadOnlyList<string> matchedIntrinsics)
+        {
+            //If we can't get the intrinsics keys collection, there's nothing to be done
+            if (!environmentSettings.Host.TryGetHostParamDefault("meta:intrinsics-keys", out string intrinsicsKeys))
+            {
+                matchedIntrinsics = null;
+                specificIdentities = null;
+                return false;
+            }
+
+            //Build up the intrinsics map
+            string[] keys = intrinsicsKeys.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+            Dictionary<string, string> intrinsics = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (string key in keys)
+            {
+                if (environmentSettings.Host.TryGetHostParamDefault(key, out string value))
+                {
+                    intrinsics[key] = value;
+                }
+            }
+
+            //If we made it through all that & didn't actually find any intrinsics, quit
+            if (intrinsics.Count == 0)
+            {
+                matchedIntrinsics = null;
+                specificIdentities = null;
+                return false;
+            }
+
+            HashSet<string> matchedTemplatesByIntrinsic = new HashSet<string>(StringComparer.Ordinal);
+            HashSet<ITemplateMatchInfo> matchedMatches = new HashSet<ITemplateMatchInfo>();
+
+            //Choice type parameters are represented as tags in the cache, see if any of the valid choices
+            //  match any of the intrinsics
+            foreach (ITemplateMatchInfo matchInfo in unambiguousTemplateGroup)
+            {
+                IReadOnlyDictionary<string, ICacheTag> tags = matchInfo.Info.Tags;
+
+                foreach (KeyValuePair<string, string> entry in intrinsics)
+                {
+                    foreach (KeyValuePair<string, ICacheTag> choiceParmeter in tags)
+                    {
+                        if (choiceParmeter.Value.ChoicesAndDescriptions.ContainsKey(entry.Value))
+                        {
+                            matchedTemplatesByIntrinsic.Add(entry.Key);
+                            matchedMatches.Add(matchInfo);
+                        }
+                    }
+                }
+            }
+
+            //If we didn't turn up anything that matched one of the instrinsics or we matched everything, quit
+            if (matchedMatches.Count == 0 || matchedMatches.Count == unambiguousTemplateGroup.Count)
+            {
+                matchedIntrinsics = null;
+                specificIdentities = null;
+                return false;
+            }
+
+            matchedIntrinsics = matchedTemplatesByIntrinsic.ToList();
+            specificIdentities = matchedMatches.Select(x => x.Info.Identity).ToList();
+            return true;
+        }
+    }
+}

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -49,7 +49,9 @@ namespace dotnet_new3
         {
             var preferences = new Dictionary<string, string>
             {
-                { "prefs:language", "C#" }
+                { "prefs:language", "C#" },
+                { "meta:intrinsics-keys", "prop:framework" },
+                { "prop:framework", "netcoreapp2.1" }
             };
 
             try


### PR DESCRIPTION
This PR will eventually address #1491, but for now is just a place to discuss different implementation ideas.

So far, this is just a proof of concept for how the filtering could work & a little bit of the plumbing work for passing the `--show-all` flag through to help.

There are a couple different approaches that could be taken at this point:
* Expanding the data in `ITemplateMatchInfo` to capture whether a particular template is the one preferred by some intrinsic properties of the host
* Formalizing template groups (having the core query, or an adaptation on it, actually return things according to group identity, ordering the templates within it, having the ability to designate one or more as defining the help schema, etc.)

The current structure of the logic in `EnterTemplateManipulationFlow` essentially goes like this:
* If we're listing or asking for help
  * If it's a list, show a list
  * If it's help
    * If it's multiple groups, show a list
    * If it's a single group, show detailed help, aggregating parameters
* If we're not asking for help or a list
  * If it's a single group
    * Try to select a single template
      * If a single template was able to be selected, instantiate it
      * If a single template was not able to be selected, log to the authoring stream & show a list
  * If it's multiple groups
    * Show a list

There are two other usages of `CoordinateHelpAndUsageDisplay` outside of `EnterTemplateManipulationFlow` that relate to maintenance flows - this kind of limits how much extra stuff feels natural to pass in (as a bunch of extra context could be obtained up front in the manipulation flows that isn't relevant in the maintenance flow).

I wonder if we should rework things as follows:
* Perform the core query with the user's values (name matches, parameter matches, etc.)
* Establish the set of groups of templates returned
* Each group should have a notion of the "invokable match" as determined by a combination of the current logic & host intrinsics (which includes language)
* If there are multiple groups, or list is requested, show a list
* If there's a single group
  * If help is specified or there is no invokable match on the group, show help
    * If `--show-all` is specified or there is no invokable match on the group, do the current logic
    * If it's not specified, use the invokable match on the group to set the "help schema" & show help
  * Otherwise, invoke the invokable match

With this approach, help/list coordination always just takes in the following pieces of information & wouldn't need more context in particular cases
* The set of template groups
* Whether this is an explicit list operation