### PR TITLE
Block bad installs and improve authoring messages

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
@@ -71,6 +71,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Missing &apos;{0}&apos; in &apos;{1}&apos;.
+        /// </summary>
+        internal static string Authoring_MissingValue {
+            get {
+                return ResourceManager.GetString("Authoring_MissingValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A non-bool DataType was specified for a regexMatch type symbol.
         /// </summary>
         internal static string Authoring_NonBoolDataTypeForRegexMatch {
@@ -121,6 +130,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         internal static string Authoring_TemplateNameDisplay {
             get {
                 return ResourceManager.GetString("Authoring_TemplateNameDisplay", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; was not installed.
+        /// </summary>
+        internal static string Authoring_TemplateNotInstalled {
+            get {
+                return ResourceManager.GetString("Authoring_TemplateNotInstalled", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
@@ -125,6 +125,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is missing common information.
+        /// </summary>
+        internal static string Authoring_TemplateMissingCommonInformation {
+            get {
+                return ResourceManager.GetString("Authoring_TemplateMissingCommonInformation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Template: &apos;{0}&apos;.
         /// </summary>
         internal static string Authoring_TemplateNameDisplay {
@@ -134,7 +143,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; was not installed.
+        ///   Looks up a localized string similar to &apos;{0}&apos; was not loaded.
         /// </summary>
         internal static string Authoring_TemplateNotInstalled {
             get {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
@@ -138,11 +138,14 @@
   <data name="Authoring_SourcePathRelativeToInstall" xml:space="preserve">
     <value>    Source path relative to install location: '{0}'</value>
   </data>
+  <data name="Authoring_TemplateMissingCommonInformation" xml:space="preserve">
+    <value>'{0}' is missing common information</value>
+  </data>
   <data name="Authoring_TemplateNameDisplay" xml:space="preserve">
     <value>Template: '{0}'</value>
   </data>
   <data name="Authoring_TemplateNotInstalled" xml:space="preserve">
-    <value>'{0}' was not installed</value>
+    <value>'{0}' was not loaded</value>
   </data>
   <data name="Authoring_TemplateRootOutsideInstallSource" xml:space="preserve">
     <value>Template: '{0}' - Template root is outside the specified install source location.</value>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
@@ -120,6 +120,9 @@
   <data name="Authoring_InvalidRegex" xml:space="preserve">
     <value>'{0}' could not be parsed as a regular expression</value>
   </data>
+  <data name="Authoring_MissingValue" xml:space="preserve">
+    <value>Missing '{0}' in '{1}'</value>
+  </data>
   <data name="Authoring_NonBoolDataTypeForRegexMatch" xml:space="preserve">
     <value>A non-bool DataType was specified for a regexMatch type symbol</value>
   </data>
@@ -137,6 +140,9 @@
   </data>
   <data name="Authoring_TemplateNameDisplay" xml:space="preserve">
     <value>Template: '{0}'</value>
+  </data>
+  <data name="Authoring_TemplateNotInstalled" xml:space="preserve">
+    <value>'{0}' was not installed</value>
   </data>
   <data name="Authoring_TemplateRootOutsideInstallSource" xml:space="preserve">
     <value>Template: '{0}' - Template root is outside the specified install source location.</value>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -238,6 +238,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             }
 
             IFile localeFile = localeFileConfig as IFile;
+            ITemplateEngineHost host = templateFileConfig.MountPoint.EnvironmentSettings.Host;
 
             try
             {
@@ -256,73 +257,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 };
                 SimpleConfigModel templateModel = SimpleConfigModel.FromJObject(templateFile.MountPoint.EnvironmentSettings, srcObject, configModifiers, localeSourceObject);
 
-                //Do some basic checks...
-                List<string> errorMessages = new List<string>();
-                List<string> warningMessages = new List<string>();
-                if (string.IsNullOrEmpty(templateModel.Identity))
+                if (!PerformTemplateValidation(templateModel, templateFile, host))
                 {
-                    errorMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "identity", templateFile.FullPath));
-                }
-
-                if (string.IsNullOrEmpty(templateModel.Name))
-                {
-                    errorMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "name", templateFile.FullPath));
-                }
-
-                if ((templateModel.ShortNameList?.Count ?? 0) == 0)
-                {
-                    errorMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "shortName", templateFile.FullPath));
-                }
-
-                if (string.IsNullOrEmpty(templateModel.SourceName))
-                {
-                    warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "sourceName", templateFile.FullPath));
-                }
-
-                if (string.IsNullOrEmpty(templateModel.Author))
-                {
-                    warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "author", templateFile.FullPath));
-                }
-
-                if (string.IsNullOrEmpty(templateModel.GroupIdentity))
-                {
-                    warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "groupIdentity", templateFile.FullPath));
-                }
-
-                if (string.IsNullOrEmpty(templateModel.GeneratorVersions))
-                {
-                    warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "generatorVersions", templateFile.FullPath));
-                }
-
-                if (templateModel.Precedence == 0)
-                {
-                    warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "precedence", templateFile.FullPath));
-                }
-
-                if ((templateModel.Classifications?.Count ?? 0) == 0)
-                {
-                    warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "classifications", templateFile.FullPath));
-                }
-
-                if (warningMessages.Count > 0)
-                {
-                    templateFileConfig.MountPoint.EnvironmentSettings.Host.LogDiagnosticMessage(string.Format(LocalizableStrings.Authoring_TemplateMissingCommonInformation, templateFile.FullPath), "Authoring");
-
-                    foreach (string message in warningMessages)
-                    {
-                        templateFileConfig.MountPoint.EnvironmentSettings.Host.LogDiagnosticMessage("    " + message, "Authoring");
-                    }
-                }
-
-                if (errorMessages.Count > 0)
-                {
-                    templateFileConfig.MountPoint.EnvironmentSettings.Host.LogDiagnosticMessage(string.Format(LocalizableStrings.Authoring_TemplateNotInstalled, templateFile.FullPath), "Authoring");
-
-                    foreach (string message in errorMessages)
-                    {
-                        templateFileConfig.MountPoint.EnvironmentSettings.Host.LogDiagnosticMessage("    " + message, "Authoring");
-                    }
-
                     template = null;
                     return false;
                 }
@@ -345,12 +281,86 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             }
             catch (Exception ex)
             {
-                ITemplateEngineHost host = templateFileConfig.MountPoint.EnvironmentSettings.Host;
                 host.LogMessage($"Error reading template from file: {templateFile.FullPath} | Error = {ex.Message}");
             }
 
             template = null;
             return false;
+        }
+
+        private bool PerformTemplateValidation(SimpleConfigModel templateModel, IFile templateFile, ITemplateEngineHost host)
+        {
+            //Do some basic checks...
+            List<string> errorMessages = new List<string>();
+            List<string> warningMessages = new List<string>();
+            if (string.IsNullOrEmpty(templateModel.Identity))
+            {
+                errorMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "identity", templateFile.FullPath));
+            }
+
+            if (string.IsNullOrEmpty(templateModel.Name))
+            {
+                errorMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "name", templateFile.FullPath));
+            }
+
+            if ((templateModel.ShortNameList?.Count ?? 0) == 0)
+            {
+                errorMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "shortName", templateFile.FullPath));
+            }
+
+            if (string.IsNullOrEmpty(templateModel.SourceName))
+            {
+                warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "sourceName", templateFile.FullPath));
+            }
+
+            if (string.IsNullOrEmpty(templateModel.Author))
+            {
+                warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "author", templateFile.FullPath));
+            }
+
+            if (string.IsNullOrEmpty(templateModel.GroupIdentity))
+            {
+                warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "groupIdentity", templateFile.FullPath));
+            }
+
+            if (string.IsNullOrEmpty(templateModel.GeneratorVersions))
+            {
+                warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "generatorVersions", templateFile.FullPath));
+            }
+
+            if (templateModel.Precedence == 0)
+            {
+                warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "precedence", templateFile.FullPath));
+            }
+
+            if ((templateModel.Classifications?.Count ?? 0) == 0)
+            {
+                warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "classifications", templateFile.FullPath));
+            }
+
+            if (warningMessages.Count > 0)
+            {
+                host.LogDiagnosticMessage(string.Format(LocalizableStrings.Authoring_TemplateMissingCommonInformation, templateFile.FullPath), "Authoring");
+
+                foreach (string message in warningMessages)
+                {
+                    host.LogDiagnosticMessage("    " + message, "Authoring");
+                }
+            }
+
+            if (errorMessages.Count > 0)
+            {
+                host.LogDiagnosticMessage(string.Format(LocalizableStrings.Authoring_TemplateNotInstalled, templateFile.FullPath), "Authoring");
+
+                foreach (string message in errorMessages)
+                {
+                    host.LogDiagnosticMessage("    " + message, "Authoring");
+                }
+
+                return false;
+            }
+
+            return true;
         }
 
         private bool CheckGeneratorVersionRequiredByTemplate(string generatorVersionsAllowed)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -256,6 +256,41 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 };
                 SimpleConfigModel templateModel = SimpleConfigModel.FromJObject(templateFile.MountPoint.EnvironmentSettings, srcObject, configModifiers, localeSourceObject);
 
+                //Do some basic checks...
+                List<string> errors = new List<string>();
+                if (string.IsNullOrEmpty(templateModel.Identity))
+                {
+                    errors.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "identity", templateFile.FullPath));
+                }
+
+                if (string.IsNullOrEmpty(templateModel.Name))
+                {
+                    errors.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "name", templateFile.FullPath));
+                }
+
+                if (string.IsNullOrEmpty(templateModel.SourceName))
+                {
+                    errors.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "sourceName", templateFile.FullPath));
+                }
+
+                if ((templateModel.ShortNameList?.Count ?? 0) == 0)
+                {
+                    errors.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "shortName", templateFile.FullPath));
+                }
+
+                if (errors.Count > 0)
+                {
+                    templateFileConfig.MountPoint.EnvironmentSettings.Host.LogDiagnosticMessage(string.Format(LocalizableStrings.Authoring_TemplateNotInstalled, templateFile.FullPath), "Authoring");
+
+                    foreach (string errorMessage in errors)
+                    {
+                        templateFileConfig.MountPoint.EnvironmentSettings.Host.LogDiagnosticMessage("    " + errorMessage, "Authoring");
+                    }
+
+                    template = null;
+                    return false;
+                }
+
                 if (!CheckGeneratorVersionRequiredByTemplate(templateModel.GeneratorVersions))
                 {   // template isn't compatible with this generator version
                     template = null;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -257,34 +257,70 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 SimpleConfigModel templateModel = SimpleConfigModel.FromJObject(templateFile.MountPoint.EnvironmentSettings, srcObject, configModifiers, localeSourceObject);
 
                 //Do some basic checks...
-                List<string> errors = new List<string>();
+                List<string> errorMessages = new List<string>();
+                List<string> warningMessages = new List<string>();
                 if (string.IsNullOrEmpty(templateModel.Identity))
                 {
-                    errors.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "identity", templateFile.FullPath));
+                    errorMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "identity", templateFile.FullPath));
                 }
 
                 if (string.IsNullOrEmpty(templateModel.Name))
                 {
-                    errors.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "name", templateFile.FullPath));
-                }
-
-                if (string.IsNullOrEmpty(templateModel.SourceName))
-                {
-                    errors.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "sourceName", templateFile.FullPath));
+                    errorMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "name", templateFile.FullPath));
                 }
 
                 if ((templateModel.ShortNameList?.Count ?? 0) == 0)
                 {
-                    errors.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "shortName", templateFile.FullPath));
+                    errorMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "shortName", templateFile.FullPath));
                 }
 
-                if (errors.Count > 0)
+                if (string.IsNullOrEmpty(templateModel.SourceName))
+                {
+                    warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "sourceName", templateFile.FullPath));
+                }
+
+                if (string.IsNullOrEmpty(templateModel.Author))
+                {
+                    warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "author", templateFile.FullPath));
+                }
+
+                if (string.IsNullOrEmpty(templateModel.GroupIdentity))
+                {
+                    warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "groupIdentity", templateFile.FullPath));
+                }
+
+                if (string.IsNullOrEmpty(templateModel.GeneratorVersions))
+                {
+                    warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "generatorVersions", templateFile.FullPath));
+                }
+
+                if (templateModel.Precedence == 0)
+                {
+                    warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "precedence", templateFile.FullPath));
+                }
+
+                if ((templateModel.Classifications?.Count ?? 0) == 0)
+                {
+                    warningMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "classifications", templateFile.FullPath));
+                }
+
+                if (warningMessages.Count > 0)
+                {
+                    templateFileConfig.MountPoint.EnvironmentSettings.Host.LogDiagnosticMessage(string.Format(LocalizableStrings.Authoring_TemplateMissingCommonInformation, templateFile.FullPath), "Authoring");
+
+                    foreach (string message in warningMessages)
+                    {
+                        templateFileConfig.MountPoint.EnvironmentSettings.Host.LogDiagnosticMessage("    " + message, "Authoring");
+                    }
+                }
+
+                if (errorMessages.Count > 0)
                 {
                     templateFileConfig.MountPoint.EnvironmentSettings.Host.LogDiagnosticMessage(string.Format(LocalizableStrings.Authoring_TemplateNotInstalled, templateFile.FullPath), "Authoring");
 
-                    foreach (string errorMessage in errors)
+                    foreach (string message in errorMessages)
                     {
-                        templateFileConfig.MountPoint.EnvironmentSettings.Host.LogDiagnosticMessage("    " + errorMessage, "Authoring");
+                        templateFileConfig.MountPoint.EnvironmentSettings.Host.LogDiagnosticMessage("    " + message, "Authoring");
                     }
 
                     template = null;


### PR DESCRIPTION
Fixes #1492

Fixes #1498 

Example output from the repro in #1498
```
D:\Projects\repro>dotnet new3 -i .\ThisFails --trace:authoring
Authoring: '/ClientApp/node_modules/caniuse-db/features-json/template.json' was not installed
Authoring:     Missing 'identity' in '/ClientApp/node_modules/caniuse-db/features-json/template.json'
Authoring:     Missing 'name' in '/ClientApp/node_modules/caniuse-db/features-json/template.json'
Authoring:     Missing 'sourceName' in '/ClientApp/node_modules/caniuse-db/features-json/template.json'
Authoring:     Missing 'shortName' in '/ClientApp/node_modules/caniuse-db/features-json/template.json'
Usage: new3 [options]

Options:
  -h, --help          Displays help for this command.
  -l, --list          Lists templates containing the specified name. If no name is specified, lists all templates.
  -n, --name          The name for the output being created. If no name is specified, the name of the current directory is used.
  -o, --output        Location to place the generated output.
  -i, --install       Installs a source or a template pack.
  -u, --uninstall     Uninstalls a source or a template pack.
  --nuget-source      Specifies a NuGet source to use during install.
  --type              Filters templates based on available types. Predefined values are "project", "item" or "other".
  --force             Forces content to be generated even if it would change existing files.
  -lang, --language   Filters templates based on language and specifies the language of the template to create.


Templates                Short Name       Language          Tags
--------------------------------------------------------------------------
Console Application      console          [C#], F#, VB      Common/Console
Class library            classlib         [C#], F#, VB      Common/Library
Unit Test Project        mstest           [C#], F#, VB      Test/MSTest
xUnit Test Project       xunit            [C#], F#, VB      Test/xUnit
BadTemplate              badtemplate      [C#]              Web
global.json file         globaljson                         Config
NuGet Config             nugetconfig                        Config
Web Config               webconfig                          Config
Solution File            sln                                Solution

Examples:
    dotnet new3 mstest
    dotnet new3 classlib --framework netcoreapp2.0
    dotnet new3 --help

D:\Projects\repro>
```