### PR TITLE
Sign template packages

### DIFF
--- a/sign.proj
+++ b/sign.proj
@@ -61,6 +61,9 @@
       <FilesToSign Include="$(OutDir)packages\**\*.nupkg" Exclude="$(OutDir)packages\**\*.symbols.nupkg">
         <Authenticode>NuGet</Authenticode>
       </FilesToSign>
+      <FilesToSign Include="$(OutDir)templates\**\*.nupkg">
+        <Authenticode>NuGet</Authenticode>
+      </FilesToSign>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This was missed in the first pass of package signing implementation because the packages don't appear under 'artifacts\packages'