### PR TITLE
Add source-build exclusion to resetting output paths.

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/build.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/build.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <OutputPath>$(TemplatesFolder)</OutputPath>
     <EnableDefaultItems>False</EnableDefaultItems>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Remove="Microsoft.NETCore.App" />

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/build.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/build.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <OutputPath>$(TemplatesFolder)</OutputPath>
     <EnableDefaultItems>False</EnableDefaultItems>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Remove="Microsoft.NETCore.App" />

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/build.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/build.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <OutputPath>$(TemplatesFolder)</OutputPath>
     <EnableDefaultItems>False</EnableDefaultItems>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Remove="Microsoft.NETCore.App" />

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/build.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/build.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <OutputPath>$(TemplatesFolder)</OutputPath>
     <EnableDefaultItems>False</EnableDefaultItems>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Remove="Microsoft.NETCore.App" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/build.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/build.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <OutputPath>$(TemplatesFolder)</OutputPath>
     <EnableDefaultItems>False</EnableDefaultItems>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Remove="Microsoft.NETCore.App" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/build.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/build.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <OutputPath>$(TemplatesFolder)</OutputPath>
     <EnableDefaultItems>False</EnableDefaultItems>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Remove="Microsoft.NETCore.App" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/build.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/build.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <OutputPath>$(TemplatesFolder)</OutputPath>
     <EnableDefaultItems>False</EnableDefaultItems>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(DotNetBuildFromSource)' != 'true'">$(MSBuildThisFileDirectory)..\..\artifacts\scratch</BaseIntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Remove="Microsoft.NETCore.App" />


### PR DESCRIPTION
Source-build is using a newer CLI that has a problem with changing `BaseIntermediateOutputPath` at this point in the build.  For now, do not reset this property in source-build.