### PR TITLE
Updating test templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.1.x/content/XUnit-VisualBasic/Company.TestProject1.vbproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.0/content/XUnit-VisualBasic/Company.TestProject1.vbproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.1" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/Company.TestProject1.vbproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0-preview-20180605-02" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />


### PR DESCRIPTION
Updating the Microsoft.NET.Test.Sdk and MSTest adapter package reference in templates.

TestPlatform Release [v15.8.0-preview-20180605-02](https://github.com/Microsoft/vstest/releases/tag/v15.8.0-preview-20180605-02)
[Release Notes](https://github.com/Microsoft/vstest-docs/blob/master/docs/releases.md#1570)

MSTest Release [v1.3.1](https://github.com/Microsoft/testfx/releases/tag/v1.3.1)
[Release Notes](https://github.com/Microsoft/testfx-docs/blob/master/docs/releases.md#131-may-2018)