### PR TITLE
Add special cases to common conversions that invoke the applicable TryParse rather than always going through Convert.ChangeType

### DIFF
--- a/src/Microsoft.TemplateEngine.Core/Expressions/OperatorSetBuilder.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/OperatorSetBuilder.cs
@@ -626,7 +626,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions
 
             public bool TryCoreConvert<T>(object source, out T result)
             {
-                result = default;
+                result = default(T);
 
                 switch(result)
                 {
@@ -661,7 +661,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions
                 }
                 catch
                 {
-                    result = default;
+                    result = default(T);
                     return false;
                 }
             }
@@ -679,7 +679,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions
                             result = (T)(object)value;
                             return true;
                         }
-                        result = default;
+                        result = default(T);
                         return false;
                     default:
                         try
@@ -689,7 +689,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions
                         }
                         catch
                         {
-                            result = default;
+                            result = default(T);
                             return false;
                         }
                 }
@@ -708,7 +708,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions
                             result = (T)(object)f;
                             return true;
                         }
-                        result = default;
+                        result = default(T);
                         return false;
                     default:
                         try
@@ -718,7 +718,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions
                         }
                         catch
                         {
-                            result = default;
+                            result = default(T);
                             return false;
                         }
                 }
@@ -737,7 +737,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions
                             result = (T)(object)f;
                             return true;
                         }
-                        result = default;
+                        result = default(T);
                         return false;
                     default:
                         try
@@ -747,7 +747,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions
                         }
                         catch
                         {
-                            result = default;
+                            result = default(T);
                             return false;
                         }
                 }
@@ -766,7 +766,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions
                             result = (T)(object)f;
                             return true;
                         }
-                        result = default;
+                        result = default(T);
                         return false;
                     default:
                         try
@@ -776,7 +776,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions
                         }
                         catch
                         {
-                            result = default;
+                            result = default(T);
                             return false;
                         }
                 }
@@ -795,7 +795,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions
                             result = (T)(object)f;
                             return true;
                         }
-                        result = default;
+                        result = default(T);
                         return false;
                     default:
                         try
@@ -805,7 +805,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions
                         }
                         catch
                         {
-                            result = default;
+                            result = default(T);
                             return false;
                         }
                 }

--- a/src/Microsoft.TemplateEngine.Core/Expressions/OperatorSetBuilder.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/OperatorSetBuilder.cs
@@ -626,20 +626,25 @@ namespace Microsoft.TemplateEngine.Core.Expressions
 
             public bool TryCoreConvert<T>(object source, out T result)
             {
-                result = default(T);
-
-                switch(result)
+                if (typeof(T) == typeof(bool))
                 {
-                    case bool _:
-                        return TryCoreConvertToBool(source, out result);
-                    case int _:
-                        return TryCoreConvertToInt(source, out result);
-                    case long _:
-                        return TryCoreConvertToLong(source, out result);
-                    case float _:
-                        return TryCoreConvertToFloat(source, out result);
-                    case double _:
-                        return TryCoreConvertToDouble(source, out result);
+                    return TryCoreConvertToBool(source, out result);
+                }
+                else if (typeof(T) == typeof(int))
+                {
+                    return TryCoreConvertToInt(source, out result);
+                }
+                else if (typeof(T) == typeof(long))
+                {
+                    return TryCoreConvertToLong(source, out result);
+                }
+                else if (typeof(T) == typeof(float))
+                {
+                    return TryCoreConvertToFloat(source, out result);
+                }
+                else if (typeof(T) == typeof(double))
+                {
+                    return TryCoreConvertToDouble(source, out result);
                 }
 
                 if (typeof(T).GetTypeInfo().IsEnum && source is string s)

--- a/src/Microsoft.TemplateEngine.Core/Expressions/OperatorSetBuilder.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/OperatorSetBuilder.cs
@@ -626,11 +626,27 @@ namespace Microsoft.TemplateEngine.Core.Expressions
 
             public bool TryCoreConvert<T>(object source, out T result)
             {
-                if (typeof(T).GetTypeInfo().IsEnum && source is string)
+                result = default;
+
+                switch(result)
+                {
+                    case bool _:
+                        return TryCoreConvertToBool(source, out result);
+                    case int _:
+                        return TryCoreConvertToInt(source, out result);
+                    case long _:
+                        return TryCoreConvertToLong(source, out result);
+                    case float _:
+                        return TryCoreConvertToFloat(source, out result);
+                    case double _:
+                        return TryCoreConvertToDouble(source, out result);
+                }
+
+                if (typeof(T).GetTypeInfo().IsEnum && source is string s)
                 {
                     try
                     {
-                        result = (T) Enum.Parse(typeof(T), (string) source, true);
+                        result = (T) Enum.Parse(typeof(T), s, true);
                         return true;
                     }
                     catch
@@ -645,8 +661,153 @@ namespace Microsoft.TemplateEngine.Core.Expressions
                 }
                 catch
                 {
-                    result = default(T);
+                    result = default;
                     return false;
+                }
+            }
+
+            private static bool TryCoreConvertToBool<T>(object source, out T result)
+            {
+                switch (source)
+                {
+                    case bool x:
+                        result = (T)source;
+                        return true;
+                    case string x:
+                        if (bool.TryParse(x, out bool value))
+                        {
+                            result = (T)(object)value;
+                            return true;
+                        }
+                        result = default;
+                        return false;
+                    default:
+                        try
+                        {
+                            result = (T)Convert.ChangeType(source, typeof(T));
+                            return true;
+                        }
+                        catch
+                        {
+                            result = default;
+                            return false;
+                        }
+                }
+            }
+
+            private static bool TryCoreConvertToDouble<T>(object source, out T result)
+            {
+                switch (source)
+                {
+                    case double x:
+                        result = (T)source;
+                        return true;
+                    case string x:
+                        if (double.TryParse(x, out double f))
+                        {
+                            result = (T)(object)f;
+                            return true;
+                        }
+                        result = default;
+                        return false;
+                    default:
+                        try
+                        {
+                            result = (T)Convert.ChangeType(source, typeof(T));
+                            return true;
+                        }
+                        catch
+                        {
+                            result = default;
+                            return false;
+                        }
+                }
+            }
+
+            private static bool TryCoreConvertToFloat<T>(object source, out T result)
+            {
+                switch (source)
+                {
+                    case float x:
+                        result = (T)source;
+                        return true;
+                    case string x:
+                        if (float.TryParse(x, out float f))
+                        {
+                            result = (T)(object)f;
+                            return true;
+                        }
+                        result = default;
+                        return false;
+                    default:
+                        try
+                        {
+                            result = (T)Convert.ChangeType(source, typeof(T));
+                            return true;
+                        }
+                        catch
+                        {
+                            result = default;
+                            return false;
+                        }
+                }
+            }
+
+            private static bool TryCoreConvertToInt<T>(object source, out T result)
+            {
+                switch (source)
+                {
+                    case int x:
+                        result = (T)source;
+                        return true;
+                    case string x:
+                        if (int.TryParse(x, out int f))
+                        {
+                            result = (T)(object)f;
+                            return true;
+                        }
+                        result = default;
+                        return false;
+                    default:
+                        try
+                        {
+                            result = (T)Convert.ChangeType(source, typeof(T));
+                            return true;
+                        }
+                        catch
+                        {
+                            result = default;
+                            return false;
+                        }
+                }
+            }
+
+            private static bool TryCoreConvertToLong<T>(object source, out T result)
+            {
+                switch (source)
+                {
+                    case long x:
+                        result = (T)source;
+                        return true;
+                    case string x:
+                        if (long.TryParse(x, out long f))
+                        {
+                            result = (T)(object)f;
+                            return true;
+                        }
+                        result = default;
+                        return false;
+                    default:
+                        try
+                        {
+                            result = (T)Convert.ChangeType(source, typeof(T));
+                            return true;
+                        }
+                        catch
+                        {
+                            result = default;
+                            return false;
+                        }
                 }
             }
 

--- a/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
+++ b/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <Description>Common operations for instantiating templates using forward-only input stream operations</Description>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
+++ b/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
@@ -1,8 +1,9 @@
-﻿<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk">
+<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\Version.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <Description>Common operations for instantiating templates using forward-only input stream operations</Description>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #1549