### PR TITLE
Adds the ability to do a dry run of template creation with the --dry-run switch

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -132,6 +132,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                     Create.Option("-u|--uninstall", LocalizableStrings.UninstallHelp, Accept.ZeroOrMoreArguments()),
                     Create.Option("--nuget-source", LocalizableStrings.NuGetSourceHelp, Accept.OneOrMoreArguments()),
                     Create.Option("--type", LocalizableStrings.ShowsFilteredTemplates, Accept.ExactlyOneArgument()),
+                    Create.Option("--dry-run", LocalizableStrings.DryRunDescription, Accept.NoArguments()),
                     Create.Option("--force", LocalizableStrings.ForcesTemplateCreation, Accept.NoArguments()),
                     Create.Option("-lang|--language", LocalizableStrings.LanguageParameter,
                                     Accept.ExactlyOneArgument()

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
@@ -28,6 +28,8 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         IList<string> InstallNuGetSourceList { get; }
 
+        bool IsDryRun { get; }
+
         IList<string> ToUninstallList { get; }
 
         bool IsForceFlagSpecified { get; }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -222,6 +222,8 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         public IList<string> ToUninstallList => _parseResult.GetArgumentListAtPath(new[] { _commandName, "uninstall" })?.ToList();
 
+        public bool IsDryRun => _parseResult.HasAppliedOption(new[] { _commandName, "dry-run" });
+
         public bool IsForceFlagSpecified => _parseResult.HasAppliedOption(new[] { _commandName, "force" });
 
         public bool IsHelpFlagSpecified => _parseResult.HasAppliedOption(new[] { _commandName, "help" });

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -62,6 +62,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Action would have been taken automatically:.
+        /// </summary>
+        public static string ActionWouldHaveBeenTakenAutomatically {
+            get {
+                return ResourceManager.GetString("ActionWouldHaveBeenTakenAutomatically", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to add project(s) {0} to solution file {1}.
         /// </summary>
         public static string AddProjToSlnPostActionFailed {
@@ -700,6 +709,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Displays a summary of what would happen if the given command line were run if it would result in a template creation..
+        /// </summary>
+        public static string DryRunDescription {
+            get {
+                return ResourceManager.GetString("DryRunDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to After expanding the extra args files, the command is:
         ///    dotnet {0}.
         /// </summary>
@@ -724,6 +742,15 @@ namespace Microsoft.TemplateEngine.Cli {
         public static string Factory {
             get {
                 return ResourceManager.GetString("Factory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File actions would have been taken:.
+        /// </summary>
+        public static string FileActionsWouldHaveBeenTaken {
+            get {
+                return ResourceManager.GetString("FileActionsWouldHaveBeenTaken", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -607,4 +607,13 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="SwitchWithoutValueDefaultFootnote" xml:space="preserve">
     <value>* Indicates the value used if the switch is provided without a value.</value>
   </data>
+  <data name="DryRunDescription" xml:space="preserve">
+    <value>Displays a summary of what would happen if the given command line were run if it would result in a template creation.</value>
+  </data>
+  <data name="ActionWouldHaveBeenTakenAutomatically" xml:space="preserve">
+    <value>Action would have been taken automatically:</value>
+  </data>
+  <data name="FileActionsWouldHaveBeenTaken" xml:space="preserve">
+    <value>File actions would have been taken:</value>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreationResult.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreationResult.cs
@@ -1,20 +1,21 @@
-﻿using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Edge.Template
 {
     public class TemplateCreationResult
     {
         public TemplateCreationResult(string message, CreationResultStatus status, string templateFullName)
-            :this(message, status, templateFullName, null, null)
+            :this(message, status, templateFullName, null, null, null)
         { }
 
-        public TemplateCreationResult(string message, CreationResultStatus status, string templateFullName, ICreationResult creationOutputs, string outputBaseDir)
+        public TemplateCreationResult(string message, CreationResultStatus status, string templateFullName, ICreationResult creationOutputs, string outputBaseDir, ICreationEffects creationEffects)
         {
             Message = message;
             Status = status;
             TemplateFullName = templateFullName;
             ResultInfo = creationOutputs;
             OutputBaseDirectory = outputBaseDir;
+            CreationEffects = creationEffects;
         }
 
         public string Message { get; }
@@ -26,5 +27,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
         public ICreationResult ResultInfo { get; }
 
         public string OutputBaseDirectory { get; }
+
+        public ICreationEffects CreationEffects { get; }
     }
 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -52,6 +52,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 
         public IList<string> ToUninstallList { get; set; }
 
+        public bool IsDryRun { get; set; }
+
         public bool IsForceFlagSpecified { get; set; }
 
         public bool IsHelpFlagSpecified { get; set; }


### PR DESCRIPTION
Adds a --dry-run switch which is currently only honored for template creation. This should be extended to support --install and --uninstall in some fashion

Fixes #794 

Support for seeing the templates that would be uninstalled as part of uninstall will come separately, support for seeing what would be installed will come with the refactor of installer