### PR TITLE
Shows the list of templates included in an install descriptor when -u is passed without argument

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -555,7 +555,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to  Commit Hash: {0}.
+        ///   Looks up a localized string similar to Commit Hash:.
         /// </summary>
         public static string CommitHash {
             get {
@@ -875,7 +875,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the language of the template to create..
+        ///   Looks up a localized string similar to Filters templates based on language and specifies the language of the template to create..
         /// </summary>
         public static string LanguageParameter {
             get {
@@ -1479,7 +1479,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to  Version:     {0}.
+        ///   Looks up a localized string similar to Version:.
         /// </summary>
         public static string Version {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -554,10 +554,10 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
     <value>Some partially matched templates may not support these input switches:</value>
   </data>
   <data name="CommitHash" xml:space="preserve">
-    <value> Commit Hash: {0}</value>
+    <value>Commit Hash:</value>
   </data>
   <data name="Version" xml:space="preserve">
-    <value> Version:     {0}</value>
+    <value>Version:</value>
   </data>
   <data name="InstalledItems" xml:space="preserve">
     <value>Currently installed items:</value>


### PR DESCRIPTION
Fixes #1296

Example output:
```
D:\Projects>dotnet new3 -u
Template Instantiation Commands for .NET Core CLI

Currently installed items:
  D:\Projects\templating\template_feed
    Templates:
      global.json file (globaljson)
      NuGet Config (nugetconfig)
      Solution File (sln)
      Web Config (webconfig)
      Class library (classlib) C#
      Class library (classlib) F#
      Class library (classlib) VB
      Console Application (console) C#
      Console Application (console) F#
      Console Application (console) VB
      Unit Test Project (mstest) C#
      Unit Test Project (mstest) F#
      Unit Test Project (mstest) VB
      xUnit Test Project (xunit) C#
      xUnit Test Project (xunit) F#
      xUnit Test Project (xunit) VB
  Microsoft.DotNet.Web.Spa.ProjectTemplates
    Version: 2.1.0
    Templates:
      ASP.NET Core with Angular (angular) C#
      ASP.NET Core with React.js (react) C#
      ASP.NET Core with React.js and Redux (reactredux) C#
```