### PR TITLE
Remove dotnet-xunit from 2.1 project templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-CSharp/Company.TestProject1.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-FSharp/Company.TestProject1.fsproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Test.ProjectTemplates.2.1/content/XUnit-VisualBasic/Company.TestProject1.vbproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
xunit is deprecating support for this package.

https://twitter.com/xunit/status/1001321969189437440
https://xunit.github.io/releases/2.4-beta2

cc @mlorbetske @vijayrkn do you think we should patch the 2.1.3xx SDK with this change? Also, should we drop this from 1.x and 2.0 templates too?