### PR TITLE
Enable SourceLink

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -75,7 +75,7 @@
 
     <!-- Build the inner ring (abstractions, core, core contracts, etc.) -->
     <MSBuild Projects="$(InnerRingProjects)" Targets="Restore;Build"
-             Properties="TargetFramework=$(InnerRingTargetFramework);Configuration=$(Configuration)"
+             Properties="TargetFramework=$(InnerRingTargetFramework);Configuration=$(Configuration);SourceLinkCreate=true"
              RunEachTargetSeparately="true" StopOnFirstFailure="true" />
 
     <MSBuild Projects="$(InnerRingProjects)" Targets="Pack"
@@ -84,7 +84,7 @@
 
     <!-- Build Edge (the only outerring component that CLI depends on) -->
     <MSBuild Projects="src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj" Targets="Restore;Build"
-             Properties="TargetFramework=$(OuterRingTargetFramework);Configuration=$(Configuration)"
+             Properties="TargetFramework=$(OuterRingTargetFramework);Configuration=$(Configuration);SourceLinkCreate=true"
              RunEachTargetSeparately="true" StopOnFirstFailure="true" />
 
     <MSBuild Projects="src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj" Targets="Pack"
@@ -93,7 +93,7 @@
 
     <!-- Build projects that only build for the dotnet CLI -->
     <MSBuild Projects="$(CliProjects)" Targets="Restore;Build"
-             Properties="TargetFramework=$(OuterRingTargetFramework);Configuration=$(Configuration);PackageOutputPath=$(PackageOutputPath);NoBuild=true"
+             Properties="TargetFramework=$(OuterRingTargetFramework);Configuration=$(Configuration);SourceLinkCreate=true"
              RunEachTargetSeparately="true" StopOnFirstFailure="true" />
 
     <MSBuild Projects="$(CliProjects)" Targets="Pack"
@@ -113,24 +113,24 @@
     <!-- Build the inner ring (abstractions, core, core contracts, etc.) -->
     <MSBuild Projects="$(InnerRingProjects)" Targets="Restore;Build"
              Condition="'$(EngineBuild)' == 'true'"
-             Properties="TargetFramework=$(InnerRingTargetFramework);Configuration=$(Configuration)"
+             Properties="TargetFramework=$(InnerRingTargetFramework);Configuration=$(Configuration);SourceLinkCreate=true"
              RunEachTargetSeparately="true" StopOnFirstFailure="true" />
 
     <MSBuild Projects="$(InnerRingProjects)" Targets="Restore;Build"
              Condition="'$(IsFullFrameworkBuildSupported)' == 'true' AND '$(EngineBuild)' == 'true'"
-             Properties="TargetFramework=$(FullFrameworkTargetFramework);Configuration=$(Configuration)"
+             Properties="TargetFramework=$(FullFrameworkTargetFramework);Configuration=$(Configuration);SourceLinkCreate=true"
              RunEachTargetSeparately="true" StopOnFirstFailure="true" />
 
 
     <!-- Build the outer ring (edge, mocks, etc.) -->
     <MSBuild Projects="$(OuterRingProjects)" Targets="Restore;Build"
              Condition="'$(EngineBuild)' == 'true'"
-             Properties="TargetFramework=$(OuterRingTargetFramework);Configuration=$(Configuration)"
+             Properties="TargetFramework=$(OuterRingTargetFramework);Configuration=$(Configuration);SourceLinkCreate=true"
              RunEachTargetSeparately="true" StopOnFirstFailure="true" />
 
     <MSBuild Projects="$(OuterRingProjects)" Targets="Restore;Build"
              Condition="'$(IsFullFrameworkBuildSupported)' == 'true' AND '$(EngineBuild)' == 'true'"
-             Properties="TargetFramework=$(FullFrameworkTargetFramework);Configuration=$(Configuration)"
+             Properties="TargetFramework=$(FullFrameworkTargetFramework);Configuration=$(Configuration);SourceLinkCreate=true"
              RunEachTargetSeparately="true" StopOnFirstFailure="true" />
 
     <MSBuild Projects="$(SharedTestProjects)" Targets="Restore;Build"
@@ -147,7 +147,7 @@
     <!-- Build projects that only build for the dotnet CLI -->
     <MSBuild Projects="$(CliProjects)" Targets="Restore;Build"
              Condition="'$(EngineBuild)' == 'true'"
-             Properties="TargetFramework=$(OuterRingTargetFramework);Configuration=$(Configuration);PackageOutputPath=$(PackageOutputPath);NoBuild=true"
+             Properties="TargetFramework=$(OuterRingTargetFramework);Configuration=$(Configuration);SourceLinkCreate=true"
              RunEachTargetSeparately="true" StopOnFirstFailure="true" />
 
     <!-- Build templates -->

--- a/src/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
+++ b/src/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
@@ -4,4 +4,9 @@
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <Description>Contracts for extending Template Engine</Description>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="0.1.1-alpha-167" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Core.Contracts/Microsoft.TemplateEngine.Core.Contracts.csproj
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/Microsoft.TemplateEngine.Core.Contracts.csproj
@@ -4,7 +4,13 @@
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <Description>Contracts for extending Microsoft.TemplateEngine.Core</Description>
   </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
+++ b/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
@@ -14,4 +14,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
+++ b/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
@@ -4,20 +4,27 @@
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
     <Description>Helper package for adding Template Engine to consuming applications</Description>
   </PropertyGroup>
+  
   <ItemGroup>
     <Compile Include="..\Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' != 'net45'">
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
   </ItemGroup>

--- a/src/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj
+++ b/src/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj
@@ -11,5 +11,10 @@
     <ProjectReference Include="..\Microsoft.TemplateEngine.Edge\Microsoft.TemplateEngine.Edge.csproj" />
     <ProjectReference Include="..\Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj
@@ -4,21 +4,31 @@
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <Description>An extension for Template Engine that allows projects that still run to be used as templates</Description>
   </PropertyGroup>
+  
   <ItemGroup>
     <Compile Include="..\Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
     <ProjectReference Include="..\Microsoft.TemplateEngine.Core.Contracts\Microsoft.TemplateEngine.Core.Contracts.csproj" />
     <ProjectReference Include="..\Microsoft.TemplateEngine.Core\Microsoft.TemplateEngine.Core.csproj" />
     <ProjectReference Include="..\Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard1.3'">
     <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Update="LocalizableStrings.Designer.cs">
       <DesignTime>True</DesignTime>
@@ -26,6 +36,7 @@
       <DependentUpon>LocalizableStrings.resx</DependentUpon>
     </Compile>
   </ItemGroup>
+
   <ItemGroup>
     <EmbeddedResource Update="LocalizableStrings.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
+++ b/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
@@ -4,9 +4,16 @@
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <Description>Components used by all Template Engine extensions and consumers</Description>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>

--- a/src/Microsoft.TemplateEngine.VisualStudioWizard/Microsoft.TemplateEngine.VisualStudioWizard.csproj
+++ b/src/Microsoft.TemplateEngine.VisualStudioWizard/Microsoft.TemplateEngine.VisualStudioWizard.csproj
@@ -9,6 +9,8 @@
     <PackageReference Include="EnvDTE" Version="8.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.0.26201" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Interop" Version="7.10.6071" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/dotnet-new3/dotnet-new3.csproj
+++ b/src/dotnet-new3/dotnet-new3.csproj
@@ -19,6 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
+++ b/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
@@ -3,11 +3,17 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.5;net45</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Core.Contracts\Microsoft.TemplateEngine.Core.Contracts.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Core\Microsoft.TemplateEngine.Core.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Edge\Microsoft.TemplateEngine.Edge.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Symbols should still get uploaded to the symbol server rather than just being pushed to the MyGet feed, otherwise fixes #1574 