### PR TITLE
Return an error if no templates are found when list is specified

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/TemplateListResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListResolver.cs
@@ -178,9 +178,7 @@ namespace Microsoft.TemplateEngine.Cli
         {
             IReadOnlyCollection<ITemplateMatchInfo> coreMatchedTemplates = PerformCoreTemplateQuery(templateInfo, hostDataLoader, commandInput, defaultLanguage);
             IReadOnlyCollection<ITemplateMatchInfo> allTemplatesInContext = PerformAllTemplatesInContextQuery(templateInfo, hostDataLoader, commandInput.TypeFilter);
-            TemplateListResolutionResult result = new TemplateListResolutionResult(commandInput.TemplateName, commandInput.Language, coreMatchedTemplates, allTemplatesInContext);
-            result.ComputeContextBasedAndOtherPartialMatches();
-            return result;
+            return new TemplateListResolutionResult(commandInput.TemplateName, commandInput.Language, coreMatchedTemplates, allTemplatesInContext);
         }
 
         // Query for template matches, filtered by everything available: name, language, context, parameters, and the host file.

--- a/src/Microsoft.TemplateEngine.Cli/TemplateListResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListResolver.cs
@@ -178,7 +178,9 @@ namespace Microsoft.TemplateEngine.Cli
         {
             IReadOnlyCollection<ITemplateMatchInfo> coreMatchedTemplates = PerformCoreTemplateQuery(templateInfo, hostDataLoader, commandInput, defaultLanguage);
             IReadOnlyCollection<ITemplateMatchInfo> allTemplatesInContext = PerformAllTemplatesInContextQuery(templateInfo, hostDataLoader, commandInput.TypeFilter);
-            return new TemplateListResolutionResult(commandInput.TemplateName, commandInput.Language, coreMatchedTemplates, allTemplatesInContext);
+            TemplateListResolutionResult result = new TemplateListResolutionResult(commandInput.TemplateName, commandInput.Language, coreMatchedTemplates, allTemplatesInContext);
+            result.ComputeContextBasedAndOtherPartialMatches();
+            return result;
         }
 
         // Query for template matches, filtered by everything available: name, language, context, parameters, and the host file.


### PR DESCRIPTION
Move logic for determining whether there's a problem with the resolution into the resolution result, return an error code if no templates are matched instead of just printing a message

Fixes #1589 