### PR TITLE
Add not found handler to template create

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
@@ -117,7 +117,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 
         // TODO: rework this method... it's a bit of a god-method, for very specific purposes.
         // Number of times I've deferred on reworking this method: 4
-        internal static TemplateUsageInformation GetTemplateUsageInformation(ITemplateInfo templateInfo, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, TemplateCreator templateCreator)
+        internal static TemplateUsageInformation? GetTemplateUsageInformation(ITemplateInfo templateInfo, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, TemplateCreator templateCreator)
         {
             IParameterSet allParams;
             IReadOnlyList<string> userParamsWithInvalidValues;
@@ -125,6 +125,12 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             bool hasPostActionScriptRunner;
 
             ITemplate template = environmentSettings.SettingsLoader.LoadTemplate(templateInfo, commandInput.BaselineName);
+
+            if (template == null)
+            {
+                return null;
+            }
+
             TemplateListResolver.ParseTemplateArgs(templateInfo, hostDataLoader, commandInput);
             allParams = templateCreator.SetupDefaultParamValuesFromTemplateAndHost(template, template.DefaultName ?? "testName", out IReadOnlyList<string> defaultParamsWithInvalidValues);
             templateCreator.ResolveUserParameters(template, allParams, commandInput.InputTemplateParams, out userParamsWithInvalidValues);

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -938,6 +938,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to locate the specified template content, the template cache may be corrupted. Try running &apos;dotnet {0} --debug:reinit&apos; to fix the issue..
+        /// </summary>
+        public static string MissingTemplateContentDetected {
+            get {
+                return ResourceManager.GetString("MissingTemplateContentDetected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Mount Point Factories.
         /// </summary>
         public static string MountPointFactories {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -616,4 +616,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="FileActionsWouldHaveBeenTaken" xml:space="preserve">
     <value>File actions would have been taken:</value>
   </data>
+  <data name="MissingTemplateContentDetected" xml:space="preserve">
+    <value>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</value>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -311,6 +311,9 @@ namespace Microsoft.TemplateEngine.Cli
                     break;
                 case CreationResultStatus.OperationNotSpecified:
                     break;
+                case CreationResultStatus.NotFound:
+                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.MissingTemplateContentDetected, CommandName).Bold().Red());
+                    break;
                 case CreationResultStatus.InvalidParamValues:
                     TemplateUsageInformation usageInformation = TemplateUsageHelp.GetTemplateUsageInformation(template, EnvironmentSettings, _commandInput, _hostDataLoader, _templateCreator);
                     string invalidParamsError = InvalidParameterInfo.InvalidParameterListToString(usageInformation.InvalidParameters);

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -315,10 +315,19 @@ namespace Microsoft.TemplateEngine.Cli
                     Reporter.Error.WriteLine(string.Format(LocalizableStrings.MissingTemplateContentDetected, CommandName).Bold().Red());
                     break;
                 case CreationResultStatus.InvalidParamValues:
-                    TemplateUsageInformation usageInformation = TemplateUsageHelp.GetTemplateUsageInformation(template, EnvironmentSettings, _commandInput, _hostDataLoader, _templateCreator);
-                    string invalidParamsError = InvalidParameterInfo.InvalidParameterListToString(usageInformation.InvalidParameters);
-                    Reporter.Error.WriteLine(invalidParamsError.Bold().Red());
-                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.RunHelpForInformationAboutAcceptedParameters, $"{CommandName} {TemplateName}").Bold().Red());
+                    TemplateUsageInformation? usageInformation = TemplateUsageHelp.GetTemplateUsageInformation(template, EnvironmentSettings, _commandInput, _hostDataLoader, _templateCreator);
+
+                    if (usageInformation != null)
+                    {
+                        string invalidParamsError = InvalidParameterInfo.InvalidParameterListToString(usageInformation.Value.InvalidParameters);
+                        Reporter.Error.WriteLine(invalidParamsError.Bold().Red());
+                        Reporter.Error.WriteLine(string.Format(LocalizableStrings.RunHelpForInformationAboutAcceptedParameters, $"{CommandName} {TemplateName}").Bold().Red());
+                    }
+                    else
+                    {
+                        Reporter.Error.WriteLine(string.Format(LocalizableStrings.MissingTemplateContentDetected, CommandName).Bold().Red());
+                        return CreationResultStatus.NotFound;
+                    }
                     break;
                 default:
                     break;


### PR DESCRIPTION
Fixes #1589 

Adds the not found handler that prints out a message about configuration corruption. Also adds handling for the same case to the help display routine