### PR TITLE
Get rid of the not implemented exceptions in the FromJObject methods …

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNameValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNameValueFormModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
@@ -6,11 +7,26 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
     {
         public new static readonly string FormName = "lower_safe_name";
 
+        public DefaultLowerSafeNameValueFormModel()
+            : base()
+        {
+        }
+
+        public DefaultLowerSafeNameValueFormModel(string name)
+            : base(name)
+        {
+        }
+
         public override string Identifier => FormName;
 
         public override string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
         {
             return base.Process(forms, value).ToLowerInvariant();
+        }
+
+        public override IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new DefaultLowerSafeNameValueFormModel(name);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNameValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNameValueFormModel.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
     public class DefaultLowerSafeNameValueFormModel : DefaultSafeNameValueFormModel
     {
         public new static readonly string FormName = "lower_safe_name";
+        private readonly string _name;
 
         public DefaultLowerSafeNameValueFormModel()
             : base()
@@ -15,9 +16,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
         public DefaultLowerSafeNameValueFormModel(string name)
             : base(name)
         {
+            _name = name;
         }
 
-        public override string Identifier => FormName;
+        public override string Identifier => _name ?? FormName;
 
         public override string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
         {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNamespaceValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNamespaceValueFormModel.cs
@@ -6,6 +6,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
     public class DefaultLowerSafeNamespaceValueFormModel : DefaultSafeNamespaceValueFormModel
     {
         public new static readonly string FormName = "lower_safe_namespace";
+        private readonly string _name;
 
         public DefaultLowerSafeNamespaceValueFormModel()
             : base()
@@ -15,9 +16,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
         public DefaultLowerSafeNamespaceValueFormModel(string name)
             : base(name)
         {
+            _name = name;
         }
 
-        public override string Identifier => FormName;
+        public override string Identifier => _name ?? FormName;
 
         public override string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
         {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNamespaceValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNamespaceValueFormModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
@@ -6,11 +7,26 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
     {
         public new static readonly string FormName = "lower_safe_namespace";
 
+        public DefaultLowerSafeNamespaceValueFormModel()
+            : base()
+        {
+        }
+
+        public DefaultLowerSafeNamespaceValueFormModel(string name)
+            : base(name)
+        {
+        }
+
         public override string Identifier => FormName;
 
         public override string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
         {
             return base.Process(forms, value).ToLowerInvariant();
+        }
+
+        public override IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new DefaultLowerSafeNamespaceValueFormModel(name);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNameValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNameValueFormModel.cs
@@ -7,15 +7,23 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     public class DefaultSafeNameValueFormModel : IValueForm
     {
+        private readonly string _name;
+
         public DefaultSafeNameValueFormModel()
+            : this(null)
         {
+        }
+
+        public DefaultSafeNameValueFormModel(string name)
+        {
+            _name = name;
         }
 
         public static readonly string FormName = "safe_name";
 
         public virtual string Identifier => FormName;
 
-        public virtual string Name => Identifier;
+        public virtual string Name => _name ?? Identifier;
 
         public IValueForm FromJObject(string name, JObject configuration)
         {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNameValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNameValueFormModel.cs
@@ -25,9 +25,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         public virtual string Name => _name ?? Identifier;
 
-        public IValueForm FromJObject(string name, JObject configuration)
+        public virtual IValueForm FromJObject(string name, JObject configuration)
         {
-            throw new NotImplementedException();
+            return new DefaultSafeNameValueFormModel(name);
         }
 
         public virtual string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNamespaceValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNamespaceValueFormModel.cs
@@ -25,9 +25,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         public string Name => Identifier;
 
-        public IValueForm FromJObject(string name, JObject configuration)
+        public virtual IValueForm FromJObject(string name, JObject configuration)
         {
-            return new DefaultLowerSafeNamespaceValueFormModel(name);
+            return new DefaultSafeNamespaceValueFormModel(name);
         }
 
         public virtual string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNamespaceValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNamespaceValueFormModel.cs
@@ -7,19 +7,27 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     public class DefaultSafeNamespaceValueFormModel : IValueForm
     {
+        private readonly string _name;
+
         public DefaultSafeNamespaceValueFormModel()
+            : this(null)
         {
+        }
+
+        public DefaultSafeNamespaceValueFormModel(string name)
+        {
+            _name = name;
         }
 
         public static readonly string FormName = "safe_namespace";
 
-        public virtual string Identifier => FormName;
+        public virtual string Identifier => _name ?? FormName;
 
         public string Name => Identifier;
 
         public IValueForm FromJObject(string name, JObject configuration)
         {
-            throw new NotImplementedException();
+            return new DefaultLowerSafeNamespaceValueFormModel(name);
         }
 
         public virtual string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)


### PR DESCRIPTION
…for safe_name and safe_namespace value forms

In updating the schema to have value forms, I noticed that safe_name and safe_namespace forms throw if you try to read them from config. This PR has them return new instances of themselves - it's not overly useful, but we shouldn't crash if someone tries to use them