### PR TITLE
Introduce new interfaces to preserve source to target mappings and consume them in post-actions

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/ICreationEffects.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ICreationEffects.cs
@@ -1,10 +1,17 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Abstractions
 {
     public interface ICreationEffects
     {
         IReadOnlyList<IFileChange> FileChanges { get; }
+
+        ICreationResult CreationResult { get; }
+    }
+
+    public interface ICreationEffects2
+    {
+        IReadOnlyList<IFileChange2> FileChanges { get; }
 
         ICreationResult CreationResult { get; }
     }

--- a/src/Microsoft.TemplateEngine.Abstractions/IFileChange.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IFileChange.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.TemplateEngine.Abstractions
+namespace Microsoft.TemplateEngine.Abstractions
 {
     public interface IFileChange
     {
@@ -7,5 +7,10 @@
         ChangeKind ChangeKind { get; }
 
         byte[] Contents { get; }
+    }
+
+    public interface IFileChange2 : IFileChange
+    {
+        string SourceRelativePath { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -600,6 +600,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Couldn&apos;t determine files to restore..
+        /// </summary>
+        public static string CouldntDetermineFilesToRestore {
+            get {
+                return ResourceManager.GetString("CouldntDetermineFilesToRestore", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not find something to uninstall called &apos;{0}&apos;..
         /// </summary>
         public static string CouldntUninstall {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -622,4 +622,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="InvalidNameParameter" xml:space="preserve">
     <value>Name cannot contain any of the following characters {0} or character codes {1}</value>
   </data>
+  <data name="CouldntDetermineFilesToRestore" xml:space="preserve">
+    <value>Couldn't determine files to restore.</value>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
@@ -153,7 +153,7 @@ namespace Microsoft.TemplateEngine.Cli
         {
             if (actionProcessor is IPostActionProcessor2 actionProcessor2 && _creationResult.CreationEffects is ICreationEffects2 creationEffects)
             {
-                return actionProcessor2.Process(_environment, action, creationEffects, _creationResult.OutputBaseDirectory);
+                return actionProcessor2.Process(_environment, action, creationEffects, _creationResult.ResultInfo, _creationResult.OutputBaseDirectory);
             }
 
             return actionProcessor.Process(_environment, action, _creationResult.ResultInfo, _creationResult.OutputBaseDirectory);

--- a/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
@@ -151,6 +151,11 @@ namespace Microsoft.TemplateEngine.Cli
 
         private bool ProcessAction(IPostAction action, IPostActionProcessor actionProcessor)
         {
+            if (actionProcessor is IPostActionProcessor2 actionProcessor2 && _creationResult.CreationEffects is ICreationEffects2 creationEffects)
+            {
+                return actionProcessor2.Process(_environment, action, creationEffects, _creationResult.OutputBaseDirectory);
+            }
+
             return actionProcessor.Process(_environment, action, _creationResult.ResultInfo, _creationResult.OutputBaseDirectory);
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddProjectsToSolutionPostAction.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddProjectsToSolutionPostAction.cs
@@ -98,7 +98,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
             }
         }
 
-        public bool Process(IEngineEnvironmentSettings environment, IPostAction action, ICreationEffects2 creationEffects, string outputBasePath)
+        public bool Process(IEngineEnvironmentSettings environment, IPostAction action, ICreationEffects2 creationEffects, ICreationResult templateCreationResult, string outputBasePath)
         {
             if (string.IsNullOrEmpty(outputBasePath))
             {
@@ -157,10 +157,10 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 
                 projectFiles = allProjects;
             }
-            else if (!TryGetProjectFilesToAdd(environment, action, creationEffects.CreationResult, outputBasePath, out projectFiles))
+            else
             {
-                environment.Host.LogMessage(LocalizableStrings.AddProjToSlnPostActionNoProjFiles);
-                return false;
+                //If the author didn't opt in to the new behavior by specifying "projectFiles", use the old behavior
+                return Process(environment, action, templateCreationResult, outputBasePath);
             }
 
             Dotnet addProjToSlnCommand = Dotnet.AddProjectsToSolution(nearestSlnFilesFould[0], projectFiles);

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddReferencePostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddReferencePostActionProcessor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 
         public Guid Id => ActionProcessorId;
 
-        public bool Process(IEngineEnvironmentSettings environment, IPostAction action, ICreationEffects2 creationEffects, string outputBasePath)
+        public bool Process(IEngineEnvironmentSettings environment, IPostAction action, ICreationEffects2 creationEffects, ICreationResult templateCreationResult, string outputBasePath)
         {
             IReadOnlyList<string> allTargets = null;
             if (action.Args.TryGetValue("targetFiles", out string singleTarget) && singleTarget != null)
@@ -47,7 +47,8 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
             }
             else
             {
-                allTargets = null;
+                //If the author didn't opt in to the new behavior by using "targetFiles", do things the old way
+                return Process(environment, action, templateCreationResult, outputBasePath);
             }
 
             if (allTargets is null)

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/DotnetRestorePostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/DotnetRestorePostActionProcessor.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
         {
         }
 
-        public bool Process(IEngineEnvironmentSettings environment, IPostAction actionConfig, ICreationEffects2 creationEffects, string outputBasePath)
+        public bool Process(IEngineEnvironmentSettings environment, IPostAction actionConfig, ICreationEffects2 creationEffects, ICreationResult templateCreationResult, string outputBasePath)
         {
             bool allSucceeded = true;
             IEnumerable<string> targetFiles = null;
@@ -51,12 +51,13 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
             }
             else
             {
-                targetFiles = creationEffects.FileChanges.Select(x => x.TargetRelativePath);
+                //If the author didn't opt in to the new behavior by using "files", do things the old way
+                return Process(environment, actionConfig, templateCreationResult, outputBasePath);
             }
 
             if (targetFiles is null)
             {
-                //TODO: add a message indicating that the files to restore couldn't be determined
+                environment.Host.LogMessage(string.Format(LocalizableStrings.CouldntDetermineFilesToRestore));
                 return false;
             }
 

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/DotnetRestorePostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/DotnetRestorePostActionProcessor.cs
@@ -1,10 +1,12 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 {
-    public class DotnetRestorePostActionProcessor : IPostActionProcessor
+    public class DotnetRestorePostActionProcessor : PostActionProcessor2Base, IPostActionProcessor, IPostActionProcessor2
     {
         private static readonly Guid ActionProcessorId = new Guid("210D431B-A78B-4D2F-B762-4ED3E3EA9025");
 
@@ -12,6 +14,51 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 
         public DotnetRestorePostActionProcessor()
         {
+        }
+
+        public bool Process(IEngineEnvironmentSettings environment, IPostAction actionConfig, ICreationEffects2 creationEffects, string outputBasePath)
+        {
+            bool allSucceeded = true;
+            IEnumerable<string> targetFiles;
+
+            if (actionConfig.Args.TryGetValue("files", out string specificFilesString))
+            {
+                targetFiles = specificFilesString.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).SelectMany(x => GetTargetForSource(creationEffects, x));
+            }
+            else
+            {
+                targetFiles = creationEffects.FileChanges.Select(x => x.TargetRelativePath);
+            }
+
+            foreach (string targetRelativePath in targetFiles)
+            {
+                string pathToRestore = !string.IsNullOrEmpty(outputBasePath) ? Path.Combine(outputBasePath, targetRelativePath) : targetRelativePath;
+
+                if (string.IsNullOrEmpty(pathToRestore) ||
+                    (!Directory.Exists(pathToRestore)
+                        && !Path.GetExtension(pathToRestore).EndsWith("proj", StringComparison.OrdinalIgnoreCase)
+                        && !Path.GetExtension(pathToRestore).Equals(".sln", StringComparison.OrdinalIgnoreCase)
+                    ))
+                {
+                    continue;
+                }
+
+                environment.Host.LogMessage(string.Format(LocalizableStrings.RunningDotnetRestoreOn, pathToRestore));
+                Dotnet restoreCommand = Dotnet.Restore(pathToRestore).ForwardStdErr().ForwardStdOut();
+                Dotnet.Result commandResult = restoreCommand.Execute();
+
+                if (commandResult.ExitCode != 0)
+                {
+                    environment.Host.LogMessage(LocalizableStrings.RestoreFailed);
+                    allSucceeded = false;
+                }
+                else
+                {
+                    environment.Host.LogMessage(LocalizableStrings.RestoreSucceeded);
+                }
+            }
+
+            return allSucceeded;
         }
 
         public bool Process(IEngineEnvironmentSettings environment, IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath)

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/IPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/IPostActionProcessor.cs
@@ -1,9 +1,14 @@
-﻿using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 {
     public interface IPostActionProcessor : IIdentifiedComponent
     {
         bool Process(IEngineEnvironmentSettings environment, IPostAction action, ICreationResult templateCreationResult, string outputBasePath);
+    }
+
+    public interface IPostActionProcessor2 : IIdentifiedComponent
+    {
+        bool Process(IEngineEnvironmentSettings environment, IPostAction action, ICreationEffects2 creationEffects, string outputBasePath);
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/IPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/IPostActionProcessor.cs
@@ -9,6 +9,6 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 
     public interface IPostActionProcessor2 : IIdentifiedComponent
     {
-        bool Process(IEngineEnvironmentSettings environment, IPostAction action, ICreationEffects2 creationEffects, string outputBasePath);
+        bool Process(IEngineEnvironmentSettings environment, IPostAction action, ICreationEffects2 creationEffects, ICreationResult templateCreationResult, string outputBasePath);
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/PostActionProcessorBase.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/PostActionProcessorBase.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Utils;
+
+namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
+{
+    public abstract class PostActionProcessor2Base
+    {
+        protected IReadOnlyList<string> GetTargetForSource(ICreationEffects2 creationEffects, string sourcePathGlob)
+        {
+            Glob g = Glob.Parse(sourcePathGlob);
+            List<string> results = new List<string>();
+
+            if (creationEffects.FileChanges != null)
+            {
+                foreach (IFileChange2 change in creationEffects.FileChanges)
+                {
+                    if (g.IsMatch(change.SourceRelativePath))
+                    {
+                        results.Add(change.TargetRelativePath);
+                    }
+                }
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IOrchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IOrchestrator.cs
@@ -14,4 +14,15 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 
         IReadOnlyList<IFileChange> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
     }
+
+    public interface IOrchestrator2
+    {
+        void Run(string runSpecPath, IDirectory sourceDir, string targetDir);
+
+        void Run(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
+
+        IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir);
+
+        IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
+    }
 }

--- a/src/Microsoft.TemplateEngine.Core/FileChange.cs
+++ b/src/Microsoft.TemplateEngine.Core/FileChange.cs
@@ -1,18 +1,21 @@
-﻿using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Core
 {
-    public class FileChange : IFileChange
+    public class FileChange : IFileChange2
     {
+        public string SourceRelativePath { get; }
+
         public string TargetRelativePath { get; }
 
         public ChangeKind ChangeKind { get; }
 
         public byte[] Contents { get; }
 
-        public FileChange(string path, ChangeKind changeKind, byte[] contents = null)
+        public FileChange(string sourceRelativePath, string targetRelativePath, ChangeKind changeKind, byte[] contents = null)
         {
-            TargetRelativePath = path;
+            SourceRelativePath = sourceRelativePath;
+            TargetRelativePath = targetRelativePath;
             ChangeKind = changeKind;
             Contents = contents;
         }

--- a/src/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
@@ -9,7 +9,7 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Core.Util
 {
-    public class Orchestrator : IOrchestrator
+    public class Orchestrator : IOrchestrator, IOrchestrator2
     {
         public void Run(string runSpecPath, IDirectory sourceDir, string targetDir)
         {
@@ -31,7 +31,7 @@ namespace Microsoft.TemplateEngine.Core.Util
             RunInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetDir, spec);
         }
 
-        public IReadOnlyList<IFileChange> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
+        public IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
         {
             IGlobalRunSpec spec;
             using (Stream stream = sourceDir.MountPoint.EnvironmentSettings.Host.FileSystem.OpenRead(runSpecPath))
@@ -56,9 +56,19 @@ namespace Microsoft.TemplateEngine.Core.Util
             RunInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetDir, spec);
         }
 
-        public IReadOnlyList<IFileChange> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
+        public IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
         {
             return GetFileChangesInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetDir, spec);
+        }
+
+        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
+        {
+            return GetFileChanges(runSpecPath, sourceDir, targetDir);
+        }
+
+        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
+        {
+            return GetFileChanges(spec, sourceDir, targetDir);
         }
 
         protected virtual IGlobalRunSpec RunSpecLoader(Stream runSpec)
@@ -97,12 +107,12 @@ namespace Microsoft.TemplateEngine.Core.Util
             return processorList;
         }
 
-        private IReadOnlyList<IFileChange> GetFileChangesInternal(IEngineEnvironmentSettings environmentSettings, IDirectory sourceDir, string targetDir, IGlobalRunSpec spec)
+        private IReadOnlyList<IFileChange2> GetFileChangesInternal(IEngineEnvironmentSettings environmentSettings, IDirectory sourceDir, string targetDir, IGlobalRunSpec spec)
         {
             EngineConfig cfg = new EngineConfig(environmentSettings, EngineConfig.DefaultWhitespaces, EngineConfig.DefaultLineEndings, spec.RootVariableCollection);
             IProcessor fallback = Processor.Create(cfg, spec.Operations);
 
-            List<IFileChange> changes = new List<IFileChange>();
+            List<IFileChange2> changes = new List<IFileChange2>();
             List<KeyValuePair<IPathMatcher, IProcessor>> fileGlobProcessors = CreateFileGlobProcessors(sourceDir.MountPoint.EnvironmentSettings, spec);
 
             foreach (IFile file in sourceDir.EnumerateFiles("*", SearchOption.AllDirectories))
@@ -147,20 +157,20 @@ namespace Microsoft.TemplateEngine.Core.Util
 
                                 if (environmentSettings.Host.FileSystem.DirectoryExists(targetPath))
                                 {
-                                    changes.Add(new FileChange(targetRel, ChangeKind.Overwrite));
+                                    changes.Add(new FileChange(sourceRel, targetRel, ChangeKind.Overwrite));
                                 }
                                 else
                                 {
-                                    changes.Add(new FileChange(targetRel, ChangeKind.Create));
+                                    changes.Add(new FileChange(sourceRel, targetRel, ChangeKind.Create));
                                 }
                             }
                             else if (environmentSettings.Host.FileSystem.FileExists(targetPath))
                             {
-                                changes.Add(new FileChange(targetRel, ChangeKind.Overwrite));
+                                changes.Add(new FileChange(sourceRel, targetRel, ChangeKind.Overwrite));
                             }
                             else
                             {
-                                changes.Add(new FileChange(targetRel, ChangeKind.Create));
+                                changes.Add(new FileChange(sourceRel, targetRel, ChangeKind.Create));
                             }
                         }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationEffects.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationEffects.cs
@@ -1,9 +1,5 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationEffects.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationEffects.cs
@@ -1,13 +1,24 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Core;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
     public class CreationEffects : ICreationEffects
     {
         public IReadOnlyList<IFileChange> FileChanges { get; set; }
+
+        public ICreationResult CreationResult { get; set; }
+    }
+
+    public class CreationEffects2 : ICreationEffects, ICreationEffects2
+    {
+        public IReadOnlyList<IFileChange2> FileChanges { get; set; }
+
+        IReadOnlyList<IFileChange> ICreationEffects.FileChanges => FileChanges;
 
         public ICreationResult CreationResult { get; set; }
     }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -34,7 +34,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             IVariableCollection variables = VariableCollection.SetupVariables(environmentSettings, parameters, template.Config.OperationConfig.VariableSetup);
             template.Config.Evaluate(parameters, variables, template.ConfigFile);
 
-            IOrchestrator basicOrchestrator = new Core.Util.Orchestrator();
+            IOrchestrator2 basicOrchestrator = new Core.Util.Orchestrator();
             RunnableProjectOrchestrator orchestrator = new RunnableProjectOrchestrator(basicOrchestrator);
 
             GlobalRunSpec runSpec = new GlobalRunSpec(template.TemplateSourceRoot, componentManager, parameters, variables, template.Config.OperationConfig, template.Config.SpecialOperationConfig, template.Config.LocalizationOperations, template.Config.IgnoreFileNames);
@@ -673,11 +673,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             IVariableCollection variables = VariableCollection.SetupVariables(environmentSettings, parameters, template.Config.OperationConfig.VariableSetup);
             template.Config.Evaluate(parameters, variables, template.ConfigFile);
 
-            IOrchestrator basicOrchestrator = new Core.Util.Orchestrator();
+            IOrchestrator2 basicOrchestrator = new Core.Util.Orchestrator();
             RunnableProjectOrchestrator orchestrator = new RunnableProjectOrchestrator(basicOrchestrator);
 
             GlobalRunSpec runSpec = new GlobalRunSpec(template.TemplateSourceRoot, componentManager, parameters, variables, template.Config.OperationConfig, template.Config.SpecialOperationConfig, template.Config.LocalizationOperations, template.Config.IgnoreFileNames);
-            List<IFileChange> changes = new List<IFileChange>();
+            List<IFileChange2> changes = new List<IFileChange2>();
 
             foreach (FileSourceMatchInfo source in template.Config.Sources)
             {
@@ -686,7 +686,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 changes.AddRange(orchestrator.GetFileChanges(runSpec, template.TemplateSourceRoot.DirectoryInfo(source.Source), target));
             }
 
-            return new CreationEffects()
+            return new CreationEffects2
             {
                 FileChanges = changes,
                 CreationResult = GetCreationResult(environmentSettings, template, variables)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectOrchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectOrchestrator.cs
@@ -1,27 +1,39 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.Core;
 using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
-    public class RunnableProjectOrchestrator : IOrchestrator
+    public class RunnableProjectOrchestrator : IOrchestrator, IOrchestrator2
     {
-        private readonly IOrchestrator _basicOrchestrator;
+        private readonly IOrchestrator2 _basicOrchestrator;
 
-        public RunnableProjectOrchestrator(IOrchestrator basicOrchestrator)
+        public RunnableProjectOrchestrator(IOrchestrator2 basicOrchestrator)
         {
             _basicOrchestrator = basicOrchestrator;
         }
 
-        public IReadOnlyList<IFileChange> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
+        public IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
         {
             return _basicOrchestrator.GetFileChanges(runSpecPath, sourceDir, targetDir);
         }
 
-        public IReadOnlyList<IFileChange> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
+        public IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
         {
             return _basicOrchestrator.GetFileChanges(spec, sourceDir, targetDir);
+        }
+
+        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
+        {
+            return GetFileChanges(runSpecPath, sourceDir, targetDir);
+        }
+
+        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
+        {
+            return GetFileChanges(spec, sourceDir, targetDir);
         }
 
         public void Run(string runSpecPath, IDirectory sourceDir, string targetDir)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
@@ -839,7 +839,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                         {
                             pathModel.PathResolved = targetPath;
                         }
-                        else
+                        //Don't overwrite an already resolved output value
+                        else if (string.IsNullOrEmpty(pathModel.PathResolved))
                         {
                             pathModel.PathResolved = pathModel.PathOriginal;
                         }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/FileRenameTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/FileRenameTests.cs
@@ -17,10 +17,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
 
             TestTemplateSetup setup = SetupSourceRenameIsCaseSensitveTestTemplate(environment, sourceBasePath);
             string targetDir = FileSystemHelpers.GetNewVirtualizedPath(environment);
-            IReadOnlyDictionary<string, IReadOnlyList<IFileChange>> allChanges = setup.GetFileChanges(targetDir);
+            IReadOnlyDictionary<string, IReadOnlyList<IFileChange2>> allChanges = setup.GetFileChanges(targetDir);
 
             Assert.Equal(1, allChanges.Count);  // one source had changes
-            Assert.True(allChanges.TryGetValue("./", out IReadOnlyList<IFileChange> changes), "No changes for source './'");
+            Assert.True(allChanges.TryGetValue("./", out IReadOnlyList<IFileChange2> changes), "No changes for source './'");
 
             Assert.Equal(2, changes.Count);
             Assert.Equal(1, changes.Count(x => string.Equals(x.TargetRelativePath, "YesNewName.txt", StringComparison.Ordinal)));
@@ -61,10 +61,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
 
             TestTemplateSetup setup = SetupSourceModifierRenameIsCaseSensitiveTestTemplate(environment, sourceBasePath);
             string targetDir = FileSystemHelpers.GetNewVirtualizedPath(environment);
-            IReadOnlyDictionary<string, IReadOnlyList<IFileChange>> allChanges = setup.GetFileChanges(targetDir);
+            IReadOnlyDictionary<string, IReadOnlyList<IFileChange2>> allChanges = setup.GetFileChanges(targetDir);
 
             Assert.Equal(1, allChanges.Count);  // one source had changes
-            Assert.True(allChanges.TryGetValue("./", out IReadOnlyList<IFileChange> changes), "No changes for source './'");
+            Assert.True(allChanges.TryGetValue("./", out IReadOnlyList<IFileChange2> changes), "No changes for source './'");
 
             Assert.Equal(2, changes.Count);
             Assert.Equal(1, changes.Count(x => string.Equals(x.TargetRelativePath, "YesNewName.txt", StringComparison.Ordinal)));

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/SourceConfigTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/SourceConfigTests.cs
@@ -31,12 +31,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
 
             TestTemplateSetup setup = SetupCopyOnlyWithoutCorrespondingIncludeTemplate(environment, sourceBasePath);
             string targetDir = FileSystemHelpers.GetNewVirtualizedPath(environment);
-            IReadOnlyDictionary<string, IReadOnlyList<IFileChange>> allChanges = setup.GetFileChanges(targetDir);
+            IReadOnlyDictionary<string, IReadOnlyList<IFileChange2>> allChanges = setup.GetFileChanges(targetDir);
 
             // one source, should cause one set of changes
             Assert.Equal(1, allChanges.Count);
 
-            if (!allChanges.TryGetValue("./", out IReadOnlyList<IFileChange> changes))
+            if (!allChanges.TryGetValue("./", out IReadOnlyList<IFileChange2> changes))
             {
                 Assert.True(false, "no changes for source './'");
             }
@@ -54,11 +54,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
 
             TestTemplateSetup setup = SetupCopyOnlyWithParentInclude(environment, sourceBasePath);
             string targetDir = FileSystemHelpers.GetNewVirtualizedPath(environment);
-            IReadOnlyDictionary<string, IReadOnlyList<IFileChange>> allChanges = setup.GetFileChanges(targetDir);
+            IReadOnlyDictionary<string, IReadOnlyList<IFileChange2>> allChanges = setup.GetFileChanges(targetDir);
 
             Assert.Equal(1, allChanges.Count);
 
-            if (!allChanges.TryGetValue("./", out IReadOnlyList<IFileChange> changes))
+            if (!allChanges.TryGetValue("./", out IReadOnlyList<IFileChange2> changes))
             {
                 Assert.True(false, "no changes for source './'");
             }
@@ -76,11 +76,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
 
             TestTemplateSetup setup = SetupCopyOnlyWithWildcardAndParentInclude(environment, sourceBasePath);
             string targetDir = FileSystemHelpers.GetNewVirtualizedPath(environment);
-            IReadOnlyDictionary<string, IReadOnlyList<IFileChange>> allChanges = setup.GetFileChanges(targetDir);
+            IReadOnlyDictionary<string, IReadOnlyList<IFileChange2>> allChanges = setup.GetFileChanges(targetDir);
 
             Assert.Equal(1, allChanges.Count);
 
-            if (!allChanges.TryGetValue("./", out IReadOnlyList<IFileChange> changes))
+            if (!allChanges.TryGetValue("./", out IReadOnlyList<IFileChange2> changes))
             {
                 Assert.True(false, "no changes for source './'");
             }
@@ -98,11 +98,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
 
             TestTemplateSetup setup = SetupXYZFilesForModifierOverrideTestsTemplate(environment, sourceBasePath, IncludeModifierOverridesPreviousExcludeModifierConfigText);
             string targetDir = FileSystemHelpers.GetNewVirtualizedPath(environment);
-            IReadOnlyDictionary<string, IReadOnlyList<IFileChange>> allChanges = setup.GetFileChanges(targetDir);
+            IReadOnlyDictionary<string, IReadOnlyList<IFileChange2>> allChanges = setup.GetFileChanges(targetDir);
 
             Assert.Equal(1, allChanges.Count);
 
-            if (!allChanges.TryGetValue("./", out IReadOnlyList<IFileChange> changes))
+            if (!allChanges.TryGetValue("./", out IReadOnlyList<IFileChange2> changes))
             {
                 Assert.True(false, "no changes for source './'");
             }
@@ -120,22 +120,22 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
 
             TestTemplateSetup setup = SetupXYZFilesForModifierOverrideTestsTemplate(environment, sourceBasePath, ExcludeModifierOverridesPreviousIncludeModifierConfigText);
             string targetDir = FileSystemHelpers.GetNewVirtualizedPath(environment);
-            IReadOnlyDictionary<string, IReadOnlyList<IFileChange>> allChanges = setup.GetFileChanges(targetDir);
+            IReadOnlyDictionary<string, IReadOnlyList<IFileChange2>> allChanges = setup.GetFileChanges(targetDir);
 
             Assert.Equal(1, allChanges.Count);
 
-            if (!allChanges.TryGetValue("./", out IReadOnlyList<IFileChange> changes))
+            if (!allChanges.TryGetValue("./", out IReadOnlyList<IFileChange2> changes))
             {
                 Assert.True(false, "no changes for source './'");
             }
 
             Assert.Equal(2, changes.Count);
 
-            IFileChange includeXyzChangeInfo = changes.FirstOrDefault(x => string.Equals(x.TargetRelativePath, "include.xyz"));
+            IFileChange2 includeXyzChangeInfo = changes.FirstOrDefault(x => string.Equals(x.TargetRelativePath, "include.xyz"));
             Assert.NotNull(includeXyzChangeInfo);
             Assert.Equal(ChangeKind.Create, includeXyzChangeInfo.ChangeKind);
 
-            IFileChange otherXyzChangeInfo = changes.FirstOrDefault(x => string.Equals(x.TargetRelativePath, "other.xyz"));
+            IFileChange2 otherXyzChangeInfo = changes.FirstOrDefault(x => string.Equals(x.TargetRelativePath, "other.xyz"));
             Assert.NotNull(otherXyzChangeInfo);
             Assert.Equal(ChangeKind.Create, otherXyzChangeInfo.ChangeKind);
         }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TestTemplateSetup.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TestTemplateSetup.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
@@ -106,7 +106,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             runSpec.RootVariableCollection = variables;
             IDirectory sourceDir = SourceMountPoint.DirectoryInfo("/");
 
-            IOrchestrator basicOrchestrator = new Core.Util.Orchestrator();
+            IOrchestrator2 basicOrchestrator = new Core.Util.Orchestrator();
             RunnableProjectOrchestrator orchestrator = new RunnableProjectOrchestrator(basicOrchestrator);
 
             foreach (FileSourceMatchInfo source in runnableConfig.Sources)
@@ -117,7 +117,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             }
         }
 
-        public IReadOnlyDictionary<string, IReadOnlyList<IFileChange>> GetFileChanges(string targetBaseDir, IParameterSet parameters = null, IVariableCollection variables = null)
+        public IReadOnlyDictionary<string, IReadOnlyList<IFileChange2>> GetFileChanges(string targetBaseDir, IParameterSet parameters = null, IVariableCollection variables = null)
         {
             if (parameters == null)
             {
@@ -136,16 +136,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             MockGlobalRunSpec runSpec = new MockGlobalRunSpec();
             IDirectory sourceDir = SourceMountPoint.DirectoryInfo("/");
 
-            IOrchestrator basicOrchestrator = new Core.Util.Orchestrator();
+            IOrchestrator2 basicOrchestrator = new Core.Util.Orchestrator();
             RunnableProjectOrchestrator orchestrator = new RunnableProjectOrchestrator(basicOrchestrator);
 
-            Dictionary<string, IReadOnlyList<IFileChange>> changesByTarget = new Dictionary<string, IReadOnlyList<IFileChange>>();
+            Dictionary<string, IReadOnlyList<IFileChange2>> changesByTarget = new Dictionary<string, IReadOnlyList<IFileChange2>>();
 
             foreach (FileSourceMatchInfo source in runnableConfig.Sources)
             {
                 TemplateConfigTestHelpers.SetupFileSourceMatchersOnGlobalRunSpec(runSpec, source);
                 string targetDirForSource = Path.Combine(targetBaseDir, source.Target);
-                IReadOnlyList<IFileChange> changes = orchestrator.GetFileChanges(runSpec, sourceDir, targetDirForSource);
+                IReadOnlyList<IFileChange2> changes = orchestrator.GetFileChanges(runSpec, sourceDir, targetDirForSource);
                 changesByTarget[source.Target] = changes;
             }
 


### PR DESCRIPTION
This should make referring to outputs in post-actions much easier after the rest have been adapted

Fixes #1622
Fixes #1623

On merging this, we'll need to update the documentation for the restore post-action to include the "files" parameter, the add reference post-action to include the "targetFiles" parameter and the add projects to solution post-action to include the "projectFiles" parameter, indicating that these will options are available in the 2.2+ CLI only.

This also adds an optional base class for post-actions that allows for looking up output files by their template sources (or globs)