### PR TITLE
Join macro

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/JoinMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/JoinMacroConfig.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Microsoft.TemplateEngine.Core.Contracts;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
+{
+    public class JoinMacroConfig : IMacroConfig
+    {
+        public string VariableName { get; private set; }
+
+        public string Type { get; private set; }
+
+        public string DataType { get; private set; }
+
+        // type -> value
+        public IList<KeyValuePair<string,string>> Symbols { get; private set; }
+
+        public string Separator { get; private set; }
+
+        public JoinMacroConfig(string variableName, string dataType, IList<KeyValuePair<string,string>> symbols, string separator)
+        {
+            VariableName = variableName;
+            Type = "join";
+            DataType = dataType;
+            Symbols = symbols;
+            Separator = separator;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/JoinMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/JoinMacro.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config;
+using Microsoft.TemplateEngine.Utils;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
+{
+    public class JoinMacro : IMacro, IDeferredMacro
+    {
+        public Guid Id => new Guid("6A2C58E5-8743-484B-AF3C-536770D31CEE");
+
+        public string Type => "join";
+
+        public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars,
+            IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
+        {
+            JoinMacroConfig config = rawConfig as JoinMacroConfig;
+            if (config == null)
+            {
+                throw new InvalidCastException("Couldn't cast the rawConfig as ConcatenationMacroConfig");
+            }
+
+            List<string> values = new List<string>();
+            foreach (KeyValuePair<string, string> symbol in config.Symbols)
+            {
+                switch (symbol.Key)
+                {
+                    case "ref":
+                        string value;
+                        if (!vars.TryGetValue(symbol.Value, out object working))
+                        {
+                            if (parameters.TryGetRuntimeValue(environmentSettings, symbol.Value,
+                                out object resolvedValue, true))
+                            {
+                                value = resolvedValue.ToString();
+                            }
+                            else
+                            {
+                                value = string.Empty;
+                            }
+                        }
+                        else
+                        {
+                            value = working?.ToString() ?? "";
+                        }
+
+                        values.Add(value);
+                        break;
+                    case "const":
+                        values.Add(symbol.Value);
+                        break;
+                    default:
+                        values.Add(symbol.Value);
+                        break;
+                }
+            }
+
+            string result = string.Join(config.Separator, values);
+            Parameter p;
+            if (parameters.TryGetParameterDefinition(config.VariableName, out ITemplateParameter existingParam))
+            {
+                // If there is an existing parameter with this name, it must be reused so it can be referenced by name
+                // for other processing, for example: if the parameter had value forms defined for creating variants.
+                // When the param already exists, use its definition, but set IsVariable = true for consistency.
+                p = (Parameter) existingParam;
+                p.IsVariable = true;
+                if (string.IsNullOrEmpty(p.DataType))
+                {
+                    p.DataType = config.DataType;
+                }
+            }
+            else
+            {
+                p = new Parameter
+                {
+                    IsVariable = true,
+                    Name = config.VariableName,
+                    DataType = config.DataType
+                };
+            }
+
+            vars[config.VariableName] = result;
+            setter(p, result);
+        }
+
+        public IMacroConfig CreateConfig(IEngineEnvironmentSettings environmentSettings, IMacroConfig rawConfig)
+        {
+            if (!(rawConfig is GeneratedSymbolDeferredMacroConfig deferredConfig))
+            {
+                throw new InvalidCastException("Couldn't cast the rawConfig as a GeneratedSymbolDeferredMacroConfig");
+            }
+
+            string separator = string.Empty;
+            if (deferredConfig.Parameters.TryGetValue("separator", out JToken separatorToken))
+            {
+                separator = separatorToken?.ToString();
+            }
+
+            List<KeyValuePair<string, string>> symbolsList = new List<KeyValuePair<string, string>>();
+            if (deferredConfig.Parameters.TryGetValue("symbols", out JToken symbolsToken))
+            {
+                JArray switchJArray = (JArray) symbolsToken;
+                foreach (JToken switchInfo in switchJArray)
+                {
+                    JObject map = (JObject) switchInfo;
+                    string condition = map.ToString("type");
+                    string value = map.ToString("value");
+                    symbolsList.Add(new KeyValuePair<string, string>(condition, value));
+                }
+            }
+
+            return new JoinMacroConfig(deferredConfig.VariableName, deferredConfig.DataType, symbolsList,
+                separator);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/JoinMacroTest.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/JoinMacroTest.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Core;
+using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config;
+using Microsoft.TemplateEngine.TestHelper;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.MacroTests
+{
+    public class JoinMacroTest : TestBase
+    {
+        [Theory(DisplayName = nameof(TestJoinConstantAndReferenceSymbolConfig))]
+        [InlineData(",")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TestJoinConstantAndReferenceSymbolConfig(string separator)
+        {
+            string variableName = "joinedParameter";
+            string referenceSymbolName = "referenceSymbol";
+            string referenceSymbolValue = "referenceValue";
+            string constantValue = "constantValue";
+
+            List<KeyValuePair<string,string>> definitions = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string,string>("const",constantValue),
+                new KeyValuePair<string,string>("ref",referenceSymbolName)
+            };
+
+            JoinMacroConfig macroConfig = new JoinMacroConfig(variableName, null,definitions,separator);
+
+            IVariableCollection variables = new VariableCollection();
+            IRunnableProjectConfig config = new SimpleConfigModel();
+            IParameterSet parameters = new RunnableProjectGenerator.ParameterSet(config);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
+
+            Parameter referenceParam = new Parameter
+            {
+                IsVariable = true,
+                Name = referenceSymbolName
+            };
+
+            variables[referenceSymbolName] = referenceSymbolValue;
+            setter(referenceParam, referenceSymbolValue);
+
+            JoinMacro macro = new JoinMacro();
+            macro.EvaluateConfig(EngineEnvironmentSettings, variables, macroConfig, parameters, setter);
+
+            Assert.True(parameters.TryGetParameterDefinition(variableName, out ITemplateParameter convertedParam));
+
+            string convertedValue = (string) parameters.ResolvedValues[convertedParam];
+            string expectedValue = string.Join(separator, constantValue, referenceSymbolValue);
+            Assert.Equal(convertedValue, expectedValue);
+        }
+
+        [Theory(DisplayName = nameof(TestDeferredJoinConfig))]
+        [InlineData(",")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void TestDeferredJoinConfig(string separator)
+        {
+            string variableName = "joinedParameter";
+            string referenceSymbolName = "referenceSymbol";
+            string referenceSymbolValue = "referenceValue";
+            string constantValue = "constantValue";
+
+            Dictionary<string, JToken> jsonParameters = new Dictionary<string, JToken>();
+            string symbols =
+                $"[ {{\"type\":\"const\" , \"value\":\"{constantValue}\"  }}, {{\"type\":\"ref\" , \"value\":\"{referenceSymbolName}\"  }} ]";
+            jsonParameters.Add("symbols", JArray.Parse(symbols));
+            if (!string.IsNullOrEmpty(separator))
+            {
+                jsonParameters.Add("separator", separator);
+            }
+
+            GeneratedSymbolDeferredMacroConfig deferredConfig = new GeneratedSymbolDeferredMacroConfig("JoinMacro", null, variableName, jsonParameters);
+
+            IVariableCollection variables = new VariableCollection();
+            IRunnableProjectConfig config = new SimpleConfigModel();
+            IParameterSet parameters = new RunnableProjectGenerator.ParameterSet(config);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(EngineEnvironmentSettings, parameters);
+
+            Parameter referenceParam = new Parameter
+            {
+                IsVariable = true,
+                Name = referenceSymbolName
+            };
+
+            variables[referenceSymbolName] = referenceSymbolValue;
+            setter(referenceParam, referenceSymbolValue);
+
+            JoinMacro macro = new JoinMacro();
+            IMacroConfig realConfig = macro.CreateConfig(EngineEnvironmentSettings, deferredConfig);
+            macro.EvaluateConfig(EngineEnvironmentSettings, variables, realConfig, parameters, setter);
+
+            Assert.True(parameters.TryGetParameterDefinition(variableName, out ITemplateParameter convertedParam));
+
+            string convertedValue = (string) parameters.ResolvedValues[convertedParam];
+            string expectedValue = string.Join(separator, constantValue, referenceSymbolValue);
+            Assert.Equal(convertedValue, expectedValue);
+        }
+    }
+}


### PR DESCRIPTION
Implementation of issue https://github.com/dotnet/templating/issues/1721
Behaviour like a string.Join()
Grammar 
```
{  
   "symbols":{  
      "name":{  
         "type":"parameter",
         "defaultValue":"Service",
         "replaces":"_App",
         "dataType":"string",
         "fileRename":"_App"
      },
      "createdate":{  
         "type":"generated",
         "generator":"now",
         "parameters":{  
            "format":"MM/dd/yyyy"
         },
         "replaces":"01/01/1999"
      },
      "fullname":{  
        "type":"generated",
         "generator":"join",
         "parameters":{  
            "separator": "-"   // optional, default is empty string.
            "symbols" : [
               { "type": "ref", "value": "name" }, //reference to other symbols
               { "type": "ref", "value": "createdate" },
               { "type": "const", "value": <any string value> }, // any constant string
               ...
            ]
         }
      }
   }
}
```