### PR TITLE
Set copyright and package license

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,38 +1,22 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <!-- Leave this file here, even if it's empty. It stops chaining imports. -->
-  <PropertyGroup>
-    <ImportNetSdkFromRepoToolset>false</ImportNetSdkFromRepoToolset>
+    <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)eng\Key.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>7.3</LangVersion>
-  </PropertyGroup>
+    <PropertyGroup>
+        <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)eng\Key.snk</AssemblyOriginatorKeyFile>
+        <LangVersion>7.3</LangVersion>
+        <Product>Microsoft .NET Core</Product>
 
-  <PropertyGroup>
-      <!-- <RestoreSources>$(RestoreSources);http://api.nuget.org/v3/index.json;</RestoreSources> -->
-
-      <!-- aspnetcore-dev feed for internal packages like Microsoft.Extensions.Logging.Testing -->
-      <RestoreSources>$(RestoreSources);https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</RestoreSources>
-      <RestoreSources>$(RestoreSources);https://dotnet.myget.org/F/dotnet-core/api/v3/index.json</RestoreSources>
-  </PropertyGroup>
-
-  <PropertyGroup Label="Package and Assembly Metadata">
-    <Product>Microsoft ASP.NET Core</Product>
-  </PropertyGroup>
-
-  <PropertyGroup Label="Warning Suppressions">
-    <!--
-      Suppress a warning about upcoming deprecation of PackageLicenseUrl. When embedding licenses are supported,
-      replace PackageLicenseUrl with PackageLicenseExpression.
-    -->
-    <NoWarn>$(NoWarn);NU5125</NoWarn>
-  </PropertyGroup>
-
+        <!--
+          Suppress a warning about upcoming deprecation of PackageLicenseUrl. When embedding licenses are supported,
+          replace PackageLicenseUrl with PackageLicenseExpression.
+        -->
+        <NoWarn>$(NoWarn);NU5125</NoWarn>
+    </PropertyGroup>
 
     <PropertyGroup>
         <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
 
-        <RepoRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory),Microsoft.TemplateEngine.sln))\</RepoRoot>
         <BuildDir>$(RepoRoot)build\</BuildDir>
         <ArtifactsDir>$(RepoRoot)artifacts\</ArtifactsDir>
         <DevDir>$(RepoRoot)dev\</DevDir>
@@ -50,7 +34,4 @@
     </PropertyGroup>
 
     <Import Project="Version.props" />
-
-
-  <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-
-	    <ItemGroup>
+    <ItemGroup>
         <PackageReference Update="System.Diagnostics.Process" Version="4.3.0" />
         <PackageReference Update="System.IO.Compression" Version="4.3.0" />
         <PackageReference Update="System.Memory" Version="4.4.0-preview1-25305-02" />
@@ -24,7 +23,7 @@
     <ItemGroup Condition="'$(TestProject)' == 'true'">
         <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
     </ItemGroup>
-    
-  <!-- Leave this file here, even if it's empty. It stops chaining imports. -->
-  <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
+
+    <!-- Leave this file here, even if it's empty. It stops chaining imports. -->
+    <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -1,13 +1,9 @@
 <Project ToolsVersion="15.0">
   <PropertyGroup>
-    <Authors>Microsoft</Authors>
     <ProjectUrl>https://github.com/dotnet/templating</ProjectUrl>
-    <LicenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</LicenseUrl>
     <ImageUrl>http://go.microsoft.com/fwlink/?LinkID=288859</ImageUrl>
     <Tags>template</Tags>
-    <Company>Microsoft</Company>
-    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    
+
     <NuGet>&quot;$(ToolsTempDir)nuget.exe&quot;</NuGet>
     </PropertyGroup>
   <Target Name="CollectGitInfo">


### PR DESCRIPTION
Prepares repo for change https://github.com/dotnet/arcade/pull/2003 by setting `Copyright` and `PackageLicenseExpression` properties. These values will be required to be set by each repository once https://github.com/dotnet/arcade/pull/2003 is merged.

In order to not break the current builds this change sets the properties conditionally. This condition can be removed once all repos switch to Arcade that has https://github.com/dotnet/arcade/pull/2003.

@markwilkie
