### PR TITLE
Serializer for alias registration. 

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Json;
 using Microsoft.TemplateEngine.Edge.Template;
 
 namespace Microsoft.TemplateEngine.Cli.CommandParsing
@@ -82,7 +83,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         string HelpText { get; }
 
-        int Execute(params string[] args);
+        int Execute(IJsonDocumentObjectModelFactory jsonDomFactory, params string[] args);
 
         void OnExecute(Func<Task<CreationResultStatus>> invoke);
 

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.DotNet.Cli.CommandLine;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Json;
 using Microsoft.TemplateEngine.Edge.Template;
 using Microsoft.TemplateEngine.Utils;
 
@@ -50,7 +51,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         public bool ExpandedExtraArgsFiles { get; private set; }
 
-        public int Execute(params string[] args)
+        public int Execute(IJsonDocumentObjectModelFactory jsonDomFactory, params string[] args)
         {
             _args = args;
             ParseArgs();
@@ -59,7 +60,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             if (ExtraArgsFileNames != null && ExtraArgsFileNames.Count > 0)
             {   // add the extra args to the _args and force a reparse
                 // This cannot adjust the template name, so no need to re-check here.
-                IReadOnlyList<string> extraArgs = AppExtensions.CreateArgListFromAdditionalFiles(ExtraArgsFileNames);
+                IReadOnlyList<string> extraArgs = AppExtensions.CreateArgListFromAdditionalFiles(ExtraArgsFileNames, jsonDomFactory);
                 List<string> allArgs = RemoveExtraArgsTokens(_args);
                 allArgs.AddRange(extraArgs);
                 _args = allArgs;

--- a/src/Microsoft.TemplateEngine.Edge/Settings/AliasJsonSerializer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/AliasJsonSerializer.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Edge.Settings
+{
+    internal class AliasJsonSerializer
+    {
+        public AliasJsonSerializer()
+        {
+        }
+
+        public bool TrySerialize(AliasModel aliasModel, out string serialized)
+        {
+            JObject commandAliasesObject = new JObject();
+
+            foreach (KeyValuePair<string, IReadOnlyList<string>> alias in aliasModel.CommandAliases)
+            {
+                if (JsonSerializerHelpers.TrySerializeIEnumerable(alias.Value, JsonSerializerHelpers.StringValueConverter, out JArray serializedAlias))
+                {
+                    commandAliasesObject.Add(alias.Key, serializedAlias);
+                }
+                else
+                {
+                    serialized = null;
+                    return false;
+                }
+            }
+
+            JObject serializedObject = new JObject();
+            serializedObject.Add(nameof(aliasModel.CommandAliases), commandAliasesObject);
+
+            serialized = serializedObject.ToString();
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/AliasRegistry.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/AliasRegistry.cs
@@ -51,8 +51,11 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
         private void Save()
         {
-            JObject serialized = JObject.FromObject(_aliases);
-            _environmentSettings.Host.FileSystem.WriteAllText(_paths.User.AliasesFile, serialized.ToString());
+            AliasJsonSerializer serializer = new AliasJsonSerializer();
+            if (serializer.TrySerialize(_aliases, out string serialized))
+            {
+                _environmentSettings.Host.FileSystem.WriteAllText(_paths.User.AliasesFile, serialized);
+            }
         }
 
         public AliasManipulationResult TryCreateOrRemoveAlias(string aliasName, IReadOnlyList<string> aliasTokens)

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Json;
 using Microsoft.TemplateEngine.Cli;
 using Microsoft.TemplateEngine.Cli.PostActionProcessors;
 using Microsoft.TemplateEngine.Edge;
@@ -42,7 +43,9 @@ namespace dotnet_new3
                 AddInstallLogger(host);
             }
 
-            return New3Command.Run(CommandName, host, new TelemetryLogger(null, debugTelemetry), FirstRun, args);
+            IJsonDocumentObjectModelFactory jsonDomFactory = new SystemTextJsonDocumentObjectModel();
+
+            return New3Command.Run(CommandName, host, new TelemetryLogger(null, debugTelemetry), FirstRun, jsonDomFactory, args);
         }
 
         private static DefaultTemplateEngineHost CreateHost(bool emitTimings)

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Json;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
 using Microsoft.TemplateEngine.Edge.Template;
 
@@ -100,7 +101,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 
         public bool ExpandedExtraArgsFiles { get; set; }
 
-        public int Execute(params string[] args)
+        public int Execute(IJsonDocumentObjectModelFactory jsonDomFactory, params string[] args)
         {
             throw new NotImplementedException();
         }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateInstallTests/NupkgInstallTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateInstallTests/NupkgInstallTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Json;
 using Microsoft.TemplateEngine.Cli.PostActionProcessors;
 using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
 using Microsoft.TemplateEngine.Edge;
@@ -33,7 +34,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateInstallTests
             Assert.NotNull(host);
 
             ITelemetryLogger telemetryLogger = new TelemetryLogger(null, false);
-            int initializeResult = New3Command.Run(CommandName, host, telemetryLogger, null, new string[] { });
+            IJsonDocumentObjectModelFactory jsonDomFactory = null;
+
+            int initializeResult = New3Command.Run(CommandName, host, telemetryLogger, null, jsonDomFactory, new string[] { });
             Assert.Equal(0, initializeResult);
 
             string codebase = typeof(NupkgInstallTests).GetTypeInfo().Assembly.CodeBase;
@@ -51,7 +54,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateInstallTests
             };
 
             // install the test pack
-            int firstInstallResult = New3Command.Run(CommandName, host, telemetryLogger, null, installArgs);
+            int firstInstallResult = New3Command.Run(CommandName, host, telemetryLogger, null, jsonDomFactory, installArgs);
             Assert.Equal(0, firstInstallResult);
 
             EngineEnvironmentSettings environemnt = new EngineEnvironmentSettings(host, x => new SettingsLoader(x));
@@ -63,7 +66,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateInstallTests
             Assert.Contains(checkTemplateName, allTemplates.Select(t => t.Info.ShortName));
 
             // install the same test pack again
-            int secondInstallResult = New3Command.Run(CommandName, host, telemetryLogger, null, installArgs);
+            int secondInstallResult = New3Command.Run(CommandName, host, telemetryLogger, null, jsonDomFactory, installArgs);
             Assert.Equal(0, secondInstallResult);
 
             // check that the template is still installed after the second install.

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/SettingsLoaderTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/SettingsLoaderTests.cs
@@ -132,16 +132,30 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
 
             userSettings.MountPoints.AddRange(mountPoints ?? new MountPointInfo[0]);
 
-            JObject serialized = JObject.FromObject(userSettings);
-            _fileSystem.Add(Path.Combine(BaseDir, "settings.json"), serialized.ToString());
+            SettingsStoreJsonSerializer serializer = new SettingsStoreJsonSerializer();
+            if (serializer.TrySerialize(userSettings, out string serialized))
+            {
+                _fileSystem.Add(Path.Combine(BaseDir, "settings.json"), serialized.ToString());
+            }
+            else
+            {
+                throw new Exception("Unable to serialized the user settings store");
+            }
         }
 
         private void SetupTemplates(List<TemplateInfo> templates)
         {
             TemplateCache cache = new TemplateCache(_environmentSettings, templates);
 
-            JObject serialized = JObject.FromObject(cache);
-            _fileSystem.Add(Path.Combine(BaseDir, "templatecache.json"), serialized.ToString());
+            TemplateCacheJsonSerializer serializer = new TemplateCacheJsonSerializer();
+            if (serializer.TrySerialize(cache, out string serialized))
+            {
+                _fileSystem.Add(Path.Combine(BaseDir, "templatecache.json"), serialized.ToString());
+            }
+            else
+            {
+                throw new Exception("Unable to serialized the template cache");
+            }
         }
 
         private List<TemplateInfo> TemplatesFromMountPoints(IEnumerable<MountPointInfo> mountPoints)

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Json;
 using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
 using Microsoft.TemplateEngine.Cli;
 using Microsoft.TemplateEngine.Cli.PostActionProcessors;
@@ -61,7 +62,9 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
             host.VirtualizeDirectory(hivePath);
             host.VirtualizeDirectory(outputPath);
 
-            int result = New3Command.Run(CommandName, host, new TelemetryLogger(null), FirstRun, passthroughArgs, hivePath);
+            IJsonDocumentObjectModelFactory jsonDomFactory = null;
+
+            int result = New3Command.Run(CommandName, host, new TelemetryLogger(null), FirstRun, jsonDomFactory, passthroughArgs, hivePath);
             bool verificationsPassed = false;
 
             for (int i = 0; i < batteryCount; ++i)


### PR DESCRIPTION
Also, settings loader tests now use the manual serializer.

The second commit:
- Plumbs through the IJsonDocumentObjectModelFactory so it can be used throughout. 
- Uses the new reader for parsing the extra args file.