### PR TITLE
Update --langVersion option's description

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -61,7 +61,7 @@
     "langVersion": {
       "type": "parameter",
       "datatype": "text",
-      "description": "Sets langVersion in the created project file",
+      "description": "Sets the LangVersion property in the created project file",
       "defaultValue": "",
       "replaces": "$(ProjectLanguageVersion)"
     },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -61,7 +61,7 @@
     "langVersion": {
       "type": "parameter",
       "datatype": "text",
-      "description": "Sets langVersion in the created project file",
+      "description": "Sets the LangVersion property in the created project file",
       "defaultValue": "",
       "replaces": "$(ProjectLanguageVersion)"
     },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -39,7 +39,7 @@
     "langVersion": {
       "type": "parameter",
       "datatype": "text",
-      "description": "Sets langVersion in the created project file",
+      "description": "Sets the LangVersion property in the created project file",
       "defaultValue": "",
       "replaces": "$(ProjectLanguageVersion)"
     },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ConsoleApplication-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ConsoleApplication-VisualBasic/.template.config/template.json
@@ -39,7 +39,7 @@
     "langVersion": {
       "type": "parameter",
       "datatype": "text",
-      "description": "Sets langVersion in the created project file",
+      "description": "Sets the LangVersion property in the created project file",
       "defaultValue": "",
       "replaces": "$(ProjectLanguageVersion)"
     },


### PR DESCRIPTION
Adjust the `--langVersion` option's description to be more accurate. The property added to the project file is `LangVersion`, not `langVersion`.

/cc: @seancpeters 