### PR TITLE
Allow setting an env var to override the online or in-box search config file

### DIFF
--- a/src/Microsoft.TemplateSearch.Common/ISearchInfoFileProvider.cs
+++ b/src/Microsoft.TemplateSearch.Common/ISearchInfoFileProvider.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Edge;
 
 namespace Microsoft.TemplateSearch.Common
@@ -12,6 +13,6 @@ namespace Microsoft.TemplateSearch.Common
         /// <param name="paths">A Paths instance, so the abstracted file system operations are available.</param>
         /// <param name="metadataFileTargetLocation">The expected location of the metadata file, after this is run.</param>
         /// <returns></returns>
-        Task<bool> TryEnsureSearchFileAsync(Paths paths, string metadataFileTargetLocation);
+        Task<bool> TryEnsureSearchFileAsync(IEngineEnvironmentSettings environmentSettings, Paths paths, string metadataFileTargetLocation);
     }
 }

--- a/src/Microsoft.TemplateSearch.Common/NuGetMetadataSearchSource.cs
+++ b/src/Microsoft.TemplateSearch.Common/NuGetMetadataSearchSource.cs
@@ -27,7 +27,7 @@ namespace Microsoft.TemplateSearch.Common
             Paths paths = new Paths(environmentSettings);
             string searchMetadataFileLocation = Path.Combine(paths.User.BaseDir, _templateDiscoveryMetadataFile);
 
-            if (!await _searchInfoFileProvider.TryEnsureSearchFileAsync(paths, searchMetadataFileLocation))
+            if (!await _searchInfoFileProvider.TryEnsureSearchFileAsync(environmentSettings, paths, searchMetadataFileLocation))
             {
                 return false;
             }


### PR DESCRIPTION
I realized that with the existing setup, placing a custom search/update metadata file in the hive directory will still get overwritten by a file downloaded from an fwlink. 

This change allows setting the environment variable DOTNET_NEW_SEARCH_FILE_OVERRIDE to the location of a local file, which will unconditionally override any existing in-box or blob-store search metadata file. Note that if the file doesn't exist, it doesn't fallback to one of the other sources for the file. The search just isn't performed in that case.