### PR TITLE
Fix for installing a template pack twice.

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Installer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Installer.cs
@@ -105,7 +105,18 @@ namespace Microsoft.TemplateEngine.Cli
                     && descriptor.FactoryId == testDescriptor.FactoryId
                     && descriptor.DescriptorId != testDescriptor.DescriptorId)
                 {
-                    UninstallMountPoint(testDescriptor.MountPointId);
+                    if (descriptor.MountPointId != testDescriptor.MountPointId)
+                    {
+                        // Uninstalls the mount point and the descriptor(s) for packs that were installed under that mount point.
+                        UninstallMountPoint(testDescriptor.MountPointId);
+                    }
+                    else
+                    {
+                        // The new install is in the same place as the old install. Don't remove the mount point, just the old descriptor.
+                        // This is for when the exact same pack is installed over-the-top of an existing install of it.
+                        // Works for both zip/nupkg and for local file sources.
+                        ((SettingsLoader)(_environmentSettings.SettingsLoader)).InstallUnitDescriptorCache.RemoveDescriptor(testDescriptor);
+                    }
                 }
             }
         }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/SettingsLoader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/SettingsLoader.cs
@@ -212,6 +212,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         {
             _isLoaded = false;
             EnsureLoaded();
+            ReloadTemplates();
         }
 
         private void UpdateTemplateListFromCache(TemplateCache cache, ISet<ITemplateInfo> templates)

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateInstallTests/NupkgInstallTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateInstallTests/NupkgInstallTests.cs
@@ -67,6 +67,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateInstallTests
             int secondInstallResult = New3Command.Run(CommandName, host, telemetryLogger, null, installArgs);
             Assert.Equal(0, secondInstallResult);
 
+            settingsLoader.Reload();
+
             // check that the template is still installed after the second install.
             IReadOnlyCollection<ITemplateMatchInfo> allTemplatesAfterSecondInstall = TemplateListResolver.PerformAllTemplatesQuery(settingsLoader.UserTemplateCache.TemplateInfo, hostDataLoader);
             Assert.Contains(checkTemplateName, allTemplatesAfterSecondInstall.Select(t => t.Info.ShortName));


### PR DESCRIPTION
Without this fix, installing the same pack twice would cause the pack to be uninstalled. This was partially fixed previously, for situations where the new install is a different version than the old one But when it's the exact same pack, it would get uninstalled. 

Also fixes the unit test which already existed to test for this problem.