### PR TITLE
Add feeds from Versions.props to NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,6 +4,10 @@
     <clear />
     <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-web" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
+    <add key="msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
+    <add key="myget-dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
We need all restore sources to be located in NuGet.config since internal feeds can only be restored from there. More details including next steps [here](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md)