### PR TITLE
Versions.props cleanup

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,14 +11,4 @@
     <NewtonsoftJsonPackageVersion>10.0.3</NewtonsoftJsonPackageVersion>
     <DotNetCliCommandLineVersion>0.1.1-alpha-167</DotNetCliCommandLineVersion>
   </PropertyGroup>
-  <PropertyGroup>
-    <RestoreSources>
-      $(RestoreSources);
-      https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
-      https://dotnet.myget.org/F/msbuild/api/v3/index.json;
-      https://www.myget.org/F/nugetbuild/api/v3/index.json;
-      https://dotnet.myget.org/F/dotnet-web/api/v3/index.json;
-      https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
-    </RestoreSources>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Remove `RestoreSources` from Versions.props in order to complete [step 2](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md#part-2)

@phenning can you PTAL?