### PR TITLE
Add --interactive flag 

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -130,6 +130,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                     Create.Option("-o|--output", LocalizableStrings.OutputPath, Accept.ExactlyOneArgument()),
                     Create.Option("-i|--install", LocalizableStrings.InstallHelp, Accept.OneOrMoreArguments()),
                     Create.Option("-u|--uninstall", LocalizableStrings.UninstallHelp, Accept.ZeroOrMoreArguments()),
+                    Create.Option("--interactive", LocalizableStrings.InteractiveHelp, Accept.NoArguments()),
                     Create.Option("--nuget-source", LocalizableStrings.NuGetSourceHelp, Accept.OneOrMoreArguments()),
                     Create.Option("--type", LocalizableStrings.ShowsFilteredTemplates, Accept.ExactlyOneArgument()),
                     Create.Option("--dry-run", LocalizableStrings.DryRunDescription, Accept.NoArguments()),

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
@@ -42,6 +42,8 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         bool IsShowAllFlagSpecified { get; }
 
+        bool IsInteractiveFlagSpecified { get; }
+
         string TypeFilter { get; }
 
         string Language { get; }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -234,6 +234,8 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         public bool IsShowAllFlagSpecified => _parseResult.HasAppliedOption(new[] { _commandName, "all" });
 
+        public bool IsInteractiveFlagSpecified => _parseResult.HasAppliedOption(new[] { _commandName, "interactive" });
+
         public string TypeFilter => _parseResult.GetArgumentValueAtPath(new[] { _commandName, "type" });
 
         public string Language => _parseResult.GetArgumentValueAtPath(new[] { _commandName, "language" });

--- a/src/Microsoft.TemplateEngine.Cli/IInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Cli/IInstaller.cs
@@ -8,5 +8,7 @@ namespace Microsoft.TemplateEngine.Cli
         void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources);
 
         void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall);
+
+        void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall, bool interactive);
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -845,6 +845,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allows the internal dotnet restore command to stop and wait for user input or action (for example to complete authentication)..
+        /// </summary>
+        public static string InteractiveHelp {
+            get {
+                return ResourceManager.GetString("InteractiveHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid input switch:.
         /// </summary>
         public static string InvalidInputSwitch {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -661,4 +661,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="UpdateCheckCommandHelp" xml:space="preserve">
     <value>Check the currently installed template packs for updates.</value>
   </data>
+  <data name="InteractiveHelp" xml:space="preserve">
+    <value>Allows the internal dotnet restore command to stop and wait for user input or action (for example to complete authentication).</value>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -230,7 +230,7 @@ namespace Microsoft.TemplateEngine.Cli
             _telemetryLogger.TrackEvent(CommandName + TelemetryConstants.InstallEventSuffix, new Dictionary<string, string> { { TelemetryConstants.ToInstallCount, _commandInput.ToInstallList.Count.ToString() } });
 
             bool allowDevInstall = _commandInput.HasDebuggingFlag("--dev:install");
-            Installer.InstallPackages(_commandInput.ToInstallList, _commandInput.InstallNuGetSourceList, allowDevInstall);
+            Installer.InstallPackages(_commandInput.ToInstallList, _commandInput.InstallNuGetSourceList, allowDevInstall, _commandInput.IsInteractiveFlagSpecified);
 
             //TODO: When an installer that directly calls into NuGet is available,
             //  return a more accurate representation of the outcome of the operation

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -64,6 +64,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 
         public bool IsShowAllFlagSpecified { get; set; }
 
+        public bool IsInteractiveFlagSpecified { get; set; }
+
         public string TypeFilter { get; set; }
 
         public string Language { get; set; }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateUpdateTests/MockInstaller.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateUpdateTests/MockInstaller.cs
@@ -21,12 +21,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateUpdateTests
 
         public HashSet<string> Installed { get; private set; }
 
-        public void InstallPackages(IEnumerable<string> installationRequests) => InstallPackages(installationRequests, null, false);
+        public void InstallPackages(IEnumerable<string> installationRequests) => InstallPackages(installationRequests, null, false, false);
 
         // unconditionally adds the installation requests to the _installed list.
-        public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources) => InstallPackages(installationRequests, nuGetSources, false);
+        public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources) => InstallPackages(installationRequests, nuGetSources, false, false);
 
-        public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall)
+        public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall) => InstallPackages(installationRequests, nuGetSources, debugAllowDevInstall, false);
+
+        public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall, bool interactive)
         {
             Installed.UnionWith(installationRequests);
         }


### PR DESCRIPTION
Add `--interactive` flag which if specified is passed through to the internal `dotnet restore` calls. This addresses issue #1747 