### PR TITLE
update class library templates for dotnet3.0 to use netcoreapp3.0

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-CSharp/Company.ClassLibrary1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-CSharp/Company.ClassLibrary1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netstandard2.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ClassLibrary1</RootNamespace>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-FSharp/Company.ClassLibrary1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-FSharp/Company.ClassLibrary1.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netstandard2.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ClassLibrary1</RootNamespace>
   </PropertyGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-VisualBasic/Company.ClassLibrary1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-VisualBasic/Company.ClassLibrary1.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Company.ClassLibrary1</RootNamespace>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netstandard2.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp3.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
The dotnet 3.0 templates for class libraries currently uses `netstandard2.0` as default target framework. This updates them to use `netcoreapp3.0` as default instead.