### PR TITLE
Move dotnet-tools to dotnet-eng

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,11 +2,10 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="arcade" value="https://dotnetfeed.blob.core.windows.net/dotnet-tools-internal/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-web" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
     <add key="msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
-    <add key="myget-dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
     <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
While we didn't explictly use it in this repo, updating for conistency.

dotnet/arcade#4197