### PR TITLE
Allow data columns in grids to shrink to fit the screen buffer width

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/IEnvironment.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IEnvironment.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Abstractions
 {
@@ -11,5 +11,10 @@ namespace Microsoft.TemplateEngine.Abstractions
         IReadOnlyDictionary<string, string> GetEnvironmentVariables();
 
         string NewLine { get; }
+
+        /// <summary>
+        /// The width of the console buffer. This is typically the value of <see cref="System.Console.BufferWidth" />.
+        /// </summary>
+        int ConsoleBufferWidth { get;  }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/AliasSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/AliasSupport.cs
@@ -182,9 +182,16 @@ namespace Microsoft.TemplateEngine.Cli
                 Reporter.Output.WriteLine(LocalizableStrings.AliasShowAllAliasesHeader);
             }
 
-            HelpFormatter<KeyValuePair<string, IReadOnlyList<string>>> formatter = new HelpFormatter<KeyValuePair<string, IReadOnlyList<string>>>(environment, aliasesToShow, 2, '-', false)
-                            .DefineColumn(t => t.Key, LocalizableStrings.AliasName)
-                            .DefineColumn(t => string.Join(" ", t.Value), LocalizableStrings.AliasValue);
+            HelpFormatter<KeyValuePair<string, IReadOnlyList<string>>> formatter =
+                new HelpFormatter<KeyValuePair<string, IReadOnlyList<string>>>(
+                    environment,
+                    aliasesToShow,
+                    columnPadding: 2,
+                    headerSeparator: '-',
+                    blankLineBetweenRows: false)
+                .DefineColumn(t => t.Key, LocalizableStrings.AliasName)
+                .DefineColumn(t => string.Join(" ", t.Value), LocalizableStrings.AliasValue);
+
             Reporter.Output.WriteLine(formatter.Layout());
             return CreationResultStatus.Success;
         }

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -195,7 +195,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                         columnPadding: 6,
                         headerSeparator: '-',
                         blankLineBetweenRows: false)
-                    .DefineColumn(t => t.Name, LocalizableStrings.Templates)
+                    .DefineColumn(t => t.Name, LocalizableStrings.Templates, shrinkIfNeeded: true)
                     .DefineColumn(t => t.ShortName, LocalizableStrings.ShortName)
                     .DefineColumn(t => t.Languages, out object languageColumn, LocalizableStrings.Language)
                     .DefineColumn(t => t.Classifications, out object tagsColumn, LocalizableStrings.Tags)

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -187,13 +187,20 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
         {
             IReadOnlyList<TemplateGroupForListDisplay> groupsForDisplay = GetTemplateGroupsForListDisplay(templates, language, defaultLanguage);
 
-            HelpFormatter<TemplateGroupForListDisplay> formatter = HelpFormatter.For(environmentSettings, groupsForDisplay, 6, '-', false)
-                .DefineColumn(t => t.Name, LocalizableStrings.Templates)
-                .DefineColumn(t => t.ShortName, LocalizableStrings.ShortName)
-                .DefineColumn(t => t.Languages, out object languageColumn, LocalizableStrings.Language)
-                .DefineColumn(t => t.Classifications, out object tagsColumn, LocalizableStrings.Tags)
-                .OrderByDescending(languageColumn, new NullOrEmptyIsLastStringComparer())
-                .OrderBy(tagsColumn);
+            HelpFormatter<TemplateGroupForListDisplay> formatter =
+                HelpFormatter
+                    .For(
+                        environmentSettings,
+                        groupsForDisplay,
+                        columnPadding: 6,
+                        headerSeparator: '-',
+                        blankLineBetweenRows: false)
+                    .DefineColumn(t => t.Name, LocalizableStrings.Templates)
+                    .DefineColumn(t => t.ShortName, LocalizableStrings.ShortName)
+                    .DefineColumn(t => t.Languages, out object languageColumn, LocalizableStrings.Language)
+                    .DefineColumn(t => t.Classifications, out object tagsColumn, LocalizableStrings.Tags)
+                    .OrderByDescending(languageColumn, new NullOrEmptyIsLastStringComparer())
+                    .OrderBy(tagsColumn);
             Reporter.Output.WriteLine(formatter.Layout());
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/HelpFormatter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpFormatter.cs
@@ -103,14 +103,18 @@ namespace Microsoft.TemplateEngine.Cli
             // Render header separator, if set
             if (_headerSeparator.HasValue)
             {
-                int totalWidth = _columnPadding * (_columns.Count - 1);
-
                 for (int i = 0; i < _columns.Count; ++i)
                 {
-                    totalWidth += Math.Max(header[i].MaxWidth, columnWidthLookup[i]);
+                    var columnWidth = Math.Max(header[i].MaxWidth, columnWidthLookup[i]);
+                    b.Append(new string(_headerSeparator.Value, columnWidth));
+
+                    if (i < _columns.Count - 1)
+                    {
+                        b.Append(new string(' ', _columnPadding));
+                    }
                 }
 
-                b.AppendLine("".PadRight(totalWidth, _headerSeparator.Value));
+                b.AppendLine();
             }
 
             IEnumerable<TextWrapper[]> rows = grid;

--- a/src/Microsoft.TemplateEngine.Cli/HelpFormatter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpFormatter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -11,9 +11,9 @@ namespace Microsoft.TemplateEngine.Cli
 {
     public class HelpFormatter
     {
-        public static HelpFormatter<T> For<T>(IEngineEnvironmentSettings environmentSettings, IEnumerable<T> items, int columnPadding, char? headerSeparator = null, bool blankLineBetweenRows = false)
+        public static HelpFormatter<T> For<T>(IEngineEnvironmentSettings environmentSettings, IEnumerable<T> rows, int columnPadding, char? headerSeparator = null, bool blankLineBetweenRows = false)
         {
-            return new HelpFormatter<T>(environmentSettings, items, columnPadding, headerSeparator, blankLineBetweenRows);
+            return new HelpFormatter<T>(environmentSettings, rows, columnPadding, headerSeparator, blankLineBetweenRows);
         }
     }
 
@@ -23,28 +23,28 @@ namespace Microsoft.TemplateEngine.Cli
         private readonly int _columnPadding;
         private readonly List<ColumnDefinition> _columns = new List<ColumnDefinition>();
         private readonly char? _headerSeparator;
-        private readonly IEnumerable<T> _items;
+        private readonly IEnumerable<T> _rowDataItems;
         private readonly List<Tuple<int, bool, IComparer<string>>> _ordering = new List<Tuple<int, bool, IComparer<string>>>();
         private readonly IEngineEnvironmentSettings _environmentSettings;
 
-        public HelpFormatter(IEngineEnvironmentSettings environmentSettings, IEnumerable<T> items, int columnPadding, char? headerSeparator, bool blankLineBetweenRows)
+        public HelpFormatter(IEngineEnvironmentSettings environmentSettings, IEnumerable<T> rows, int columnPadding, char? headerSeparator, bool blankLineBetweenRows)
         {
-            _items = items ?? Enumerable.Empty<T>();
+            _rowDataItems = rows ?? Enumerable.Empty<T>();
             _columnPadding = columnPadding;
             _headerSeparator = headerSeparator;
             _blankLineBetweenRows = blankLineBetweenRows;
             _environmentSettings = environmentSettings;
         }
 
-        public HelpFormatter<T> DefineColumn(Func<T, string> binder, string header = null, int maxWidth = 0, bool alwaysMaximizeWidth = false)
+        public HelpFormatter<T> DefineColumn(Func<T, string> binder, string header = null)
         {
-            _columns.Add(new ColumnDefinition(_environmentSettings, header, binder, maxWidth, alwaysMaximizeWidth));
+            _columns.Add(new ColumnDefinition(_environmentSettings, header, binder));
             return this;
         }
 
-        public HelpFormatter<T> DefineColumn(Func<T, string> binder, out object column, string header = null, int maxWidth = 0, bool alwaysMaximizeWidth = false)
+        public HelpFormatter<T> DefineColumn(Func<T, string> binder, out object column, string header = null)
         {
-            ColumnDefinition c = new ColumnDefinition(_environmentSettings, header, binder, maxWidth, alwaysMaximizeWidth);
+            ColumnDefinition c = new ColumnDefinition(_environmentSettings, header, binder);
             _columns.Add(c);
             column = c;
             return this;
@@ -52,67 +52,70 @@ namespace Microsoft.TemplateEngine.Cli
 
         public string Layout()
         {
-            Dictionary<int, int> widthLookup = new Dictionary<int, int>();
-            Dictionary<int, int> lineCountLookup = new Dictionary<int, int>();
-            List<TextWrapper[]> textByRow = new List<TextWrapper[]>();
+            Dictionary<int, int> columnWidthLookup = new Dictionary<int, int>();
+            Dictionary<int, int> rowHeightForRow = new Dictionary<int, int>();
+            List<TextWrapper[]> grid = new List<TextWrapper[]>();
 
             TextWrapper[] header = new TextWrapper[_columns.Count];
             int headerLines = 0;
             for (int i = 0; i < _columns.Count; ++i)
             {
-                header[i] = new TextWrapper(_environmentSettings, _columns[i].Header, _columns[i].MaxWidth, _columns[i].AlwaysMaximizeWidth);
+                header[i] = new TextWrapper(_environmentSettings, _columns[i].Header, _columns[i].MaxWidth);
                 headerLines = Math.Max(headerLines, header[i].LineCount);
-                widthLookup[i] = header[i].MaxWidth;
+                columnWidthLookup[i] = header[i].MaxWidth;
             }
 
             int lineNumber = 0;
 
-            foreach (T item in _items)
+            foreach (T rowDataItem in _rowDataItems)
             {
-                TextWrapper[] line = new TextWrapper[_columns.Count];
-                int maxLineCount = 0;
+                TextWrapper[] row = new TextWrapper[_columns.Count];
+                int rowHeight = 0;
 
                 for (int i = 0; i < _columns.Count; ++i)
                 {
-                    line[i] = _columns[i].GetCell(item);
-                    widthLookup[i] = Math.Max(widthLookup[i], line[i].MaxWidth);
-                    maxLineCount = Math.Max(maxLineCount, line[i].LineCount);
+                    row[i] = _columns[i].GetCell(rowDataItem);
+                    columnWidthLookup[i] = Math.Max(columnWidthLookup[i], row[i].MaxWidth);
+                    rowHeight = Math.Max(rowHeight, row[i].LineCount);
                 }
 
-                lineCountLookup[lineNumber++] = maxLineCount;
-                textByRow.Add(line);
+                rowHeightForRow[lineNumber++] = rowHeight;
+                grid.Add(row);
             }
 
             StringBuilder b = new StringBuilder();
 
+            // Render column headers, if any exist
             if (_columns.Any(x => !string.IsNullOrEmpty(x.Header)))
             {
                 for (int j = 0; j < headerLines; ++j)
                 {
                     for (int i = 0; i < _columns.Count - 1; ++i)
                     {
-                        b.Append(header[i][j, widthLookup[i]]);
+                        b.Append(header[i][j, padTo: columnWidthLookup[i]]);
                         b.Append("".PadRight(_columnPadding));
                     }
 
-                    b.AppendLine(header[_columns.Count - 1][j, widthLookup[_columns.Count - 1]]);
+                    b.AppendLine(header[_columns.Count - 1][j, padTo: columnWidthLookup[_columns.Count - 1]]);
                 }
             }
 
+            // Render header separator, if set
             if (_headerSeparator.HasValue)
             {
                 int totalWidth = _columnPadding * (_columns.Count - 1);
 
                 for (int i = 0; i < _columns.Count; ++i)
                 {
-                    totalWidth += Math.Max(header[i].MaxWidth, widthLookup[i]);
+                    totalWidth += Math.Max(header[i].MaxWidth, columnWidthLookup[i]);
                 }
 
                 b.AppendLine("".PadRight(totalWidth, _headerSeparator.Value));
             }
 
-            IEnumerable<TextWrapper[]> rows = textByRow;
+            IEnumerable<TextWrapper[]> rows = grid;
 
+            // Apply ordering to list
             if (_ordering.Count > 0)
             {
                 IOrderedEnumerable<TextWrapper[]> orderedRows;
@@ -141,18 +144,21 @@ namespace Microsoft.TemplateEngine.Cli
                 rows = orderedRows;
             }
 
-            int currentLine = 0;
-            foreach (TextWrapper[] line in rows)
+            // Render row contents (each row can have more than 1 line for multi-line content)
+            int currentRowIndex = 0;
+            foreach (TextWrapper[] rowToRender in rows)
             {
-                for (int j = 0; j < lineCountLookup[currentLine]; ++j)
+                for (int lineWithinRow = 0; lineWithinRow < rowHeightForRow[currentRowIndex]; ++lineWithinRow)
                 {
-                    for (int i = 0; i < _columns.Count - 1; ++i)
+                    // Render all columns except last column
+                    for (int columnIndex = 0; columnIndex < _columns.Count - 1; ++columnIndex)
                     {
-                        b.Append(line[i][j, widthLookup[i]]);
+                        b.Append(rowToRender[columnIndex][lineWithinRow, padTo: columnWidthLookup[columnIndex]]);
                         b.Append("".PadRight(_columnPadding));
                     }
 
-                    b.AppendLine(line[_columns.Count - 1][j, widthLookup[_columns.Count - 1]]);
+                    // Render last column
+                    b.AppendLine(rowToRender[_columns.Count - 1][lineWithinRow, padTo: columnWidthLookup[_columns.Count - 1]]);
                 }
 
                 if (_blankLineBetweenRows)
@@ -160,7 +166,7 @@ namespace Microsoft.TemplateEngine.Cli
                     b.AppendLine();
                 }
 
-                ++currentLine;
+                ++currentRowIndex;
             }
 
             return b.ToString();
@@ -171,27 +177,23 @@ namespace Microsoft.TemplateEngine.Cli
             private readonly int _maxWidth;
             private readonly string _header;
             private readonly Func<T, string> _binder;
-            private readonly bool _alwaysMaximizeWidth;
             private readonly IEngineEnvironmentSettings _environmentSettings;
 
-            public ColumnDefinition(IEngineEnvironmentSettings environmentSettings, string header, Func<T, string> binder, int maxWidth = -1, bool alwaysMaximizeWidth = false)
+            public ColumnDefinition(IEngineEnvironmentSettings environmentSettings, string header, Func<T, string> binder, int maxWidth = -1)
             {
                 _header = header;
                 _maxWidth = maxWidth > 0 ? maxWidth : int.MaxValue;
                 _binder = binder;
-                _alwaysMaximizeWidth = alwaysMaximizeWidth && maxWidth > 0;
                 _environmentSettings = environmentSettings;
             }
 
             public string Header => _header;
 
-            public bool AlwaysMaximizeWidth => _alwaysMaximizeWidth;
-
             public int MaxWidth => _maxWidth;
 
             public TextWrapper GetCell(T value)
             {
-                return new TextWrapper(_environmentSettings, _binder(value), _maxWidth, _alwaysMaximizeWidth);
+                return new TextWrapper(_environmentSettings, _binder(value), _maxWidth);
             }
         }
 
@@ -199,11 +201,11 @@ namespace Microsoft.TemplateEngine.Cli
         {
             private readonly IReadOnlyList<string> _lines;
 
-            public TextWrapper(IEngineEnvironmentSettings environmentSettings, string text, int maxWidth, bool alwaysMax)
+            public TextWrapper(IEngineEnvironmentSettings environmentSettings, string text, int maxWidth)
             {
                 List<string> lines = new List<string>();
                 int position = 0;
-                int realMaxWidth = alwaysMax ? maxWidth : 0;
+                int realMaxWidth = 0;
 
                 while (position < text.Length)
                 {

--- a/src/Microsoft.TemplateEngine.Utils/EngineEnvironmentSettings.cs
+++ b/src/Microsoft.TemplateEngine.Utils/EngineEnvironmentSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -101,6 +101,8 @@ namespace Microsoft.TemplateEngine.Utils
             }
 
             public string NewLine { get; }
+
+            public int ConsoleBufferWidth => Console.BufferWidth;
 
             public string ExpandEnvironmentVariables(string name)
             {

--- a/src/Microsoft.TemplateEngine.Utils/EngineEnvironmentSettings.cs
+++ b/src/Microsoft.TemplateEngine.Utils/EngineEnvironmentSettings.cs
@@ -102,7 +102,11 @@ namespace Microsoft.TemplateEngine.Utils
 
             public string NewLine { get; }
 
-            public int ConsoleBufferWidth => Console.BufferWidth;
+            private const int DefaultBufferWidth = 80;
+
+            // Console.BufferWidth can throw if there's no console, such as when output is redirected, so
+            // first check if it is redirected, and fall back to a default value if needed.
+            public int ConsoleBufferWidth => Console.IsOutputRedirected ? DefaultBufferWidth : Console.BufferWidth;
 
             public string ExpandEnvironmentVariables(string name)
             {


### PR DESCRIPTION
Updated layout logic for grid to allow a single column to be maked as `shrinkIfNeeded`. If the screen buffer is not wide enough to fit the data, the shrinkable column will be shrunk to fit the screen exactly. If the screen is so small so that there isn't even room for that, the rendering uses a minimum width, so it looks a bit ugly, but not as bad as it might otherwise look with huge wrapped text.

The only help grid that is marked as having a shrinkable column is the one that lists the installed templates.

Fixes these issues:
* dotnet new -l : Table view can be improved on. #361
* dotnet new usage results in line wrapping under default console size #1815
* The table in "dotnet new" is too big #2062

Note: This PR contains a few commits because of some code cleanup that doesn't change any functionality. The main part is the last commit that changes the grid layout functionality.

Here are examples of the new rendering:

Full width:

```
Templates                                    Short Name                Language          Tags
---------------------------------------      --------------------      ------------      --------------------
Experimental Mobile Blazor Bindings App      mobileblazorbindings      [C#]              Blazor/Xamarin.Forms
NUnit 3 Test Project                         nunit                     [C#], F#, VB      Test/NUnit
NUnit 3 Test Item                            nunit-test                [C#], F#, VB      Test/NUnit
```

A bit narrower (first item shortened):

```
Templates                                  Short Name                Language          Tags
-------------------------------------      --------------------      ------------      --------------------
Experimental Mobile Blazor Binding...      mobileblazorbindings      [C#]              Blazor/Xamarin.Forms
NUnit 3 Test Project                       nunit                     [C#], F#, VB      Test/NUnit
NUnit 3 Test Item                          nunit-test                [C#], F#, VB      Test/NUnit
```

Even narrower (all items shortened):

```
Templates             Short Name                Language          Tags
----------------      --------------------      ------------      --------------------
Experimental ...      mobileblazorbindings      [C#]              Blazor/Xamarin.Forms
NUnit 3 Test ...      nunit                     [C#], F#, VB      Test/NUnit
NUnit 3 Test ...      nunit-test                [C#], F#, VB      Test/NUnit
```

So narrow that even column header is shortened:

```
Temp...      Short Name                Language          Tags
-------      --------------------      ------------      --------------------
Expe...      mobileblazorbindings      [C#]              Blazor/Xamarin.Forms
NUni...      nunit                     [C#], F#, VB      Test/NUnit
NUni...      nunit-test                [C#], F#, VB      Test/NUnit
```

And when it's extremely narrow that even the non-shrinkable column can't fit, it renders it at its minimum allowed width, which is 5. It looks silly, but it always did, and there's not much you can do when the screen is absurdly narrow:

```
Te...      Short Name                Language          Tags

-----      --------------------      ------------      --------------
------
Ex...      mobileblazorbindings      [C#]              Blazor/Xamarin
.Forms
NU...      nunit                     [C#], F#, VB      Test/NUnit

NU...      nunit-test                [C#], F#, VB      Test/NUnit
```

Fixes #361
Fixes #1815
Fixes #2062
