### PR TITLE
Yml cleanup and fix publishing in official builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,8 +20,6 @@ variables:
     value: DotNetCore
   - name: _PublishUsingPipelines
     value: true
-  - name: _DotNetArtifactsCategory
-    value: .NETCore
 
 resources:
   containers:
@@ -53,8 +51,6 @@ stages:
             queue: buildpool.windows.10.amd64.vs2017
           
         variables:
-        - _Script: eng\common\cibuild.cmd
-        - _ValidateSdkArgs: ''
         - _InternalBuildArgs: ''
 
         # Only enable publishing in non-public, non PR scenarios.
@@ -63,49 +59,37 @@ stages:
           # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat, symweb-symbol-server-pat
           # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
           - group: DotNet-Blob-Feed
-          - group: DotNet-Symbol-Server-Pats
           - group: Publish-Build-Assets
-          - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
           - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
-              /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-              /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
-              /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
               /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
-              /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
-              /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
-              /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
               /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-
+        
         strategy:
           matrix:
-            Build_Debug:
-              _BuildConfig: Debug
-              _PublishType: none
-              _SignType: test
-              _DotNetPublishToBlobFeed : false
             Build_Release:
               _BuildConfig: Release
               # PRs or external builds are not signed.
               ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-                _PublishType: none
                 _SignType: test
                 _DotNetPublishToBlobFeed : false
               ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-                _PublishType: blob
                 _SignType: real
                 _DotNetPublishToBlobFeed : true
-                # _Script: eng\validate-sdk.cmd
-                # _ValidateSdkArgs: -gitHubPat $(BotAccount-dotnet-maestro-bot-PAT) -barToken $(MaestroAccessToken)
+            ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+              Build_Debug:
+                _BuildConfig: Debug
+                _SignType: test
+              
         steps:
         - checkout: self
           clean: true
         # Use utility script to run script command dependent on agent OS.
-        - script: $(_Script)
+        - script: eng/common/cibuild.cmd
             -configuration $(_BuildConfig) 
             -prepareMachine
             $(_InternalBuildArgs)
-            $(_ValidateSdkArgs)
           displayName: Windows Build / Publish
+
       - job: OSX
         pool:
           name: Hosted macOS
@@ -113,15 +97,16 @@ stages:
           matrix:
             debug_configuration:
               _BuildConfig: Debug
+              _SignType: none
             release_configuration:
               _BuildConfig: Release
+              _SignType: none
         steps:
         - script: eng/common/cibuild.sh
             --configuration $(_BuildConfig)
             --prepareMachine
           name: Build
           displayName: Build
-          condition: succeeded()
 
       - job: Linux
         pool:
@@ -131,8 +116,10 @@ stages:
           matrix:
             debug_configuration:
               _BuildConfig: Debug
+              _SignType: none
             release_configuration:
               _BuildConfig: Release
+              _SignType: none
         steps:
         - script: eng/common/cibuild.sh
             --configuration $(_BuildConfig)


### PR DESCRIPTION
Debug builds were overwriting the release nupkg assets. Disabling the
debug publishing.
Additionally cleaning up unused yml variables

Fixes the same issue as in https://github.com/dotnet/arcade/issues/4963

cc @JohnTortugo 