### PR TITLE
Fix csharp classlib template to point to net5.0

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-CSharp/Company.ClassLibrary1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-CSharp/Company.ClassLibrary1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netstandard2.0</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net5.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ClassLibrary1</RootNamespace>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>


### PR DESCRIPTION
All other classlibs use net5.0 by default, fixing this oversight.

cc @grinrag 