### PR TITLE
Update the Last Write Time of nugetTemplateSearchInfo.json on NotModified

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/PhysicalFileSystem/IFileLastWriteTimeSource.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/PhysicalFileSystem/IFileLastWriteTimeSource.cs
@@ -5,5 +5,7 @@ namespace Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem
     public interface IFileLastWriteTimeSource
     {
         DateTime GetLastWriteTimeUtc(string file);
+
+        void SetLastWriteTimeUtc(string file, DateTime lastWriteTimeUtc);
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/PhysicalFileSystem/IPhysicalFileSystem.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/PhysicalFileSystem/IPhysicalFileSystem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 

--- a/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
+++ b/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
@@ -819,8 +819,10 @@ namespace Microsoft.TemplateEngine.Utils
             if (!IsPathInCone(file, out string processedPath))
             {
                 if (_basis is IFileLastWriteTimeSource lastWriteTimeSource)
+                {
                     return lastWriteTimeSource.GetLastWriteTimeUtc(file);
-                throw new NotImplementedException("Basis file system must implement IFileLastWriteTimeSource");
+                }
+                throw new NotImplementedException($"Basis file system must implement {nameof(IFileLastWriteTimeSource)}");
             }
 
             file = processedPath;
@@ -854,8 +856,10 @@ namespace Microsoft.TemplateEngine.Utils
             if (!IsPathInCone(file, out string processedPath))
             {
                 if (_basis is IFileLastWriteTimeSource lastWriteTimeSource)
+                {
                     lastWriteTimeSource.SetLastWriteTimeUtc(file, lastWriteTimeUtc);
-                throw new NotImplementedException("Basis file system must implement IFileLastWriteTimeSource");
+                }
+                throw new NotImplementedException($"Basis file system must implement {nameof(IFileLastWriteTimeSource)}");
             }
 
             file = processedPath;

--- a/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
+++ b/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
@@ -109,7 +109,7 @@ namespace Microsoft.TemplateEngine.Utils
             }
 
             public FileAttributes Attributes { get; set; }
-            public DateTime LastWriteTimeUtc { get; private set; }
+            public DateTime LastWriteTimeUtc { get; set; }
         }
 
         private class DisposingStream : Stream
@@ -847,6 +847,41 @@ namespace Microsoft.TemplateEngine.Utils
             }
 
             return targetFile.LastWriteTimeUtc;
+        }
+
+        public void SetLastWriteTimeUtc(string file, DateTime lastWriteTimeUtc)
+        {
+            if (!IsPathInCone(file, out string processedPath))
+            {
+                if (_basis is IFileLastWriteTimeSource lastWriteTimeSource)
+                    lastWriteTimeSource.SetLastWriteTimeUtc(file, lastWriteTimeUtc);
+                throw new NotImplementedException("Basis file system must implement IFileLastWriteTimeSource");
+            }
+
+            file = processedPath;
+            string rel = file.Substring(_root.FullPath.Length).Trim('/', '\\');
+            string[] parts = rel.Split('/', '\\');
+            FileSystemDirectory currentDir = _root;
+
+            for (int i = 0; i < parts.Length - 1; ++i)
+            {
+                FileSystemDirectory dir;
+                if (!currentDir.Directories.TryGetValue(parts[i], out dir))
+                {
+                    dir = new FileSystemDirectory(parts[i], Path.Combine(currentDir.FullPath, parts[i]));
+                    currentDir.Directories[parts[i]] = dir;
+                }
+
+                currentDir = dir;
+            }
+
+            FileSystemFile targetFile;
+            if (!currentDir.Files.TryGetValue(parts[parts.Length - 1], out targetFile))
+            {
+                throw new FileNotFoundException("File not found", file);
+            }
+
+            targetFile.LastWriteTimeUtc = lastWriteTimeUtc;
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Utils/PhysicalFileSystem.cs
+++ b/src/Microsoft.TemplateEngine.Utils/PhysicalFileSystem.cs
@@ -96,5 +96,10 @@ namespace Microsoft.TemplateEngine.Utils
         {
             return File.GetLastWriteTimeUtc(file);
         }
+
+        public void SetLastWriteTimeUtc(string file, DateTime lastWriteTimeUtc)
+        {
+            File.SetLastWriteTimeUtc(file, lastWriteTimeUtc);
+        }
     }
 }

--- a/test/Microsoft.TemplateEngine.Mocks/MockFileSystem.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockFileSystem.cs
@@ -237,5 +237,15 @@ namespace Microsoft.TemplateEngine.Mocks
 
             return _files[file].LastWriteTimeUtc;
         }
+
+        public void SetLastWriteTimeUtc(string file, DateTime lastWriteTimeUtc)
+        {
+            if (!FileExists(file))
+            {
+                throw new Exception($"File {file} doesn't exist");
+            }
+
+            _files[file].LastWriteTimeUtc = lastWriteTimeUtc;
+        }
     }
 }


### PR DESCRIPTION
Follow on to #2307.

Download of nugetTemplateSearchInfo.json now uses ETags and If-None-Match to avoid downloading the entire payload if it matches the local copy.  The download code also avoids attempting to download more often than every hour.  The composition of these two changes resulted in a bug where after one hour we always attempt to download because the local file isn't modified when there are no changes.  Thus, the last write time won't change until the remote copy of the file is updated.

This change modifies the last write time of the local file when it is determined that the remote copy is the same as the local copy, so that no attempts are made to re-download the file for at least one hour.