### PR TITLE
Make truncating of template information opt-in rather than opt-out

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -140,6 +140,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                                         // don't give this a default, otherwise 'new -lang' is valid and assigns the default. User should have to explicitly give the value.
                     Create.Option("--update-check", LocalizableStrings.UpdateCheckCommandHelp, Accept.NoArguments()),
                     Create.Option("--update-apply", LocalizableStrings.UpdateApplyCommandHelp, Accept.NoArguments()),
+                    Create.Option("--allow-clip", LocalizableStrings.AllowClipDescription, Accept.NoArguments()),
                 };
             }
         }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
@@ -42,6 +42,8 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         bool IsShowAllFlagSpecified { get; }
 
+        bool IsAllowClipFlagSpecified { get; }
+
         string TypeFilter { get; }
 
         string Language { get; }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -234,6 +234,8 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         public bool IsShowAllFlagSpecified => _parseResult.HasAppliedOption(new[] { _commandName, "all" });
 
+        public bool IsAllowClipFlagSpecified => _parseResult.HasAppliedOption(new[] { _commandName, "allow-clip" });
+
         public string TypeFilter => _parseResult.GetArgumentValueAtPath(new[] { _commandName, "type" });
 
         public string Language => _parseResult.GetArgumentValueAtPath(new[] { _commandName, "language" });

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -64,7 +64,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                     unambiguousTemplateGroupForList = new List<ITemplateMatchInfo>();
                 }
 
-                DisplayTemplateList(unambiguousTemplateGroupForList, environmentSettings, commandInput.Language, defaultLanguage);
+                DisplayTemplateList(unambiguousTemplateGroupForList, environmentSettings, commandInput.Language, defaultLanguage, commandInput.IsAllowClipFlagSpecified);
                 // list flag specified, so no usage examples or detailed help
                 return CreationResultStatus.Success;
             }
@@ -134,7 +134,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             }
 
             ShowContextAndTemplateNameMismatchHelp(templateResolutionResult, commandInput.TemplateName, commandInput.TypeFilter);
-            DisplayTemplateList(templatesForDisplay, environmentSettings, commandInput.Language, defaultLanguage);
+            DisplayTemplateList(templatesForDisplay, environmentSettings, commandInput.Language, defaultLanguage, commandInput.IsAllowClipFlagSpecified);
 
             if (!commandInput.IsListFlagSpecified)
             {
@@ -186,7 +186,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
         // - Short Name: displays the first short name from the highest precedence template in the group.
         // - Language: All languages supported by any template in the group are displayed, with the default language in brackets, e.g.: [C#]
         // - Tags
-        private static void DisplayTemplateList(IReadOnlyList<ITemplateMatchInfo> templates, IEngineEnvironmentSettings environmentSettings, string language, string defaultLanguage)
+        private static void DisplayTemplateList(IReadOnlyList<ITemplateMatchInfo> templates, IEngineEnvironmentSettings environmentSettings, string language, string defaultLanguage, bool allowClippingContent)
         {
             IReadOnlyList<TemplateGroupForListDisplay> groupsForDisplay = GetTemplateGroupsForListDisplay(templates, language, defaultLanguage);
 
@@ -198,7 +198,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                         columnPadding: 6,
                         headerSeparator: '-',
                         blankLineBetweenRows: false)
-                    .DefineColumn(t => t.Name, LocalizableStrings.Templates, shrinkIfNeeded: true)
+                    .DefineColumn(t => t.Name, LocalizableStrings.Templates, shrinkIfNeeded: allowClippingContent)
                     .DefineColumn(t => t.ShortName, LocalizableStrings.ShortName)
                     .DefineColumn(t => t.Languages, out object languageColumn, LocalizableStrings.Language)
                     .DefineColumn(t => t.Classifications, out object tagsColumn, LocalizableStrings.Tags)

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1665,5 +1665,14 @@ namespace Microsoft.TemplateEngine.Cli {
                 return ResourceManager.GetString("WillCreateTemplate", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Allow clipping output content to the size of the console..
+        /// </summary>
+        public static string AllowClipDescription {
+            get {
+                return ResourceManager.GetString("AllowClipDescription", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -661,4 +661,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="UpdateCheckCommandHelp" xml:space="preserve">
     <value>Check the currently installed template packs for updates.</value>
   </data>
+  <data name="AllowClipDescription" xml:space="preserve">
+    <value>Allow clipping output content to the size of the console.</value>
+  </data>
 </root>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -64,6 +64,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 
         public bool IsShowAllFlagSpecified { get; set; }
 
+        public bool IsAllowClipFlagSpecified { get; set; }
+
         public string TypeFilter { get; set; }
 
         public string Language { get; set; }


### PR DESCRIPTION
## Description

#2360 details the problem more fully, but basically template information in a command like `dotnet new --list` is very likely to be truncated when run in a subprocess or output to a file or similar.

## Solution

Added a new `--allow-clip` flag to make this truncation opt-in rather than opt-out based on the recommendations set forth in [this issue comment for #2360](https://github.com/dotnet/templating/issues/2360#issuecomment-614099788).

If the `--allow-clip` flag is added to a `dotnet new` command, output will be truncated per the changes in #2270. If not added, no data will be clipped/truncated, no matter the size of the console.

## Notes

* The name and description is open for debate. I thought "--allow-clip" was better than something like "--truncate-data" because it uses shorter and easier English words and describes the change it will make a little bit better.
* ~~I also increased the default console buffer width to a rather arbitrary value of 1024 to make things more _likely_ to look OK if redirecting output and the `--allow-clip` parameter is set. I realize this isn't going to work for everyone since template names could be arbitrarily long.~~

## Related Issues

Closes #2360