### PR TITLE
Increase value of DefaultBufferWidth to 160

### DIFF
--- a/src/Microsoft.TemplateEngine.Utils/EngineEnvironmentSettings.cs
+++ b/src/Microsoft.TemplateEngine.Utils/EngineEnvironmentSettings.cs
@@ -102,7 +102,7 @@ namespace Microsoft.TemplateEngine.Utils
 
             public string NewLine { get; }
 
-            private const int DefaultBufferWidth = 80;
+            private const int DefaultBufferWidth = 160;
 
             // Console.BufferWidth can throw if there's no console, such as when output is redirected, so
             // first check if it is redirected, and fall back to a default value if needed.


### PR DESCRIPTION
Data is now less likely to be truncated when output is being redirected, e.g. to a file or another process. I realize this isn't going to work / fix the problem for everyone since template names could be arbitrarily long.

See discussion in #2360 and comment [here](https://github.com/dotnet/templating/pull/2364#pullrequestreview-394093098) about increasing the buffer width to 160.