### PR TITLE
Create and Plumb New3Callbacks to Allow for Removal of Extra Processes in Dotnet CLI

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/New3Callbacks.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Callbacks.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Cli
+{
+    /// <summary>
+    /// The set of callbacks that should be implemented by callers of <code>New3Command.Run</code>.
+    /// These callbacks provide a mechanism for the template engine to invoke these operations without
+    /// requiring a built-time dependency on the actual implementation.
+    /// </summary>
+    public sealed class New3Callbacks
+    {
+        /// <summary>
+        /// Callback to be executed on first run of the template engine.
+        /// </summary>
+        public Action<IEngineEnvironmentSettings, IInstaller> OnFirstRun { get; set; }
+
+        /// <summary>
+        /// Callback to be executed to restore a project.
+        /// </summary>
+        public Func<string, bool> RestoreProject { get; set; }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
@@ -17,12 +17,14 @@ namespace Microsoft.TemplateEngine.Cli
     {
         private readonly TemplateCreationResult _creationResult;
         private readonly IEngineEnvironmentSettings _environment;
+        private readonly New3Callbacks _callbacks;
         private readonly AllowPostActionsSetting _canRunScripts;
         private readonly bool _isDryRun;
 
-        public PostActionDispatcher(IEngineEnvironmentSettings environment, TemplateCreationResult creationResult, AllowPostActionsSetting canRunStatus, bool isDryRun)
+        public PostActionDispatcher(IEngineEnvironmentSettings environment, New3Callbacks callbacks, TemplateCreationResult creationResult, AllowPostActionsSetting canRunStatus, bool isDryRun)
         {
             _environment = environment;
+            _callbacks = callbacks;
             _creationResult = creationResult;
             _canRunScripts = canRunStatus;
             _isDryRun = isDryRun;
@@ -151,6 +153,11 @@ namespace Microsoft.TemplateEngine.Cli
 
         private bool ProcessAction(IPostAction action, IPostActionProcessor actionProcessor)
         {
+            if(actionProcessor is PostActionProcessor2Base actionProcessor2Base)
+            {
+                actionProcessor2Base.Callbacks = _callbacks;
+            }
+
             if (actionProcessor is IPostActionProcessor2 actionProcessor2 && _creationResult.CreationEffects is ICreationEffects2 creationEffects)
             {
                 return actionProcessor2.Process(_environment, action, creationEffects, _creationResult.ResultInfo, _creationResult.OutputBaseDirectory);

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/DotnetRestorePostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/DotnetRestorePostActionProcessor.cs
@@ -75,10 +75,21 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
                 }
 
                 environment.Host.LogMessage(string.Format(LocalizableStrings.RunningDotnetRestoreOn, pathToRestore));
-                Dotnet restoreCommand = Dotnet.Restore(pathToRestore).ForwardStdErr().ForwardStdOut();
-                Dotnet.Result commandResult = restoreCommand.Execute();
 
-                if (commandResult.ExitCode != 0)
+                // Prefer to restore the project in-proc vs. creating a new process.
+                bool succeeded = false;
+                if (Callbacks.RestoreProject != null)
+                {
+                    succeeded = Callbacks.RestoreProject(pathToRestore);
+                }
+                else
+                {
+                    Dotnet restoreCommand = Dotnet.Restore(pathToRestore).ForwardStdErr().ForwardStdOut();
+                    Dotnet.Result commandResult = restoreCommand.Execute();
+                    succeeded = commandResult.ExitCode == 0;
+                }
+
+                if (!succeeded)
                 {
                     environment.Host.LogMessage(LocalizableStrings.RestoreFailed);
                     allSucceeded = false;
@@ -116,10 +127,21 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
                 }
 
                 environment.Host.LogMessage(string.Format(LocalizableStrings.RunningDotnetRestoreOn, pathToRestore));
-                Dotnet restoreCommand = Dotnet.Restore(pathToRestore).ForwardStdErr().ForwardStdOut();
-                Dotnet.Result commandResult = restoreCommand.Execute();
 
-                if (commandResult.ExitCode != 0)
+                // Prefer to restore the project in-proc vs. creating a new process.
+                bool succeeded = false;
+                if (Callbacks.RestoreProject != null)
+                {
+                    succeeded = Callbacks.RestoreProject(pathToRestore);
+                }
+                else
+                {
+                    Dotnet restoreCommand = Dotnet.Restore(pathToRestore).ForwardStdErr().ForwardStdOut();
+                    Dotnet.Result commandResult = restoreCommand.Execute();
+                    succeeded = commandResult.ExitCode == 0;
+                }
+
+                if (!succeeded)
                 {
                     environment.Host.LogMessage(LocalizableStrings.RestoreFailed);
                     allSucceeded = false;

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/PostActionProcessorBase.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/PostActionProcessorBase.cs
@@ -9,6 +9,8 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 {
     public abstract class PostActionProcessor2Base
     {
+        protected internal New3Callbacks Callbacks { get; set; }
+
         protected IReadOnlyList<string> GetTargetForSource(ICreationEffects2 creationEffects, string sourcePathGlob)
         {
             Glob g = Glob.Parse(sourcePathGlob);

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvocationAndAcquisitionCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvocationAndAcquisitionCoordinator.cs
@@ -26,13 +26,14 @@ namespace Microsoft.TemplateEngine.Cli
         private readonly string _defaultLanguage;
         private readonly string _commandName;
         private readonly Func<string> _inputGetter;
+        private readonly New3Callbacks _callbacks;
 
         private bool _resolutionResultInitialized = false;
         TemplateListResolutionResult _templateResolutionResult;
         ITemplateMatchInfo _templateToInvoke;
         SingularInvokableMatchCheckStatus _singleMatchStatus;
 
-        public TemplateInvocationAndAcquisitionCoordinator(SettingsLoader settingsLoader, INewCommandInput commandInput, TemplateCreator templateCreator, IHostSpecificDataLoader hostDataLoader, ITelemetryLogger telemetryLogger, string defaultLanguage, string commandName, Func<string> inputGetter)
+        public TemplateInvocationAndAcquisitionCoordinator(SettingsLoader settingsLoader, INewCommandInput commandInput, TemplateCreator templateCreator, IHostSpecificDataLoader hostDataLoader, ITelemetryLogger telemetryLogger, string defaultLanguage, string commandName, Func<string> inputGetter, New3Callbacks callbacks)
         {
             _settingsLoader = settingsLoader;
             _environment = _settingsLoader.EnvironmentSettings;
@@ -43,6 +44,7 @@ namespace Microsoft.TemplateEngine.Cli
             _defaultLanguage = defaultLanguage;
             _commandName = commandName;
             _inputGetter = inputGetter;
+            _callbacks = callbacks;
         }
 
         public async Task<CreationResultStatus> CoordinateInvocationOrAcquisitionAsync()
@@ -132,7 +134,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         private async Task<CreationResultStatus> InvokeTemplateAsync()
         {
-            TemplateInvoker invoker = new TemplateInvoker(_environment, _commandInput, _telemetryLogger, _commandName, _inputGetter);
+            TemplateInvoker invoker = new TemplateInvoker(_environment, _commandInput, _telemetryLogger, _commandName, _inputGetter, _callbacks);
             return await invoker.InvokeTemplate(_templateToInvoke);
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -18,17 +18,19 @@ namespace Microsoft.TemplateEngine.Cli
         private readonly ITelemetryLogger _telemetryLogger;
         private readonly string _commandName;
         private readonly Func<string> _inputGetter;
+        private readonly New3Callbacks _callbacks;
 
         private readonly TemplateCreator _templateCreator;
         private readonly IHostSpecificDataLoader _hostDataLoader;
 
-        public TemplateInvoker(IEngineEnvironmentSettings environment, INewCommandInput commandInput, ITelemetryLogger telemetryLogger, string commandName, Func<string> inputGetter)
+        public TemplateInvoker(IEngineEnvironmentSettings environment, INewCommandInput commandInput, ITelemetryLogger telemetryLogger, string commandName, Func<string> inputGetter, New3Callbacks callbacks)
         {
             _environment = environment;
             _commandInput = commandInput;
             _telemetryLogger = telemetryLogger;
             _commandName = commandName;
             _inputGetter = inputGetter;
+            _callbacks = callbacks;
 
             _templateCreator = new TemplateCreator(_environment);
             _hostDataLoader = new HostSpecificDataLoader(_environment.SettingsLoader);
@@ -292,7 +294,7 @@ namespace Microsoft.TemplateEngine.Cli
                 scriptRunSettings = AllowPostActionsSetting.Prompt;
             }
 
-            PostActionDispatcher postActionDispatcher = new PostActionDispatcher(_environment, creationResult, scriptRunSettings, _commandInput.IsDryRun);
+            PostActionDispatcher postActionDispatcher = new PostActionDispatcher(_environment, _callbacks, creationResult, scriptRunSettings, _commandInput.IsDryRun);
             postActionDispatcher.Process(_inputGetter);
         }
     }


### PR DESCRIPTION
Part of #2359.

Exposes `New3Callbacks` class that declares a set of callbacks to be implemented by the CLI.  The template engine will then invoke these callbacks when necessary, in the course of executing a call to `New3Command.Run`.

The first new addition to `New3Callbacks` allows the CLI to implement project restore without requiring the template engine to invoke a new process to call `dotnet new project/to/restore.csproj`.  Instead, the template engine will call the `RestoreProject` callback in-process.

I have tested this functionality locally and recorded these numbers:

Baseline: 8,080.724ms
Change: 6,901.032ms
Diff: -1,179.692 (-14.599%)

Note that the binaries are privates that came from the sdk repo and not from the installer repo, so these are not absolute numbers.  They are only useful as an indicator of relative change.