### PR TITLE
Update information in the listing

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1034,13 +1034,13 @@ namespace Microsoft.TemplateEngine.Cli {
                 return ResourceManager.GetString("NoPrimaryOutputsToRestore", resourceCulture);
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to No templates matched the input template name: {0}..
+        ///   Looks up a localized string similar to No templates found matching the following input parameter(s): {0}..
         /// </summary>
-        public static string NoTemplatesMatchName {
+        public static string NoTemplatesMatchingInputParameters {
             get {
-                return ResourceManager.GetString("NoTemplatesMatchName", resourceCulture);
+                return ResourceManager.GetString("NoTemplatesMatchingInputParameters", resourceCulture);
             }
         }
 
@@ -1061,6 +1061,14 @@ namespace Microsoft.TemplateEngine.Cli {
         {
             get {
                 return ResourceManager.GetString("OptionalWorkloadsSyncFailed", resourceCulture);
+            }
+        }
+
+        ///   Looks up a localized string similar to No templates matched the input template name: {0}..
+        /// </summary>
+        public static string NoTemplatesMatchName {
+            get {
+                return ResourceManager.GetString("NoTemplatesMatchName", resourceCulture);
             }
         }
 
@@ -1487,7 +1495,16 @@ namespace Microsoft.TemplateEngine.Cli {
                 return ResourceManager.GetString("Templates", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Templates found the following matching input parameter(s): {0}.
+        /// </summary>
+        public static string TemplatesFoundMatchingInputParameters {
+            get {
+                return ResourceManager.GetString("TemplatesFoundMatchingInputParameters", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to An error occured updating templates for: {0}.
         /// </summary>

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -273,14 +273,17 @@
   <data name="NoParameters" xml:space="preserve">
     <value>    (No Parameters)</value>
   </data>
-  <data name="NoTemplatesMatchName" xml:space="preserve">
-    <value>No templates matched the input template name: {0}.</value>
+  <data name="NoTemplatesMatchingInputParameters" xml:space="preserve">
+    <value>No templates found matching the following input parameter(s): {0}.</value>
   </data>
   <data name="OptionalWorkloadsSynchronized" xml:space="preserve">
     <value>The list of templates was synchronized with the Optional SDK Workloads.</value>
   </data>
   <data name="OptionalWorkloadsSyncFailed" xml:space="preserve">
     <value>Error during synchronization with the Optional SDK Workloads.</value>
+  </data>
+  <data name="NoTemplatesMatchName" xml:space="preserve">
+    <value>No templates matched the input template name: {0}.</value>
   </data>
   <data name="NoUpdates" xml:space="preserve">
     <value>No updates were found.</value>
@@ -348,6 +351,9 @@ See https://aka.ms/dotnet-install-templates to learn how to install additional t
   </data>
   <data name="Templates" xml:space="preserve">
     <value>Templates</value>
+  </data>
+  <data name="TemplatesFoundMatchingInputParameters" xml:space="preserve">
+    <value>Templates found matching the following input parameter(s): {0}</value>
   </data>
   <data name="Type" xml:space="preserve">
     <value>Type</value>


### PR DESCRIPTION
Delivers dotnet#2346 item. 

Changes
- update and unify the listing comments, including -lang option. 
```
$ dotnet dotnet-new3.dll re -l -lang c#
Templates found matching the following input parameter(s): 're', lang=c#

Templates                              Short Name      Language      Tags                       
---------------------------------      ----------      --------      -------------------------------------
ASP.NET Core with Aurelia              aurelia         C#            Web/MVC/SPA                
ASP.NET Core with Knockout.js          knockout        C#            Web/MVC/SPA   

$ dotnet dotnet-new3.dll re -l -lang c# --type item
No templates found matching the following input parameter(s): 're', lang=c#, type=item.

$ dotnet dotnet-new3.dll -l -lang NotExists
No templates found matching the following input parameter(s): lang=NotExists.
```

- fix wrong behavior of -l option using with the template name and/or language. Listing should not show partial matches and in particular should not show the whole table of templates in case of language mismatch.  
