### PR TITLE
design proposal: IInstaller interface changes for Optional Workloads

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/IInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Cli/IInstaller.cs
@@ -5,6 +5,12 @@ namespace Microsoft.TemplateEngine.Cli
 {
     public interface IInstaller : IInstallerBase
     {
+        void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources);
+
+        void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall);
+
+        void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall, bool interactive);
+
         /// <param name="optionalWorkloadRequests">Requests from <paramref name="installationRequests"/> which are part of an optional workload.</param>
         void InstallPackages(IEnumerable<string> installationRequests, IList<string> optionalWorkloadRequests, IList<string> nuGetSources);
 

--- a/src/Microsoft.TemplateEngine.Cli/IInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Cli/IInstaller.cs
@@ -5,10 +5,13 @@ namespace Microsoft.TemplateEngine.Cli
 {
     public interface IInstaller : IInstallerBase
     {
-        void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources);
+        /// <param name="optionalWorkloadRequests">Requests from <paramref name="installationRequests"/> which are part of an optional workload.</param>
+        void InstallPackages(IEnumerable<string> installationRequests, IList<string> optionalWorkloadRequests, IList<string> nuGetSources);
 
-        void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall);
+        /// <param name="optionalWorkloadRequests">Requests from <paramref name="installationRequests"/> which are part of an optional workload.</param>
+        void InstallPackages(IEnumerable<string> installationRequests, IList<string> optionalWorkloadRequests, IList<string> nuGetSources, bool debugAllowDevInstall);
 
-        void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall, bool interactive);
+        /// <param name="optionalWorkloadRequests">Requests from <paramref name="installationRequests"/> which are part of an optional workload.</param>
+        void InstallPackages(IEnumerable<string> installationRequests, IList<string> optionalWorkloadRequests, IList<string> nuGetSources, bool debugAllowDevInstall, bool interactive);
     }
 }


### PR DESCRIPTION
When installing new templates, we need the ability to specify which template is part of an optional workload and which is not.

All overloads of `InstallPackages` method accept a list of installation requests of type `string` ( `IEnumerable<string> installationRequests`), but no way to pass which templates are optional.

Changes in this PR propose changing the signature of the methods so that it is possible to pass a new list of requests: `optionalWorkloadRequests`.

Some notes on the changes:
- Existing `installationRequests` parameter will continue to contain all the templates to be installed.
- New `optionalWorkloadRequests` parameter will be a subset of `installationRequests` and it will only contain the templates that are part of an optional workload.
- Interface has no documentation. We should add more to make things more clear. I only added some that is relevant to this proposal.