### PR TITLE
Added support for installing packages as optional

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/TemplateUpdates/IInstallUnitDescriptor.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/TemplateUpdates/IInstallUnitDescriptor.cs
@@ -21,5 +21,7 @@ namespace Microsoft.TemplateEngine.Abstractions.TemplateUpdates
         string UninstallString { get; }
 
         IReadOnlyList<string> DetailKeysDisplayOrder { get; }
+
+        bool IsPartOfAnOptionalWorkload { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/TemplateUpdates/IInstallUnitDescriptorFactory.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/TemplateUpdates/IInstallUnitDescriptorFactory.cs
@@ -7,9 +7,10 @@ namespace Microsoft.TemplateEngine.Abstractions.TemplateUpdates
     public interface IInstallUnitDescriptorFactory : IIdentifiedComponent
     {
         // for existing descriptors saved in the metadata
-        bool TryCreateFromDetails(Guid descriptorId, string identifier, Guid mountPointId, IReadOnlyDictionary<string, string> details, out IInstallUnitDescriptor descriptor);
+        bool TryCreateFromDetails(Guid descriptorId, string identifier, Guid mountPointId, bool isPartOfAnOptionalWorkload,
+            IReadOnlyDictionary<string, string> details, out IInstallUnitDescriptor descriptor);
 
         // for creating from a mount point
-        bool TryCreateFromMountPoint(IMountPoint mountPoint, out IReadOnlyList<IInstallUnitDescriptor> descriptorList);
+        bool TryCreateFromMountPoint(IMountPoint mountPoint, bool isPartOfAnOptionalWorkload, out IReadOnlyList<IInstallUnitDescriptor> descriptorList);
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/IInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Cli/IInstaller.cs
@@ -10,5 +10,7 @@ namespace Microsoft.TemplateEngine.Cli
         void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall);
 
         void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall, bool interactive);
+
+        void InstallPackages(IEnumerable<InstallationRequest> installationRequests, IList<string> nuGetSources = null, bool debugAllowDevInstall = false, bool interactive = false);
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/InstallationRequest.cs
+++ b/src/Microsoft.TemplateEngine.Cli/InstallationRequest.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Microsoft.TemplateEngine.Cli
+{
+    public struct InstallationRequest : IEquatable<InstallationRequest>
+    {
+        public InstallationRequest(string installString, bool isPartOfAnOptionalWorkload = false)
+        {
+            InstallString = installString;
+            IsPartOfAnOptionalWorkload = isPartOfAnOptionalWorkload;
+        }
+
+        /// <summary>
+        /// String to identify the package/directory/archive containing the templates
+        /// </summary>
+        public string InstallString { get; set; }
+
+        /// <summary>
+        /// Is this package being installed as part of an optional workload?
+        /// </summary>
+        public bool IsPartOfAnOptionalWorkload { get; set; }
+
+        public bool Equals(InstallationRequest other)
+        {
+            return InstallString == other.InstallString &&
+                IsPartOfAnOptionalWorkload == other.IsPartOfAnOptionalWorkload;
+        }
+
+        public override string ToString()
+        {
+            return $"{(IsPartOfAnOptionalWorkload ? "[OW]" : string.Empty)}{InstallString}";
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/InstallationRequest.cs
+++ b/src/Microsoft.TemplateEngine.Cli/InstallationRequest.cs
@@ -26,9 +26,34 @@ namespace Microsoft.TemplateEngine.Cli
                 IsPartOfAnOptionalWorkload == other.IsPartOfAnOptionalWorkload;
         }
 
+        public override bool Equals(object obj)
+        {
+            if (!(obj is InstallationRequest other))
+            {
+                return false;
+            }
+
+            return Equals(other);
+        }
+
         public override string ToString()
         {
             return $"{(IsPartOfAnOptionalWorkload ? "[OW]" : string.Empty)}{InstallString}";
+        }
+
+        public override int GetHashCode()
+        {
+            return unchecked((InstallString?.GetHashCode() ?? 0) + 13 * IsPartOfAnOptionalWorkload.GetHashCode());
+        }
+
+        public static bool operator ==(InstallationRequest x, InstallationRequest y)
+        {
+            return x.Equals(y);
+        }
+
+        public static bool operator !=(InstallationRequest x, InstallationRequest y)
+        {
+            return !(x == y);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/Installer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Installer.cs
@@ -77,7 +77,7 @@ namespace Microsoft.TemplateEngine.Cli
             _environmentSettings.SettingsLoader.Save();
         }
 
-        public void InstallPackages(IEnumerable<InstallationRequest> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall, bool interactive)
+        public void InstallPackages(IEnumerable<InstallationRequest> installationRequests, IList<string> nuGetSources = null, bool debugAllowDevInstall = false, bool interactive = false)
         {
             List<InstallationRequest> localSources = new List<InstallationRequest>();
             List<Package> packages = new List<Package>();

--- a/src/Microsoft.TemplateEngine.Edge/Settings/InstallUnitDescriptorCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/InstallUnitDescriptorCache.cs
@@ -41,7 +41,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         [JsonProperty]
         public IReadOnlyDictionary<Guid, IInstallUnitDescriptor> Descriptors => _cache;
 
-        public bool TryAddDescriptorForLocation(Guid mountPointId, out IReadOnlyList<IInstallUnitDescriptor> descriptorList)
+        public bool TryAddDescriptorForLocation(Guid mountPointId, bool isPartOfAnOptionalWorkload, out IReadOnlyList<IInstallUnitDescriptor> descriptorList)
         {
             IMountPoint mountPoint = null;
 
@@ -53,7 +53,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     return false;
                 }
 
-                if (InstallUnitDescriptorFactory.TryCreateFromMountPoint(_environmentSettings, mountPoint, out descriptorList))
+                if (InstallUnitDescriptorFactory.TryCreateFromMountPoint(_environmentSettings, mountPoint, isPartOfAnOptionalWorkload, out descriptorList))
                 {
                     foreach (IInstallUnitDescriptor descriptor in descriptorList)
                     {

--- a/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/DefaultInstallUnitDescriptor.cs
+++ b/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/DefaultInstallUnitDescriptor.cs
@@ -7,13 +7,14 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
 {
     public sealed class DefaultInstallUnitDescriptor : IInstallUnitDescriptor
     {
-        public DefaultInstallUnitDescriptor(Guid descriptorId, Guid mountPointId, string identifier)
+        public DefaultInstallUnitDescriptor(Guid descriptorId, Guid mountPointId, string identifier, bool isPartOfAnOptionalWorkload)
         {
             DescriptorId = descriptorId;
             MountPointId = mountPointId;
             Identifier = identifier;
             Details = _details;
             DetailKeysDisplayOrder = Empty<string>.List.Value;
+            IsPartOfAnOptionalWorkload = isPartOfAnOptionalWorkload;
         }
 
         private static readonly IReadOnlyDictionary<string, string> _details = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
@@ -31,5 +32,7 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
         public string UninstallString => Identifier;
 
         public IReadOnlyList<string> DetailKeysDisplayOrder { get; }
+
+        public bool IsPartOfAnOptionalWorkload { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/DefaultInstallUnitDescriptorFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/DefaultInstallUnitDescriptorFactory.cs
@@ -11,17 +11,18 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
 
         public Guid Id => FactoryId;
 
-        public bool TryCreateFromDetails(Guid descriptorId, string identifier, Guid mountPointId, IReadOnlyDictionary<string, string> details, out IInstallUnitDescriptor descriptor)
+        public bool TryCreateFromDetails(Guid descriptorId, string identifier, Guid mountPointId, bool isPartOfAnOptionalWorkload,
+            IReadOnlyDictionary<string, string> details, out IInstallUnitDescriptor descriptor)
         {
-            descriptor = new DefaultInstallUnitDescriptor(descriptorId, mountPointId, identifier);
+            descriptor = new DefaultInstallUnitDescriptor(descriptorId, mountPointId, identifier, isPartOfAnOptionalWorkload);
             return true;
         }
 
-        public bool TryCreateFromMountPoint(IMountPoint mountPoint, out IReadOnlyList<IInstallUnitDescriptor> descriptorList)
+        public bool TryCreateFromMountPoint(IMountPoint mountPoint, bool isPartOfAnOptionalWorkload, out IReadOnlyList<IInstallUnitDescriptor> descriptorList)
         {
             descriptorList = new List<IInstallUnitDescriptor>()
             {
-                new DefaultInstallUnitDescriptor(Guid.NewGuid(), mountPoint.Info.MountPointId, mountPoint.Info.Place),
+                new DefaultInstallUnitDescriptor(Guid.NewGuid(), mountPoint.Info.MountPointId, mountPoint.Info.Place, isPartOfAnOptionalWorkload),
             };
 
             return true;

--- a/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/InstallUnitDescriptorFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/InstallUnitDescriptorFactory.cs
@@ -58,6 +58,12 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
                 return false;
             }
 
+            bool isPartOfAnOptionalWorkload = false;
+            if (descriptorObj.TryGetValue(nameof(IInstallUnitDescriptor.IsPartOfAnOptionalWorkload), StringComparison.OrdinalIgnoreCase, out JToken optionalToken))
+            {
+                _ = bool.TryParse(optionalToken.ToString(), out isPartOfAnOptionalWorkload);
+            }
+
             Dictionary<string, string> details = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (JProperty property in descriptorObj.PropertiesOf(nameof(IInstallUnitDescriptor.Details)))
             {
@@ -70,7 +76,7 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
                 details[property.Name] = property.Value.ToString();
             }
 
-            if (factory.TryCreateFromDetails(descriptorId, identifierToken.ToString(), mountPointId, details, out IInstallUnitDescriptor descriptor))
+            if (factory.TryCreateFromDetails(descriptorId, identifierToken.ToString(), mountPointId, isPartOfAnOptionalWorkload, details, out IInstallUnitDescriptor descriptor))
             {
                 parsedDescriptor = descriptor;
                 return true;
@@ -81,7 +87,8 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
         }
 
         // For creating descriptors.
-        public static bool TryCreateFromMountPoint(IEngineEnvironmentSettings environmentSettings, IMountPoint mountPoint, out IReadOnlyList<IInstallUnitDescriptor> descriptorList)
+        public static bool TryCreateFromMountPoint(IEngineEnvironmentSettings environmentSettings, IMountPoint mountPoint,
+            bool isPartOfAnOptionalWorkload, out IReadOnlyList<IInstallUnitDescriptor> descriptorList)
         {
             IInstallUnitDescriptorFactory defaultFactory = null;
 
@@ -93,13 +100,13 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
                     continue;
                 }
 
-                if (factory.TryCreateFromMountPoint(mountPoint, out descriptorList))
+                if (factory.TryCreateFromMountPoint(mountPoint, isPartOfAnOptionalWorkload, out descriptorList))
                 {
                     return true;
                 }
             }
 
-            return defaultFactory.TryCreateFromMountPoint(mountPoint, out descriptorList);
+            return defaultFactory.TryCreateFromMountPoint(mountPoint, isPartOfAnOptionalWorkload, out descriptorList);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/NupkgInstallUnitDescriptor.cs
+++ b/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/NupkgInstallUnitDescriptor.cs
@@ -7,11 +7,12 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
 {
     public class NupkgInstallUnitDescriptor : IInstallUnitDescriptor
     {
-        public NupkgInstallUnitDescriptor(Guid descriptorId, Guid mountPointId, string identifier, string version, string author)
+        public NupkgInstallUnitDescriptor(Guid descriptorId, Guid mountPointId, string identifier, bool isPartOfAnOptionalWorkload, string version, string author)
         {
             DescriptorId = descriptorId;
             MountPointId = mountPointId;
             Identifier = identifier;
+            IsPartOfAnOptionalWorkload = isPartOfAnOptionalWorkload;
             Version = version;
             Author = author;
         }
@@ -65,5 +66,8 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
 
         [JsonIgnore]
         public IReadOnlyList<string> DetailKeysDisplayOrder => _detailKeysDisplayOrder;
+
+        [JsonProperty]
+        public bool IsPartOfAnOptionalWorkload { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/NupkgInstallUnitDescriptorFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/TemplateUpdates/NupkgInstallUnitDescriptorFactory.cs
@@ -14,7 +14,8 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
 
         public Guid Id => FactoryId;
 
-        public bool TryCreateFromDetails(Guid descriptorId, string identifier, Guid mountPointId, IReadOnlyDictionary<string, string> details, out IInstallUnitDescriptor descriptor)
+        public bool TryCreateFromDetails(Guid descriptorId, string identifier, Guid mountPointId, bool isPartOfAnOptionalWorkload,
+            IReadOnlyDictionary<string, string> details, out IInstallUnitDescriptor descriptor)
         {
             if (string.IsNullOrEmpty(identifier) || mountPointId == Guid.Empty)
             {
@@ -36,11 +37,11 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
                 return false;
             }
 
-            descriptor = new NupkgInstallUnitDescriptor(descriptorId, mountPointId, identifier, version, author);
+            descriptor = new NupkgInstallUnitDescriptor(descriptorId, mountPointId, identifier, isPartOfAnOptionalWorkload, version, author);
             return true;
         }
 
-        public bool TryCreateFromMountPoint(IMountPoint mountPoint, out IReadOnlyList<IInstallUnitDescriptor> descriptorList)
+        public bool TryCreateFromMountPoint(IMountPoint mountPoint, bool isPartOfAnOptionalWorkload, out IReadOnlyList<IInstallUnitDescriptor> descriptorList)
         {
             List<IInstallUnitDescriptor> allDescriptors = new List<IInstallUnitDescriptor>();
             descriptorList = allDescriptors;
@@ -50,7 +51,13 @@ namespace Microsoft.TemplateEngine.Edge.TemplateUpdates
                 && TryGetPackageInfoFromNuspec(mountPoint, out string packageName, out string version, out string author))
             {
                 Guid descriptorId = Guid.NewGuid();
-                IInstallUnitDescriptor descriptor = new NupkgInstallUnitDescriptor(descriptorId, mountPoint.Info.MountPointId, packageName, version, author);
+                IInstallUnitDescriptor descriptor = new NupkgInstallUnitDescriptor(
+                    descriptorId,
+                    mountPoint.Info.MountPointId,
+                    packageName,
+                    isPartOfAnOptionalWorkload,
+                    version,
+                    author);
                 allDescriptors.Add(descriptor);
                 return true;
             }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearcherTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearcherTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         private static readonly PackInfo _bluePackInfo = new PackInfo("bluePack", "2.1");
         private static readonly PackInfo _greenPackInfo = new PackInfo("greenPack", "3.0.0");
 
-        private static readonly IInstallUnitDescriptor _fooPackInstallDescriptor = new NupkgInstallUnitDescriptor(Guid.NewGuid(), Guid.NewGuid(), _fooPackInfo.Name, _fooPackInfo.Version, string.Empty);
+        private static readonly IInstallUnitDescriptor _fooPackInstallDescriptor = new NupkgInstallUnitDescriptor(Guid.NewGuid(), Guid.NewGuid(), _fooPackInfo.Name, false, _fooPackInfo.Version, string.Empty);
 
         private static IReadOnlyDictionary<string, IReadOnlyList<ITemplateNameSearchResult>> GetMockNameSearchResults()
         {

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateUpdateTests/MockInstallUnitDescriptor.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateUpdateTests/MockInstallUnitDescriptor.cs
@@ -27,5 +27,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateUpdateTests
         public string UninstallString => Identifier;
 
         public IReadOnlyList<string> DetailKeysDisplayOrder { get; }
+
+        public bool IsPartOfAnOptionalWorkload { get; set; }
     }
 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateUpdateTests/MockInstaller.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateUpdateTests/MockInstaller.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.TemplateEngine.Abstractions;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateUpdateTests
 {
@@ -31,6 +32,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateUpdateTests
         public void InstallPackages(IEnumerable<string> installationRequests, IList<string> nuGetSources, bool debugAllowDevInstall, bool interactive)
         {
             Installed.UnionWith(installationRequests);
+        }
+
+        public void InstallPackages(IEnumerable<InstallationRequest> installationRequests, IList<string> nuGetSources = null, bool debugAllowDevInstall = false, bool interactive = false)
+        {
+            Installed.UnionWith(installationRequests.Select(r => r.InstallString));
         }
 
         // Removes the uninstallRequests from the _installed list.

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateUpdateTests/UpdateCheckerTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateUpdateTests/UpdateCheckerTests.cs
@@ -21,12 +21,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateUpdateTests
 
             // an updater that isn't related
             Guid unrelatedMountPointId = new Guid("44E776BF-0E75-43E3-97B0-1807B5207D90");
-            IInstallUnitDescriptor unrelatedInstallDescriptor = new NupkgInstallUnitDescriptor(Guid.NewGuid(), unrelatedMountPointId, "unrelatedPackage", "2.0.0", "TestAuthor");
+            IInstallUnitDescriptor unrelatedInstallDescriptor = new NupkgInstallUnitDescriptor(Guid.NewGuid(), unrelatedMountPointId, "unrelatedPackage", false, "2.0.0", "TestAuthor");
             IUpdateUnitDescriptor unrelatedUpdateDescriptor = new UpdateUnitDescriptor(unrelatedInstallDescriptor, "unrelatedPackage::2.1.0", "Unrelated Package Version 2.1.0");
 
             // the updater that should be found
             Guid mockMountPointId = new Guid("1EB31CA7-28C2-4AAD-B994-32A96A2EACB7");
-            IInstallUnitDescriptor testInstallDescriptor = new NupkgInstallUnitDescriptor(Guid.NewGuid(), mockMountPointId, "testPackage", "1.0.0", "TestAuthor");
+            IInstallUnitDescriptor testInstallDescriptor = new NupkgInstallUnitDescriptor(Guid.NewGuid(), mockMountPointId, "testPackage", false, "1.0.0", "TestAuthor");
             IUpdateUnitDescriptor mockUpdateDescriptor = new UpdateUnitDescriptor(testInstallDescriptor, "testPackage::1.1.0", "Test Package Version 1.0.0");
 
             MockNupkgUpdater.SetMockUpdates(new List<IUpdateUnitDescriptor>() { mockUpdateDescriptor, unrelatedUpdateDescriptor });

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/NupkgInstallUnitDescriptorTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/NupkgInstallUnitDescriptorTests.cs
@@ -21,14 +21,16 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             string packageName = "TestPackage";
             string version = "1.2.3";
             string author = "TestAuthor";
+            bool isOptional = true;
 
-            IInstallUnitDescriptor descriptor = new NupkgInstallUnitDescriptor(descriptorId, mountPointId, packageName, version, author);
+            IInstallUnitDescriptor descriptor = new NupkgInstallUnitDescriptor(descriptorId, mountPointId, packageName, isOptional, version, author);
             Assert.Equal(descriptorId, descriptor.DescriptorId);
             Assert.Equal(packageName, descriptor.Identifier);
             Assert.Equal(NupkgInstallUnitDescriptorFactory.FactoryId, descriptor.FactoryId);
             Assert.Equal(mountPointId, descriptor.MountPointId);
             Assert.Equal(version, descriptor.Details[VersionKey]);
             Assert.Equal(author, descriptor.Details[nameof(NupkgInstallUnitDescriptor.Author)]);
+            Assert.Equal(isOptional, descriptor.IsPartOfAnOptionalWorkload);
         }
 
         [Fact(DisplayName = nameof(NupkgDescriptorFactoryCreatesFromDetailsTest))]
@@ -39,6 +41,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             string packageName = "TestPackage";
             string version = "1.2.3";
             string author = "Microsoft";
+            bool isOptional = true;
 
             Dictionary<string, string> details = new Dictionary<string, string>()
             {
@@ -46,7 +49,8 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
                 { nameof(NupkgInstallUnitDescriptor.Author), author }
             };
 
-            Assert.True(new NupkgInstallUnitDescriptorFactory().TryCreateFromDetails(descriptorId, packageName, mountPointId, details, out IInstallUnitDescriptor descriptor));
+            Assert.True(new NupkgInstallUnitDescriptorFactory().TryCreateFromDetails(descriptorId, packageName, mountPointId,
+                isOptional, details, out IInstallUnitDescriptor descriptor));
             Assert.Equal(descriptorId, descriptor.DescriptorId);
             Assert.Equal(packageName, descriptor.Identifier);
             Assert.Equal(NupkgInstallUnitDescriptorFactory.FactoryId, descriptor.FactoryId);
@@ -95,13 +99,14 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         {
             string packageName = "TestPackage";
             string version = "1.2.3";
+            bool isOptional = false;
 
             Dictionary<string, string> details = new Dictionary<string, string>()
             {
                 { VersionKey, version }
             };
 
-            Assert.False(new NupkgInstallUnitDescriptorFactory().TryCreateFromDetails(Guid.NewGuid(), packageName, Guid.Empty, details, out IInstallUnitDescriptor descriptor));
+            Assert.False(new NupkgInstallUnitDescriptorFactory().TryCreateFromDetails(Guid.NewGuid(), packageName, Guid.Empty, isOptional, details, out _));
         }
 
         [Fact(DisplayName = nameof(NupkgDescriptorFactoryFailsOnMissingPackageNameTest))]
@@ -109,13 +114,14 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         {
             Guid mountPointId = new Guid("D1ADBDAF-0382-4EEA-A43C-8356A8BEFAA9");
             string version = "1.2.3";
+            bool isOptional = false;
 
             Dictionary<string, string> details = new Dictionary<string, string>()
             {
                 { VersionKey, version }
             };
 
-            Assert.False(new NupkgInstallUnitDescriptorFactory().TryCreateFromDetails(Guid.Empty, null, mountPointId, details, out IInstallUnitDescriptor descriptor));
+            Assert.False(new NupkgInstallUnitDescriptorFactory().TryCreateFromDetails(Guid.Empty, null, mountPointId, isOptional, details, out _));
         }
 
         [Fact(DisplayName = nameof(NupkgDescriptorFactoryFailsOnMissingVersionTest))]
@@ -123,12 +129,13 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         {
             Guid mountPointId = new Guid("D1ADBDAF-0382-4EEA-A43C-8356A8BEFAA9");
             string packageName = "TestPackage";
+            bool isOptional = false;
 
             Dictionary<string, string> details = new Dictionary<string, string>()
             {
             };
 
-            Assert.False(new NupkgInstallUnitDescriptorFactory().TryCreateFromDetails(Guid.NewGuid(), packageName, mountPointId, details, out IInstallUnitDescriptor descriptor));
+            Assert.False(new NupkgInstallUnitDescriptorFactory().TryCreateFromDetails(Guid.NewGuid(), packageName, mountPointId, isOptional, details, out _));
         }
     }
 }


### PR DESCRIPTION
Delivers https://github.com/dotnet/templating/issues/2426

Added a new method to `IInstaller` to support marking some packages as optional.
Added a new property `bool IsPartOfAnOptionalWorkload` to `IInstallUnityDescriptor`.
Updated `IInstallUnitDescriptorFactory` to pipe the additional data during template installation.

Updated all the implementations of the above interfaces to comply with the changes.
Updated the tests that were broken because of the changes.