### PR TITLE
[release/3.1] Mark template packages as nonshipping

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/Microsoft.DotNet.Common.ItemTemplates.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/Microsoft.DotNet.Common.ItemTemplates.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard1.0</TargetFramework>
+        <IsShipping>False</IsShipping>
         <IncludeBuildOutput>False</IncludeBuildOutput>
         <IncludeSource>False</IncludeSource>
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/Microsoft.DotNet.Common.ProjectTemplates.1.x.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/Microsoft.DotNet.Common.ProjectTemplates.1.x.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard1.0</TargetFramework>
+        <IsShipping>False</IsShipping>
         <IncludeBuildOutput>False</IncludeBuildOutput>
         <IncludeSource>False</IncludeSource>
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/Microsoft.DotNet.Common.ProjectTemplates.2.0.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/Microsoft.DotNet.Common.ProjectTemplates.2.0.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard1.0</TargetFramework>
+        <IsShipping>False</IsShipping>
         <IncludeBuildOutput>False</IncludeBuildOutput>
         <IncludeSource>False</IncludeSource>
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/Microsoft.DotNet.Common.ProjectTemplates.2.1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/Microsoft.DotNet.Common.ProjectTemplates.2.1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard1.0</TargetFramework>
+        <IsShipping>False</IsShipping>
         <IncludeBuildOutput>False</IncludeBuildOutput>
         <IncludeSource>False</IncludeSource>
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.2/Microsoft.DotNet.Common.ProjectTemplates.2.2.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.2/Microsoft.DotNet.Common.ProjectTemplates.2.2.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard1.0</TargetFramework>
+        <IsShipping>False</IsShipping>
         <IncludeBuildOutput>False</IncludeBuildOutput>
         <IncludeSource>False</IncludeSource>
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/Microsoft.DotNet.Common.ProjectTemplates.3.0.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/Microsoft.DotNet.Common.ProjectTemplates.3.0.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard1.0</TargetFramework>
+        <IsShipping>False</IsShipping>
         <IncludeBuildOutput>False</IncludeBuildOutput>
         <IncludeSource>False</IncludeSource>
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/Microsoft.DotNet.Common.ProjectTemplates.3.1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/Microsoft.DotNet.Common.ProjectTemplates.3.1.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard1.0</TargetFramework>
+        <IsShipping>False</IsShipping>
         <IncludeBuildOutput>False</IncludeBuildOutput>
         <IncludeSource>False</IncludeSource>
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>


### PR DESCRIPTION
These are evidently transport packages, not shipping packages intended for nuget.org. Marking them as such