### PR TITLE
Temporarily disable the failing unit test.

### DIFF
--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using Microsoft.TemplateEngine.Core.Contracts;
@@ -6,6 +7,18 @@ using Xunit;
 
 namespace Microsoft.TemplateEngine.Core.UnitTests
 {
+
+    public sealed class SkipOnNonEnUsLocale : FactAttribute
+    {
+        public SkipOnNonEnUsLocale(string displayName, string message) {
+            DisplayName = displayName;
+            if (!CultureInfo.CurrentCulture.Name.Equals("en-US"))
+            {
+                Skip = "Skipped : non en-US locale. " + message;
+            }
+        }
+    }
+
     public partial class ConditionalTests
     {
         [Fact(DisplayName=nameof(VerifyIfEndifTrueCondition))]
@@ -1395,7 +1408,7 @@ There";
             Verify(Encoding.UTF8, output, changed, value, expected);
         }
 
-        [Fact(DisplayName = nameof(VerifyIfElseEndifConditionUsesDouble))]
+        [SkipOnNonEnUsLocale(nameof(VerifyIfElseEndifConditionUsesDouble), "The test is temporarily disabled, tracked in issue #2436.")]
         public void VerifyIfElseEndifConditionUsesDouble()
         {
             string value = @"Hello


### PR DESCRIPTION
The changes disable the unit test which fails in RUS, FRA (and maybe in some other) locales.
This is to make the project buildable in all locales while we are fixing the problem.

The test should be turned on after fixing issue #2436 .  