### PR TITLE
Host.Version from SDK has a leading 'v'. Add for local version as well to avoid exception from TemplateLocator.

### DIFF
--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -21,7 +21,7 @@ namespace dotnet_new3
     public class Program
     {
         private const string HostIdentifier = "dotnetcli-preview";
-        private const string HostVersion = "1.0.0";
+        private const string HostVersion = "v1.0.0";
         private const string CommandName = "new3";
 
         public static int Main(string[] args)

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
@@ -20,7 +20,7 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
     class Program
     {
         private const string HostIdentifier = "endtoendtestharness";
-        private const string HostVersion = "1.0.0";
+        private const string HostVersion = "v1.0.0";
         private const string CommandName = "test-test";
         private static readonly Dictionary<string, Func<IPhysicalFileSystem, JObject, string, bool>> VerificationLookup = new Dictionary<string, Func<IPhysicalFileSystem, JObject, string, bool>>(StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
…