### PR TITLE
Additional value forms

### DIFF
--- a/docs/Runnable-Project-Templates---Value-Forms.md
+++ b/docs/Runnable-Project-Templates---Value-Forms.md
@@ -61,3 +61,55 @@ upperCase - Upper cases a value
 ```
             `identifier`  -> `upperCase` or `upperCaseInvariant`
 ```
+
+`firstLowerCase` - converts the first letter of the value to lowercase using the casing rules of the current culture. Available since version 5.0.200.
+```
+    "forms": {
+        "first_lc": {
+          "identifier": "firstLowerCase"
+        }
+    }
+```
+`firstLowerCaseInvariant` - converts the first letter of the value to lowercase using the casing rules of the invariant culture. Available since version 5.0.200.
+```
+    "forms": {
+        "first_lc": {
+          "identifier": "firstLowerCaseInvariant"
+        }
+    }
+```
+
+`firstUpperCase` - converts the first letter of the value to uppercase using the casing rules of the current culture. Available since version 5.0.200.
+```
+    "forms": {
+        "first_uc": {
+          "identifier": "firstUpperCase"
+        }
+    }
+```
+`firstUpperCaseInvariant` - converts the first letter of the value to uppercase using the casing rules of the invariant culture. Available since version 5.0.200.
+```
+    "forms": {
+        "first_uc": {
+          "identifier": "firstUpperCaseInvariant"
+        }
+    }
+```
+
+`titleCase` - converts the value to title case using the casing rules of the current culture. See [TextInfo.ToTitleCase(String) documentation](https://docs.microsoft.com/dotnet/api/system.globalization.textinfo.totitlecase) for more details. Available since version 5.0.200.
+```
+    "forms": {
+        "title": {
+          "identifier": "titleCase"
+        }
+    }
+```
+
+`kebabCase` - converts the value to kebab case using the casing rules of the invariant culture. Available since version 5.0.200.
+```
+    "forms": {
+        "kebab": {
+          "identifier": "kebabCase"
+        }
+    }
+```

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
@@ -732,7 +732,13 @@
                     "lowerCase",
                     "identity",
                     "upperCase",
-                    "jsonEncode"
+                    "jsonEncode",
+                    "firstLowerCase",
+                    "firstLowerCaseInvariant",
+                    "firstUpperCase",
+                    "firstUpperCaseInvariant",
+                    "titleCase",
+                    "kebabCase"
                   ]
                 }
               }
@@ -848,6 +854,54 @@
             "properties": {
               "identifier": {
                 "enum": [ "jsonEncode" ]
+              }
+            }
+          },
+          {
+            "description": "Converts the first letter of the value to lowercase using the casing rules of the current culture.",
+            "properties": {
+              "identifier": {
+                "enum": [ "firstLowerCase" ]
+              }
+            }
+          },
+          {
+            "description": "Converts the first letter of the value to lowercase using the casing rules of the invariant culture.",
+            "properties": {
+              "identifier": {
+                "enum": [ "firstLowerCaseInvariant" ]
+              }
+            }
+          },
+          {
+            "description": "Converts the first letter of the value to uppercase using the casing rules of the current culture.",
+            "properties": {
+              "identifier": {
+                "enum": [ "firstUpperCase" ]
+              }
+            }
+          },
+          {
+            "description": "Converts the first letter of the value to uppercase using the casing rules of the invariant culture.",
+            "properties": {
+              "identifier": {
+                "enum": [ "firstUpperCaseInvariant" ]
+              }
+            }
+          },
+          {
+            "description": "Converts the value to title case using the casing rules of the current culture.",
+            "properties": {
+              "identifier": {
+                "enum": [ "titleCase" ]
+              }
+            }
+          },
+          {
+            "description": "Converts the value to kebab case using the casing rules of the invariant culture.",
+            "properties": {
+              "identifier": {
+                "enum": [ "kebabCase" ]
               }
             }
           }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueFormModel.cs
@@ -41,6 +41,19 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             x = new UpperCaseInvariantValueFormModel();
             lookup[x.Identifier] = x;
 
+            x = new FirstLowerCaseValueFormModel();
+            lookup[x.Identifier] = x;
+            x = new FirstUpperCaseValueFormModel();
+            lookup[x.Identifier] = x;
+            x = new FirstLowerCaseInvariantValueFormModel();
+            lookup[x.Identifier] = x;
+            x = new FirstUpperCaseInvariantValueFormModel();
+            lookup[x.Identifier] = x;
+            x = new KebabCaseValueFormModel();
+            lookup[x.Identifier] = x;
+            x = new TitleCaseValueFormModel();
+            lookup[x.Identifier] = x;
+
             return lookup;
         }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstLowerCaseInvariantValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstLowerCaseInvariantValueFormModel.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class FirstLowerCaseInvariantValueFormModel : IValueForm
+    {
+        public string Identifier => "firstLowerCaseInvariant";
+
+        public string Name { get; }
+
+        public FirstLowerCaseInvariantValueFormModel()
+        {
+        }
+
+        public FirstLowerCaseInvariantValueFormModel(string name)
+        {
+            Name = name;
+        }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new FirstLowerCaseValueFormModel(name);
+        }
+
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            switch (value)
+            {
+                case null: return null;
+                case "": return value;
+                default: return value.First().ToString().ToLowerInvariant() + value.Substring(1);
+            }
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstLowerCaseValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstLowerCaseValueFormModel.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class FirstLowerCaseValueFormModel : IValueForm
+    {
+        public string Identifier => "firstLowerCase";
+
+        public string Name { get; }
+
+        public FirstLowerCaseValueFormModel()
+        {
+        }
+
+        public FirstLowerCaseValueFormModel(string name)
+        {
+            Name = name;
+        }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new FirstLowerCaseValueFormModel(name);
+        }
+
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            switch (value)
+            {
+                case null: return null;
+                case "": return value;
+                default: return value.First().ToString().ToLower() + value.Substring(1);
+            }
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstUpperCaseInvariantValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstUpperCaseInvariantValueFormModel.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class FirstUpperCaseInvariantValueFormModel : IValueForm
+    {
+        public string Identifier => "firstUpperCaseInvariant";
+
+        public string Name { get; }
+
+        public FirstUpperCaseInvariantValueFormModel()
+        {
+        }
+
+        public FirstUpperCaseInvariantValueFormModel(string name)
+        {
+            Name = name;
+        }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new FirstUpperCaseValueFormModel(name);
+        }
+
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            switch (value)
+            {
+                case null: return null;
+                case "": return value;
+                default: return value.First().ToString().ToUpperInvariant() + value.Substring(1);
+            }
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstUpperCaseValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstUpperCaseValueFormModel.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class FirstUpperCaseValueFormModel : IValueForm
+    {
+        public string Identifier => "firstUpperCase";
+
+        public string Name { get; }
+
+        public FirstUpperCaseValueFormModel()
+        {
+        }
+
+        public FirstUpperCaseValueFormModel(string name)
+        {
+            Name = name;
+        }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new FirstUpperCaseValueFormModel(name);
+        }
+
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            switch (value)
+            {
+                case null: return null;
+                case "": return value;
+                default: return value.First().ToString().ToUpper() + value.Substring(1);
+            }
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/KebabCaseValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/KebabCaseValueFormModel.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class KebabCaseValueFormModel : IValueForm
+    {
+        public string Identifier => "kebabCase";
+
+        public string Name { get; }
+
+        public KebabCaseValueFormModel()
+        {
+        }
+
+        public KebabCaseValueFormModel(string name)
+        {
+            Name = name;
+        }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new KebabCaseValueFormModel(name);
+        }
+
+        /// <summary>
+        /// PascalCase to kebab-case using Microsoft's capitalization conventions (https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions).
+        /// Todd Skelton's solution (https://stackoverflow.com/a/54012346/164680)
+        /// </summary>
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            if (value is null)
+            {
+                return null;
+            }
+            if (value.Length == 0)
+            {
+                return string.Empty;
+            }
+            var builder = new StringBuilder();
+
+            for (var i = 0; i < value.Length; i++)
+            {
+                if (char.IsLower(value[i])) // if current char is already lowercase
+                {
+                    builder.Append(value[i]);
+                }
+                else if (i == 0) // if current char is the first char
+                {
+                    builder.Append(char.ToLower(value[i]));
+                }
+                else if (char.IsLower(value[i - 1])) // if current char is upper and previous char is lower
+                {
+                    builder.Append("-");
+                    builder.Append(char.ToLower(value[i]));
+                }
+                else if (i + 1 == value.Length || char.IsUpper(value[i + 1])) // if current char is upper and next char doesn't exist or is upper
+                {
+                    builder.Append(char.ToLower(value[i]));
+                }
+                else // if current char is upper and next char is lower
+                {
+                    builder.Append("-");
+                    builder.Append(char.ToLower(value[i]));
+                }
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/KebabCaseValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/KebabCaseValueFormModel.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
@@ -24,48 +26,19 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
             return new KebabCaseValueFormModel(name);
         }
 
-        /// <summary>
-        /// PascalCase to kebab-case using Microsoft's capitalization conventions (https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions).
-        /// Todd Skelton's solution (https://stackoverflow.com/a/54012346/164680)
-        /// </summary>
         public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
         {
             if (value is null)
             {
                 return null;
             }
-            if (value.Length == 0)
+            if (string.IsNullOrWhiteSpace(value))
             {
                 return string.Empty;
             }
-            var builder = new StringBuilder();
 
-            for (var i = 0; i < value.Length; i++)
-            {
-                if (char.IsLower(value[i])) // if current char is already lowercase
-                {
-                    builder.Append(value[i]);
-                }
-                else if (i == 0) // if current char is the first char
-                {
-                    builder.Append(char.ToLower(value[i]));
-                }
-                else if (char.IsLower(value[i - 1])) // if current char is upper and previous char is lower
-                {
-                    builder.Append("-");
-                    builder.Append(char.ToLower(value[i]));
-                }
-                else if (i + 1 == value.Length || char.IsUpper(value[i + 1])) // if current char is upper and next char doesn't exist or is upper
-                {
-                    builder.Append(char.ToLower(value[i]));
-                }
-                else // if current char is upper and next char is lower
-                {
-                    builder.Append("-");
-                    builder.Append(char.ToLower(value[i]));
-                }
-            }
-            return builder.ToString();
+            Regex pattern = new Regex(@"(?:\p{Lu}\p{M}*)?(?:\p{Ll}\p{M}*)+|(?:\p{Lu}\p{M}*)+(?!\p{Ll})|\p{N}+|[^\p{C}\p{P}\p{Z}]+|[\u2700-\u27BF]");
+            return string.Join("-", pattern.Matches(value).Cast<Match>().Select(m => m.Value)).ToLowerInvariant();
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/TitleCaseValueFormModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/TitleCaseValueFormModel.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Globalization;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    public class TitleCaseValueFormModel : IValueForm
+    {
+        public string Identifier => "titleCase";
+
+        public string Name { get; }
+
+        public TitleCaseValueFormModel()
+        {
+        }
+
+        public TitleCaseValueFormModel(string name)
+        {
+            Name = name;
+        }
+
+        public IValueForm FromJObject(string name, JObject configuration)
+        {
+            return new TitleCaseValueFormModel(name);
+        }
+
+        public string Process(IReadOnlyDictionary<string, IValueForm> forms, string value)
+        {
+            switch (value)
+            {
+                case null: return null;
+                case "": return value;
+                default: return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value);
+            }
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateWithValueForms.json
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateWithValueForms.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "kind": "file_contains",
     "path": "bar.cs",
@@ -21,5 +21,68 @@
   {
     "kind": "file_does_not_exist",
     "path": "bar2.cs"
+  },
+  {
+    "kind": "file_exists",
+    "path": "FirstLetterCaseForms\\myPascalTestValue.cs"
+  },
+  {
+    "kind": "file_contains",
+    "path": "FirstLetterCaseForms\\myPascalTestValue.cs",
+    "text": "namespace Test\r\n{\r\n    class ContentReplacementTest\r\n    {\r\n        private string myPascalTestValue;\r\n    }\r\n}\r\n"
+  },
+  {
+    "kind": "file_exists",
+    "path": "FirstLetterCaseForms\\MyCamelTestValue.cs"
+  },
+  {
+    "kind": "file_contains",
+    "path": "FirstLetterCaseForms\\MyCamelTestValue.cs",
+    "text": "namespace Test\r\n{\r\n    class ContentReplacementTest\r\n    {\r\n        private string MyCamelTestValue;\r\n    }\r\n}\r\n"
+  },
+  {
+    "kind": "file_exists",
+    "path": "IdentityForms\\myCamelTestValue.cs"
+  },
+  {
+    "kind": "file_contains",
+    "path": "IdentityForms\\myCamelTestValue.cs",
+    "text": "namespace Test\r\n{\r\n    class ContentReplacementTest\r\n    {\r\n        private string myCamelTestValue;\r\n    }\r\n}\r\n"
+  },
+  {
+    "kind": "file_exists",
+    "path": "IdentityForms\\MyPascalTestValue.cs"
+  },
+  {
+    "kind": "file_contains",
+    "path": "IdentityForms\\MyPascalTestValue.cs",
+    "text": "namespace Test\r\n{\r\n    class ContentReplacementTest\r\n    {\r\n        private string MyPascalTestValue;\r\n    }\r\n}\r\n"
+  },
+  {
+    "kind": "file_exists",
+    "path": "IdentityForms\\my test text.cs"
+  },
+  {
+    "kind": "file_contains",
+    "path": "IdentityForms\\my test text.cs",
+    "text": "namespace Test\r\n{\r\n    class ContentReplacementTest\r\n    {\r\n        private string param3 = \"my test text\";\r\n    }\r\n}\r\n"
+  },
+  {
+    "kind": "file_exists",
+    "path": "KebabCaseForms\\my-pascal-test-value.cs"
+  },
+  {
+    "kind": "file_contains",
+    "path": "KebabCaseForms\\my-pascal-test-value.cs",
+    "text": "namespace Test\r\n{\r\n    class ContentReplacementTest\r\n    {\r\n        private string my-pascal-test-value;\r\n    }\r\n}\r\n"
+  },
+  {
+    "kind": "file_exists",
+    "path": "TitleCaseForms\\My Test Text.cs"
+  },
+  {
+    "kind": "file_contains",
+    "path": "TitleCaseForms\\My Test Text.cs",
+    "text": "namespace Test\r\n{\r\n    class ContentReplacementTest\r\n    {\r\n        private string param3 = \"My Test Text\";\r\n    }\r\n}\r\n"
   }
 ]

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ValueFormsTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ValueFormsTests.cs
@@ -5,7 +5,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
     public class ValueFormsTests : EndToEndTestBase
     {
         [Theory(DisplayName = nameof(ValueFormsTest))]
-        [InlineData("TestAssets.TemplateWithValueForms --foo Test.Value6", "TemplateWithValueForms.json")]
+        [InlineData("TestAssets.TemplateWithValueForms --foo Test.Value6 --param1 MyPascalTestValue --param2 myCamelTestValue --param3 \"my test text\"", "TemplateWithValueForms.json")]
         [InlineData("TestAssets.TemplateWithDerivedSymbolWithValueForms -n Test.AppSeven", "DerivedSymbolWithValueForms.json")]
         public void ValueFormsTest(string args, params string[] scripts)
         {

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseInvariantValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseInvariantValueFormTests.cs
@@ -4,17 +4,17 @@ using Xunit;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
 {
-    public class FirstUpperCaseValueFormTests
+    public class FirstLowerCaseInvariantValueFormTests
     {
         [Theory]
-        [InlineData("a", "A", null)]
-        [InlineData("no", "No", null)]
-        [InlineData("new", "New", null)]
+        [InlineData("A", "a", null)]
+        [InlineData("NO", "nO", null)]
+        [InlineData("NEW", "nEW", null)]
         [InlineData("", "", null)]
         [InlineData(null, null, null)]
-        [InlineData("indigo", "İndigo", "tr-TR")]
-        [InlineData("ındigo", "Indigo", "tr-TR")]
-        public void FirstUpperCaseWorksAsExpected(string input, string expected, string culture)
+        [InlineData("Indigo", "indigo", "tr-TR")]
+        [InlineData("İndigo", "İndigo", "tr-TR")]
+        public void FirstLowerCaseInvariantWorksAsExpected(string input, string expected, string culture)
         {
             if (!string.IsNullOrEmpty(culture))
             {
@@ -28,7 +28,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
                 }
             }
 
-            var model = new FirstUpperCaseValueFormModel();
+            var model = new FirstLowerCaseInvariantValueFormModel();
             string actual = model.Process(null, input);
             Assert.Equal(expected, actual);
         }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseValueFormTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
+using System.Globalization;
 using Xunit;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
@@ -6,13 +7,27 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
     public class FirstLowerCaseValueFormTests
     {
         [Theory]
-        [InlineData("A", "a")]
-        [InlineData("NO", "nO")]
-        [InlineData("NEW", "nEW")]
-        [InlineData("", "")]
-        [InlineData(null, null)]
-        public void FirstLowerCaseWorksAsExpected(string input, string expected)
+        [InlineData("A", "a", null)]
+        [InlineData("NO", "nO", null)]
+        [InlineData("NEW", "nEW", null)]
+        [InlineData("", "", null)]
+        [InlineData(null, null, null)]
+        [InlineData("İndigo", "indigo", "tr-TR")]
+        [InlineData("Indigo", "ındigo", "tr-TR")]
+        public void FirstLowerCaseWorksAsExpected(string input, string expected, string culture)
         {
+            if (!string.IsNullOrEmpty(culture))
+            {
+                if (culture == "invariant")
+                {
+                    CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+                }
+                else
+                {
+                    CultureInfo.CurrentCulture = new CultureInfo(culture);
+                }
+            }
+
             var model = new FirstLowerCaseValueFormModel();
             string actual = model.Process(null, input);
             Assert.Equal(expected, actual);

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseValueFormTests.cs
@@ -1,0 +1,21 @@
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
+{
+    public class FirstLowerCaseValueFormTests
+    {
+        [Theory]
+        [InlineData("A", "a")]
+        [InlineData("NO", "nO")]
+        [InlineData("NEW", "nEW")]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        public void FirstLowerCaseWorksAsExpected(string input, string expected)
+        {
+            var model = new FirstLowerCaseValueFormModel();
+            string actual = model.Process(null, input);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseInvariantValueFormModel.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseInvariantValueFormModel.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
 {
-    public class FirstUpperCaseValueFormTests
+    public class FirstUpperCaseInvariantValueFormTests
     {
         [Theory]
         [InlineData("a", "A", null)]
@@ -12,9 +12,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [InlineData("new", "New", null)]
         [InlineData("", "", null)]
         [InlineData(null, null, null)]
-        [InlineData("indigo", "İndigo", "tr-TR")]
-        [InlineData("ındigo", "Indigo", "tr-TR")]
-        public void FirstUpperCaseWorksAsExpected(string input, string expected, string culture)
+        [InlineData("indigo", "Indigo", "tr-TR")]
+        [InlineData("ındigo", "ındigo", "tr-TR")]
+        public void FirstUpperCaseInvariantWorksAsExpected(string input, string expected, string culture)
         {
             if (!string.IsNullOrEmpty(culture))
             {
@@ -27,8 +27,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
                     CultureInfo.CurrentCulture = new CultureInfo(culture);
                 }
             }
-
-            var model = new FirstUpperCaseValueFormModel();
+            var model = new FirstUpperCaseInvariantValueFormModel();
             string actual = model.Process(null, input);
             Assert.Equal(expected, actual);
         }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseValueFormTests.cs
@@ -1,0 +1,21 @@
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
+{
+    public class FirstUpperCaseValueFormTests
+    {
+        [Theory]
+        [InlineData("a", "A")]
+        [InlineData("no", "No")]
+        [InlineData("new", "New")]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        public void FirstUpperCaseWorksAsExpected(string input, string expected)
+        {
+            var model = new FirstUpperCaseValueFormModel();
+            string actual = model.Process(null, input);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/KebabCaseValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/KebabCaseValueFormTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
+{
+    public class KebabCaseValueFormTests
+    {
+        [Theory]
+        [InlineData("I", "i")]
+        [InlineData("IO", "io")]
+        [InlineData("FileIO", "file-io")]
+        [InlineData("SignalR", "signal-r")]
+        [InlineData("IOStream", "io-stream")]
+        [InlineData("COMObject", "com-object")]
+        [InlineData("WebAPI", "web-api")]
+        [InlineData("XProjectX", "x-project-x")]
+        [InlineData("NextXXXProject", "next-xxx-project")]
+        [InlineData("NoNewProject", "no-new-project")]
+        [InlineData("NONewProject", "no-new-project")]
+        [InlineData("NewProjectName", "new-project-name")]
+        [InlineData("ABBREVIATIONAndSomeName", "abbreviation-and-some-name")]
+        [InlineData("NoNoNoNoNoNoNoName", "no-no-no-no-no-no-no-name")]
+        [InlineData("AnotherNewNewNewNewNewProjectName", "another-new-new-new-new-new-project-name")]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+
+        public void KebabCaseWorksAsExpected(string input, string expected)
+        {
+            var model = new KebabCaseValueFormModel();
+            string actual = model.Process(null, input);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/KebabCaseValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/KebabCaseValueFormTests.cs
@@ -21,8 +21,19 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [InlineData("ABBREVIATIONAndSomeName", "abbreviation-and-some-name")]
         [InlineData("NoNoNoNoNoNoNoName", "no-no-no-no-no-no-no-name")]
         [InlineData("AnotherNewNewNewNewNewProjectName", "another-new-new-new-new-new-project-name")]
+        [InlineData("Param1TestValue", "param-1-test-value")]
+        [InlineData("Windows10", "windows-10")]
+        [InlineData("WindowsServer2016R2", "windows-server-2016-r-2")]
         [InlineData("", "")]
         [InlineData(null, null)]
+        [InlineData(";MyWord;", "my-word")]
+        [InlineData("My Word", "my-word")]
+        [InlineData("My    Word", "my-word")]
+        [InlineData(";;;;;", "")]
+        [InlineData ("       ", "")]
+        [InlineData("Simple TEXT_here", "simple-text-here")]
+        [InlineData("НоваяПеременная", "новая-переменная")]
+
 
         public void KebabCaseWorksAsExpected(string input, string expected)
         {

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/TitleCaseValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/TitleCaseValueFormTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [InlineData("project x", "Project X")]
         [InlineData("x project x", "X Project X")]
         [InlineData("new project name", "New Project Name")]
+        [InlineData("new-project%name", "New-Project%Name")]
         [InlineData("", "")]
         [InlineData(null, null)]
         public void TitleCaseWorksAsExpected(string input, string expected)

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/TitleCaseValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/TitleCaseValueFormTests.cs
@@ -1,0 +1,21 @@
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
+{
+    public class TitleCaseValueFormTests
+    {
+        [Theory]
+        [InlineData("project x", "Project X")]
+        [InlineData("x project x", "X Project X")]
+        [InlineData("new project name", "New Project Name")]
+        [InlineData("", "")]
+        [InlineData(null, null)]
+        public void TitleCaseWorksAsExpected(string input, string expected)
+        {
+            var model = new TitleCaseValueFormModel();
+            string actual = model.Process(null, input);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/.template.config/template.json
@@ -16,6 +16,33 @@
       "forms": {
         "global": [ "identity", "chained", "chained2", "dotToUnderscore" ]
       }
+    },
+    "param1": {
+      "type": "parameter",
+      "dataType": "string",
+      "replaces": "Param1TestValue",
+      "fileRename": "Param1TestValue",
+      "forms": {
+        "global": [ "identity", "first_lc", "kebab" ]
+      }
+    },
+    "param2": {
+      "type": "parameter",
+      "dataType": "string",
+      "replaces": "param2TestValue",
+      "fileRename": "param2TestValue",
+      "forms": {
+        "global": [ "identity", "first_uc" ]
+      }
+    },
+    "param3": {
+      "type": "parameter",
+      "dataType": "string",
+      "replaces": "param 3 test value",
+      "fileRename": "param 3 test value",
+      "forms": {
+        "global": [ "identity", "title" ]
+      }
     }
   },
   "forms": {
@@ -41,6 +68,18 @@
       "identifier": "replace",
       "pattern": "\\.",
       "replacement": "?"
+    },
+    "first_lc": {
+      "identifier": "firstLowerCaseInvariant"
+    },
+    "first_uc": {
+      "identifier": "firstUpperCaseInvariant"
+    },
+    "kebab": {
+      "identifier": "kebabCase"
+    },
+    "title": {
+      "identifier": "titleCase"
     }
   }
 }

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/FirstLetterCaseForms/Param2TestValue.cs
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/FirstLetterCaseForms/Param2TestValue.cs
@@ -1,0 +1,7 @@
+namespace Test
+{
+    class ContentReplacementTest
+    {
+        private string Param2TestValue;
+    }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/FirstLetterCaseForms/param1TestValue.cs
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/FirstLetterCaseForms/param1TestValue.cs
@@ -1,0 +1,7 @@
+namespace Test
+{
+    class ContentReplacementTest
+    {
+        private string param1TestValue;
+    }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/IdentityForms/Param1TestValue.cs
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/IdentityForms/Param1TestValue.cs
@@ -1,0 +1,7 @@
+namespace Test
+{
+    class ContentReplacementTest
+    {
+        private string Param1TestValue;
+    }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/IdentityForms/param 3 test value.cs
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/IdentityForms/param 3 test value.cs
@@ -1,0 +1,7 @@
+namespace Test
+{
+    class ContentReplacementTest
+    {
+        private string param3 = "param 3 test value";
+    }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/IdentityForms/param2TestValue.cs
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/IdentityForms/param2TestValue.cs
@@ -1,0 +1,7 @@
+namespace Test
+{
+    class ContentReplacementTest
+    {
+        private string param2TestValue;
+    }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/KebabCaseForms/param-1-test-value.cs
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/KebabCaseForms/param-1-test-value.cs
@@ -1,0 +1,7 @@
+namespace Test
+{
+    class ContentReplacementTest
+    {
+        private string param-1-test-value;
+    }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/TitleCaseForms/Param 3 Test Value.cs
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/TitleCaseForms/Param 3 Test Value.cs
@@ -1,0 +1,7 @@
+namespace Test
+{
+    class ContentReplacementTest
+    {
+        private string param3 = "Param 3 Test Value";
+    }
+}


### PR DESCRIPTION
I was not able to find a convenient way to transform `sourceName` to kebab-case nor camelCase even using `replace` with RegExp pattern. 
Additional value form identifiers:
* firstLowerCase
* firstUpperCase
* kebabCase
* titleCase

By a combination of these and `replace`, it will be also possible to convert any `sourceName` to camelCase, PascalCase and snake_case together with kebab-case and Title Case.

Should I also add the `*InvariantValueFormModel`s for each or should I extend their `JObject configuration`s with `bool isInvariant` property?


Just note, I tried hardly to come up with solution, but the best I was able to make kebab-case is following configuration (it fails in some edge cases covered by unit tests). I didn't find any way to do camelCase. Alternative way to resolve camelCase could be to implement `JoinValueForm` for joining strings.

```
  "forms": {
    "kebab": {
      "identifier": "replace",
      "pattern": "([a-zA-Z]{1,4})([A-Z]+)",
      "replacement": "$1-$2"
    },
    "lowerCase": {
      "identifier": "lowerCaseInvariant"
    },
    "kebabCase": {
      "identifier": "chain",
      "steps": [ "kebab", "lowerCase"]
    },
    "alternativeKebab": {
      "identifier": "replace",
      "pattern": "(?<!^)([A-Z][a-z]|(?<=[a-z])[A-Z])",
      "replacement": "-$1"
    }
 }
```