### PR TITLE
#2353 Add example of template invocation with --help option

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
@@ -65,6 +65,10 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 
             // show a help example
             Reporter.Output.WriteLine($"    dotnet {commandName} --help");
+
+            // show a help example for template
+            string preferredTemplateName = bestMatchedTemplates.First().Info.ShortName;
+            Reporter.Output.WriteLine($"    dotnet {commandName} {preferredTemplateName} --help");
         }
 
         private static bool GenerateUsageForTemplate(ITemplateInfo templateInfo, IHostSpecificDataLoader hostDataLoader, string commandName)


### PR DESCRIPTION
Fixes: dotnet/templating#2353: 

In case of running `dotnet new <template name> --help` and in case there is no exact match to show template help:
- template list for matching templates by name should be shown
- invocation examples should contain option `dotnet new <one of matched template names> --help`