### PR TITLE
#2342: when executing dotnet new --help do not show template list

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -22,6 +22,12 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 ShowUsageHelp(commandInput, telemetryLogger);
             }
 
+            //in case only --help option is specified we don't need to show templates list
+            if (commandInput.IsHelpFlagSpecified && string.IsNullOrEmpty(commandInput.TemplateName))
+            {
+                return CreationResultStatus.Success; 
+            }
+
             // in case list is specified we always need to list templates 
             if (commandInput.IsListFlagSpecified)
             {


### PR DESCRIPTION
fixes dotnet/templating#2342: when executing dotnet new --help do not show template list, only show the list of possible commands.
