### PR TITLE
Fix paths for post action 'Add project to a solution file'

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddProjectsToSolutionPostAction.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddProjectsToSolutionPostAction.cs
@@ -65,10 +65,10 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
         // If any indexes are out of range or non-numeric, thsi method returns false and projectFiles is set to null.
         internal static bool TryGetProjectFilesToAdd(IEngineEnvironmentSettings environment, IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath, out IReadOnlyList<string> projectFiles)
         {
+            List<string> filesToAdd = new List<string>();
+
             if ((actionConfig.Args != null) && actionConfig.Args.TryGetValue("primaryOutputIndexes", out string projectIndexes))
             {
-                List<string> filesToAdd = new List<string>();
-
                 foreach (string indexString in projectIndexes.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
                 {
                     if (int.TryParse(indexString.Trim(), out int index))
@@ -93,7 +93,12 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
             }
             else
             {
-                projectFiles = templateCreationResult.PrimaryOutputs.Select(x => x.Path).ToList();
+                foreach (string pathString in templateCreationResult.PrimaryOutputs.Select(x => x.Path))
+                {
+                    filesToAdd.Add(!string.IsNullOrEmpty(outputBasePath) ? Path.Combine(outputBasePath, pathString) : pathString);
+                }
+
+                projectFiles = filesToAdd;
                 return true;
             }
         }


### PR DESCRIPTION
Delivers issue #1991 (precisely [this comment](https://github.com/dotnet/templating/issues/1991#issuecomment-686299488)). 

The post-action "Add projects to a solution file" sometimes fails if the `-o` or `-n` option presents. The changes fix paths and add unit tests for non-empty `-o` option.