### PR TITLE
dotnet/templating#1661: updated help output for --list and --name:

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -937,7 +937,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Lists templates containing the specified name. If no name is specified, lists all templates..
+        ///   Looks up a localized string similar to Lists templates containing the specified template name. If no name is specified, lists all templates..
         /// </summary>
         public static string ListsTemplates {
             get {
@@ -1009,7 +1009,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The name for the output being created. If no name is specified, the name of the current directory is used..
+        ///   Looks up a localized string similar to The name for the output being created. If no name is specified, the name of the output directory is used..
         /// </summary>
         public static string NameOfOutput {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -244,7 +244,7 @@
     <value>Filters templates based on language and specifies the language of the template to create.</value>
   </data>
   <data name="ListsTemplates" xml:space="preserve">
-    <value>Lists templates containing the specified name. If no name is specified, lists all templates.</value>
+    <value>Lists templates containing the specified template name. If no name is specified, lists all templates.</value>
   </data>
   <data name="LocaleHelp" xml:space="preserve">
     <value>The locale to use.</value>
@@ -265,7 +265,7 @@
     <value>Multiple values specified for single value parameter: {0}.</value>
   </data>
   <data name="NameOfOutput" xml:space="preserve">
-    <value>The name for the output being created. If no name is specified, the name of the current directory is used.</value>
+    <value>The name for the output being created. If no name is specified, the name of the output directory is used.</value>
   </data>
   <data name="NoItems" xml:space="preserve">
     <value>(No Items)</value>


### PR DESCRIPTION
fixes dotnet/templating#1661: updated help output for --list and --name:
```
  -l, --list          Lists templates containing the specified template name. If no name is specified, lists all templates.
  -n, --name          The name for the output being created. If no name is specified, the name of the output directory is used.
```