### PR TITLE
Set GenerateDocumentationFile to true for F# libraries

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-FSharp/Company.ClassLibrary1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-FSharp/Company.ClassLibrary1.fsproj
@@ -4,6 +4,7 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net5.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ClassLibrary1</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This resolves https://github.com/dotnet/fsharp/issues/9162

It is necessary to set this to `true` for F# because C# can only read the F# XML doc comment information if there is a documentation file set.

For F# consumers, this property isn't important.