### PR TITLE
dotnet/templating #2503 #2014

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -287,7 +287,17 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         {
             foreach (string variant in VariantsForCanonical(canonical))
             {
-                if (_parseResult.Tokens.Any(s => s.Contains(variant)))
+                if (_parseResult.Tokens.Contains(variant))
+                {
+                    return variant;
+                }
+            }
+
+            // in case parameter is specified as --aaa=bbb, Tokens collection contains --aaa=bbb as single token
+            // in this case we need to check if token starts with variant=
+            foreach (string variant in VariantsForCanonical(canonical))
+            {
+                if (_parseResult.Tokens.Any(s => s.StartsWith($"{variant}=")))
                 {
                     return variant;
                 }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -287,7 +287,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         {
             foreach (string variant in VariantsForCanonical(canonical))
             {
-                if (_parseResult.Tokens.Contains(variant))
+                if (_parseResult.Tokens.Any(s => s.Contains(variant)))
                 {
                     return variant;
                 }

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
@@ -23,15 +23,19 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             }
 
             IReadOnlyList<ITemplateInfo> templateInfoList = templateGroup.Select(x => x.Info).ToList();
-            ShowTemplateDetailHeaders(templateInfoList);
-
             TemplateGroupParameterDetails? groupParameterDetails = DetermineParameterDispositionsForTemplateGroup(templateInfoList, environmentSettings, commandInput, hostDataLoader, templateCreator);
 
             if (groupParameterDetails != null)
             {
-                // get the input params valid for any param in the group
+                if (!string.IsNullOrEmpty(groupParameterDetails.Value.AdditionalInfo))
+                {
+                    Reporter.Error.WriteLine(groupParameterDetails.Value.AdditionalInfo.Bold().Red());
+                    Reporter.Output.WriteLine();
+                    return;
+                }
+                // get the input params valid for any param in the group              
                 IReadOnlyDictionary<string, string> inputTemplateParams = CoalesceInputParameterValuesFromTemplateGroup(templateGroup);
-
+                ShowTemplateDetailHeaders(templateInfoList);
                 ShowParameterHelp(inputTemplateParams, showImplicitlyHiddenParams, groupParameterDetails.Value, environmentSettings);
             }
             else
@@ -82,11 +86,6 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 
         private static void ShowParameterHelp(IReadOnlyDictionary<string, string> inputParams, bool showImplicitlyHiddenParams, TemplateGroupParameterDetails parameterDetails, IEngineEnvironmentSettings environmentSettings)
         {
-            if (!string.IsNullOrEmpty(parameterDetails.AdditionalInfo))
-            {
-                Reporter.Error.WriteLine(parameterDetails.AdditionalInfo.Bold().Red());
-                Reporter.Output.WriteLine();
-            }
 
             IEnumerable<ITemplateParameter> filteredParams = TemplateParameterHelpBase.FilterParamsForHelp(parameterDetails.AllParams.ParameterDefinitions, parameterDetails.ExplicitlyHiddenParams,
                                                                                     showImplicitlyHiddenParams, parameterDetails.HasPostActionScriptRunner, parameterDetails.ParametersToAlwaysShow);

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
@@ -30,7 +30,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 if (!string.IsNullOrEmpty(groupParameterDetails.Value.AdditionalInfo))
                 {
                     Reporter.Error.WriteLine(groupParameterDetails.Value.AdditionalInfo.Bold().Red());
-                    Reporter.Output.WriteLine();
+                    Reporter.Error.WriteLine();
                     return;
                 }
                 // get the input params valid for any param in the group              


### PR DESCRIPTION
fixes dotnet/templating #2503 dotnet/templating #2014:
- corrects error message when value provided for parameter is incorrect: it should show the input paramater as enterd by user and not canonical name
- when  when value provided for parameter is incorrect: do not show generic help and help for template, just error message