### PR TITLE
#2495 match templates for list by tags

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/ListOrHelpTemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/ListOrHelpTemplateListResolutionResult.cs
@@ -72,7 +72,11 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             {
                 if (_partiallyMatchedTemplates == null)
                 {
-                    _partiallyMatchedTemplates = _coreMatchedTemplates.Where(t => t.HasNameMatchOrPartialMatch() && t.HasAnyMismatch()).ToList();
+                    // TODO: clarify if collection should include matching by classification only.
+                    // At the moment defintion of partial match:
+                    // - has exact or partial match by name or short name or classification
+                    // - has mismatch in language, type or baseline
+                    _partiallyMatchedTemplates = _coreMatchedTemplates.Where(t => t.HasNameOrClassificationMatchOrPartialMatch() && t.HasAnyMismatch()).ToList();
                 }
                 return _partiallyMatchedTemplates;
             }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/ListOrHelpTemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/ListOrHelpTemplateListResolutionResult.cs
@@ -40,9 +40,17 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                     {
                         _exactMatchedTemplates = _coreMatchedTemplates.Where(t => t.IsInvokableMatch()).ToList();
                     }
-                    else
+                    else if (_coreMatchedTemplates.Where(t => t.IsMatch).Any())
                     {
                         _exactMatchedTemplates = _coreMatchedTemplates.Where(t => t.IsMatch).ToList();
+                    }
+                    // if there is no match try to match by classification (tag) and other filters ignoring name mismatch.
+                    // in case classification matches given template name in command these templates still to be shown in the list.
+                    // classfication matching is only done in case --list is specified in column, otherwise collection of match disposition doesn't have matchs on classification
+                    // TODO: when matching on tags is implemented via special parameter (--tags) keep IsMatch condition only
+                    else
+                    {
+                        _exactMatchedTemplates = _coreMatchedTemplates.Where(t => t.HasClassificationMatchAndNameMismatch()).ToList();
                     }
                 }
                 return _exactMatchedTemplates;

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateListResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateListResolver.cs
@@ -170,13 +170,14 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         {
             IReadOnlyList<FilterableTemplateInfo> filterableTemplateInfo = SetupFilterableTemplateInfoFromTemplateInfo(templateInfo);
 
+            // for list we also try to get match on template name in classification (tags). These matches only will be used if short name and name has a mismatch.
+            // filter below only sets the exact or partial match if name matches the tag. If name doesn't match the tag, no match disposition is added to collection.
             IReadOnlyList<ITemplateMatchInfo> coreMatchedTemplates = TemplateListFilter.GetTemplateMatchInfo
             (
                 filterableTemplateInfo,
                 TemplateListFilter.PartialMatchFilter,
                 WellKnownSearchFilters.NameFilter(commandInput.TemplateName),
-                //TODO: check if search for Classification is needed
-                //         WellKnownSearchFilters.ClassificationsFilter(commandInput.TemplateName),
+                WellKnownSearchFilters.ClassificationsFilter(commandInput.TemplateName),
                 WellKnownSearchFilters.LanguageFilter(commandInput.Language),
                 WellKnownSearchFilters.ContextFilter(commandInput.TypeFilter),
                 WellKnownSearchFilters.BaselineFilter(commandInput.BaselineName)
@@ -195,8 +196,6 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                 filterableTemplateInfo,
                 TemplateListFilter.PartialMatchFilter,
                 WellKnownSearchFilters.NameFilter(commandInput.TemplateName),
-                //TODO: check if search for Classification is needed
-                //         WellKnownSearchFilters.ClassificationsFilter(commandInput.TemplateName),
                 WellKnownSearchFilters.LanguageFilter(commandInput.Language),
                 WellKnownSearchFilters.ContextFilter(commandInput.TypeFilter),
                 WellKnownSearchFilters.BaselineFilter(commandInput.BaselineName)

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateMatchInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateMatchInfoExtensions.cs
@@ -200,7 +200,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             return hasOtherThanMismatch && hasContextMismatch;
         }
 
-        public static bool HasNameMatchOrPartialMatch(this ITemplateMatchInfo templateMatchInfo)
+        public static bool HasNameOrClassificationMatchOrPartialMatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any((x => (x.Location == MatchLocation.Name || x.Location == MatchLocation.ShortName || x.Location == MatchLocation.Classification) && (x.Kind == MatchKind.Exact || x.Kind == MatchKind.Partial)));
         }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateMatchInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateMatchInfoExtensions.cs
@@ -202,12 +202,52 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 
         public static bool HasNameMatchOrPartialMatch(this ITemplateMatchInfo templateMatchInfo)
         {
-            return templateMatchInfo.MatchDisposition.Any((x => (x.Location == MatchLocation.Name || x.Location == MatchLocation.ShortName) && (x.Kind == MatchKind.Exact || x.Kind == MatchKind.Partial)));
+            return templateMatchInfo.MatchDisposition.Any((x => (x.Location == MatchLocation.Name || x.Location == MatchLocation.ShortName || x.Location == MatchLocation.Classification) && (x.Kind == MatchKind.Exact || x.Kind == MatchKind.Partial)));
         }
 
         public static bool HasAnyMismatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(m => m.Kind == MatchKind.Mismatch);
+        }
+
+        public static bool HasClassificationMatchAndNameMismatch(this ITemplateMatchInfo templateMatchInfo)
+        {
+            if (templateMatchInfo.MatchDisposition.Count == 0)
+            {
+                return false;
+            }
+
+            bool hasNameMismatch = false;
+            bool hasClassificationMatch = false;
+
+            foreach (MatchInfo disposition in templateMatchInfo.MatchDisposition)
+            {
+                if (disposition.Location == MatchLocation.Name && disposition.Kind == MatchKind.Mismatch)
+                {
+                    hasNameMismatch = true;
+                }
+                else if (disposition.Location == MatchLocation.ShortName && disposition.Kind == MatchKind.Mismatch)
+                {
+                    hasNameMismatch = true;
+                }
+                else if (disposition.Location == MatchLocation.Classification)
+                {
+                    if (disposition.Kind == MatchKind.Exact || disposition.Kind == MatchKind.Partial)
+                    {
+                        hasClassificationMatch = true;
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                else if (disposition.Kind == MatchKind.Mismatch)
+                {
+                    return false;
+                }
+            }
+
+            return hasNameMismatch && hasClassificationMatch;
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateMatchInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateMatchInfoExtensions.cs
@@ -222,9 +222,17 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 
             foreach (MatchInfo disposition in templateMatchInfo.MatchDisposition)
             {
-                if (disposition.Location == MatchLocation.Name && disposition.Kind == MatchKind.Mismatch)
+                if (disposition.Location == MatchLocation.Name && disposition.Kind != MatchKind.Mismatch)
+                {
+                    return false;
+                }
+                else if (disposition.Location == MatchLocation.Name && disposition.Kind == MatchKind.Mismatch)
                 {
                     hasNameMismatch = true;
+                }
+                else if (disposition.Location == MatchLocation.ShortName && disposition.Kind != MatchKind.Mismatch)
+                {
+                    return false;
                 }
                 else if (disposition.Location == MatchLocation.ShortName && disposition.Kind == MatchKind.Mismatch)
                 {

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/HelpTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/HelpTemplateListResolverTests.cs
@@ -986,5 +986,46 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             Assert.Equal(0, invalidForSomeTemplates.Count);
             Assert.Equal(1, invalidForAllTemplates.Count);
         }
+
+        [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_MatchByTagsIgnoredForHelp))]
+        public void TestGetTemplateResolutionResult_MatchByTagsIgnoredForHelp()
+        {
+            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "console",
+                Name = "Long name for Console App",
+                Identity = "Console.App.T1",
+                GroupIdentity = "Console.App.Test",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+                Classifications = new List<string> { "Common", "Test" },
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
+                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
+                },
+                BaselineInfo = new Dictionary<string, IBaselineInfo>()
+                {
+                    { "app", new BaselineInfo() },
+                    { "standard", new BaselineInfo() }
+                }
+            });
+
+
+            INewCommandInput userInputs = new MockNewCommandInput()
+            {
+                TemplateName = "Common",
+                IsHelpFlagSpecified = true,
+            };
+
+            ListOrHelpTemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            Assert.False(matchResult.HasExactMatches);
+            Assert.False(matchResult.HasPartialMatches);
+            Assert.Equal(0, matchResult.ExactMatchedTemplatesGrouped.Count);
+            Assert.Equal(0, matchResult.ExactMatchedTemplates.Count);
+            Assert.False(matchResult.HasLanguageMismatch);
+            Assert.False(matchResult.HasContextMismatch);
+            Assert.False(matchResult.HasBaselineMismatch);
+        }
     }
 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
@@ -530,5 +530,216 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             Assert.False(matchResult.HasUnambiguousTemplateGroup);
             Assert.Equal(0, matchResult.UnambiguousTemplateGroup.Count);
         }
+
+
+
+        [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_MatchByTags))]
+        public void TestGetTemplateResolutionResult_MatchByTags()
+        {
+            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "console",
+                Name = "Long name for Console App",
+                Identity = "Console.App.T1",
+                GroupIdentity = "Console.App.Test",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+                Classifications = new List <string> {  "Common", "Test" },
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
+                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
+                },
+                BaselineInfo = new Dictionary<string, IBaselineInfo>()
+                {
+                    { "app", new BaselineInfo() },
+                    { "standard", new BaselineInfo() }
+                }
+            });
+
+
+            INewCommandInput userInputs = new MockNewCommandInput()
+            {
+                TemplateName = "Common",
+                IsListFlagSpecified = true,
+            };
+
+            ListOrHelpTemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            Assert.True(matchResult.HasExactMatches);
+            Assert.Equal(1, matchResult.ExactMatchedTemplatesGrouped.Count);
+            Assert.Equal(1, matchResult.ExactMatchedTemplates.Count);
+            Assert.False(matchResult.HasLanguageMismatch);
+            Assert.False(matchResult.HasContextMismatch);
+            Assert.False(matchResult.HasBaselineMismatch);
+        }
+
+        [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_MatchByTagsIgnoredOnNameMatch))]
+        public void TestGetTemplateResolutionResult_MatchByTagsIgnoredOnNameMatch()
+        {
+            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "console1",
+                Name = "Long name for Console App Test",
+                Identity = "Console.App.T1",
+                GroupIdentity = "Console.App.Test",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+                Classifications = new List<string> { "Common", "Test" },
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
+                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
+                },
+                BaselineInfo = new Dictionary<string, IBaselineInfo>()
+                {
+                    { "app", new BaselineInfo() },
+                    { "standard", new BaselineInfo() }
+                }
+            });
+
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "console2",
+                Name = "Long name for Console App",
+                Identity = "Console.App.T2",
+                GroupIdentity = "Console.App.Test2",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+                Classifications = new List<string> { "Common", "Test" },
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
+                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
+                },
+                BaselineInfo = new Dictionary<string, IBaselineInfo>()
+                {
+                    { "app", new BaselineInfo() },
+                    { "standard", new BaselineInfo() }
+                }
+            });
+
+
+            INewCommandInput userInputs = new MockNewCommandInput()
+            {
+                TemplateName = "Test",
+                IsListFlagSpecified = true,
+            };
+
+            ListOrHelpTemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            Assert.True(matchResult.HasExactMatches);
+            Assert.Equal(1, matchResult.ExactMatchedTemplatesGrouped.Count);
+            Assert.Equal(1, matchResult.ExactMatchedTemplates.Count);
+            Assert.False(matchResult.HasLanguageMismatch);
+            Assert.False(matchResult.HasContextMismatch);
+            Assert.False(matchResult.HasBaselineMismatch);
+            Assert.Equal("console1", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
+            Assert.Equal("Console.App.T1", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
+        }
+
+        [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_MatchByTagsIgnoredOnShortNameMatch))]
+        public void TestGetTemplateResolutionResult_MatchByTagsIgnoredOnShortNameMatch()
+        {
+            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "console",
+                Name = "Long name for Console App Test",
+                Identity = "Console.App.T1",
+                GroupIdentity = "Console.App.Test",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+                Classifications = new List<string> { "Common", "Test", "Console" },
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
+                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
+                },
+                BaselineInfo = new Dictionary<string, IBaselineInfo>()
+                {
+                    { "app", new BaselineInfo() },
+                    { "standard", new BaselineInfo() }
+                }
+            });
+
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "cons",
+                Name = "Long name for Cons App",
+                Identity = "Console.App.T2",
+                GroupIdentity = "Console.App.Test2",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+                Classifications = new List<string> { "Common", "Test", "Console" },
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
+                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
+                },
+                BaselineInfo = new Dictionary<string, IBaselineInfo>()
+                {
+                    { "app", new BaselineInfo() },
+                    { "standard", new BaselineInfo() }
+                }
+            });
+
+
+            INewCommandInput userInputs = new MockNewCommandInput()
+            {
+                TemplateName = "Console",
+                IsListFlagSpecified = true,
+            };
+
+            ListOrHelpTemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            Assert.True(matchResult.HasExactMatches);
+            Assert.Equal(1, matchResult.ExactMatchedTemplatesGrouped.Count);
+            Assert.Equal(1, matchResult.ExactMatchedTemplates.Count);
+            Assert.False(matchResult.HasLanguageMismatch);
+            Assert.False(matchResult.HasContextMismatch);
+            Assert.False(matchResult.HasBaselineMismatch);
+            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
+            Assert.Equal("Console.App.T1", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
+        }
+
+        [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_MatchByTagsAndMismatchByFilter))]
+        public void TestGetTemplateResolutionResult_MatchByTagsAndMismatchByFilter()
+        {
+            List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
+            templatesToSearch.Add(new TemplateInfo()
+            {
+                ShortName = "console",
+                Name = "Long name for Console App",
+                Identity = "Console.App.T1",
+                GroupIdentity = "Console.App.Test",
+                CacheParameters = new Dictionary<string, ICacheParameter>(),
+                Classifications = new List<string> { "Common", "Test" },
+                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
+                {
+                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
+                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
+                },
+                BaselineInfo = new Dictionary<string, IBaselineInfo>()
+                {
+                    { "app", new BaselineInfo() },
+                    { "standard", new BaselineInfo() }
+                }
+            });
+
+
+            INewCommandInput userInputs = new MockNewCommandInput()
+            {
+                TemplateName = "Common",
+                IsListFlagSpecified = true,
+                Language = "L2",
+                TypeFilter = "item",
+            };
+
+            ListOrHelpTemplateListResolutionResult matchResult = TemplateListResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            Assert.False(matchResult.HasExactMatches);
+            Assert.Equal(0, matchResult.ExactMatchedTemplatesGrouped.Count);
+            Assert.Equal(0, matchResult.ExactMatchedTemplates.Count);
+            Assert.True(matchResult.HasPartialMatches);
+            Assert.Equal(1, matchResult.PartiallyMatchedTemplates.Count);
+            Assert.Equal(1, matchResult.PartiallyMatchedTemplatesGrouped.Count);
+            Assert.True(matchResult.HasLanguageMismatch);
+            Assert.True(matchResult.HasContextMismatch);
+            Assert.False(matchResult.HasBaselineMismatch);
+        }
     }
 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateMatchInfoExtensionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateMatchInfoExtensionTests.cs
@@ -1,0 +1,235 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Cli.TemplateResolution;
+using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.Edge.Template;
+using Microsoft.TemplateEngine.Utils;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
+{
+    public class TemplateMatchInfoExtensionTests
+    {
+
+        [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_ShortNameMismatchAndClassificationExact))]
+        public void TestHasClassificationMatchAndNameMismatch_ShortNameMismatchAndClassificationExact()
+        {
+            List<MatchInfo> testDisposiions = new List<MatchInfo>();
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.ShortName,
+                Kind = MatchKind.Mismatch
+            });
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Classification,
+                Kind = MatchKind.Exact
+            });
+
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
+            {
+                Name = "Template1",
+                Identity = "Template1",
+                GroupIdentity = "TestGroup"
+            }, testDisposiions);
+
+            Assert.True(testTemplate.HasClassificationMatchAndNameMismatch());
+        }
+
+        [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_NameMismatchAndClassificationExact))]
+        public void TestHasClassificationMatchAndNameMismatch_NameMismatchAndClassificationExact()
+        {
+            List<MatchInfo> testDisposiions = new List<MatchInfo>();
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Name,
+                Kind = MatchKind.Mismatch
+            });
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Classification,
+                Kind = MatchKind.Exact
+            });
+
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
+            {
+                Name = "Template1",
+                Identity = "Template1",
+                GroupIdentity = "TestGroup"
+            }, testDisposiions);
+
+            Assert.True(testTemplate.HasClassificationMatchAndNameMismatch());
+        }
+
+        [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_NameMismatchAndClassificationPartial))]
+        public void TestHasClassificationMatchAndNameMismatch_NameMismatchAndClassificationPartial()
+        {
+            List<MatchInfo> testDisposiions = new List<MatchInfo>();
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Name,
+                Kind = MatchKind.Mismatch
+            });
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Classification,
+                Kind = MatchKind.Partial
+            });
+
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
+            {
+                Name = "Template1",
+                Identity = "Template1",
+                GroupIdentity = "TestGroup"
+            }, testDisposiions);
+
+            Assert.True(testTemplate.HasClassificationMatchAndNameMismatch());
+        }
+
+        [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_NameExactAndClassificationPartial))]
+        public void TestHasClassificationMatchAndNameMismatch_NameExactAndClassificationPartial()
+        {
+            List<MatchInfo> testDisposiions = new List<MatchInfo>();
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Name,
+                Kind = MatchKind.Exact
+            });
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Classification,
+                Kind = MatchKind.Partial
+            });
+
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
+            {
+                Name = "Template1",
+                Identity = "Template1",
+                GroupIdentity = "TestGroup"
+            }, testDisposiions);
+
+            Assert.False(testTemplate.HasClassificationMatchAndNameMismatch());
+        }
+
+        [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_ShortNameExactAndClassificationPartial))]
+        public void TestHasClassificationMatchAndNameMismatch_ShortNameExactAndClassificationPartial()
+        {
+            List<MatchInfo> testDisposiions = new List<MatchInfo>();
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.ShortName,
+                Kind = MatchKind.Exact
+            });
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Classification,
+                Kind = MatchKind.Partial
+            });
+
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
+            {
+                Name = "Template1",
+                Identity = "Template1",
+                GroupIdentity = "TestGroup"
+            }, testDisposiions);
+
+            Assert.False(testTemplate.HasClassificationMatchAndNameMismatch());
+        }
+
+        [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_ShortNameExactNameMismatchAndClassificationPartial))]
+        public void TestHasClassificationMatchAndNameMismatch_ShortNameExactNameMismatchAndClassificationPartial()
+        {
+            List<MatchInfo> testDisposiions = new List<MatchInfo>();
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.ShortName,
+                Kind = MatchKind.Exact
+            });
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Name,
+                Kind = MatchKind.Mismatch
+            });
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Classification,
+                Kind = MatchKind.Partial
+            });
+
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
+            {
+                Name = "Template1",
+                Identity = "Template1",
+                GroupIdentity = "TestGroup"
+            }, testDisposiions);
+
+            Assert.False(testTemplate.HasClassificationMatchAndNameMismatch());
+        }
+
+        [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_NameMismatchClassificationPartialLanguageMismatch))]
+        public void TestHasClassificationMatchAndNameMismatch_NameMismatchClassificationPartialLanguageMismatch()
+        {
+            List<MatchInfo> testDisposiions = new List<MatchInfo>();
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Name,
+                Kind = MatchKind.Mismatch
+            });
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Classification,
+                Kind = MatchKind.Partial
+            });
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Language,
+                Kind = MatchKind.Mismatch
+            });
+
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
+            {
+                Name = "Template1",
+                Identity = "Template1",
+                GroupIdentity = "TestGroup"
+            }, testDisposiions);
+
+            Assert.False(testTemplate.HasClassificationMatchAndNameMismatch());
+        }
+
+        [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_NameMismatchClassificationPartialOtherStartsWith))]
+        public void TestHasClassificationMatchAndNameMismatch_NameMismatchClassificationPartialOtherStartsWith()
+        {
+            List<MatchInfo> testDisposiions = new List<MatchInfo>();
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Name,
+                Kind = MatchKind.Mismatch
+            });
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.Classification,
+                Kind = MatchKind.Partial
+            });
+            testDisposiions.Add(new MatchInfo()
+            {
+                Location = MatchLocation.OtherParameter,
+                Kind = MatchKind.SingleStartsWith
+            });
+
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
+            {
+                Name = "Template1",
+                Identity = "Template1",
+                GroupIdentity = "TestGroup"
+            }, testDisposiions);
+
+            Assert.True(testTemplate.HasClassificationMatchAndNameMismatch());
+        }
+    }
+}


### PR DESCRIPTION
fixes dotnet / templating #2495
list shows also the templates matched by tags in case:
- template name given in CLI exactly matches tag (classification)
- there no match for this template name (exact or partial) in name or short name