### PR TITLE
#2397 Removed reference to invalid link from error message.

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1306,8 +1306,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Run dotnet {0} --help for usage information.
-        ///See https://aka.ms/dotnet-install-templates to learn how to install additional template packs..
+        ///   Looks up a localized string similar to Run dotnet {0} --help for usage information..
         /// </summary>
         public static string RunHelpForInformationAboutAcceptedParameters {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -322,8 +322,7 @@
     <value>Rerun the command and pass --force to accept and create.</value>
   </data>
   <data name="RunHelpForInformationAboutAcceptedParameters" xml:space="preserve">
-    <value>Run dotnet {0} --help for usage information.
-See https://aka.ms/dotnet-install-templates to learn how to install additional template packs.</value>
+    <value>Run dotnet {0} --help for usage information.</value>
   </data>
   <data name="ShortName" xml:space="preserve">
     <value>Short Name</value>


### PR DESCRIPTION
fixes dotnet/templating#2397
Removed reference to invalid link from error message.