### PR TITLE
[release/5.0-rc2] Update target frameworks to supported versions

### DIFF
--- a/src/Microsoft.TemplateSearch.ScraperOutputComparison/Microsoft.TemplateSearch.ScraperOutputComparison.csproj
+++ b/src/Microsoft.TemplateSearch.ScraperOutputComparison/Microsoft.TemplateSearch.ScraperOutputComparison.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
   </PropertyGroup>

--- a/tools/ComparisonCleanup/ComparisonCleanup.csproj
+++ b/tools/ComparisonCleanup/ComparisonCleanup.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
netcoreapp2.0 and 3.0 are out of support, and newer SDK versions will show warnings when targeting them.