### PR TITLE
set culture to invariant to avoid culture ambiguity in processing doubles

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -71,6 +72,9 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 _defaultLanguage = null;
             }
+
+            //currently only invariant culture is supported in templates
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
         }
 
         internal static Installer Installer { get; set; }


### PR DESCRIPTION
(temporary) fixes dotnet/templating #2073  fixes dotnet/templating#2436 set culture to invariant to avoid culture ambiguity

We have several issues reported when working with templates in different cultures:
#2073
#2436
https://github.com/dotnet/templating/issues/2433

The issue affects processing doubles, as different cultures have different numbers separators: thus if template was written in en-US culture, and features doubles with "." separator, launching same template in locale with "," separator won't work / won't work correctly. 

The full solution was recently discussed and summarized in https://github.com/dotnet/templating/issues/2542, however needs adding new configuration and potentially larger amount of work. 

This PR offers a workaround of setting culture to invariant for processing templates. The templates are required to be written in invariant culture in order to work correctly, the parameter values should be also given in invariant culture.

@KathleenDollard @donJoseLuis there are couple of alternatives to move forward:

**Option 1: (fix with new feature)**
We prioritize https://github.com/dotnet/templating/issues/2542 (potentially 1.5 - 2 weeks of work) and do solid fix and configuration adjustment to replace this PR and do not merge this PR with workaround.

**Option 2: (go with workaround)**
We merge this PR with workaround for now, and keep https://github.com/dotnet/templating/issues/2542 for later.

**Option 3: (do nothing)**
We do not merge this PR with workaround, and keep https://github.com/dotnet/templating/issues/2542 for later.
Therefore deprioritizing #2073 and #2436 from template authoring  high prio backlog.


