### PR TITLE
Normalize primary outputs

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationPathModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationPathModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
@@ -22,7 +23,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             {
                 ICreationPathModel pathModel = new CreationPathModel()
                 {
-                    PathOriginal = pathInfo.ToString("path"),
+                    PathOriginal = pathInfo.ToString("path").NormalizePath(),
                     Condition = pathInfo.ToString("condition")
                 };
 

--- a/src/Microsoft.TemplateEngine.Utils/FileSystemInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Utils/FileSystemInfoExtensions.cs
@@ -27,6 +27,11 @@ namespace Microsoft.TemplateEngine.Utils
             }
         }
 
+        public static string NormalizePath(this string path)
+        {
+            return path.Replace('\\', '/');
+        }
+
         public static string CombinePaths(this string basePath, params string[] paths)
         {
             Stack<string> partStack = new Stack<string>();


### PR DESCRIPTION
Delivers issue #2068.

Renaming of primary outputs does not work if backslashes are used. The changes normalize primary outputs paths from template.json.