### PR TITLE
updates to build

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,7 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Opt out of certain Arcade features -->
   <PropertyGroup>
-    <MicrosoftNETCoreAppVersion>3.0.0-preview6-27720-09</MicrosoftNETCoreAppVersion>
     <UsingToolXliff>false</UsingToolXliff>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <VersionPrefix>6.0.0</VersionPrefix>

--- a/global.json
+++ b/global.json
@@ -3,8 +3,7 @@
     "dotnet": "5.0.100-rc.1.20452.10",
     "runtimes": {
       "dotnet": [
-        "2.1.7",
-        "$(MicrosoftNETCoreAppVersion)"
+        "2.1.7"
       ]
     }
   },

--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -3,6 +3,7 @@
         <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <Description>Template creation for the dotnet CLI</Description>
         <IsPackable>true</IsPackable>
+		<IsShipping>false</IsShipping>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
+++ b/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
@@ -3,6 +3,7 @@
         <TargetFrameworks Condition="'$(PackSpecific)' != 'true'">netstandard2.0;net45</TargetFrameworks>
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">netstandard2.0</TargetFrameworks>
         <IsPackable>true</IsPackable>
+		<IsShipping>false</IsShipping>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
marked Microsoft.TemplateEngine.Cli and Microsoft.TemplateEngine.Mocks as non-shipping. Microsoft.TemplateEngine.Cli cannot be shipped at the moment as CommandLine library is not shipped.

Removed MicrosoftNETCoreAppVersion property from Versions.props and global.json as template engine doesn't depend on .NET Core version at them moment