### PR TITLE
Use UseShellExecute=false for chmod process

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/ChmodPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/ChmodPostActionProcessor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
                     {
                         RedirectStandardError = false,
                         RedirectStandardOutput = false,
-                        UseShellExecute = true,
+                        UseShellExecute = false,
                         CreateNoWindow = false,
                         WorkingDirectory = outputBasePath,
                         FileName = "/bin/sh",


### PR DESCRIPTION
Delivers issue #2072. 
Related to PR #1555 and issue #1547.

The chmod post-action got broken because `UseShellExecute` option of `System.Diagnostics.Process.Start` changed its meaning from "run /bin/sh" to "run xdg-open" on Linux (and "run open" on Mac OS). 
PR #1555 partially fixed the problem, but it is needed also to switch the `UseShellExecute` from true to false and refuse to use this unstable option to completely fix the problem.