### PR TITLE
Fixing help message for boolean parameter of a template

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -653,7 +653,18 @@ namespace Microsoft.TemplateEngine.Cli {
                 return ResourceManager.GetString("DefaultValue", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Default if option is provided without a value: {0}.
+        /// </summary>
+        public static string DefaultIfOptionWithoutValue
+        {
+            get
+            {
+                return ResourceManager.GetString("DefaultIfOptionWithoutValue", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Default: {0} / (*) {1}.
         /// </summary>

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -604,6 +604,9 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="DefaultValuePlusSwitchWithoutValueDefault" xml:space="preserve">
     <value>Default: {0} / (*) {1}</value>
   </data>
+  <data name="DefaultIfOptionWithoutValue" xml:space="preserve">
+    <value>Default if option is provided without a value: {0}</value>
+  </data>
   <data name="SwitchWithoutValueDefaultFootnote" xml:space="preserve">
     <value>* Indicates the value used if the switch is provided without a value.</value>
   </data>


### PR DESCRIPTION
Fixes issue #2492. 

The help message for defaults of a parameter is changed.