### PR TITLE
added additional choices for framework symbol for console and classlib project

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ClassLibrary-CSharp/.template.config/template.json
@@ -47,6 +47,10 @@
           "description": "Target netcoreapp3.1"
         },
         {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
+        },
+        {
           "choice": "netstandard2.1",
           "description": "Target netstandard2.1"
         },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ClassLibrary-FSharp/.template.config/template.json
@@ -47,6 +47,10 @@
           "description": "Target netcoreapp3.1"
         },
         {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
+        },
+        {
           "choice": "netstandard2.1",
           "description": "Target netstandard2.1"
         },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -47,6 +47,10 @@
           "description": "Target netcoreapp3.1"
         },
         {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
+        },
+        {
           "choice": "netstandard2.1",
           "description": "Target netstandard2.1"
         },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -31,6 +31,10 @@
         {
           "choice": "netcoreapp3.1",
           "description": "Target netcoreapp3.1"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
         }
       ],
       "replaces": "netcoreapp3.1",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ConsoleApplication-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ConsoleApplication-FSharp/.template.config/template.json
@@ -31,6 +31,10 @@
         {
           "choice": "netcoreapp3.1",
           "description": "Target netcoreapp3.1"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
         }
       ],
       "replaces": "netcoreapp3.1",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ConsoleApplication-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ConsoleApplication-VisualBasic/.template.config/template.json
@@ -31,6 +31,10 @@
         {
           "choice": "netcoreapp3.1",
           "description": "Target netcoreapp3.1"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
         }
       ],
       "replaces": "netcoreapp3.1",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -47,6 +47,14 @@
           "description": "Target net5.0"
         },
         {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
+        },
+        {
           "choice": "netstandard2.1",
           "description": "Target netstandard2.1"
         },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-FSharp/.template.config/template.json
@@ -47,6 +47,14 @@
           "description": "Target net5.0"
         },
         {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
+        },
+        {
           "choice": "netstandard2.1",
           "description": "Target netstandard2.1"
         },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -47,6 +47,14 @@
           "description": "Target net5.0"
         },
         {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
+        },
+        {
           "choice": "netstandard2.1",
           "description": "Target netstandard2.1"
         },

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -31,6 +31,14 @@
         {
           "choice": "net5.0",
           "description": "Target net5.0"
+        },
+        {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
         }
       ],
       "replaces": "net5.0",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ConsoleApplication-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ConsoleApplication-FSharp/.template.config/template.json
@@ -31,6 +31,14 @@
         {
           "choice": "net5.0",
           "description": "Target net5.0"
+        },
+        {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
         }
       ],
       "replaces": "net5.0",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ConsoleApplication-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ConsoleApplication-VisualBasic/.template.config/template.json
@@ -31,6 +31,14 @@
         {
           "choice": "net5.0",
           "description": "Target net5.0"
+        },
+        {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
         }
       ],
       "replaces": "net5.0",


### PR DESCRIPTION
The following choices are used for framework:

|version|template|framework|baselines|
|-|-|-|-|
|Microsoft.DotNet.Common.ProjectTemplates.2.1|classlib|netcoreapp2.1, netstandard2.0 (default)|app:netcoreapp2.1, standard:netstandard2.0|
|Microsoft.DotNet.Common.ProjectTemplates.2.1|console|netcoreapp2.1 (default)|-|
|Microsoft.DotNet.Common.ProjectTemplates.3.1|classlib|netcorapp3.1, **netcoreapp2.1**, netstandard2.1, netstandard2.0 (default)|app:netcoreapp3.1, standard:netstandard2.0|
|Microsoft.DotNet.Common.ProjectTemplates.3.1|console|netcorapp3.1 (default), **netcoreapp2.1**|-|
|Microsoft.DotNet.Common.ProjectTemplates.5.0|classlib|net5.0(default), **netcorapp3.1, netcoreapp2.1**, netstandard2.1, netstandard2.0|app:net5.0, standard:netstandard2.0|
|Microsoft.DotNet.Common.ProjectTemplates.5.0|console|net5.0(default), **netcorapp3.1, netcoreapp2.1**|-|

Added values are in **bold**
Other versions were not modified