### PR TITLE
-removed "other" as possible value of type parameter.

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1433,7 +1433,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Filters templates based on available types. Predefined values are &quot;project&quot;, &quot;item&quot; or &quot;other&quot;..
+        ///   Looks up a localized string similar to Filters templates based on available types. Predefined values are &quot;project&quot; and &quot;item&quot;..
         /// </summary>
         public static string ShowsFilteredTemplates {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -331,7 +331,7 @@
     <value>Shows all templates.</value>
   </data>
   <data name="ShowsFilteredTemplates" xml:space="preserve">
-    <value>Filters templates based on available types. Predefined values are "project", "item" or "other".</value>
+    <value>Filters templates based on available types. Predefined values are "project" and "item".</value>
   </data>
   <data name="Tags" xml:space="preserve">
     <value>Tags</value>

--- a/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
@@ -82,10 +82,6 @@ namespace Microsoft.TemplateEngine.Edge.Template
                     {
                         return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Exact };
                     }
-                    else if (string.Equals(context, "other", StringComparison.OrdinalIgnoreCase) && !typeTag.ChoicesAndDescriptions.ContainsKey("project") && !typeTag.ChoicesAndDescriptions.ContainsKey("item"))
-                    {
-                        return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Exact };
-                    }
                     else
                     {
                         return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Mismatch };

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateListResolverTests.cs
@@ -152,9 +152,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             Assert.Equal(1, itemTemplates.Count);
             Assert.True(itemTemplates.Where(x => string.Equals(x.Info.Identity, "Template2", StringComparison.Ordinal)).Any());
 
+            //Visual Studio only supports "project" and "item", so using other types is no longer allowed, therefore "other" handling is removed.
+            //support of match on custom type still remains
             IReadOnlyCollection<ITemplateMatchInfo> otherTemplates = TemplateListResolver.PerformAllTemplatesInContextQuery(templatesToSearch, hostDataLoader, "other");
-            Assert.Equal(1, otherTemplates.Count);
-            Assert.True(otherTemplates.Where(x => string.Equals(x.Info.Identity, "Template3", StringComparison.Ordinal)).Any());
+            Assert.Equal(0, otherTemplates.Count);
+            Assert.False(otherTemplates.Where(x => string.Equals(x.Info.Identity, "Template3", StringComparison.Ordinal)).Any());
+
+            IReadOnlyCollection<ITemplateMatchInfo> customTypeTemplates = TemplateListResolver.PerformAllTemplatesInContextQuery(templatesToSearch, hostDataLoader, "myType");
+            Assert.Equal(1, customTypeTemplates.Count);
+            Assert.True(customTypeTemplates.Where(x => string.Equals(x.Info.Identity, "Template3", StringComparison.Ordinal)).Any());
         }
 
         [Fact(DisplayName = nameof(TestPerformCoreTemplateQuery_UniqueNameMatchesCorrectly))]


### PR DESCRIPTION
as of https://github.com/dotnet/templating/pull/2599 the only possible values for type are "project" and "item"
removed "other" as possible value of type parameter from help reference and in code.