### PR TITLE
User can specify columns to show in the list. Supported columns: language, type, author, tags

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/AliasSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/AliasSupport.cs
@@ -185,12 +185,13 @@ namespace Microsoft.TemplateEngine.Cli
             HelpFormatter<KeyValuePair<string, IReadOnlyList<string>>> formatter =
                 new HelpFormatter<KeyValuePair<string, IReadOnlyList<string>>>(
                     environment,
+                    commandInput,
                     aliasesToShow,
                     columnPadding: 2,
                     headerSeparator: '-',
                     blankLineBetweenRows: false)
-                .DefineColumn(t => t.Key, LocalizableStrings.AliasName)
-                .DefineColumn(t => string.Join(" ", t.Value), LocalizableStrings.AliasValue);
+                .DefineColumn(t => t.Key, LocalizableStrings.AliasName, showAlways: true)
+                .DefineColumn(t => string.Join(" ", t.Value), LocalizableStrings.AliasValue, showAlways: true);
 
             Reporter.Output.WriteLine(formatter.Layout());
             return CreationResultStatus.Success;

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -143,7 +143,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                     Create.Option("--update-apply", LocalizableStrings.UpdateApplyCommandHelp, Accept.NoArguments()),
                     Create.Option("--columns", LocalizableStrings.OptionDescriptionColumns, Accept.ExactlyOneArgument().With(LocalizableStrings.OptionDescriptionColumns, "COLUMNS_LIST"))
                 };
-            }           
+            }
         }
 
         private static Option[] NewCommandHiddenArgs

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -143,7 +143,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                     Create.Option("--update-apply", LocalizableStrings.UpdateApplyCommandHelp, Accept.NoArguments()),
                     Create.Option("--columns", LocalizableStrings.OptionDescriptionColumns, Accept.ExactlyOneArgument().With(LocalizableStrings.OptionDescriptionColumns, "COLUMNS_LIST"))
                 };
-            
+            }           
         }
 
         private static Option[] NewCommandHiddenArgs

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -141,9 +141,9 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                                         // don't give this a default, otherwise 'new -lang' is valid and assigns the default. User should have to explicitly give the value.
                     Create.Option("--update-check", LocalizableStrings.UpdateCheckCommandHelp, Accept.NoArguments()),
                     Create.Option("--update-apply", LocalizableStrings.UpdateApplyCommandHelp, Accept.NoArguments()),
-                    Create.Option("--columns", LocalizableStrings.OptionDescriptionColumns, Accept.ExactlyOneArgument().With(LocalizableStrings.OptionDescriptionColumns, "<COLUMNS_LIST>"))
+                    Create.Option("--columns", LocalizableStrings.OptionDescriptionColumns, Accept.ExactlyOneArgument().With(LocalizableStrings.OptionDescriptionColumns, "COLUMNS_LIST"))
                 };
-            }
+            
         }
 
         private static Option[] NewCommandHiddenArgs

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -141,6 +141,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                                         // don't give this a default, otherwise 'new -lang' is valid and assigns the default. User should have to explicitly give the value.
                     Create.Option("--update-check", LocalizableStrings.UpdateCheckCommandHelp, Accept.NoArguments()),
                     Create.Option("--update-apply", LocalizableStrings.UpdateApplyCommandHelp, Accept.NoArguments()),
+                    Create.Option("--columns", LocalizableStrings.OptionDescriptionColumns, Accept.ExactlyOneArgument().With(LocalizableStrings.OptionDescriptionColumns, "<COLUMNS_LIST>"))
                 };
             }
         }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
@@ -93,5 +93,11 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         void ResetArgs(params string[] args);
 
         bool ExpandedExtraArgsFiles { get; }
+
+        IReadOnlyCollection<string> Columns { get; }
+
+        bool HasColumnsParseError { get; }
+
+        string ColumnsParseError { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         private readonly string _commandName;
 
         internal static string[] SupportedFilterableColumnNames = new[]
-{
+        {
             AuthorColumnFilter,
             TypeColumnFilter,
             LanguageColumnFilter,
@@ -287,7 +287,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         {
             get
             {
-                List<string> invalidColumns = new List<string>();
+                List<string> invalidColumns = new List<string>(Columns.Count);
                 foreach (string columnToShow in Columns)
                 {
                     if (!SupportedFilterableColumnNames.Contains(columnToShow))

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -25,6 +25,19 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         private readonly Command _noTemplateCommand;
         private readonly string _commandName;
 
+        internal static string[] SupportedFilterableColumnNames = new[]
+{
+            AuthorColumnFilter,
+            TypeColumnFilter,
+            LanguageColumnFilter,
+            TagsColumnFilter
+        };
+
+        internal const string AuthorColumnFilter = "author";
+        internal const string TypeColumnFilter = "type";
+        internal const string LanguageColumnFilter = "language";
+        internal const string TagsColumnFilter = "tags";
+
         public NewCommandInputCli(string commandName)
         {
             _commandName = commandName;
@@ -37,7 +50,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         {
             get
             {
-                return _parseResult.Errors.Any();
+                return _parseResult.Errors.Any() || HasColumnsParseError;
             }
         }
 
@@ -251,6 +264,47 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         public bool CheckForUpdates => _parseResult.HasAppliedOption(new[] { _commandName, "update-check" });
 
         public bool CheckForUpdatesNoPrompt => _parseResult.HasAppliedOption(new[] { _commandName, "update-apply" });
+
+        public IReadOnlyCollection<string> Columns
+        {
+            get
+            {
+                string columnNames = _parseResult.GetArgumentValueAtPath(new[] { _commandName, "columns" });
+                if (!string.IsNullOrWhiteSpace(columnNames))
+                {
+                    return columnNames.Split(',').Select(s => s.Trim()).ToList();
+                }
+                else
+                {
+                    return new List<string>();
+                }
+            }
+        }
+
+        public bool HasColumnsParseError => Columns.Any(column => !SupportedFilterableColumnNames.Contains(column));
+
+        public string ColumnsParseError
+        {
+            get
+            {
+                List<string> invalidColumns = new List<string>();
+                foreach (string columnToShow in Columns)
+                {
+                    if (!SupportedFilterableColumnNames.Contains(columnToShow))
+                    {
+                        invalidColumns.Add(columnToShow);
+                    }
+                }
+                if (invalidColumns.Any())
+                {
+                    return string.Format(
+                         LocalizableStrings.ColumnNamesAreNotSupported,
+                         string.Join(", ", invalidColumns.Select(s => $"'{s}'")),
+                         string.Join(", ", SupportedFilterableColumnNames.Select(s => $"'{s}'")));
+                }
+                return string.Empty;
+            }
+        }
 
         public string AllowScriptsToRun
         {

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
@@ -36,7 +36,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 // get the input params valid for any param in the group              
                 IReadOnlyDictionary<string, string> inputTemplateParams = CoalesceInputParameterValuesFromTemplateGroup(templateGroup);
                 ShowTemplateDetailHeaders(templateInfoList);
-                ShowParameterHelp(inputTemplateParams, showImplicitlyHiddenParams, groupParameterDetails.Value, environmentSettings);
+                ShowParameterHelp(inputTemplateParams, showImplicitlyHiddenParams, groupParameterDetails.Value, environmentSettings, commandInput);
             }
             else
             {
@@ -84,7 +84,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             }
         }
 
-        private static void ShowParameterHelp(IReadOnlyDictionary<string, string> inputParams, bool showImplicitlyHiddenParams, TemplateGroupParameterDetails parameterDetails, IEngineEnvironmentSettings environmentSettings)
+        private static void ShowParameterHelp(IReadOnlyDictionary<string, string> inputParams, bool showImplicitlyHiddenParams, TemplateGroupParameterDetails parameterDetails, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput)
         {
 
             IEnumerable<ITemplateParameter> filteredParams = TemplateParameterHelpBase.FilterParamsForHelp(parameterDetails.AllParams.ParameterDefinitions, parameterDetails.ExplicitlyHiddenParams,
@@ -92,7 +92,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 
             if (filteredParams.Any())
             {
-                HelpFormatter<ITemplateParameter> formatter = new HelpFormatter<ITemplateParameter>(environmentSettings, filteredParams, 2, null, true);
+                HelpFormatter<ITemplateParameter> formatter = new HelpFormatter<ITemplateParameter>(environmentSettings, commandInput, filteredParams, 2, null, true);
 
                 formatter.DefineColumn(
                     param =>

--- a/src/Microsoft.TemplateEngine.Cli/HelpFormatter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpFormatter.cs
@@ -43,7 +43,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         public HelpFormatter<T> DefineColumn(Func<T, string> binder,  string header = null, string columnName = null, bool shrinkIfNeeded = false, int minWidth = 2, bool showAlways = false, bool defaultColumn = true)
         {
-            return DefineColumn(binder, out object c,  header, columnName, minWidth, shrinkIfNeeded, showAlways, defaultColumn);
+            return DefineColumn(binder, out object c,  header, columnName, shrinkIfNeeded, minWidth, showAlways, defaultColumn);
         }
 
         public HelpFormatter<T> DefineColumn(Func<T, string> binder, out object column, string header = null, string columnName = null, bool shrinkIfNeeded = false, int minWidth = 2, bool showAlways = false, bool defaultColumn = true)

--- a/src/Microsoft.TemplateEngine.Cli/HelpFormatter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpFormatter.cs
@@ -4,16 +4,18 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Cli.CommandParsing;
 
 namespace Microsoft.TemplateEngine.Cli
 {
     public class HelpFormatter
     {
-        public static HelpFormatter<T> For<T>(IEngineEnvironmentSettings environmentSettings, IEnumerable<T> rows, int columnPadding, char? headerSeparator = null, bool blankLineBetweenRows = false)
+        public static HelpFormatter<T> For<T>(IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IEnumerable<T> rows, int columnPadding, char? headerSeparator = null, bool blankLineBetweenRows = false)
         {
-            return new HelpFormatter<T>(environmentSettings, rows, columnPadding, headerSeparator, blankLineBetweenRows);
+            return new HelpFormatter<T>(environmentSettings, commandInput, rows, columnPadding, headerSeparator, blankLineBetweenRows);
         }
     }
 
@@ -27,27 +29,32 @@ namespace Microsoft.TemplateEngine.Cli
         private readonly List<Tuple<int, bool, IComparer<string>>> _ordering = new List<Tuple<int, bool, IComparer<string>>>();
         private readonly IEngineEnvironmentSettings _environmentSettings;
         private const string ShrinkReplacement = "...";
+        private readonly INewCommandInput _commandInput;
 
-        public HelpFormatter(IEngineEnvironmentSettings environmentSettings, IEnumerable<T> rows, int columnPadding, char? headerSeparator, bool blankLineBetweenRows)
+        public HelpFormatter(IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IEnumerable<T> rows, int columnPadding, char? headerSeparator, bool blankLineBetweenRows)
         {
             _rowDataItems = rows ?? Enumerable.Empty<T>();
             _columnPadding = columnPadding;
             _headerSeparator = headerSeparator;
             _blankLineBetweenRows = blankLineBetweenRows;
             _environmentSettings = environmentSettings;
+            _commandInput = commandInput;
         }
 
-        public HelpFormatter<T> DefineColumn(Func<T, string> binder, string header = null, bool shrinkIfNeeded = false, int minWidth = 2)
+        public HelpFormatter<T> DefineColumn(Func<T, string> binder,  string header = null, string columnName = null, bool shrinkIfNeeded = false, int minWidth = 2, bool showAlways = false, bool defaultColumn = true)
         {
-            _columns.Add(new ColumnDefinition(_environmentSettings, header, binder, shrinkIfNeeded: shrinkIfNeeded, minWidth: minWidth));
-            return this;
+            return DefineColumn(binder, out object c,  header, columnName, minWidth, shrinkIfNeeded, showAlways, defaultColumn);
         }
 
-        public HelpFormatter<T> DefineColumn(Func<T, string> binder, out object column, string header = null, bool shrinkIfNeeded = false, int minWidth = 2)
+        public HelpFormatter<T> DefineColumn(Func<T, string> binder, out object column, string header = null, string columnName = null, bool shrinkIfNeeded = false, int minWidth = 2, bool showAlways = false, bool defaultColumn = true)
         {
-            ColumnDefinition c = new ColumnDefinition(_environmentSettings, header, binder, shrinkIfNeeded: shrinkIfNeeded, minWidth: minWidth);
-            _columns.Add(c);
-            column = c;
+            column = null;
+            if ((_commandInput.Columns.Count == 0  && defaultColumn) || showAlways || (!string.IsNullOrWhiteSpace(columnName) && _commandInput.Columns.Contains(columnName)))
+            {
+                ColumnDefinition c = new ColumnDefinition(_environmentSettings, header, binder, shrinkIfNeeded: shrinkIfNeeded, minWidth: minWidth);
+                _columns.Add(c);
+                column = c;
+            }
             return this;
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -509,6 +509,33 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Author.
+        /// </summary>
+        public static string ColumnNameAuthor {
+            get {
+                return ResourceManager.GetString("ColumnNameAuthor", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The column {0} is/are not supported, the supported columns are: {1}..
+        /// </summary>
+        public static string ColumnNamesAreNotSupported {
+            get {
+                return ResourceManager.GetString("ColumnNamesAreNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type.
+        /// </summary>
+        public static string ColumnNameType {
+            get {
+                return ResourceManager.GetString("ColumnNameType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Template Instantiation Commands for .NET Core CLI.
         /// </summary>
         public static string CommandDescription {
@@ -1125,6 +1152,21 @@ namespace Microsoft.TemplateEngine.Cli {
         public static string OptionalWorkloadsSynchronized {
             get {
                 return ResourceManager.GetString("OptionalWorkloadsSynchronized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specifies which output columns to print for --list or -l option.  The supported columns are: 
+        ///- language - displays comma separated list of languages supported by the template
+        ///- tags - displays the list of template tags
+        ///- author - displays the template author
+        ///- type - displays the template type: project or item
+        ///The template name and short name are shown always.
+        ///The default list of columns shown without the option: template name, short name, language, tags..
+        /// </summary>
+        public static string OptionDescriptionColumns {
+            get {
+                return ResourceManager.GetString("OptionDescriptionColumns", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1156,13 +1156,13 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies which output columns to print for --list or -l option.  The supported columns are: 
+        ///   Looks up a localized string similar to Comma separated list of columns to show for --list or -l option.  The supported columns are: 
         ///- language - displays comma separated list of languages supported by the template
         ///- tags - displays the list of template tags
         ///- author - displays the template author
         ///- type - displays the template type: project or item
         ///The template name and short name are shown always.
-        ///The default list of columns shown without the option: template name, short name, language, tags..
+        ///The default list of columns shown without the option: template name, short name, language, tags; equivalent to --columns=language,tags..
         /// </summary>
         public static string OptionDescriptionColumns {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -695,12 +695,12 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
     <value>Type</value>
   </data>
   <data name="OptionDescriptionColumns" xml:space="preserve">
-    <value>Specifies which output columns to print for --list or -l option.  The supported columns are: 
+    <value>Comma separated list of columns to show for --list or -l option.  The supported columns are: 
 - language - displays comma separated list of languages supported by the template
 - tags - displays the list of template tags
 - author - displays the template author
 - type - displays the template type: project or item
 The template name and short name are shown always.
-The default list of columns shown without the option: template name, short name, language, tags.</value>
+The default list of columns shown without the option: template name, short name, language, tags; equivalent to --columns=language,tags.</value>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -685,4 +685,22 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="ListTemplatesCommand" xml:space="preserve">
     <value>To list installed templates, run 'dotnet new --list'.</value>
   </data>
+  <data name="ColumnNameAuthor" xml:space="preserve">
+    <value>Author</value>
+  </data>
+  <data name="ColumnNamesAreNotSupported" xml:space="preserve">
+    <value>The column {0} is/are not supported, the supported columns are: {1}.</value>
+  </data>
+  <data name="ColumnNameType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="OptionDescriptionColumns" xml:space="preserve">
+    <value>Specifies which output columns to print for --list or -l option.  The supported columns are: 
+- language - displays comma separated list of languages supported by the template
+- tags - displays the list of template tags
+- author - displays the template author
+- type - displays the template type: project or item
+The template name and short name are shown always.
+The default list of columns shown without the option: template name, short name, language, tags.</value>
+  </data>
 </root>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -198,7 +198,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
             throw new NotImplementedException();
         }
 
-        public IReadOnlyCollection<string> Columns { get; set; }
+        public IReadOnlyCollection<string> Columns { get; set; } = new List<string>();
 
         public bool HasColumnsParseError => throw new NotImplementedException();
 

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -197,5 +197,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
         {
             throw new NotImplementedException();
         }
+
+        public IReadOnlyCollection<string> Columns { get; set; }
+
+        public bool HasColumnsParseError => throw new NotImplementedException();
+
+        public string ColumnsParseError => throw new NotImplementedException();
     }
 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/HelpFormatterTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/HelpFormatterTests.cs
@@ -4,6 +4,8 @@ using Xunit;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Mocks;
 using Microsoft.TemplateEngine.TestHelper;
+using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
 {
@@ -28,6 +30,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
                 }
             };
 
+            INewCommandInput command = new MockNewCommandInput();
+
             IEnumerable<Tuple<string, string>> data = new List<Tuple<string, string>>()
             {
                 new Tuple<string, string>("My test data", "My test data"),
@@ -40,6 +44,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
              HelpFormatter
                  .For(
                      environmentSettings,
+                     command,
                      data,
                      columnPadding: 2,
                      headerSeparator: '-',
@@ -70,6 +75,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
                 }
             };
 
+            INewCommandInput command = new MockNewCommandInput();
+
             IEnumerable<Tuple<string, string>> data = new List<Tuple<string, string>>()
             {
                 new Tuple<string, string>("My test data", "My test data"),
@@ -82,6 +89,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
              HelpFormatter
                  .For(
                      environmentSettings,
+                     command,
                      data,
                      columnPadding: 2,
                      headerSeparator: '-',
@@ -113,6 +121,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
                 }
             };
 
+            INewCommandInput command = new MockNewCommandInput();
+
             IEnumerable<Tuple<string, string>> data = new List<Tuple<string, string>>()
             {
                 new Tuple<string, string>("My test data", "My test data"),
@@ -125,12 +135,108 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
              HelpFormatter
                  .For(
                      environmentSettings,
+                     command,
                      data,
                      columnPadding: 2,
                      headerSeparator: '-',
                      blankLineBetweenRows: false)
                  .DefineColumn(t => t.Item1, "Column 1", shrinkIfNeeded: true, minWidth: 15)
                  .DefineColumn(t => t.Item2, "Column 2", shrinkIfNeeded: true, minWidth: 8);
+
+            string result = formatter.Layout();
+            Assert.Equal(expectedOutput, result);
+        }
+
+        [Fact(DisplayName = nameof(CanShowDefaultColumns))]
+        public void CanShowDefaultColumns()
+        {
+            ITemplateEngineHost host = new TestHost
+            {
+                HostIdentifier = "TestRunner",
+                Version = "1.0.0.0",
+                Locale = "en-US"
+            };
+
+            IEngineEnvironmentSettings environmentSettings = new MockEngineEnvironmentSettings()
+            {
+                Host = host,
+                Environment = new MockEnvironment()
+                {
+                    ConsoleBufferWidth = 100
+                }
+            };
+
+            INewCommandInput command = new MockNewCommandInput();
+
+            IEnumerable<Tuple<string, string, string>> data = new List<Tuple<string, string, string>>()
+            {
+                new Tuple<string, string, string>("My test data", "My test data", "Column 3 data"),
+                new Tuple<string, string, string>("My test data", "My test data", "Column 3 data")
+            };
+
+            string expectedOutput = $"Column 1      Column 2    {Environment.NewLine}------------  ------------{Environment.NewLine}My test data  My test data{Environment.NewLine}My test data  My test data{Environment.NewLine}";
+
+            HelpFormatter<Tuple<string, string, string>> formatter =
+             HelpFormatter
+                 .For(
+                     environmentSettings,
+                     command,
+                     data,
+                     columnPadding: 2,
+                     headerSeparator: '-',
+                     blankLineBetweenRows: false)
+                 .DefineColumn(t => t.Item1, "Column 1", showAlways: true)
+                 .DefineColumn(t => t.Item2, "Column 2", columnName: "column2")  //defaultColumn: true by default
+                 .DefineColumn(t => t.Item3, "Column 3", columnName: "column3", defaultColumn: false);
+
+            string result = formatter.Layout();
+            Assert.Equal(expectedOutput, result);
+        }
+
+        [Fact(DisplayName = nameof(CanShowUserSelectedColumns))]
+        public void CanShowUserSelectedColumns()
+        {
+            ITemplateEngineHost host = new TestHost
+            {
+                HostIdentifier = "TestRunner",
+                Version = "1.0.0.0",
+                Locale = "en-US"
+            };
+
+            IEngineEnvironmentSettings environmentSettings = new MockEngineEnvironmentSettings()
+            {
+                Host = host,
+                Environment = new MockEnvironment()
+                {
+                    ConsoleBufferWidth = 100
+                }
+            };
+
+            INewCommandInput command = new MockNewCommandInput()
+            {
+                Columns = new List<string>() { "column3" }
+            };
+
+            IEnumerable<Tuple<string, string, string>> data = new List<Tuple<string, string, string>>()
+            {
+                new Tuple<string, string, string>("My test data", "My test data", "Column 3 data"),
+                new Tuple<string, string, string>("My test data", "My test data", "Column 3 data")
+            };
+
+            string expectedOutput = $"Column 1      Column 3     {Environment.NewLine}------------  -------------{Environment.NewLine}My test data  Column 3 data{Environment.NewLine}My test data  Column 3 data{Environment.NewLine}";
+
+            HelpFormatter<Tuple<string, string, string>> formatter =
+             HelpFormatter
+                 .For(
+                     environmentSettings,
+                     command,
+                     data,
+                     columnPadding: 2,
+                     headerSeparator: '-',
+                     blankLineBetweenRows: false)
+                 .DefineColumn(t => t.Item1, "Column 1", showAlways: true)
+                 .DefineColumn(t => t.Item2, "Column 2", columnName: "column2")  //defaultColumn: true by default
+                 .DefineColumn(t => t.Item3, "Column 3", columnName: "column3", defaultColumn: false);
 
             string result = formatter.Layout();
             Assert.Equal(expectedOutput, result);


### PR DESCRIPTION
Implemented: 
- support for INewCommandInput to parse columns to show in the table
- support for HelpFormatter<T> to filter columns to show using information from INewCommandInput

Added:
- ability to show type and template author for list. By default these columns are not shown but user can opt to show it using --columns option.

fixes https://github.com/dotnet/templating/issues/2470
required for https://github.com/dotnet/templating/issues/2571