### PR TITLE
add total downloads count to template search cache file

### DIFF
--- a/src/Microsoft.TemplateSearch.Common/FileMetadataTemplateSearchCacheReader.cs
+++ b/src/Microsoft.TemplateSearch.Common/FileMetadataTemplateSearchCacheReader.cs
@@ -116,6 +116,11 @@ namespace Microsoft.TemplateSearch.Common
                             }
 
                             workingPackToTemplateMap[packName] = new PackToTemplateEntry(version, templatesInPack);
+                            if (entryValue.TryGetValue(nameof(PackToTemplateEntry.TotalDownloads), out JToken totalDownloadsToken)
+                                && long.TryParse(totalDownloadsToken.Value<string>(), out long totalDownloads))
+                            {
+                                workingPackToTemplateMap[packName].TotalDownloads = totalDownloads;
+                            }
                         }
                     }
                 }

--- a/src/Microsoft.TemplateSearch.Common/PackInfo.cs
+++ b/src/Microsoft.TemplateSearch.Common/PackInfo.cs
@@ -13,9 +13,19 @@ namespace Microsoft.TemplateSearch.Common
             Version = version;
         }
 
+        public PackInfo(string name, string version, long totalDownloads)
+        {
+            Name = name;
+            Version = version;
+            TotalDownloads = totalDownloads;
+        }
+
         public string Name { get; }
 
         public string Version { get; }
+
+        public long TotalDownloads { get; }
+
     }
 
     public class PackInfoEqualityComparer : IEqualityComparer<PackInfo>

--- a/src/Microsoft.TemplateSearch.Common/PackToTemplateEntry.cs
+++ b/src/Microsoft.TemplateSearch.Common/PackToTemplateEntry.cs
@@ -12,6 +12,8 @@ namespace Microsoft.TemplateSearch.Common
 
         public string Version { get; }
 
+        public long TotalDownloads { get; set; }
+
         public IReadOnlyList<TemplateIdentificationEntry> TemplateIdentificationEntry { get; }
     }
 }

--- a/src/Microsoft.TemplateSearch.Common/TemplateToPackMap.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateToPackMap.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TemplateSearch.Common
 
             foreach (KeyValuePair<string, PackToTemplateEntry> entry in templateDictionary)
             {
-                PackInfo packAndVersion = new PackInfo(entry.Key, entry.Value.Version);
+                PackInfo packAndVersion = new PackInfo(entry.Key, entry.Value.Version, entry.Value.TotalDownloads);
 
                 foreach (TemplateIdentificationEntry templateIdentityInfo in entry.Value.TemplateIdentificationEntry)
                 {

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackInfo.cs
@@ -11,5 +11,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
         public string Version { get; set; }
 
         public string Path { get; set; }
+
+        public long TotalDownloads { get; set; }
     }
 }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
@@ -73,7 +73,9 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
                                             VersionedPackageIdentity = sourceInfo.VersionedPackageIdentity,
                                             Id = sourceInfo.Id,
                                             Version = sourceInfo.Version,
-                                            Path = packageFilePath
+                                            Path = packageFilePath,
+                                            TotalDownloads = sourceInfo.TotalDownloads
+                                            
                                         };
 
                                         yield return packInfo;

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/UnifiedPackCheckResultReportWriter.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/UnifiedPackCheckResultReportWriter.cs
@@ -6,6 +6,7 @@ using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateSearch.Common;
 using Microsoft.TemplateSearch.TemplateDiscovery.AdditionalData;
+using Microsoft.TemplateSearch.TemplateDiscovery.Nuget;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking.Reporting;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -68,8 +69,19 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Results
             Dictionary<string, PackToTemplateEntry> packToTemplateMap = packSourceCheckResults.PackCheckData
                             .Where(r => r.AnyTemplates)
                             .ToDictionary(r => r.PackInfo.Id,
-                                        r => new PackToTemplateEntry(r.PackInfo.Version, r.FoundTemplates.Select(t => new TemplateIdentificationEntry(t.Identity, t.GroupIdentity))
-                                        .ToList()));
+                                        r =>
+                                        {
+                                            PackToTemplateEntry packToTemplateEntry = new PackToTemplateEntry(
+                                                    r.PackInfo.Version,
+                                                    r.FoundTemplates.Select(t => new TemplateIdentificationEntry(t.Identity, t.GroupIdentity)).ToList());
+
+                                            if (r.PackInfo is NugetPackInfo npi)
+                                            {
+                                                packToTemplateEntry.TotalDownloads = npi.TotalDownloads;
+                                            }
+                                            return packToTemplateEntry;
+                                        });
+
 
             Dictionary<string, object> additionalData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
https://github.com/dotnet/templating/issues/2571 

For --search option we need to show the total # of downloads for certain package, so we need to store this information in template search cache file 

(to be implemented in other PR together with --search feature)
The count will be shown as:
- <empty> when no information about downloads
- <1k for 0-999 downloads
- <N>k for 1000-999999 downloads
- <N>m for 1m+ downloads