### PR TITLE
Place version for Microsoft.DotNet.TemplateLocator in eng/Versions.props

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,6 +10,7 @@
         <PackageReference Update="System.Runtime.Loader" Version="4.3.0" />
 
         <PackageReference Update="Microsoft.DotNet.Cli.CommandLine" Version="$(MicrosoftDotNetCliCommandLinePackageVersion)" />
+        <PackageReference Update="Microsoft.DotNet.TemplateLocator" Version="$(MicrosoftDotNetTemplateLocatorPackageVersion)" />
         <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.8.0" />
         <PackageReference Update="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
         <PackageReference Update="xunit" Version="2.3.1" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,5 +10,6 @@
     <PackSpecific Condition="'$(OS)' != 'Windows_NT'">true</PackSpecific>
     <NewtonsoftJsonPackageVersion>11.0.1</NewtonsoftJsonPackageVersion>
     <MicrosoftDotNetCliCommandLinePackageVersion>1.0.0-preview.19208.1</MicrosoftDotNetCliCommandLinePackageVersion>
+    <MicrosoftDotNetTemplateLocatorPackageVersion>5.0.100-rc.1.20421.19</MicrosoftDotNetTemplateLocatorPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -19,7 +19,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.DotNet.Cli.CommandLine" />
-        <PackageReference Include="Microsoft.DotNet.TemplateLocator" Version="5.0.100-rc.1.20421.19" />
+        <PackageReference Include="Microsoft.DotNet.TemplateLocator" />
         <PackageReference Include="System.Diagnostics.Process" />
         <PackageReference Include="Newtonsoft.Json" />
     </ItemGroup>


### PR DESCRIPTION
Perhaps we should be using arcade and `Version.Details.xml` to follow the package version from the dotnet/sdk repo?