### PR TITLE
Expected input for y/n is no longer part of localization string

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -673,6 +673,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Default if option is provided without a value: {0}.
+        /// </summary>
+        public static string DefaultIfOptionWithoutValue {
+            get {
+                return ResourceManager.GetString("DefaultIfOptionWithoutValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Default: {0}.
         /// </summary>
         public static string DefaultValue {
@@ -680,18 +689,7 @@ namespace Microsoft.TemplateEngine.Cli {
                 return ResourceManager.GetString("DefaultValue", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Default if option is provided without a value: {0}.
-        /// </summary>
-        public static string DefaultIfOptionWithoutValue
-        {
-            get
-            {
-                return ResourceManager.GetString("DefaultIfOptionWithoutValue", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Default: {0} / (*) {1}.
         /// </summary>
@@ -1297,7 +1295,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid input &quot;{0}&quot;. Please enter one of (Y|N)..
+        ///   Looks up a localized string similar to Invalid input &quot;{0}&quot;. Please enter one of [{1}(yes)|{2}(no)]..
         /// </summary>
         public static string PostActionInvalidInputRePrompt {
             get {
@@ -1315,7 +1313,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Do you want to run this action (Y|N)?.
+        ///   Looks up a localized string similar to Do you want to run this action [{0}(yes)|{1}(no)]?.
         /// </summary>
         public static string PostActionPromptRequest {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -395,13 +395,13 @@
     <value>Running command '{0}'...</value>
   </data>
   <data name="PostActionInvalidInputRePrompt" xml:space="preserve">
-    <value>Invalid input "{0}". Please enter one of (Y|N).</value>
+    <value>Invalid input "{0}". Please enter one of [{1}(yes)|{2}(no)].</value>
   </data>
   <data name="PostActionPromptHeader" xml:space="preserve">
     <value>Template is configured to run the following action:</value>
   </data>
   <data name="PostActionPromptRequest" xml:space="preserve">
-    <value>Do you want to run this action (Y|N)?</value>
+    <value>Do you want to run this action [{0}(yes)|{1}(no)]?</value>
   </data>
   <data name="ProcessingPostActions" xml:space="preserve">
     <value>Processing post-creation actions...</value>

--- a/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
@@ -129,25 +129,28 @@ namespace Microsoft.TemplateEngine.Cli
 
         private bool AskUserIfActionShouldRun(IPostAction action, Func<string> inputGetter)
         {
+            const string YesAnswer = "Y";
+            const string NoAnswer = "N";
+
             Reporter.Output.WriteLine(LocalizableStrings.PostActionPromptHeader);
             DisplayInstructionsForAction(action);
 
-            Reporter.Output.WriteLine(LocalizableStrings.PostActionPromptRequest);
+            Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostActionPromptRequest, YesAnswer, NoAnswer));
 
             do
             {
                 string input = inputGetter();
 
-                if (input.Equals("Y", StringComparison.OrdinalIgnoreCase))
+                if (input.Equals(YesAnswer, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }
-                else if (input.Equals("N", StringComparison.OrdinalIgnoreCase))
+                else if (input.Equals(NoAnswer, StringComparison.OrdinalIgnoreCase))
                 {
                     return false;
                 }
 
-                Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostActionInvalidInputRePrompt, input));
+                Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostActionInvalidInputRePrompt, input, YesAnswer, NoAnswer));
             } while (true);
         }
 


### PR DESCRIPTION
fixes dotnet/templating#1638: expected input for y/n is no longer part of localization string