### PR TITLE
--columns-all option

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -141,7 +141,8 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                                         // don't give this a default, otherwise 'new -lang' is valid and assigns the default. User should have to explicitly give the value.
                     Create.Option("--update-check", LocalizableStrings.UpdateCheckCommandHelp, Accept.NoArguments()),
                     Create.Option("--update-apply", LocalizableStrings.UpdateApplyCommandHelp, Accept.NoArguments()),
-                    Create.Option("--columns", LocalizableStrings.OptionDescriptionColumns, Accept.ExactlyOneArgument().With(LocalizableStrings.OptionDescriptionColumns, "COLUMNS_LIST"))
+                    Create.Option("--columns", LocalizableStrings.OptionDescriptionColumns, Accept.ExactlyOneArgument().With(LocalizableStrings.OptionDescriptionColumns, "COLUMNS_LIST")),
+                    Create.Option("--columns-all", LocalizableStrings.OptionDescriptionColumnsAll, Accept.NoArguments())
                 };
             }
         }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
@@ -99,5 +99,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         bool HasColumnsParseError { get; }
 
         string ColumnsParseError { get; }
+
+        bool ShowAllColumns { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -283,6 +283,8 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         public bool HasColumnsParseError => Columns.Any(column => !SupportedFilterableColumnNames.Contains(column));
 
+        public bool ShowAllColumns => _parseResult.HasAppliedOption(new[] { _commandName, "columns-all" });
+
         public string ColumnsParseError
         {
             get

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -211,11 +211,11 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                         columnPadding: 2,
                         headerSeparator: '-',
                         blankLineBetweenRows: false)
-                    .DefineColumn(t => t.Name, LocalizableStrings.Templates, shrinkIfNeeded: true, minWidth:25, showAlways: true)
+                    .DefineColumn(t => t.Name, LocalizableStrings.Templates, shrinkIfNeeded: true, minWidth:15, showAlways: true)
                     .DefineColumn(t => t.ShortName, LocalizableStrings.ShortName, showAlways: true)
                     .DefineColumn(t => t.Languages, out object languageColumn,  LocalizableStrings.Language, NewCommandInputCli.LanguageColumnFilter, defaultColumn: true)
                     .DefineColumn(t => t.Type, LocalizableStrings.ColumnNameType, NewCommandInputCli.TypeColumnFilter, defaultColumn: false)
-                    .DefineColumn(t => t.Author,  LocalizableStrings.ColumnNameAuthor, NewCommandInputCli.AuthorColumnFilter, defaultColumn: false)
+                    .DefineColumn(t => t.Author,  LocalizableStrings.ColumnNameAuthor, NewCommandInputCli.AuthorColumnFilter, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)
                     .DefineColumn(t => t.Classifications, out object tagsColumn, LocalizableStrings.Tags, NewCommandInputCli.TagsColumnFilter, defaultColumn: true)
 
                     .OrderByDescending(languageColumn, new NullOrEmptyIsLastStringComparer())

--- a/src/Microsoft.TemplateEngine.Cli/HelpFormatter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpFormatter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.TemplateEngine.Cli
         public HelpFormatter<T> DefineColumn(Func<T, string> binder, out object column, string header = null, string columnName = null, bool shrinkIfNeeded = false, int minWidth = 2, bool showAlways = false, bool defaultColumn = true)
         {
             column = null;
-            if ((_commandInput.Columns.Count == 0  && defaultColumn) || showAlways || (!string.IsNullOrWhiteSpace(columnName) && _commandInput.Columns.Contains(columnName)))
+            if ((_commandInput.Columns.Count == 0  && defaultColumn) || showAlways || (!string.IsNullOrWhiteSpace(columnName) && _commandInput.Columns.Contains(columnName)) || _commandInput.ShowAllColumns)
             {
                 ColumnDefinition c = new ColumnDefinition(_environmentSettings, header, binder, shrinkIfNeeded: shrinkIfNeeded, minWidth: minWidth);
                 _columns.Add(c);

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -673,6 +673,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Default if option is provided without a value: {0}.
+        /// </summary>
+        public static string DefaultIfOptionWithoutValue {
+            get {
+                return ResourceManager.GetString("DefaultIfOptionWithoutValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Default: {0}.
         /// </summary>
         public static string DefaultValue {
@@ -680,18 +689,7 @@ namespace Microsoft.TemplateEngine.Cli {
                 return ResourceManager.GetString("DefaultValue", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Default if option is provided without a value: {0}.
-        /// </summary>
-        public static string DefaultIfOptionWithoutValue
-        {
-            get
-            {
-                return ResourceManager.GetString("DefaultIfOptionWithoutValue", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Default: {0} / (*) {1}.
         /// </summary>
@@ -1167,6 +1165,15 @@ namespace Microsoft.TemplateEngine.Cli {
         public static string OptionDescriptionColumns {
             get {
                 return ResourceManager.GetString("OptionDescriptionColumns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Shows all available columns  for --list or -l option, equivalent to --columns=language,tags,author,type..
+        /// </summary>
+        public static string OptionDescriptionColumnsAll {
+            get {
+                return ResourceManager.GetString("OptionDescriptionColumnsAll", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -703,4 +703,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
 The template name and short name are shown always.
 The default list of columns shown without the option: template name, short name, language, tags; equivalent to --columns=language,tags.</value>
   </data>
+  <data name="OptionDescriptionColumnsAll" xml:space="preserve">
+    <value>Shows all available columns  for --list or -l option, equivalent to --columns=language,tags,author,type.</value>
+  </data>
 </root>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -203,5 +203,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
         public bool HasColumnsParseError => throw new NotImplementedException();
 
         public string ColumnsParseError => throw new NotImplementedException();
+
+        public bool ShowAllColumns { get; set; } = false;
+
     }
 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/HelpFormatterTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/HelpFormatterTests.cs
@@ -241,6 +241,55 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             string result = formatter.Layout();
             Assert.Equal(expectedOutput, result);
         }
+
+        [Fact(DisplayName = nameof(CanShowAllColumns))]
+        public void CanShowAllColumns()
+        {
+            ITemplateEngineHost host = new TestHost
+            {
+                HostIdentifier = "TestRunner",
+                Version = "1.0.0.0",
+                Locale = "en-US"
+            };
+
+            IEngineEnvironmentSettings environmentSettings = new MockEngineEnvironmentSettings()
+            {
+                Host = host,
+                Environment = new MockEnvironment()
+                {
+                    ConsoleBufferWidth = 100
+                }
+            };
+
+            INewCommandInput command = new MockNewCommandInput()
+            {
+                ShowAllColumns = true
+            };
+
+            IEnumerable<Tuple<string, string, string>> data = new List<Tuple<string, string, string>>()
+            {
+                new Tuple<string, string, string>("Column 1 data", "Column 2 data", "Column 3 data"),
+                new Tuple<string, string, string>("Column 1 data", "Column 2 data", "Column 3 data")
+            };
+
+            string expectedOutput = $"Column 1       Column 2       Column 3     {Environment.NewLine}-------------  -------------  -------------{Environment.NewLine}Column 1 data  Column 2 data  Column 3 data{Environment.NewLine}Column 1 data  Column 2 data  Column 3 data{Environment.NewLine}";
+
+            HelpFormatter<Tuple<string, string, string>> formatter =
+             HelpFormatter
+                 .For(
+                     environmentSettings,
+                     command,
+                     data,
+                     columnPadding: 2,
+                     headerSeparator: '-',
+                     blankLineBetweenRows: false)
+                 .DefineColumn(t => t.Item1, "Column 1", showAlways: true)
+                 .DefineColumn(t => t.Item2, "Column 2", columnName: "column2")  //defaultColumn: true by default
+                 .DefineColumn(t => t.Item3, "Column 3", columnName: "column3", defaultColumn: false);
+
+            string result = formatter.Layout();
+            Assert.Equal(expectedOutput, result);
+        }
     }
 
 }


### PR DESCRIPTION
implements --columns-all option. If user specifies --columns-all options all columns are shown
required for https://github.com/dotnet/templating/issues/2571