### PR TITLE
Add folder .tye/ and .ionide/ to .gitignore template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -305,6 +305,9 @@ paket-files/
 # FAKE - F# Make
 .fake/
 
+# Ionide - VsCode extension for F# Support
+.ionide/
+
 # CodeRush personal settings
 .cr/personal
 

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -61,6 +61,9 @@ project.lock.json
 project.fragment.lock.json
 artifacts/
 
+# Tye
+.tye/
+
 # StyleCop
 StyleCopReport.xml
 


### PR DESCRIPTION
This PR adds two folders in `.gitignore`
Just to be sure I'm editing the right file, I'm aiming at the file generated by `dotnet new gitignore`

* `.tye/` is generated by [`tye` CLI](https://github.com/dotnet/tye/)
  It is used internally for tracking `PID` to "observe" (stop, kill, ....)
* `.ionide/` is generated by [`Ionide F#` extension in VsCode](https://github.com/ionide/ionide-vscode-fsharp)
  This folder is used to store file such as `.db` (probably for intellisens and so on like the `.vs/` folder)


Out of curiosity, I have no idea about template "releases train" in the echo system is there any chance it would be release during a `5.0.Xyy` or will it be `6.x` ?