### PR TITLE
Changed precedence for net6.0 templates, changed solution folder

### DIFF
--- a/Microsoft.TemplateEngine.sln
+++ b/Microsoft.TemplateEngine.sln
@@ -69,9 +69,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.TemplateSearch.Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.TemplateSearch.ScraperOutputComparison", "src\Microsoft.TemplateSearch.ScraperOutputComparison\Microsoft.TemplateSearch.ScraperOutputComparison.csproj", "{95D28477-05FE-4450-86B8-D7384202AB90}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "template_feed", "template_feed", "{7272B385-2422-4C57-8C1B-65C12250D8FF}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.DotNet.Common.ProjectTemplates.6.0", "template_feed\Microsoft.DotNet.Common.ProjectTemplates.6.0\Microsoft.DotNet.Common.ProjectTemplates.6.0.csproj", "{1DADD24C-5BEF-400D-9C96-8092857D346A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.DotNet.Common.ProjectTemplates.6.0", "template_feed\Microsoft.DotNet.Common.ProjectTemplates.6.0\Microsoft.DotNet.Common.ProjectTemplates.6.0.csproj", "{1DADD24C-5BEF-400D-9C96-8092857D346A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -490,7 +488,7 @@ Global
 		{4DF4A1B9-F31C-49D1-8FEB-8DB37AEBDC0B} = {7DAC892E-ADAE-4CEB-8A0C-EDC452A5826A}
 		{FBEBB725-F645-40DC-856C-D1BC7FB52CF3} = {7DAC892E-ADAE-4CEB-8A0C-EDC452A5826A}
 		{95D28477-05FE-4450-86B8-D7384202AB90} = {7DAC892E-ADAE-4CEB-8A0C-EDC452A5826A}
-		{1DADD24C-5BEF-400D-9C96-8092857D346A} = {7272B385-2422-4C57-8C1B-65C12250D8FF}
+		{1DADD24C-5BEF-400D-9C96-8092857D346A} = {CDC477F2-3C4B-446D-A2CB-21C61A3C1064}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6EA1A508-6033-4538-BF98-7F71B4E297AD}

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "Microsoft.Common.Library.CSharp.6.0",
   "shortName": "classlib",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-FSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "Microsoft.Common.Library.FSharp.6.0",
   "shortName": "classlib",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "Microsoft.Common.Library.VisualBasic.6.0",
   "shortName": "classlib",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -6,7 +6,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Common.Console",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "Microsoft.Common.Console.CSharp.6.0",
   "shortName": "console",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-FSharp/.template.config/template.json
@@ -1,12 +1,12 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": ["Common", "Console"],
+  "classifications": [ "Common", "Console" ],
   "name": "Console Application",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Common.Console",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "Microsoft.Common.Console.FSharp.6.0",
   "shortName": "console",
   "tags": {
@@ -68,7 +68,7 @@
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens Program.fs in the editor",
-      "manualInstructions": [ ],
+      "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
       "args": {
         "files": "1"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-VisualBasic/.template.config/template.json
@@ -1,12 +1,12 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
-  "classifications": ["Common", "Console"],
+  "classifications": [ "Common", "Console" ],
   "name": "Console Application",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Common.Console",
-  "precedence": "7000",
+  "precedence": "8000",
   "identity": "Microsoft.Common.Console.VisualBasic.6.0",
   "shortName": "console",
   "tags": {
@@ -75,7 +75,7 @@
     {
       "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
       "description": "Opens Program.vb in the editor",
-      "manualInstructions": [ ],
+      "manualInstructions": [],
       "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
       "args": {
         "files": "1"


### PR DESCRIPTION
Related to https://github.com/dotnet/templating/pull/2607 

- changed solution folder in use: we use "templates", not "template_feed" in solution
- changed precedence for 6.0 templates.  Now templates of 5.0 and 6.0 have same precedence and do not work when both 5.0 and 6.0 are installed.