### PR TITLE
Remove use of MyGet (release/2.1)

### DIFF
--- a/tools/ProjectTestRunner/NuGet.config
+++ b/tools/ProjectTestRunner/NuGet.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="dotnet-core" value="https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json" />
   </packageSources>
 </configuration>

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/Mvc.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/Mvc.json
@@ -6,7 +6,7 @@
     {
       "handler": "execute",
       "command": "dotnet",
-      "args": "restore -s https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://dotnet.myget.org/F/msbuild/api/v3/index.json -s https://api.nuget.org/v3/index.json",
+      "args": "restore -s https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json -s https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json -s https://api.nuget.org/v3/index.json",
       "noExit": false,
       "exitCode": 0
     },

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/MvcIndividual.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/MvcIndividual.json
@@ -6,7 +6,7 @@
     {
       "handler": "execute",
       "command": "dotnet",
-      "args": "restore -s https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://dotnet.myget.org/F/msbuild/api/v3/index.json -s https://api.nuget.org/v3/index.json",
+      "args": "restore -s https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json -s https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json -s https://api.nuget.org/v3/index.json",
       "noExit": false,
       "exitCode": 0
     },

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/RazorPages.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/RazorPages.json
@@ -6,7 +6,7 @@
     {
       "handler": "execute",
       "command": "dotnet",
-      "args": "restore -s https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://dotnet.myget.org/F/msbuild/api/v3/index.json -s https://api.nuget.org/v3/index.json",
+      "args": "restore -s https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json -s https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json -s https://api.nuget.org/v3/index.json",
       "noExit": false,
       "exitCode": 0
     },

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/Web.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/Web.json
@@ -6,7 +6,7 @@
     {
       "handler": "execute",
       "command": "dotnet",
-      "args": "restore -s https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://dotnet.myget.org/F/msbuild/api/v3/index.json -s https://api.nuget.org/v3/index.json",
+      "args": "restore -s https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json -s https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json -s https://api.nuget.org/v3/index.json",
       "noExit": false,
       "exitCode": 0
     },

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/WebApi.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/CSharp/Defaults/Web/WebApi.json
@@ -6,7 +6,7 @@
     {
       "handler": "execute",
       "command": "dotnet",
-      "args": "restore -s https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://dotnet.myget.org/F/msbuild/api/v3/index.json -s https://api.nuget.org/v3/index.json",
+      "args": "restore -s https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json -s https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json -s https://api.nuget.org/v3/index.json",
       "noExit": false,
       "exitCode": 0
     },

--- a/tools/ProjectTestRunner/TestCases/BuiltIn/FSharp/Defaults/Web/Mvc.json
+++ b/tools/ProjectTestRunner/TestCases/BuiltIn/FSharp/Defaults/Web/Mvc.json
@@ -6,7 +6,7 @@
     {
       "handler": "execute",
       "command": "dotnet",
-      "args": "restore -s https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json -s https://dotnet.myget.org/F/dotnet-core/api/v3/index.json -s https://dotnet.myget.org/F/msbuild/api/v3/index.json -s https://api.nuget.org/v3/index.json",
+      "args": "restore -s https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json -s https://dotnetmygetlegacy.blob.core.windows.net/dotnet-core/index.json -s https://api.nuget.org/v3/index.json",
       "noExit": false,
       "exitCode": 0
     },


### PR DESCRIPTION
Replace references to dotnet.myget.org feeds, which will soon be shut down.

@vlada-shubina FYI