### PR TITLE
#2519 Add example for searching the templates to message for unavailable template

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -256,7 +256,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 Reporter.Error.WriteLine(string.Format(LocalizableStrings.ListTemplatesCommand, commandInput.CommandName).Bold().Red());
             }
 
-            // To search for the templates available on Nuget.org, run 'dotnet {0} <template name> --search'.
+            // To search for the templates on NuGet.org, run 'dotnet {0} <template name> --search'.
             Reporter.Error.WriteLine(string.Format(LocalizableStrings.SearchTemplatesCommand, commandInput.CommandName, commandInput.TemplateName).Bold().Red());
             Reporter.Error.WriteLine();
         }

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -253,11 +253,11 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             if (!commandInput.IsListFlagSpecified)
             {
                 // To list installed templates, run 'dotnet {0} --list'.
-                // To search for the templates available on Nuget.org, run 'dotnet {0} <template name> --search'.
                 Reporter.Error.WriteLine(string.Format(LocalizableStrings.ListTemplatesCommand, commandInput.CommandName).Bold().Red());
-                Reporter.Error.WriteLine(string.Format(LocalizableStrings.SearchTemplatesCommand, commandInput.CommandName, commandInput.TemplateName).Bold().Red());
             }
 
+            // To search for the templates available on Nuget.org, run 'dotnet {0} <template name> --search'.
+            Reporter.Error.WriteLine(string.Format(LocalizableStrings.SearchTemplatesCommand, commandInput.CommandName, commandInput.TemplateName).Bold().Red());
             Reporter.Error.WriteLine();
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -231,16 +231,13 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             {
                 return;
             }
-            bool anythingReported = false;
             if (templateResolutionResult.HasExactMatches)
             {
                 return;
             }
-            else
-            {
-                ShowNoTemplatesFoundMessage(commandInput);
-                anythingReported = true;
-            }
+
+            // No templates found matching the following input parameter(s): {0}.
+            Reporter.Error.WriteLine(string.Format(LocalizableStrings.NoTemplatesMatchingInputParameters, GetInputParametersString(commandInput)).Bold().Red());
 
             if (templateResolutionResult.HasPartialMatches)
             {
@@ -251,14 +248,17 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                         templateResolutionResult.PartiallyMatchedTemplatesGrouped.Count,
                         GetPartialMatchReason(templateResolutionResult, commandInput))
                     .Bold().Red());
-
-                anythingReported = true;
             }
 
-            if (anythingReported)
+            if (!commandInput.IsListFlagSpecified)
             {
-                Reporter.Error.WriteLine();
+                // To list installed templates, run 'dotnet {0} --list'.
+                // To search for the templates available on Nuget.org, run 'dotnet {0} <template name> --search'.
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.ListTemplatesCommand, commandInput.CommandName).Bold().Red());
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.SearchTemplatesCommand, commandInput.CommandName, commandInput.TemplateName).Bold().Red());
             }
+
+            Reporter.Error.WriteLine();
         }
 
         // Returns a list of the parameter names that are invalid for every template in the input group.
@@ -347,14 +347,6 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 : string.IsNullOrEmpty(filters)
                     ? $"'{commandInput.TemplateName}'"
                     : $"'{commandInput.TemplateName}'" + separator + filters;
-        }
-
-        private static void ShowNoTemplatesFoundMessage(INewCommandInput commandInput)
-        {
-            // No templates found matching the following input parameter(s): {0}.
-            // To list installed templates: dotnet new --list.
-            Reporter.Error.WriteLine(string.Format(LocalizableStrings.NoTemplatesMatchingInputParameters, GetInputParametersString(commandInput)).Bold().Red());
-            Reporter.Error.WriteLine(LocalizableStrings.ListTemplatesCommand.Bold().Red());
         }
 
         private static void ShowTemplatesFoundMessage(INewCommandInput commandInput)

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1028,7 +1028,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To list installed templates, run &apos;dotnet new --list&apos;..
+        ///   Looks up a localized string similar to To list installed templates, run &apos;dotnet {0} --list&apos;..
         /// </summary>
         public static string ListTemplatesCommand {
             get {
@@ -1567,6 +1567,15 @@ namespace Microsoft.TemplateEngine.Cli {
         public static string SearchResultTemplateInfo {
             get {
                 return ResourceManager.GetString("SearchResultTemplateInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To search for the templates available on Nuget.org, run &apos;dotnet {0} {1} --search&apos;..
+        /// </summary>
+        public static string SearchTemplatesCommand {
+            get {
+                return ResourceManager.GetString("SearchTemplatesCommand", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1571,7 +1571,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To search for the templates available on Nuget.org, run &apos;dotnet {0} {1} --search&apos;..
+        ///   Looks up a localized string similar to To search for the templates on NuGet.org, run &apos;dotnet {0} {1} --search&apos;..
         /// </summary>
         public static string SearchTemplatesCommand {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -744,6 +744,6 @@ Examples:
     <value>Downloads</value>
   </data>
   <data name="SearchTemplatesCommand" xml:space="preserve">
-    <value>To search for the templates available on Nuget.org, run 'dotnet {0} {1} --search'.</value>
+    <value>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</value>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -683,7 +683,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
     <value>For a list of valid options, run '{0}'.</value>
   </data>
   <data name="ListTemplatesCommand" xml:space="preserve">
-    <value>To list installed templates, run 'dotnet new --list'.</value>
+    <value>To list installed templates, run 'dotnet {0} --list'.</value>
   </data>
   <data name="ColumnNameAuthor" xml:space="preserve">
     <value>Author</value>
@@ -742,5 +742,8 @@ Examples:
   </data>
   <data name="ColumnNameTotalDownloads" xml:space="preserve">
     <value>Downloads</value>
+  </data>
+  <data name="SearchTemplatesCommand" xml:space="preserve">
+    <value>To search for the templates available on Nuget.org, run 'dotnet {0} {1} --search'.</value>
   </data>
 </root>


### PR DESCRIPTION
fixes dotnet/templating#2519 Add example for searching the templates on nuget to message for unavailable template

Additionally:
- reordered the message for partial match to follow the order below
```
dotnet .\dotnet-new3.dll console  --type=item
No templates found matching: 'console', type='item'.
1 template(s) partially matched, but failed on type='item'.
To list installed templates, run 'dotnet new3 --list'.
To search for the templates on NuGet.org, run 'dotnet new3 console --search'
```

- the --list example is only shown in case the command is run without --list option
```
dotnet .\dotnet-new3.dll unavailable --list
No templates found matching: 'unavailable'.
To search for the templates on NuGet.org, run 'dotnet new3 unavailable --search'

dotnet .\dotnet-new3.dll unavailable 
No templates found matching: 'unavailable'.
To list installed templates, run 'dotnet new3 --list'.
To search for the templates on NuGet.org, run 'dotnet new3 unavailable --search'.
```




