### PR TITLE
fixed error message for --search (wrong brackets order)

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1477,7 +1477,7 @@ namespace Microsoft.TemplateEngine.Cli {
         
         /// <summary>
         ///   Looks up a localized string similar to Search failed: no template name is specified.
-        ///To search for the template, specify template name or use one of supported filters: {0}
+        ///To search for the template, specify template name or use one of supported filters: {0}.
         ///Examples:
         ///        dotnet {1} &lt;template name&gt; --search
         ///        dotnet {1} --search --author Microsoft

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -713,7 +713,7 @@ The default list of columns shown without the option for --search: template name
   </data>
   <data name="SearchOnlineErrorNoTemplateNameOrFilter" xml:space="preserve">
     <value>Search failed: no template name is specified.
-To search for the template, specify template name or use one of supported filters: {0}
+To search for the template, specify template name or use one of supported filters: {0}.
 Examples:
         dotnet {1} &lt;template name&gt; --search
         dotnet {1} --search --author Microsoft

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/InstructionDisplayPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/InstructionDisplayPostActionProcessor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
@@ -21,7 +21,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
             if (actionConfig.Args != null && actionConfig.Args.TryGetValue("executable", out string executable))
             {
                 actionConfig.Args.TryGetValue("args", out string commandArgs);
-                Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostActionCommand, $"{executable} {commandArgs}".Bold().Red()));
+                Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostActionCommand, $"{executable} {commandArgs}").Bold().Red());
             }
 
             return true;

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/InstructionDisplayPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/InstructionDisplayPostActionProcessor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Cli.PostActionProcessors

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -126,7 +126,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
             {
                 Reporter.Error.WriteLine(string.Format(
                                             LocalizableStrings.SearchOnlineErrorNoTemplateNameOrFilter,
-                                            string.Join(", ", SupportedFilterOptions.SupportedSearchFilters.Select(f => $"'{f.Name}'"), commandInput.CommandName).Bold().Red()));
+                                            string.Join(", ", SupportedFilterOptions.SupportedSearchFilters.Select(f => $"'{f.Name}'")), commandInput.CommandName).Bold().Red());
                 return false;
             }
 


### PR DESCRIPTION
fixed error message for --search: wrong brackets order, causes exception 