### PR TITLE
Template info extension methods to get template language(s) and type(s)

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
@@ -53,9 +53,10 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             HashSet<string> languages = new HashSet<string>();
             foreach (ITemplateInfo templateInfo in templateGroup)
             {
-                if (templateInfo.Tags != null && templateInfo.Tags.TryGetValue("language", out ICacheTag languageTag))
+                string templateLanguage = templateInfo.GetLanguage();
+                if (!string.IsNullOrWhiteSpace(templateLanguage))
                 {
-                    languages.UnionWith(languageTag.ChoicesAndDescriptions.Keys.Where(x => !string.IsNullOrWhiteSpace(x)).ToList());
+                    languages.Add(templateLanguage);
                 }
             }
 

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -342,9 +342,10 @@ namespace Microsoft.TemplateEngine.Cli
                     {
                         string str = $"      {info.Name} ({info.ShortName})";
 
-                        if (info.Tags != null && info.Tags.TryGetValue("language", out ICacheTag languageTag))
+                        string templateLanguage = info.GetLanguage();
+                        if (!string.IsNullOrWhiteSpace(templateLanguage))
                         {
-                            str += " " + string.Join(", ", languageTag.ChoicesAndDescriptions.Select(x => x.Key));
+                            str += " " + templateLanguage;
                         }
 
                         templateDisplayStrings.Add(str);

--- a/src/Microsoft.TemplateEngine.Cli/TableOutput/TemplateGroupDisplay.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TableOutput/TemplateGroupDisplay.cs
@@ -36,27 +36,25 @@ namespace Microsoft.TemplateEngine.Cli.TableOutput
 
                 foreach (ITemplateMatchInfo template in grouping)
                 {
-                    if (template.Info.Tags == null || !template.Info.Tags.TryGetValue("language", out ICacheTag languageTag))
+                    string lang = template.Info.GetLanguage();
+                    if (string.IsNullOrWhiteSpace(lang))
                     {
                         continue;
                     }
-                    foreach (string lang in languageTag.ChoicesAndDescriptions.Keys)
-                    {
-                        if (!uniqueLanguages.Add(lang))
-                        {
-                            continue;
-                        }
 
-                        if (string.IsNullOrEmpty(language) && string.Equals(defaultLanguage, lang, StringComparison.OrdinalIgnoreCase))
-                        {
-                            defaultLanguageDisplay = $"[{lang}]";
-                        }
-                        else
-                        {
-                            languageForDisplay.Add(lang);
-                        }
+                    if (!uniqueLanguages.Add(lang))
+                    {
+                        continue;
                     }
-                }
+                    if (string.IsNullOrEmpty(language) && string.Equals(defaultLanguage, lang, StringComparison.OrdinalIgnoreCase))
+                    {
+                        defaultLanguageDisplay = $"[{lang}]";
+                    }
+                    else
+                    {
+                        languageForDisplay.Add(lang);
+                    }
+                }                
 
                 languageForDisplay.Sort(StringComparer.OrdinalIgnoreCase);
                 if (!string.IsNullOrEmpty(defaultLanguageDisplay))
@@ -75,12 +73,6 @@ namespace Microsoft.TemplateEngine.Cli.TableOutput
                     shortName = highestPrecedenceTemplate.Info.ShortName;
                 }
 
-                string templateType = string.Empty;
-                if (highestPrecedenceTemplate.Info.Tags != null && highestPrecedenceTemplate.Info.Tags.TryGetValue("type", out ICacheTag typeTag))
-                {
-                    templateType = typeTag.DefaultValue;
-                }
-
                 TemplateGroupTableRow groupDisplayInfo = new TemplateGroupTableRow()
                 {
                     Name = highestPrecedenceTemplate.Info.Name,
@@ -88,7 +80,7 @@ namespace Microsoft.TemplateEngine.Cli.TableOutput
                     Languages = string.Join(",", languageForDisplay),
                     Classifications = highestPrecedenceTemplate.Info.Classifications != null ? string.Join("/", highestPrecedenceTemplate.Info.Classifications) : null,
                     Author = highestPrecedenceTemplate.Info.Author,
-                    Type = templateType
+                    Type = highestPrecedenceTemplate.Info.GetTemplateType() ?? string.Empty
                 };
                 templateGroupsForDisplay.Add(groupDisplayInfo);
             }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateListResolutionResult.cs
@@ -163,17 +163,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                 HashSet<string> languagesFound = new HashSet<string>();
                 foreach (ITemplateMatchInfo template in UnambiguousTemplateGroup)
                 {
-                    string language;
-
-                    if (template.Info.Tags != null && template.Info.Tags.TryGetValue("language", out ICacheTag languageTag))
-                    {
-                        language = languageTag.ChoicesAndDescriptions.Keys.FirstOrDefault();
-                    }
-                    else
-                    {
-                        language = string.Empty;
-                    }
-
+                    string language = template.Info.GetLanguage();
                     if (!string.IsNullOrEmpty(language))
                     {
                         languagesFound.Add(language);

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
@@ -351,29 +351,29 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 
             foreach (ITemplateMatchInfo template in listToFilter)
             {
-                if (template.Info.Tags != null)
+                MatchKind matchKind;
+
+                string templateLanguage = template.Info.GetLanguage();
+                // only add default language disposition when there is a language specified for the template.
+                if (string.IsNullOrWhiteSpace(templateLanguage))
                 {
-                    if (template.Info.Tags.TryGetValue("language", out ICacheTag languageTag))
-                    {
-                        MatchKind matchKind;
-
-                        if (languageTag.ChoicesAndDescriptions.ContainsKey(language))
-                        {
-                            matchKind = MatchKind.Exact;
-                        }
-                        else
-                        {
-                            matchKind = MatchKind.Mismatch;
-                        }
-
-                        // only add default language disposition when there is a language specified for the template.
-                        template.AddDisposition(new MatchInfo
-                        {
-                            Location = MatchLocation.DefaultLanguage,
-                            Kind = matchKind
-                        });
-                    }
+                    continue;
                 }
+
+                if (templateLanguage.Equals(language, StringComparison.OrdinalIgnoreCase))
+                {
+                    matchKind = MatchKind.Exact;
+                }
+                else
+                {
+                    matchKind = MatchKind.Mismatch;
+                }
+
+                template.AddDisposition(new MatchInfo
+                {
+                    Location = MatchLocation.DefaultLanguage,
+                    Kind = matchKind
+                });
             }
         }
 

--- a/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Edge.Template
 {
@@ -75,21 +76,14 @@ namespace Microsoft.TemplateEngine.Edge.Template
                 {
                     return null;
                 }
-
-                if (template.Tags != null && template.Tags.TryGetValue("type", out ICacheTag typeTag))
+                if (template.GetTemplateType()?.Equals(context, StringComparison.OrdinalIgnoreCase) ?? false)
                 {
-                    if (typeTag.ChoicesAndDescriptions.ContainsKey(context))
-                    {
-                        return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Exact };
-                    }
-                    else
-                    {
-                        return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Mismatch };
-                    }
+                    return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Exact };
                 }
-
-                // type is specified for the filter, but missing in template
-                return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Mismatch };
+                else
+                {
+                    return new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Mismatch };
+                }
             };
         }
 
@@ -105,19 +99,12 @@ namespace Microsoft.TemplateEngine.Edge.Template
                     return null;
                 }
 
-                if (template.Tags != null && template.Tags.TryGetValue("language", out ICacheTag languageTag))
+                if (template.GetLanguage()?.Equals(language, StringComparison.OrdinalIgnoreCase) ?? false)
                 {
-                    if (languageTag.ChoicesAndDescriptions.ContainsKey(language))
-                    {
-                        return new MatchInfo { Location = MatchLocation.Language, Kind = MatchKind.Exact };
-                    }
-                    else
-                    {
-                        return new MatchInfo { Location = MatchLocation.Language, Kind = MatchKind.Mismatch };
-                    }
+                    return new MatchInfo { Location = MatchLocation.Language, Kind = MatchKind.Exact };
                 }
                 else
-                {   // user specified a language, but the template didnt.
+                {
                     return new MatchInfo { Location = MatchLocation.Language, Kind = MatchKind.Mismatch };
                 }
             };

--- a/src/Microsoft.TemplateEngine.Utils/TemplateInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Utils/TemplateInfoExtensions.cs
@@ -1,0 +1,49 @@
+using Microsoft.TemplateEngine.Abstractions;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.TemplateEngine.Utils
+{
+    /// <summary>
+    /// The class provides ITemplateInfo extension methods
+    /// </summary>
+    public static class TemplateInfoExtensions
+    {
+        /// <summary>
+        /// Gets the language defined in <paramref name="template"/>
+        /// </summary>
+        /// <param name="template">template definition</param>
+        /// <returns>The language defined in the template or null if no language is defined</returns>
+        /// <remarks>The tags are read in <see cref="SimpleConfigModel.ConvertedDeprecatedTagsToParameterSymbols"/> method. The single value for the tag is guaranteed.</remarks>
+        public static string GetLanguage(this ITemplateInfo template)
+        {
+            return template.GetTagValues("language")?.Single();
+        }
+
+        /// <summary>
+        /// Gets the type defined in <paramref name="template"/>
+        /// </summary>
+        /// <param name="template">template definition</param>
+        /// <returns>The type defined in the template or null if no type is defined</returns>
+        /// <remarks>The tags are read in <see cref="SimpleConfigModel.ConvertedDeprecatedTagsToParameterSymbols"/> method. The single value for the tag is guaranteed.</remarks>
+        public static string GetTemplateType(this ITemplateInfo template)
+        {
+            return template.GetTagValues("type")?.Single();
+        }
+
+        /// <summary>
+        /// Gets the possible values for the tag <paramref name="tagName"/> in <paramref name="template"/>
+        /// </summary>
+        /// <param name="template">template definition</param>
+        /// <param name="tagName">tag name</param>
+        /// <returns>The values of tag defined in the template or null if the tag is not defined in the template</returns>
+        public static IEnumerable<string> GetTagValues (this ITemplateInfo template, string tagName)
+        {
+            if (template.Tags == null || !template.Tags.TryGetValue(tagName, out ICacheTag tag))
+            {
+                return null;
+            }
+            return tag.ChoicesAndDescriptions.Keys;
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCacheTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCacheTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             }
         }
 
-        [Theory(DisplayName = nameof(CacheSearchTypeFilterTest), Skip = "skipped until type fix is merged")]
+        [Theory(DisplayName = nameof(CacheSearchTypeFilterTest))]
         [InlineData("", "project", 1)]
         [InlineData("foo", "project", 1)]
         [InlineData("", "Wrong", 0)]


### PR DESCRIPTION
1. Templates have special tags defined: language and type (both can have multiple values, but usually one value is used). There are no specific properties for them: they are handled now in same way as any other tag or choice symbol defined in template, and stored in tags collection.  Added extension method for `ITemplateInfo` to return languages and types as this code is duplicated in many places.

_Point to consider: the case when there is more than 1 type or 1 language in the template is impossible now - the attempt to read template fails. However, logically the template might have more than 1 language. Please share your opinion if support for more than one language or type should be removed or kept._

2. Re-enabled previously disabled unit test.