### PR TITLE
Utils for CLI: added option for setting IEqualityComparer when using extension GroupBy method

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/TableOutput/TemplateGroupDisplay.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TableOutput/TemplateGroupDisplay.cs
@@ -27,7 +27,7 @@ namespace Microsoft.TemplateEngine.Cli.TableOutput
         internal static IReadOnlyList<TemplateGroupTableRow> GetTemplateGroupsForListDisplay(IReadOnlyCollection<ITemplateMatchInfo> templateList, string language, string defaultLanguage)
         {
             List<TemplateGroupTableRow> templateGroupsForDisplay = new List<TemplateGroupTableRow>();
-            IEnumerable<IGrouping<string, ITemplateMatchInfo>> groupedTemplateList = templateList.GroupBy(x => x.Info.GroupIdentity, x => !string.IsNullOrEmpty(x.Info.GroupIdentity));
+            IEnumerable<IGrouping<string, ITemplateMatchInfo>> groupedTemplateList = templateList.GroupBy(x => x.Info.GroupIdentity, x => !string.IsNullOrEmpty(x.Info.GroupIdentity), StringComparer.OrdinalIgnoreCase);
             foreach (IGrouping<string, ITemplateMatchInfo> grouping in groupedTemplateList)
             {
                 List<string> languageForDisplay = new List<string>();

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/ListOrHelpTemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/ListOrHelpTemplateListResolutionResult.cs
@@ -61,7 +61,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// Returns list of exact or partially matched templates by name and exact match by language, filter, baseline (if specified in command paramaters) grouped by group identity
         /// </summary>
         public IReadOnlyCollection<IGrouping<string, ITemplateMatchInfo>> ExactMatchedTemplatesGrouped =>
-            ExactMatchedTemplates.GroupBy(x => x.Info.GroupIdentity, x => !string.IsNullOrEmpty(x.Info.GroupIdentity)).ToList();
+            ExactMatchedTemplates.GroupBy(x => x.Info.GroupIdentity, x => !string.IsNullOrEmpty(x.Info.GroupIdentity), StringComparer.OrdinalIgnoreCase).ToList();
 
         /// <summary>
         /// Returns list of exact or partially matched templates by name and mismatch in any of the following: language, filter, baseline (if specified in command paramaters)
@@ -86,7 +86,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         ///  Returns list of exact or partially matched templates by name and mismatch in any of the following: language, filter, baseline (if specified in command paramaters); grouped by group identity
         /// </summary>
         public IReadOnlyCollection<IGrouping<string, ITemplateMatchInfo>> PartiallyMatchedTemplatesGrouped =>
-            PartiallyMatchedTemplates.GroupBy(x => x.Info.GroupIdentity, x => !string.IsNullOrEmpty(x.Info.GroupIdentity)).ToList();
+            PartiallyMatchedTemplates.GroupBy(x => x.Info.GroupIdentity, x => !string.IsNullOrEmpty(x.Info.GroupIdentity), StringComparer.OrdinalIgnoreCase).ToList();
 
 
         /// <summary>

--- a/test/Microsoft.TemplateEngine.Utils.UnitTests/ListExtensionsTests.cs
+++ b/test/Microsoft.TemplateEngine.Utils.UnitTests/ListExtensionsTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Utils.UnitTests
+{
+    public class ListExtensionsTests
+    {
+        internal struct GroupByTestStruct
+        {
+            internal string Identity;
+            internal string GroupIdentity;
+        }
+
+        [Fact(DisplayName = nameof(GroupByExtensionTest))]
+        public void GroupByExtensionTest()
+        {
+            List<GroupByTestStruct> templatesToGroup = new List<GroupByTestStruct>();
+            templatesToGroup.Add(new GroupByTestStruct()
+            {
+                Identity = "1",
+                GroupIdentity = null
+            });
+            templatesToGroup.Add(new GroupByTestStruct()
+            {
+                Identity = "2",
+                GroupIdentity = string.Empty
+            });
+            templatesToGroup.Add(new GroupByTestStruct()
+            {
+                Identity = "3",
+                GroupIdentity = null
+            });
+            templatesToGroup.Add(new GroupByTestStruct()
+            {
+                Identity = "4",
+                GroupIdentity = string.Empty
+            });
+            templatesToGroup.Add(new GroupByTestStruct()
+            {
+                Identity = "5",
+                GroupIdentity = "TemplateGroup"
+            });
+            templatesToGroup.Add(new GroupByTestStruct()
+            {
+                Identity = "6",
+                GroupIdentity = "templategroup"
+            });
+            templatesToGroup.Add(new GroupByTestStruct()
+            {
+                Identity = "7",
+                GroupIdentity = "TemplateGroup2"
+            });
+            templatesToGroup.Add(new GroupByTestStruct()
+            {
+                Identity = "8",
+                GroupIdentity = "other"
+            });
+            templatesToGroup.Add(new GroupByTestStruct()
+            {
+                Identity = "9",
+                GroupIdentity = "templategroup"
+            });
+
+            var templateGroups = templatesToGroup.GroupBy(x => x.GroupIdentity, x => !string.IsNullOrEmpty(x.GroupIdentity), StringComparer.OrdinalIgnoreCase);
+            Assert.Equal(7, templateGroups.Count());
+            var groupWithExpectedMultipleElements = templateGroups.Single(g => g.Key?.Equals("TemplateGroup", StringComparison.OrdinalIgnoreCase) ?? false); 
+            Assert.Equal(3, groupWithExpectedMultipleElements.Count());
+            Assert.Single(groupWithExpectedMultipleElements, s => s.Identity == "5");
+            Assert.Single(groupWithExpectedMultipleElements, s => s.Identity == "6");
+            Assert.Single(groupWithExpectedMultipleElements, s => s.Identity == "9");
+        }
+    }
+}


### PR DESCRIPTION
Extension `GroupBy` method is used by multiple methods to group templates by template group, however before used default comparer for comparison. This is not aligned with template resolution methods in `TemplateResolver` that are using `OrdinalIgnoreCase` comparison when checking the template group.

Implemented passing comparer to use and fixed usages.
Added unit test.