### PR TITLE
added reset for the map when reparsing the arguments of the command

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -412,6 +412,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             Parser parser = new Parser(parseConfig);
             _parseResult = parser.Parse(argsWithCommand.ToArray());
             _templateParamCanonicalToVariantMap = null;
+            _templateParamVariantToCanonicalMap = null;
 
             IReadOnlyList<string> templateNameList = _parseResult.GetArgumentListAtPath(new[] { _commandName })?.ToList() ?? Empty<string>.List.Value;
             if ((templateNameList.Count > 0) &&


### PR DESCRIPTION
`NewCommandInputCli` has two mappings defined:
- canonical to possible input options 
- possible input options to canonical

When executing `ParseArgs`, first map is reset, while second one is not. Fixing second one to be reset as well.