### PR TITLE
Applying file based renames to primary outputs

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileRenameGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileRenameGenerator.cs
@@ -20,7 +20,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         //  - parameters with a FileRename specified
         //  - the source & target names.
         // Any input fileRenames will be applied before the parameter symbol renames.
-        public static IReadOnlyDictionary<string, string> AugmentFileRenames(IEngineEnvironmentSettings environmentSettings, string sourceName, IFileSystemInfo configFile, string sourceDirectory, ref string targetDirectory, object resolvedNameParamValue, IParameterSet parameterSet, Dictionary<string, string> fileRenames, IReadOnlyList<IReplacementTokens> symbolBasedFileRenames = null)
+        public static IReadOnlyDictionary<string, string> AugmentFileRenames(
+            IEngineEnvironmentSettings environmentSettings,
+            string sourceName,
+            IFileSystemInfo configFile,
+            string sourceDirectory,
+            ref string targetDirectory,
+            object resolvedNameParamValue,
+            IParameterSet parameterSet,
+            Dictionary<string, string> fileRenames,
+            IReadOnlyList<IReplacementTokens> symbolBasedFileRenames = null)
         {
             Dictionary<string, string> allRenames = new Dictionary<string, string>(StringComparer.Ordinal);
 
@@ -46,7 +55,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             return allRenames;
         }
 
-        public static string ApplyRenameToPrimaryOutput(string primaryOutputPath, IEngineEnvironmentSettings environmentSettings, string sourceName, object resolvedNameParamValue, IParameterSet parameterSet, IReadOnlyList<IReplacementTokens> symbolBasedFileRenames = null)
+        public static string ApplyRenameToPrimaryOutput(
+            string primaryOutputPath,
+            IEngineEnvironmentSettings environmentSettings,
+            string sourceName,
+            object resolvedNameParamValue,
+            IParameterSet parameterSet,
+            IReadOnlyList<IReplacementTokens> symbolBasedFileRenames = null)
         {
             string targetDirectoryStub = string.Empty;
             IProcessor symbolRenameProcessor = SetupSymbolBasedRenameProcessor(environmentSettings, sourceName, ref targetDirectoryStub, resolvedNameParamValue, parameterSet, symbolBasedFileRenames);
@@ -83,7 +98,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         // Creates and returns the processor used to create the file rename mapping based on the symbols with fileRename defined.
         // Also sets up rename for the target directory.
-        private static IProcessor SetupSymbolBasedRenameProcessor(IEngineEnvironmentSettings environmentSettings, string sourceName, ref string targetDirectory, object resolvedNameParamValue, IParameterSet parameterSet, IReadOnlyList<IReplacementTokens> symbolBasedFileRenames)
+        private static IProcessor SetupSymbolBasedRenameProcessor(
+            IEngineEnvironmentSettings environmentSettings,
+            string sourceName,
+            ref string targetDirectory,
+            object resolvedNameParamValue,
+            IParameterSet parameterSet,
+            IReadOnlyList<IReplacementTokens> symbolBasedFileRenames)
         {
             List<IOperationProvider> operations = new List<IOperationProvider>();
             SetupRenameForTargetDirectory(sourceName, resolvedNameParamValue, ref targetDirectory, operations);
@@ -102,7 +123,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         }
 
         // Sets up a rename for the target directory based on the "name" parameter.
-        private static void SetupRenameForTargetDirectory(string sourceName, object resolvedNameParamValue, ref string targetDirectory, List<IOperationProvider> operations)
+        private static void SetupRenameForTargetDirectory(
+            string sourceName,
+            object resolvedNameParamValue,
+            ref string targetDirectory,
+            List<IOperationProvider> operations)
         {
             if (resolvedNameParamValue != null && sourceName != null)
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileRenameGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileRenameGenerator.cs
@@ -65,9 +65,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         {
             string targetDirectoryStub = string.Empty;
             IProcessor symbolRenameProcessor = SetupSymbolBasedRenameProcessor(environmentSettings, sourceName, ref targetDirectoryStub, resolvedNameParamValue, parameterSet, symbolBasedFileRenames);
-            string renameFinalTargetValue = ApplyRenameProcessorToFilename(symbolRenameProcessor, primaryOutputPath);
-
-            return renameFinalTargetValue;
+            return ApplyRenameProcessorToFilename(symbolRenameProcessor, primaryOutputPath);
         }
 
         private static string ApplyRenameProcessorToFilename(IProcessor processor, string sourceFilename)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileRenameGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileRenameGenerator.cs
@@ -46,6 +46,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             return allRenames;
         }
 
+        public static string ApplyRenameToPrimaryOutput(string primaryOutputPath, IEngineEnvironmentSettings environmentSettings, string sourceName, object resolvedNameParamValue, IParameterSet parameterSet, IReadOnlyList<IReplacementTokens> symbolBasedFileRenames = null)
+        {
+            string targetDirectoryStub = string.Empty;
+            IProcessor symbolRenameProcessor = SetupSymbolBasedRenameProcessor(environmentSettings, sourceName, ref targetDirectoryStub, resolvedNameParamValue, parameterSet, symbolBasedFileRenames);
+            string renameFinalTargetValue = ApplyRenameProcessorToFilename(symbolRenameProcessor, primaryOutputPath);
+
+            return renameFinalTargetValue;
+        }
+
         private static string ApplyRenameProcessorToFilename(IProcessor processor, string sourceFilename)
         {
             using (Stream source = new MemoryStream(Encoding.UTF8.GetBytes(sourceFilename)))

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
@@ -889,18 +889,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
                 if (pathModel.ConditionResult)
                 {
-                    foreach (FileSourceMatchInfo sourceInfo in _sources)
-                    {
-                        if (sourceInfo.Renames.TryGetValue(pathModel.PathOriginal, out string targetPath))
-                        {
-                            pathModel.PathResolved = targetPath;
-                        }
-                        //Don't overwrite an already resolved output value
-                        else if (string.IsNullOrEmpty(pathModel.PathResolved))
-                        {
-                            pathModel.PathResolved = pathModel.PathOriginal;
-                        }
-                    }
+                    pathModel.PathResolved = FileRenameGenerator.ApplyRenameToPrimaryOutput
+(pathModel.PathOriginal, EnvironmentSettings, SourceName, resolvedNameParamValue, parameters, SymbolFilenameReplacements);
                 }
             }
         }

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
@@ -53,8 +53,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             };
 
             //tests are not working due to bugs:
-            // - https://github.com/dotnet/templating/pull/2690
-            // - file changes are not taking into account source modifiers
+            // -file changes are not taking into account source modifiers
             //yield return new object[]
             //{
             //    "TemplateWithSourceNameAndCustomSourcePath",
@@ -174,16 +173,16 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
                     .Without("Api/bar.cs")
             };
 
-            //yield return new object[]
-            //{
-            //    "TemplateWithSourceBasedRenames",
-            //    "--barRename NewName",
-            //     new MockCreationEffects()
-            //        .WithPrimaryOutputs("baz.cs", "NewName.cs")
-            //        .WithFileChange(new MockFileChange("foo.cs", "baz.cs", ChangeKind.Create))
-            //        .WithFileChange(new MockFileChange("foo.cs", "NewName.cs", ChangeKind.Create))
-            //        .Without("foo.cs")
-            //};
+            yield return new object[]
+            {
+                "TemplateWithSourceBasedRenames",
+                "--barRename NewName",
+                 new MockCreationEffects()
+                    .WithPrimaryOutputs("baz.cs", "NewName.cs")
+                    .WithFileChange(new MockFileChange("foo.cs", "baz.cs", ChangeKind.Create))
+                    .WithFileChange(new MockFileChange("foo.cs", "NewName.cs", ChangeKind.Create))
+                    .Without("foo.cs")
+            };
         }
     
 

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
@@ -53,7 +53,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             };
 
             //tests are not working due to bugs:
-            // -file changes are not taking into account source modifiers
+            // -file changes are not taking into account source modifiers https://github.com/dotnet/templating/issues/2746
             //yield return new object[]
             //{
             //    "TemplateWithSourceNameAndCustomSourcePath",


### PR DESCRIPTION
fixes https://github.com/dotnet/templating/issues/2453 fixes https://github.com/dotnet/templating/issues/2682 by applying symbol based renames to primary outputs defined in configuration.

The solution to be discussed: it assumes that primary output should contain path to final file before applying symbol based renames (different from current definition of primaryOutputs in [Wiki ](https://github.com/dotnet/templating/wiki/Reference-for-template.json#primary-output-definition)

Integration tests are covering the fix.
Yet all not tests can be enabled due to the bug that `ICreationEffects.FileChanges` do not contain valid source and target paths if source modifiers are applied.