### PR TITLE
Cli.UnitTests: template resolution tests refactoring

### DIFF
--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -69,29 +69,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 
         public string AllowScriptsToRun { get; }
 
-        public string AuthorFilter
-        {
-            get
-            {
-                if (_commandOptions.ContainsKey("--author"))
-                {
-                    return _commandOptions["--author"];
-                }
-                return string.Empty;
-            }
-        }
+        public string AuthorFilter => _commandOptions.ContainsKey("--author") ? _commandOptions["--author"] : string.Empty;
 
-        public string BaselineName
-        {
-            get
-            {
-                if (_commandOptions.ContainsKey("--baseline"))
-                {
-                    return _commandOptions["--baseline"];
-                }
-                return string.Empty;
-            }
-        }
+        public string BaselineName => _commandOptions.ContainsKey("--baseline") ? _commandOptions["--baseline"] : string.Empty;
 
         public bool CheckForUpdates { get; }
 
@@ -143,17 +123,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 
         public bool IsShowAllFlagSpecified { get; }
 
-        public string Language 
-        {
-            get
-            {
-                if (_commandOptions.ContainsKey("--language"))
-                {
-                    return _commandOptions["--language"];
-                }
-                return string.Empty;
-            }
-        }
+        public string Language => _commandOptions.ContainsKey("--language") ? _commandOptions["--language"] : string.Empty;
 
         public string Locale { get; }
 
@@ -161,17 +131,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 
         public string OutputPath { get; }
 
-        public string PackageFilter
-        {
-            get
-            {
-                if (_commandOptions.ContainsKey("--package"))
-                {
-                    return _commandOptions["--package"];
-                }
-                return string.Empty;
-            }
-        }
+        public string PackageFilter => _commandOptions.ContainsKey("--package") ? _commandOptions["--package"] : string.Empty;
 
         // When using this mock, set the inputs using constructor input.
         // This property gets assigned based on the constructor input and the template being worked with.
@@ -198,18 +158,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
         public IReadOnlyList<string> Tokens { get; }
 
         public IList<string> ToUninstallList { get; }
-        public string TypeFilter
-        {
-            get
-            {
-                if (_commandOptions.ContainsKey("--type"))
-                {
-                    return _commandOptions["--type"];
-                }
-                return string.Empty;
-            }
-        }
-
+        public string TypeFilter => _commandOptions.ContainsKey("--type") ? _commandOptions["--type"] : string.Empty;
 
         public int Execute(params string[] args)
         {
@@ -314,6 +263,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
             _commandOptions = JsonConvert.DeserializeObject<Dictionary<string, string>>(info.GetValue<string>("command_options"));
             _templateOptions = JsonConvert.DeserializeObject<Dictionary<string, string>>(info.GetValue<string>("command_templateOptions"));
         }
+
         public void Serialize(IXunitSerializationInfo info)
         {
             info.AddValue("command_templateName", TemplateName, typeof(string));

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/HelpForTemplateResolutionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/HelpForTemplateResolutionTests.cs
@@ -3,6 +3,7 @@ using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Edge.Template;
 using Microsoft.TemplateEngine.Cli.HelpAndUsage;
 using Xunit;
+using Microsoft.TemplateEngine.Mocks;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
 {
@@ -17,20 +18,20 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             List<MatchInfo> templateOneDispositions = new List<MatchInfo>();
             templateOneDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, InputParameterName = "foo" });
             templateOneDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, InputParameterName = "bar" });
-            ITemplateMatchInfo templateOneMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateOneDispositions);
+            ITemplateMatchInfo templateOneMatchInfo = new TemplateMatchInfo(new MockTemplateInfo(), templateOneDispositions);
             matchInfo.Add(templateOneMatchInfo);
 
             // template two
             List<MatchInfo> templateTwoDispositions = new List<MatchInfo>();
             templateTwoDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, InputParameterName = "foo" });
-            ITemplateMatchInfo templateTwoMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateTwoDispositions);
+            ITemplateMatchInfo templateTwoMatchInfo = new TemplateMatchInfo(new MockTemplateInfo(), templateTwoDispositions);
             matchInfo.Add(templateTwoMatchInfo);
 
             // template three
             List<MatchInfo> templateThreeDispositions = new List<MatchInfo>();
             templateThreeDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, InputParameterName = "foo" });
             templateThreeDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, InputParameterName = "baz" });
-            ITemplateMatchInfo templateThreeMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateThreeDispositions);
+            ITemplateMatchInfo templateThreeMatchInfo = new TemplateMatchInfo(new MockTemplateInfo(), templateThreeDispositions);
             matchInfo.Add(templateThreeMatchInfo);
 
             HelpForTemplateResolution.GetParametersInvalidForTemplatesInList(matchInfo, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
@@ -52,12 +53,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             List<MatchInfo> templateOneDispositions = new List<MatchInfo>();
             templateOneDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, InputParameterName = "foo" });
             templateOneDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, InputParameterName = "bar" });
-            ITemplateMatchInfo templateOneMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateOneDispositions);
+            ITemplateMatchInfo templateOneMatchInfo = new TemplateMatchInfo(new MockTemplateInfo(), templateOneDispositions);
             matchInfo.Add(templateOneMatchInfo);
 
             // template two
             List<MatchInfo> templateTwoDispositions = new List<MatchInfo>();
-            ITemplateMatchInfo templateTwoMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateTwoDispositions);
+            ITemplateMatchInfo templateTwoMatchInfo = new TemplateMatchInfo(new MockTemplateInfo(), templateTwoDispositions);
             matchInfo.Add(templateTwoMatchInfo);
 
             HelpForTemplateResolution.GetParametersInvalidForTemplatesInList(matchInfo, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
@@ -77,13 +78,13 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             // template one
             List<MatchInfo> templateOneDispositions = new List<MatchInfo>();
             templateOneDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, InputParameterName = "foo" });
-            ITemplateMatchInfo templateOneMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateOneDispositions);
+            ITemplateMatchInfo templateOneMatchInfo = new TemplateMatchInfo(new MockTemplateInfo(), templateOneDispositions);
             matchInfo.Add(templateOneMatchInfo);
 
             // template two
             List<MatchInfo> templateTwoDispositions = new List<MatchInfo>();
             templateTwoDispositions.Add(new MatchInfo() { Location = MatchLocation.OtherParameter, Kind = MatchKind.InvalidParameterName, InputParameterName = "foo" });
-            ITemplateMatchInfo templateTwoMatchInfo = new TemplateMatchInfo(new TemplateInfo(), templateTwoDispositions);
+            ITemplateMatchInfo templateTwoMatchInfo = new TemplateMatchInfo(new MockTemplateInfo(), templateTwoDispositions);
             matchInfo.Add(templateTwoMatchInfo);
 
             HelpForTemplateResolution.GetParametersInvalidForTemplatesInList(matchInfo, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/HelpFormatterTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/HelpFormatterTests.cs
@@ -212,10 +212,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
                 }
             };
 
-            INewCommandInput command = new MockNewCommandInput()
-            {
-                Columns = new List<string>() { "column3" }
-            };
+            INewCommandInput command = new MockNewCommandInput().WithCommandOption("--columns", "column3");
 
             IEnumerable<Tuple<string, string, string>> data = new List<Tuple<string, string, string>>()
             {
@@ -261,10 +258,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
                 }
             };
 
-            INewCommandInput command = new MockNewCommandInput()
-            {
-                ShowAllColumns = true
-            };
+            INewCommandInput command = new MockNewCommandInput().WithCommandOption("--columns-all");
 
             IEnumerable<Tuple<string, string, string>> data = new List<Tuple<string, string, string>>()
             {

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/HelpTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/HelpTemplateListResolverTests.cs
@@ -38,11 +38,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 Tags = new Dictionary<string, ICacheTag>()
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console2",
-                IsHelpFlagSpecified = true
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console2").WithHelpOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -73,11 +69,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 Tags = new Dictionary<string, ICacheTag>()
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsHelpFlagSpecified = true
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console").WithHelpOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -128,11 +120,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsHelpFlagSpecified = true
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console").WithHelpOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -207,11 +195,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "c",
-                IsHelpFlagSpecified = true
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("c").WithHelpOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -249,11 +233,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsHelpFlagSpecified = true
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console").WithHelpOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "L1");
             Assert.True(matchResult.HasExactMatches);
@@ -295,12 +275,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsHelpFlagSpecified = true,
-                Language = "L2"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console", "L2").WithHelpOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "L1");
             Assert.True(matchResult.HasExactMatches);
@@ -352,11 +327,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsHelpFlagSpecified = true
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console").WithHelpOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -408,11 +379,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsHelpFlagSpecified = true
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console").WithHelpOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -446,12 +413,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsHelpFlagSpecified = true,
-                Language = "L2"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console", "L2").WithHelpOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
@@ -489,12 +451,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsHelpFlagSpecified = true,
-                TypeFilter = "item"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console", type: "item").WithHelpOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
@@ -532,12 +489,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsHelpFlagSpecified = true,
-                BaselineName = "core"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console").WithHelpOption().WithCommandOption("--baseline", "core");
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
@@ -575,14 +527,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsHelpFlagSpecified = true,
-                Language = "L2",
-                TypeFilter = "item",
-                BaselineName = "core"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console", "L2", "item").WithHelpOption().WithCommandOption("--baseline", "core");
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
@@ -639,13 +584,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsHelpFlagSpecified = true,
-                Language = "L2",
-                TypeFilter = "item"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console", "L2", "item").WithHelpOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
@@ -684,14 +623,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             });
 
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "zzzzz",
-                IsHelpFlagSpecified = true,
-                Language = "L1",
-                TypeFilter = "project",
-                BaselineName = "app"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("zzzzz", "L1", "item").WithHelpOption().WithCommandOption("--baseline", "app");
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
@@ -778,16 +710,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             });
 
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "langVersion", null }
-                }
-            )
-            {
-                TemplateName = "c",
-                IsHelpFlagSpecified = true,
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("c").WithHelpOption().WithTemplateOption("langVersion");
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -871,16 +794,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             });
 
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "framework", null }
-                }
-            )
-            {
-                TemplateName = "c",
-                IsHelpFlagSpecified = true,
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("c").WithHelpOption().WithTemplateOption("framework");
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -963,16 +877,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             });
 
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "do-not-exist", null }
-                }
-            )
-            {
-                TemplateName = "c",
-                IsHelpFlagSpecified = true,
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("c").WithHelpOption().WithTemplateOption("do-not-exist");
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -1012,11 +917,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             });
 
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "Common",
-                IsHelpFlagSpecified = true,
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("Common").WithHelpOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/HelpTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/HelpTemplateListResolverTests.cs
@@ -12,6 +12,7 @@ using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
 using System.Linq;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects;
 using Microsoft.TemplateEngine.Cli.HelpAndUsage;
+using Microsoft.TemplateEngine.Mocks;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 {
@@ -21,22 +22,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_UniqueNameMatchesCorrectly()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console1",
-                Name = "Long name for Console App",
-                Identity = "Console.App",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console2",
-                Name = "Long name for Console App #2",
-                Identity = "Console.App2",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console1", name: "Long name for Console App", identity: "Console.App"));
+            templatesToSearch.Add(new MockTemplateInfo("console2", name: "Long name for Console App #2", identity: "Console.App2"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console2").WithHelpOption();
 
@@ -52,22 +39,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_ExactMatchOnShortNameMatchesCorrectly()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console2",
-                Name = "Long name for Console App #2",
-                Identity = "Console.App2",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App"));
+            templatesToSearch.Add(new MockTemplateInfo("console2", name: "Long name for Console App #2", identity: "Console.App2"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithHelpOption();
 
@@ -83,42 +56,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_UnambiguousGroupIsFound()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L2",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L3",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L3") }
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L3", groupIdentity: "Console.App.Test").WithTag("language", "L3"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithHelpOption();
 
@@ -134,66 +74,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_MultipleGroupsAreFound()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L2",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L3",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L3") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "classlib",
-                Name = "Long name for Class Library App",
-                Identity = "Class.Library.L1",
-                GroupIdentity = "Class.Library.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "classlib",
-                Name = "Long name for Class Library App",
-                Identity = "Class.Library.L2",
-                GroupIdentity = "Class.Library.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") }
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L3", groupIdentity: "Console.App.Test").WithTag("language", "L3"));
+            templatesToSearch.Add(new MockTemplateInfo("classlib", name: "Long name for Class Library App", identity: "Class.Library.L1", groupIdentity: "Class.Library.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("classlib", name: "Long name for Class Library App", identity: "Class.Library.L2", groupIdentity: "Class.Library.Test").WithTag("language", "L2"));
 
             INewCommandInput userInputs = new MockNewCommandInput("c").WithHelpOption();
 
@@ -208,30 +93,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_DefaultLanguageDisambiguates()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L2",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") }
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithHelpOption();
 
@@ -250,30 +113,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_InputLanguageIsPreferredOverDefault()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L2",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") }
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console", "L2").WithHelpOption();
 
@@ -290,42 +131,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_UnambiguousGroup_TemplatesAreNotSameLanguage()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L2",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L3",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L3") }
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L3", groupIdentity: "Console.App.Test").WithTag("language", "L3"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithHelpOption();
 
@@ -342,42 +150,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_UnambiguousGroup_TemplatesAreSameLanguage()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T2",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T3",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T2", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T3", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithHelpOption();
 
@@ -394,24 +169,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_PartialMatch_HasLanguageMismatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                    .WithTag("language", "L1")
+                    .WithTag("type", "project")
+                    .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console", "L2").WithHelpOption();
 
@@ -432,24 +194,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_PartialMatch_HasContextMismatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                    .WithTag("language", "L1")
+                    .WithTag("type", "project")
+                    .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console", type: "item").WithHelpOption();
 
@@ -470,24 +220,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_PartialMatch_HasBaselineMismatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                    .WithTag("language", "L1")
+                    .WithTag("type", "project")
+                    .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithHelpOption().WithCommandOption("--baseline", "core");
 
@@ -508,24 +245,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_PartialMatch_HasMultipleMismatches()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                    .WithTag("language", "L1")
+                    .WithTag("type", "project")
+                    .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console", "L2", "item").WithHelpOption().WithCommandOption("--baseline", "core");
 
@@ -546,43 +271,18 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_PartialMatchGroup_HasTypeMismatch_HasGroupLanguageMatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
 
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T2",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                    .WithTag("language", "L1")
+                    .WithTag("type", "project")
+                    .WithBaselineInfo("app", "standard"));
+
+            templatesToSearch.Add(
+               new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T2", groupIdentity: "Console.App.Test")
+                   .WithTag("language", "L2")
+                   .WithTag("type", "project")
+                   .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console", "L2", "item").WithHelpOption();
 
@@ -603,25 +303,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_NoMatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
 
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                    .WithTag("language", "L1")
+                    .WithTag("type", "project")
+                    .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("zzzzz", "L1", "item").WithHelpOption().WithCommandOption("--baseline", "app");
 
@@ -644,71 +331,26 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_OtherParameterMatch_Text()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test1",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "langVersion", new CacheParameter("text", "", "test description") }
-                }
 
-            });
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test1")
+                    .WithTag("language", "L1")
+                    .WithTag("type", "project")
+                    .WithParameters("langVersion")
+                    .WithBaselineInfo("app", "standard"));
 
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T2",
-                GroupIdentity = "Console.App.Test2",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "test", new CacheParameter("text", "", "test description") }
-                }
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T2", groupIdentity: "Console.App.Test2")
+                    .WithTag("language", "L2")
+                    .WithTag("type", "project")
+                    .WithParameters("test")
+                    .WithBaselineInfo("app", "standard"));
 
-            });
-
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T3",
-                GroupIdentity = "Console.App.Test3",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L3") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
-            });
-
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T3", groupIdentity: "Console.App.Test3")
+                    .WithTag("language", "L3")
+                    .WithTag("type", "project")
+                    .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("c").WithHelpOption().WithTemplateOption("langVersion");
 
@@ -730,69 +372,26 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_OtherParameterMatch_Choice()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test1",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")},
-                    { "framework", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "netcoreapp1.0", "netcoreapp1.1" }) }
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
 
-            });
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test1")
+                    .WithTag("language", "L1")
+                    .WithTag("type", "project")
+                    .WithTag("framework", "netcoreapp1.0", "netcoreapp1.1")
+                    .WithBaselineInfo("app", "standard"));
 
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T2",
-                GroupIdentity = "Console.App.Test2",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "test", new CacheParameter("text", "", "test description") }
-                }
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T2", groupIdentity: "Console.App.Test2")
+                    .WithTag("language", "L2")
+                    .WithTag("type", "project")
+                    .WithParameters("test")
+                    .WithBaselineInfo("app", "standard"));
 
-            });
-
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T3",
-                GroupIdentity = "Console.App.Test3",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L3") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
-            });
-
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T3", groupIdentity: "Console.App.Test3")
+                    .WithTag("language", "L3")
+                    .WithTag("type", "project")
+                    .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("c").WithHelpOption().WithTemplateOption("framework");
 
@@ -813,69 +412,26 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_OtherParameterDoesNotExist()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test1",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")},
-                    { "framework", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "netcoreapp1.0", "netcoreapp1.1" }) }
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
 
-            });
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test1")
+                    .WithTag("language", "L1")
+                    .WithTag("type", "project")
+                    .WithTag("framework", "netcoreapp1.0", "netcoreapp1.1")
+                    .WithBaselineInfo("app", "standard"));
 
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T2",
-                GroupIdentity = "Console.App.Test2",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "test", new CacheParameter("text", "", "test description") }
-                }
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T2", groupIdentity: "Console.App.Test2")
+                    .WithTag("language", "L2")
+                    .WithTag("type", "project")
+                    .WithParameters("test")
+                    .WithBaselineInfo("app", "standard"));
 
-            });
-
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T3",
-                GroupIdentity = "Console.App.Test3",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L3") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
-            });
-
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T3", groupIdentity: "Console.App.Test3")
+                    .WithTag("language", "L3")
+                    .WithTag("type", "project")
+                    .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("c").WithHelpOption().WithTemplateOption("do-not-exist");
 
@@ -896,25 +452,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_MatchByTagsIgnoredForHelp()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Classifications = new List<string> { "Common", "Test" },
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test1")
+                    .WithTag("language", "L1")
+                    .WithTag("type", "project")
+                    .WithClassifications("Common", "Test")
+                    .WithBaselineInfo("app", "standard"));
 
 
             INewCommandInput userInputs = new MockNewCommandInput("Common").WithHelpOption();

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
@@ -11,6 +11,7 @@ using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
 using System.Linq;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects;
 using Xunit;
+using Microsoft.TemplateEngine.Mocks;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 {
@@ -20,22 +21,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_UniqueNameMatchesCorrectly()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console1",
-                Name = "Long name for Console App",
-                Identity = "Console.App",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console2",
-                Name = "Long name for Console App #2",
-                Identity = "Console.App2",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console1", name: "Long name for Console App", identity: "Console.App"));
+            templatesToSearch.Add(new MockTemplateInfo("console2", name: "Long name for Console App #2", identity: "Console.App2"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console2").WithListOption();
 
@@ -51,22 +38,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_ExactMatchOnShortNameMatchesCorrectly()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console2",
-                Name = "Long name for Console App #2",
-                Identity = "Console.App2",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App"));
+            templatesToSearch.Add(new MockTemplateInfo("console2", name: "Long name for Console App #2", identity: "Console.App2"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption();
 
@@ -83,42 +56,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_UnambiguousGroupIsFound()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L2",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L3",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L3") }
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L3", groupIdentity: "Console.App.Test").WithTag("language", "L3"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption();
 
@@ -134,66 +74,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_MultipleGroupsAreFound()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L2",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L3",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L3") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "classlib",
-                Name = "Long name for Class Library App",
-                Identity = "Class.Library.L1",
-                GroupIdentity = "Class.Library.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "classlib",
-                Name = "Long name for Class Library App",
-                Identity = "Class.Library.L2",
-                GroupIdentity = "Class.Library.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") }
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L3", groupIdentity: "Console.App.Test").WithTag("language", "L3"));
+            templatesToSearch.Add(new MockTemplateInfo("classlib", name: "Long name for Class Library App", identity: "Class.Library.L1", groupIdentity: "Class.Library.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("classlib", name: "Long name for Class Library App", identity: "Class.Library.L2", groupIdentity: "Class.Library.Test").WithTag("language", "L2"));
 
             INewCommandInput userInputs = new MockNewCommandInput("c").WithListOption();
 
@@ -208,30 +93,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_DefaultLanguageDisambiguates()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L2",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") }
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption();
 
@@ -249,30 +112,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_InputLanguageIsPreferredOverDefault()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.L2",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L2") }
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L1", groupIdentity: "Console.App.Test").WithTag("language", "L1"));
+            templatesToSearch.Add(new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.L2", groupIdentity: "Console.App.Test").WithTag("language", "L2"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console", "L2").WithListOption();
 
@@ -289,24 +130,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_PartialMatch_HasLanguageMismatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+            templatesToSearch.Add(
+              new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                  .WithTag("language", "L1")
+                  .WithTag("type", "project")
+                  .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console", "L2").WithListOption();
 
@@ -327,24 +155,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_PartialMatch_HasContextMismatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+            templatesToSearch.Add(
+                   new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                       .WithTag("language", "L1")
+                       .WithTag("type", "project")
+                       .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console", type: "item").WithListOption();
 
@@ -365,24 +180,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_PartialMatch_HasBaselineMismatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+            templatesToSearch.Add(
+                   new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                       .WithTag("language", "L1")
+                       .WithTag("type", "project")
+                       .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption().WithCommandOption("--baseline", "core");
 
@@ -403,24 +205,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_PartialMatch_HasMultipleMismatches()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+            templatesToSearch.Add(
+                   new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                       .WithTag("language", "L1")
+                       .WithTag("type", "project")
+                       .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console", "L2", "item").WithListOption().WithCommandOption("--baseline", "core");
 
@@ -441,25 +230,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_NoMatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
-
+            templatesToSearch.Add(
+                   new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                       .WithTag("language", "L1")
+                       .WithTag("type", "project")
+                       .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("zzzzz", "L1", "project").WithListOption().WithCommandOption("--baseline", "app");
 
@@ -483,25 +258,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_MatchByTags()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Classifications = new List <string> {  "Common", "Test" },
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test1")
+                    .WithTag("language", "L1")
+                    .WithTag("type", "project")
+                    .WithClassifications("Common", "Test")
+                    .WithBaselineInfo("app", "standard"));
 
 
             INewCommandInput userInputs = new MockNewCommandInput("Common").WithListOption();
@@ -519,46 +281,18 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_MatchByTagsIgnoredOnNameMatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console1",
-                Name = "Long name for Console App Test",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Classifications = new List<string> { "Common", "Test" },
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
-
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console2",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T2",
-                GroupIdentity = "Console.App.Test2",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Classifications = new List<string> { "Common", "Test" },
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
-
+            templatesToSearch.Add(
+                new MockTemplateInfo("console1", name: "Long name for Console App Test", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                    .WithTag("language", "L1")
+                    .WithTag("type", "project")
+                    .WithClassifications("Common", "Test")
+                    .WithBaselineInfo("app", "standard"));
+            templatesToSearch.Add(
+              new MockTemplateInfo("console2", name: "Long name for Console App", identity: "Console.App.T2", groupIdentity: "Console.App.Test2")
+                  .WithTag("language", "L1")
+                  .WithTag("type", "project")
+                  .WithClassifications("Common", "Test")
+                  .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("Test").WithListOption();
 
@@ -577,45 +311,18 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_MatchByTagsIgnoredOnShortNameMatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App Test",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Classifications = new List<string> { "Common", "Test", "Console" },
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
-
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "cons",
-                Name = "Long name for Cons App",
-                Identity = "Console.App.T2",
-                GroupIdentity = "Console.App.Test2",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Classifications = new List<string> { "Common", "Test", "Console" },
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+            templatesToSearch.Add(
+              new MockTemplateInfo("console", name: "Long name for Console App Test", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                  .WithTag("language", "L1")
+                  .WithTag("type", "project")
+                  .WithClassifications("Common", "Test", "Console")
+                  .WithBaselineInfo("app", "standard"));
+            templatesToSearch.Add(
+              new MockTemplateInfo("cons", name: "Long name for Cons App", identity: "Console.App.T2", groupIdentity: "Console.App.Test2")
+                  .WithTag("language", "L1")
+                  .WithTag("type", "project")
+                  .WithClassifications("Common", "Test", "Console")
+                  .WithBaselineInfo("app", "standard"));
 
 
             INewCommandInput userInputs = new MockNewCommandInput("Console").WithListOption();
@@ -635,25 +342,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_MatchByTagsAndMismatchByFilter()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Classifications = new List<string> { "Common", "Test" },
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
+            templatesToSearch.Add(
+               new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                   .WithTag("language", "L1")
+                   .WithTag("type", "project")
+                   .WithClassifications("Common", "Test")
+                   .WithBaselineInfo("app", "standard"));
 
 
             INewCommandInput userInputs = new MockNewCommandInput("Common", "L2", "item").WithListOption();
@@ -682,27 +376,13 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_AuthorMatch(string templateAuthor, string commandAuthor, bool matchExpected)
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Classifications = new List<string> { "Common", "Test" },
-                Author = templateAuthor,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("L1") },
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project")}
-                },
-                BaselineInfo = new Dictionary<string, IBaselineInfo>()
-                {
-                    { "app", new BaselineInfo() },
-                    { "standard", new BaselineInfo() }
-                }
-            });
 
+            templatesToSearch.Add(
+               new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test", author: templateAuthor)
+                   .WithTag("language", "L1")
+                   .WithTag("type", "project")
+                   .WithClassifications("Common", "Test")
+                   .WithBaselineInfo("app", "standard"));
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption().WithCommandOption("--author", commandAuthor);
 
@@ -738,17 +418,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestGetTemplateResolutionResult_TemplateWithoutTypeShouldNotBeMatchedForContextFilter()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "console",
-                Name = "Long name for Console App",
-                Identity = "Console.App.T1",
-                GroupIdentity = "Console.App.Test",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Classifications = new List<string> { "Common", "Test" },
-                Tags = new Dictionary<string, ICacheTag>()
-            });
-
+            templatesToSearch.Add(
+                new MockTemplateInfo("console", name: "Long name for Console App", identity: "Console.App.T1", groupIdentity: "Console.App.Test")
+                    .WithClassifications("Common", "Test"));
 
             INewCommandInput userInputs = new MockNewCommandInput("Common", type: "item").WithListOption();
 

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
@@ -37,11 +37,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 Tags = new Dictionary<string, ICacheTag>()
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console2",
-                IsListFlagSpecified = true
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console2").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -72,11 +68,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 Tags = new Dictionary<string, ICacheTag>()
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsListFlagSpecified = true
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -128,11 +120,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsListFlagSpecified = true
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -207,11 +195,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "c",
-                IsListFlagSpecified = true
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("c").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -249,11 +233,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsListFlagSpecified = true
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "L1");
             Assert.True(matchResult.HasExactMatches);
@@ -294,12 +274,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsListFlagSpecified = true,
-                Language = "L2"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console", "L2").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "L1");
             Assert.True(matchResult.HasExactMatches);
@@ -333,12 +308,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsListFlagSpecified = true,
-                Language = "L2"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console", "L2").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
@@ -376,12 +346,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsListFlagSpecified = true,
-                TypeFilter = "item"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console", type: "item").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
@@ -419,12 +384,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsListFlagSpecified = true,
-                BaselineName = "core"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption().WithCommandOption("--baseline", "core");
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
@@ -462,14 +422,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsListFlagSpecified = true,
-                Language = "L2",
-                TypeFilter = "item",
-                BaselineName = "core"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console", "L2", "item").WithListOption().WithCommandOption("--baseline", "core");
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
@@ -508,14 +461,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             });
 
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "zzzzz",
-                IsListFlagSpecified = true,
-                Language = "L1",
-                TypeFilter = "project",
-                BaselineName = "app"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("zzzzz", "L1", "project").WithListOption().WithCommandOption("--baseline", "app");
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
@@ -558,11 +504,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             });
 
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "Common",
-                IsListFlagSpecified = true,
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("Common").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -618,11 +560,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             });
 
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "Test",
-                IsListFlagSpecified = true,
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("Test").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -680,11 +618,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             });
 
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "Console",
-                IsListFlagSpecified = true,
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("Console").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
@@ -722,13 +656,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             });
 
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "Common",
-                IsListFlagSpecified = true,
-                Language = "L2",
-                TypeFilter = "item",
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("Common", "L2", "item").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
@@ -776,12 +704,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             });
 
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "console",
-                IsListFlagSpecified = true,
-                AuthorFilter = commandAuthor
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption().WithCommandOption("--author", commandAuthor);
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
 
@@ -827,13 +750,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             });
 
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "Common",
-                IsListFlagSpecified = true,
-
-                TypeFilter = "item",
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("Common", type: "item").WithListOption();
 
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/MultiShortNameResolutionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/MultiShortNameResolutionTests.cs
@@ -4,9 +4,8 @@ using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
 using Microsoft.TemplateEngine.Cli.TemplateResolution;
 using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
-using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Edge.Template;
-using Microsoft.TemplateEngine.Orchestrator.RunnableProjects;
+using Microsoft.TemplateEngine.Mocks;
 using Xunit;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
@@ -120,74 +119,28 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 {
                     List<ITemplateInfo> templateList = new List<ITemplateInfo>();
 
-                    templateList.Add(new TemplateInfo()
-                    {
-                        ShortNameList = new string[] { "aaa", "bbb" },
-                        Name = "High precedence C# in group",
-                        Precedence = 2000,
-                        Identity = "MultiName.Test.High.CSharp",
-                        GroupIdentity = "MultiName.Test",
-                        Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                        {
-                            { "language", ResolutionTestHelper.CreateTestCacheTag("C#") },
-                            { "foo", ResolutionTestHelper.CreateTestCacheTag(new string[] { "A", "W" }) }
-                        },
-                        CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
-                        {
-                            { "HighC", new CacheParameter("string", "high c", "high c description") }
-                        }
-                    });
+                    templateList.Add(
+                        new MockTemplateInfo(new string[] { "aaa", "bbb" }, name: "High precedence C# in group", precedence: 2000, identity: "MultiName.Test.High.CSharp", groupIdentity: "MultiName.Test")
+                            .WithTag("language", "C#")
+                            .WithTag("foo", "A", "W")
+                            .WithParameters("HighC"));
 
-                    templateList.Add(new TemplateInfo()
-                    {
-                        ShortNameList = new string[] { "ccc", "ddd", "eee" },
-                        Name = "Low precedence C# in group",
-                        Precedence = 100,
-                        Identity = "MultiName.Test.Low.CSharp",
-                        GroupIdentity = "MultiName.Test",
-                        Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                        {
-                            { "language", ResolutionTestHelper.CreateTestCacheTag("C#") },
-                            { "foo", ResolutionTestHelper.CreateTestCacheTag(new string[] { "A", "X" }) }
-                        },
-                        CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
-                        {
-                            { "LowC", new CacheParameter("string", "low c", "low c description") }
-                        }
-                    });
+                    templateList.Add(
+                        new MockTemplateInfo(new string[] { "ccc", "ddd", "eee" }, name: "Low precedence C# in group", precedence: 100, identity: "MultiName.Test.Low.CSharp", groupIdentity: "MultiName.Test")
+                            .WithTag("language", "C#")
+                            .WithTag("foo", "A", "X")
+                            .WithParameters("LowC"));
 
-                    templateList.Add(new TemplateInfo()
-                    {
-                        ShortNameList = new string[] { "fff" },
-                        Name = "Only F# in group",
-                        Precedence = 100,
-                        Identity = "Multiname.Test.Only.FSharp",
-                        GroupIdentity = "MultiName.Test",
-                        Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                        {
-                            { "language", ResolutionTestHelper.CreateTestCacheTag("F#") },
-                            { "foo", ResolutionTestHelper.CreateTestCacheTag(new string[] { "A", "Y" }) }
-                        },
-                        CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
-                        {
-                            { "OnlyF", new CacheParameter("string", "only f", "only f description") }
-                        }
-                    });
+                    templateList.Add(
+                       new MockTemplateInfo(new string[] { "fff" }, name: "Only F# in group", precedence: 100, identity: "Multiname.Test.Only.FSharp", groupIdentity: "MultiName.Test")
+                           .WithTag("language", "F#")
+                           .WithTag("foo", "A", "Y")
+                           .WithParameters("OnlyF"));
 
-                    templateList.Add(new TemplateInfo()
-                    {
-                        ShortNameList = new string[] { "other" },
-                        Name = "Unrelated template",
-                        Precedence = 9999,
-                        Identity = "Unrelated.Template.CSharp",
-                        GroupIdentity = "Unrelated.Template",
-                        Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                        {
-                            { "language", ResolutionTestHelper.CreateTestCacheTag("C#") },
-                            { "foo", ResolutionTestHelper.CreateTestCacheTag(new string[] { "A", "Z" }) }
-                        },
-                        CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
-                    });
+                    templateList.Add(
+                        new MockTemplateInfo(new string[] { "other" }, name: "Unrelated template", precedence: 9999, identity: "Unrelated.Template.CSharp", groupIdentity: "Unrelated.Template")
+                            .WithTag("language", "C#")
+                            .WithTag("foo", "A", "Z"));
 
                     _multiShortNameGroupTemplateInfo = templateList;
                 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/MultiShortNameResolutionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/MultiShortNameResolutionTests.cs
@@ -23,10 +23,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             foreach (string testShortName in shortNamesForGroup)
             {
-                INewCommandInput userInputs = new MockNewCommandInput()
-                {
-                    TemplateName = testShortName
-                };
+                INewCommandInput userInputs = new MockNewCommandInput(testShortName);
 
                 TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), userInputs, "C#");
                 matchResult.TryGetCoreMatchedTemplatesWithDisposition(x => x.IsMatch, out IReadOnlyList<ITemplateMatchInfo> matchedTemplateList);
@@ -51,10 +48,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             foreach (string testShortName in shortNamesForGroup)
             {
-                INewCommandInput userInputs = new MockNewCommandInput()
-                {
-                    TemplateName = testShortName
-                };
+                INewCommandInput userInputs = new MockNewCommandInput(testShortName);
 
                 TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), userInputs, "C#");
                 Assert.True(matchResult.TryGetSingularInvokableMatch(out ITemplateMatchInfo invokableTemplate, out TemplateResolutionResult.Status resultStatus));
@@ -73,11 +67,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             foreach (string testShortName in shortNamesForGroup)
             {
-                INewCommandInput userInputs = new MockNewCommandInput()
-                {
-                    TemplateName = testShortName,
-                    Language = "F#"
-                };
+                INewCommandInput userInputs = new MockNewCommandInput(testShortName, "F#");
 
                 TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), userInputs, "C#");
                 Assert.True(matchResult.TryGetSingularInvokableMatch(out ITemplateMatchInfo invokableTemplate, out TemplateResolutionResult.Status resultStatus));
@@ -95,15 +85,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [InlineData("eee", "Y", "Multiname.Test.Only.FSharp")]  // uses a short name from a different template in the group
         public void ChoiceValueDisambiguatesMatchesWithMultipleShortNames(string name, string fooChoice, string expectedIdentity)
         {
-            IReadOnlyDictionary<string, string> userParams = new Dictionary<string, string>()
-            {
-                {  "foo", fooChoice }
-            };
-
-            INewCommandInput commandInput = new MockNewCommandInput(userParams)
-            {
-                TemplateName = name
-            };
+            INewCommandInput commandInput = new MockNewCommandInput(name).WithTemplateOption("foo", fooChoice);
 
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), commandInput, "C#");
 
@@ -121,15 +103,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [InlineData("eee", "OnlyF", "someValue", "Multiname.Test.Only.FSharp")] // uses a short name from a different template in the group
         public void ParameterExistenceDisambiguatesMatchesWithMultipleShortNames(string name, string paramName, string paramValue, string expectedIdentity)
         {
-            IReadOnlyDictionary<string, string> userParams = new Dictionary<string, string>()
-            {
-                { paramName, paramValue }
-            };
-
-            INewCommandInput commandInput = new MockNewCommandInput(userParams)
-            {
-                TemplateName = name
-            };
+            INewCommandInput commandInput = new MockNewCommandInput(name).WithTemplateOption(paramName, paramValue);
 
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), commandInput, "C#");
 

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/SingularInvokableMatchTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/SingularInvokableMatchTests.cs
@@ -44,15 +44,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 CacheParameters = new Dictionary<string, ICacheParameter>(),
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "MyChoice", "value_" }
-                }
-            )
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_");
 
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, hostSpecificDataLoader, userInputs, null);
@@ -97,15 +89,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 CacheParameters = new Dictionary<string, ICacheParameter>(),
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "MyChoice", "value_" }
-                }
-            )
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_");
 
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, hostSpecificDataLoader, userInputs, null);
@@ -150,15 +134,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 CacheParameters = new Dictionary<string, ICacheParameter>(),
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "MyChoice", "value_" }
-                }
-            )
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_");
 
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, hostSpecificDataLoader, userInputs, null);
@@ -205,16 +181,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 CacheParameters = new Dictionary<string, ICacheParameter>(),
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "MyChoice", "value_" },
-                    { "OtherChoice", "foo_" }
-                }
-            )
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_").WithTemplateOption("OtherChoice", "foo_");
 
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, hostSpecificDataLoader, userInputs, null);
@@ -246,12 +213,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 CacheParameters = new Dictionary<string, ICacheParameter>(),
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { }
-            )
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo");
 
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, hostSpecificDataLoader, userInputs, null);
@@ -296,13 +258,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 CacheParameters = new Dictionary<string, ICacheParameter>(),
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { }
-            )
-            {
-                TemplateName = "foo"
-            };
-
+            INewCommandInput userInputs = new MockNewCommandInput("foo");
 
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, hostSpecificDataLoader, userInputs, null);
@@ -347,12 +303,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 CacheParameters = new Dictionary<string, ICacheParameter>(),
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { }
-            )
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo");
 
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, hostSpecificDataLoader, userInputs, null);

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/SingularInvokableMatchTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/SingularInvokableMatchTests.cs
@@ -6,6 +6,7 @@ using Microsoft.TemplateEngine.Cli.TemplateResolution;
 using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Edge.Template;
+using Microsoft.TemplateEngine.Mocks;
 using Xunit;
 using static Microsoft.TemplateEngine.Cli.TemplateResolution.TemplateResolutionResult;
 
@@ -17,32 +18,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void MultipleTemplatesInGroupHavingSingleStartsWithOnSameParamIsAmbiguous()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_1",
-                GroupIdentity = "foo.test.template",
-                Precedence = 100,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_1"}) }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_2",
-                GroupIdentity = "foo.test.template",
-                Precedence = 200,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_2"}) }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_1", groupIdentity: "foo.test.template", precedence: 100)
+                                    .WithTag("MyChoice", "value_1"));
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_2", groupIdentity: "foo.test.template", precedence: 200)
+                                    .WithTag("MyChoice", "value_2"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_");
 
@@ -62,32 +41,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void MultipleTemplatesInGroupParamPartiaMatch_TheOneHavingSingleStartsWithIsTheSingularInvokableMatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_1",
-                GroupIdentity = "foo.test.template",
-                Precedence = 100,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_1"}) }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_2",
-                GroupIdentity = "foo.test.template",
-                Precedence = 200,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_2", "value_3"}) }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_1", groupIdentity: "foo.test.template", precedence: 100)
+                                    .WithTag("MyChoice", "value_1"));
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_2", groupIdentity: "foo.test.template", precedence: 200)
+                                    .WithTag("MyChoice", "value_2", "value_3"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_");
 
@@ -107,32 +64,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void MultipleTemplatesInGroupHavingAmbiguousParamMatchOnSameParamIsAmbiguous()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_1",
-                GroupIdentity = "foo.test.template",
-                Precedence = 100,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_1", "value_2"}) }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_2",
-                GroupIdentity = "foo.test.template",
-                Precedence = 200,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_3", "value_4"}) }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_1", groupIdentity: "foo.test.template", precedence: 100)
+                        .WithTag("MyChoice", "value_1", "value_2"));
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_2", groupIdentity: "foo.test.template", precedence: 200)
+                                    .WithTag("MyChoice", "value_3", "value_4"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_");
 
@@ -152,34 +87,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void MultipleTemplatesInGroupHavingSingularStartMatchesOnDifferentParams_HighPrecedenceIsChosen()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_1",
-                GroupIdentity = "foo.test.template",
-                Precedence = 100,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_1", "other_value"}) },    // single starts with
-                    { "OtherChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "foo_" }) }          // exact
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_2",
-                GroupIdentity = "foo.test.template",
-                Precedence = 200,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "MyChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "value_" }) },    // exact
-                    { "OtherChoice", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "foo_", "bar_1"}) }      // single starts with
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_1", groupIdentity: "foo.test.template", precedence: 100)
+                                    .WithTag("MyChoice", "value_1", "other_value")
+                                    .WithTag("OtherChoice", "foo_"));
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_2", groupIdentity: "foo.test.template", precedence: 200)
+                                    .WithTag("MyChoice", "value_")
+                                    .WithTag("OtherChoice", "foo_", "bar_1"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_").WithTemplateOption("OtherChoice", "foo_");
 
@@ -199,19 +112,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void GivenOneInvokableTemplateWithNonDefaultLanguage_ItIsChosen()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_1",
-                GroupIdentity = "foo.test.template",
-                Precedence = 100,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "F#" }) },
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_1", groupIdentity: "foo.test.template", precedence: 100)
+                                    .WithTag("language", "F#"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo");
 
@@ -231,32 +133,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void GivenTwoInvokableTemplatesNonDefaultLanguage_HighPrecedenceIsChosen()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_1.FSharp",
-                GroupIdentity = "foo.test.template",
-                Precedence = 100,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "F#" }) },
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_1.VB",
-                GroupIdentity = "foo.test.template",
-                Precedence = 200,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "VB" }) },
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_1.FSharp", groupIdentity: "foo.test.template", precedence: 100)
+                        .WithTag("language", "F#"));
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_1.VB", groupIdentity: "foo.test.template", precedence: 200)
+                  .WithTag("language", "VB"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo");
 
@@ -276,32 +156,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void GivenMultipleHighestPrecedenceTemplates_ResultIsAmbiguous()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_1.FSharp",
-                GroupIdentity = "foo.test.template",
-                Precedence = 100,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "F#" }) },
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test_1.VB",
-                GroupIdentity = "foo.test.template",
-                Precedence = 100,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "VB" }) },
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_1.FSharp", groupIdentity: "foo.test.template", precedence: 100)
+                 .WithTag("language", "F#"));
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test_1.VB", groupIdentity: "foo.test.template", precedence: 100)
+                  .WithTag("language", "VB"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo");
 

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateMatchInfoExtensionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateMatchInfoExtensionTests.cs
@@ -2,14 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Cli.CommandParsing;
 using Microsoft.TemplateEngine.Cli.TemplateResolution;
-using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Edge.Template;
-using Microsoft.TemplateEngine.Utils;
+using Microsoft.TemplateEngine.Mocks;
 using Xunit;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
@@ -20,24 +16,19 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_ShortNameMismatchAndClassificationExact))]
         public void TestHasClassificationMatchAndNameMismatch_ShortNameMismatchAndClassificationExact()
         {
-            List<MatchInfo> testDisposiions = new List<MatchInfo>();
-            testDisposiions.Add(new MatchInfo()
+            List<MatchInfo> testDispositions = new List<MatchInfo>();
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.ShortName,
                 Kind = MatchKind.Mismatch
             });
-            testDisposiions.Add(new MatchInfo()
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Classification,
                 Kind = MatchKind.Exact
             });
 
-            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
-            {
-                Name = "Template1",
-                Identity = "Template1",
-                GroupIdentity = "TestGroup"
-            }, testDisposiions);
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new MockTemplateInfo("Template1", groupIdentity: "TestGroup"), testDispositions);
 
             Assert.True(testTemplate.HasClassificationMatchAndNameMismatch());
         }
@@ -45,24 +36,19 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_NameMismatchAndClassificationExact))]
         public void TestHasClassificationMatchAndNameMismatch_NameMismatchAndClassificationExact()
         {
-            List<MatchInfo> testDisposiions = new List<MatchInfo>();
-            testDisposiions.Add(new MatchInfo()
+            List<MatchInfo> testDispositions = new List<MatchInfo>();
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Name,
                 Kind = MatchKind.Mismatch
             });
-            testDisposiions.Add(new MatchInfo()
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Classification,
                 Kind = MatchKind.Exact
             });
 
-            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
-            {
-                Name = "Template1",
-                Identity = "Template1",
-                GroupIdentity = "TestGroup"
-            }, testDisposiions);
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new MockTemplateInfo("Template1", groupIdentity: "TestGroup"), testDispositions);
 
             Assert.True(testTemplate.HasClassificationMatchAndNameMismatch());
         }
@@ -70,24 +56,19 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_NameMismatchAndClassificationPartial))]
         public void TestHasClassificationMatchAndNameMismatch_NameMismatchAndClassificationPartial()
         {
-            List<MatchInfo> testDisposiions = new List<MatchInfo>();
-            testDisposiions.Add(new MatchInfo()
+            List<MatchInfo> testDispositions = new List<MatchInfo>();
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Name,
                 Kind = MatchKind.Mismatch
             });
-            testDisposiions.Add(new MatchInfo()
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Classification,
                 Kind = MatchKind.Partial
             });
 
-            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
-            {
-                Name = "Template1",
-                Identity = "Template1",
-                GroupIdentity = "TestGroup"
-            }, testDisposiions);
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new MockTemplateInfo("Template1", groupIdentity: "TestGroup"), testDispositions);
 
             Assert.True(testTemplate.HasClassificationMatchAndNameMismatch());
         }
@@ -95,24 +76,19 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_NameExactAndClassificationPartial))]
         public void TestHasClassificationMatchAndNameMismatch_NameExactAndClassificationPartial()
         {
-            List<MatchInfo> testDisposiions = new List<MatchInfo>();
-            testDisposiions.Add(new MatchInfo()
+            List<MatchInfo> testDispositions = new List<MatchInfo>();
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Name,
                 Kind = MatchKind.Exact
             });
-            testDisposiions.Add(new MatchInfo()
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Classification,
                 Kind = MatchKind.Partial
             });
 
-            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
-            {
-                Name = "Template1",
-                Identity = "Template1",
-                GroupIdentity = "TestGroup"
-            }, testDisposiions);
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new MockTemplateInfo("Template1", groupIdentity: "TestGroup"), testDispositions);
 
             Assert.False(testTemplate.HasClassificationMatchAndNameMismatch());
         }
@@ -120,24 +96,19 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_ShortNameExactAndClassificationPartial))]
         public void TestHasClassificationMatchAndNameMismatch_ShortNameExactAndClassificationPartial()
         {
-            List<MatchInfo> testDisposiions = new List<MatchInfo>();
-            testDisposiions.Add(new MatchInfo()
+            List<MatchInfo> testDispositions = new List<MatchInfo>();
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.ShortName,
                 Kind = MatchKind.Exact
             });
-            testDisposiions.Add(new MatchInfo()
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Classification,
                 Kind = MatchKind.Partial
             });
 
-            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
-            {
-                Name = "Template1",
-                Identity = "Template1",
-                GroupIdentity = "TestGroup"
-            }, testDisposiions);
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new MockTemplateInfo("Template1", groupIdentity: "TestGroup"), testDispositions);
 
             Assert.False(testTemplate.HasClassificationMatchAndNameMismatch());
         }
@@ -145,29 +116,24 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_ShortNameExactNameMismatchAndClassificationPartial))]
         public void TestHasClassificationMatchAndNameMismatch_ShortNameExactNameMismatchAndClassificationPartial()
         {
-            List<MatchInfo> testDisposiions = new List<MatchInfo>();
-            testDisposiions.Add(new MatchInfo()
+            List<MatchInfo> testDispositions = new List<MatchInfo>();
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.ShortName,
                 Kind = MatchKind.Exact
             });
-            testDisposiions.Add(new MatchInfo()
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Name,
                 Kind = MatchKind.Mismatch
             });
-            testDisposiions.Add(new MatchInfo()
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Classification,
                 Kind = MatchKind.Partial
             });
 
-            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
-            {
-                Name = "Template1",
-                Identity = "Template1",
-                GroupIdentity = "TestGroup"
-            }, testDisposiions);
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new MockTemplateInfo("Template1", groupIdentity: "TestGroup"), testDispositions);
 
             Assert.False(testTemplate.HasClassificationMatchAndNameMismatch());
         }
@@ -175,29 +141,24 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_NameMismatchClassificationPartialLanguageMismatch))]
         public void TestHasClassificationMatchAndNameMismatch_NameMismatchClassificationPartialLanguageMismatch()
         {
-            List<MatchInfo> testDisposiions = new List<MatchInfo>();
-            testDisposiions.Add(new MatchInfo()
+            List<MatchInfo> testDispositions = new List<MatchInfo>();
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Name,
                 Kind = MatchKind.Mismatch
             });
-            testDisposiions.Add(new MatchInfo()
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Classification,
                 Kind = MatchKind.Partial
             });
-            testDisposiions.Add(new MatchInfo()
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Language,
                 Kind = MatchKind.Mismatch
             });
 
-            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
-            {
-                Name = "Template1",
-                Identity = "Template1",
-                GroupIdentity = "TestGroup"
-            }, testDisposiions);
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new MockTemplateInfo("Template1", groupIdentity: "TestGroup"), testDispositions);
 
             Assert.False(testTemplate.HasClassificationMatchAndNameMismatch());
         }
@@ -205,29 +166,24 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         [Fact(DisplayName = nameof(TestHasClassificationMatchAndNameMismatch_NameMismatchClassificationPartialOtherStartsWith))]
         public void TestHasClassificationMatchAndNameMismatch_NameMismatchClassificationPartialOtherStartsWith()
         {
-            List<MatchInfo> testDisposiions = new List<MatchInfo>();
-            testDisposiions.Add(new MatchInfo()
+            List<MatchInfo> testDispositions = new List<MatchInfo>();
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Name,
                 Kind = MatchKind.Mismatch
             });
-            testDisposiions.Add(new MatchInfo()
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.Classification,
                 Kind = MatchKind.Partial
             });
-            testDisposiions.Add(new MatchInfo()
+            testDispositions.Add(new MatchInfo()
             {
                 Location = MatchLocation.OtherParameter,
                 Kind = MatchKind.SingleStartsWith
             });
 
-            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new TemplateInfo()
-            {
-                Name = "Template1",
-                Identity = "Template1",
-                GroupIdentity = "TestGroup"
-            }, testDisposiions);
+            ITemplateMatchInfo testTemplate = new TemplateMatchInfo(new MockTemplateInfo("Template1", groupIdentity: "TestGroup"), testDispositions);
 
             Assert.True(testTemplate.HasClassificationMatchAndNameMismatch());
         }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateMatchInfoTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateMatchInfoTests.cs
@@ -2,6 +2,7 @@ using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.TemplateResolution;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Edge.Template;
+using Microsoft.TemplateEngine.Mocks;
 using Xunit;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests
@@ -11,7 +12,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(EmptyMatchDisposition_ReportsCorrectly))]
         public void EmptyMatchDisposition_ReportsCorrectly()
         {
-            ITemplateInfo templateInfo = new TemplateInfo();
+            ITemplateInfo templateInfo = new MockTemplateInfo();
             ITemplateMatchInfo TemplateMatchInfo = new TemplateMatchInfo(templateInfo);
             Assert.False(TemplateMatchInfo.IsMatch);
             Assert.False(TemplateMatchInfo.IsMatchExceptContext());
@@ -28,7 +29,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(NameExactMatch_ReportsCorrectly))]
         public void NameExactMatch_ReportsCorrectly()
         {
-            ITemplateInfo templateInfo = new TemplateInfo();
+            ITemplateInfo templateInfo = new MockTemplateInfo();
             ITemplateMatchInfo TemplateMatchInfo = new TemplateMatchInfo(templateInfo);
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Name, Kind = MatchKind.Exact });
             Assert.True(TemplateMatchInfo.IsMatch);
@@ -44,7 +45,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(NamePartialMatch_ReportsCorrectly))]
         public void NamePartialMatch_ReportsCorrectly()
         {
-            ITemplateInfo templateInfo = new TemplateInfo();
+            ITemplateInfo templateInfo = new MockTemplateInfo();
             ITemplateMatchInfo TemplateMatchInfo = new TemplateMatchInfo(templateInfo);
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Name, Kind = MatchKind.Partial });
             Assert.True(TemplateMatchInfo.IsMatch);
@@ -60,7 +61,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(NameMismatch_ReportsCorrectly))]
         public void NameMismatch_ReportsCorrectly()
         {
-            ITemplateInfo templateInfo = new TemplateInfo();
+            ITemplateInfo templateInfo = new MockTemplateInfo();
             ITemplateMatchInfo TemplateMatchInfo = new TemplateMatchInfo(templateInfo);
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Name, Kind = MatchKind.Mismatch });
             Assert.False(TemplateMatchInfo.IsMatch);
@@ -76,7 +77,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(ContextMatch_ReportsCorrectly))]
         public void ContextMatch_ReportsCorrectly()
         {
-            ITemplateInfo templateInfo = new TemplateInfo();
+            ITemplateInfo templateInfo = new MockTemplateInfo();
             ITemplateMatchInfo TemplateMatchInfo = new TemplateMatchInfo(templateInfo);
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Exact });
             Assert.True(TemplateMatchInfo.IsMatch);
@@ -92,7 +93,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(ContextMismatch_ReportsCorrectly))]
         public void ContextMismatch_ReportsCorrectly()
         {
-            ITemplateInfo templateInfo = new TemplateInfo();
+            ITemplateInfo templateInfo = new MockTemplateInfo();
             ITemplateMatchInfo TemplateMatchInfo = new TemplateMatchInfo(templateInfo);
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Mismatch });
             Assert.False(TemplateMatchInfo.IsMatch);
@@ -108,7 +109,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(ContextMatch_NameMatch_ReportsCorrectly))]
         public void ContextMatch_NameMatch_ReportsCorrectly()
         {
-            ITemplateInfo templateInfo = new TemplateInfo();
+            ITemplateInfo templateInfo = new MockTemplateInfo();
             ITemplateMatchInfo TemplateMatchInfo = new TemplateMatchInfo(templateInfo);
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Name, Kind = MatchKind.Exact });
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Exact });
@@ -125,7 +126,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(ContextMatch_NameMismatch_ReportsCorrectly))]
         public void ContextMatch_NameMismatch_ReportsCorrectly()
         {
-            ITemplateInfo templateInfo = new TemplateInfo();
+            ITemplateInfo templateInfo = new MockTemplateInfo();
             ITemplateMatchInfo TemplateMatchInfo = new TemplateMatchInfo(templateInfo);
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Name, Kind = MatchKind.Mismatch });
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Exact });
@@ -142,7 +143,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(ContextMatch_NamePartialMatch_ReportsCorrectly))]
         public void ContextMatch_NamePartialMatch_ReportsCorrectly()
         {
-            ITemplateInfo templateInfo = new TemplateInfo();
+            ITemplateInfo templateInfo = new MockTemplateInfo();
             ITemplateMatchInfo TemplateMatchInfo = new TemplateMatchInfo(templateInfo);
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Name, Kind = MatchKind.Partial });
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Exact });
@@ -159,7 +160,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(ContextMismatch_NameMatch_ReportsCorrectly))]
         public void ContextMismatch_NameMatch_ReportsCorrectly()
         {
-            ITemplateInfo templateInfo = new TemplateInfo();
+            ITemplateInfo templateInfo = new MockTemplateInfo();
             ITemplateMatchInfo TemplateMatchInfo = new TemplateMatchInfo(templateInfo);
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Name, Kind = MatchKind.Exact });
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Mismatch });
@@ -176,7 +177,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [Fact(DisplayName = nameof(ContextMismatch_NamePartialMatch_ReportsCorrectly))]
         public void ContextMismatch_NamePartialMatch_ReportsCorrectly()
         {
-            ITemplateInfo templateInfo = new TemplateInfo();
+            ITemplateInfo templateInfo = new MockTemplateInfo();
             ITemplateMatchInfo TemplateMatchInfo = new TemplateMatchInfo(templateInfo);
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Name, Kind = MatchKind.Partial });
             TemplateMatchInfo.AddDisposition(new MatchInfo { Location = MatchLocation.Context, Kind = MatchKind.Mismatch });

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateResolverTests.cs
@@ -184,10 +184,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 Tags = new Dictionary<string, ICacheTag>()
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "Template2"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("Template2");
 
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
 
@@ -227,10 +224,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 CacheParameters = new Dictionary<string, ICacheParameter>()
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo");
 
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "Perl");
             Assert.Equal(1, matchResult.GetBestTemplateMatchList().Count);
@@ -268,11 +262,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 CacheParameters = new Dictionary<string, ICacheParameter>()
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "foo",
-                Language = "LISP"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo", "LISP");
 
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "Perl");
 
@@ -317,10 +307,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 Tags = new Dictionary<string, ICacheTag>()
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput()
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo");
 
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.Equal(2, matchResult.GetBestTemplateMatchList().Count);
@@ -359,15 +346,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "baz", "whatever" }
-                }
-            )
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("baz", "whatever");
 
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
@@ -406,15 +385,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 CacheParameters = new Dictionary<string, ICacheParameter>()
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "framework", "netcoreapp1.0" }
-                }
-            )
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("framework", "netcoreapp1.0");
 
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.TryGetUnambiguousTemplateGroupToUse(out IReadOnlyList<ITemplateMatchInfo> unambiguousGroup));
@@ -440,15 +411,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 }
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "baz", null }
-                }
-            )
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("baz");
 
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
 
@@ -492,15 +455,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 CacheParameters = new Dictionary<string, ICacheParameter>()
             });
 
-            INewCommandInput userInputs = new MockNewCommandInput(
-                new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "framework", "netcoreapp3.0" }
-                }
-            )
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("framework", "netcoreapp3.0");
+
 
             IHostSpecificDataLoader hostSpecificDataLoader = new MockHostSpecificDataLoader();
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templatesToSearch, hostSpecificDataLoader, userInputs, null);

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateResolverTests.cs
@@ -10,6 +10,7 @@ using Microsoft.TemplateEngine.Cli.TemplateResolution;
 using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Edge.Template;
+using Microsoft.TemplateEngine.Mocks;
 using Microsoft.TemplateEngine.Utils;
 using Xunit;
 
@@ -26,32 +27,13 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestFindHighestPrecedenceTemplateIfAllSameGroupIdentity()
         {
             List<ITemplateMatchInfo> templatesToCheck = new List<ITemplateMatchInfo>();
+
             templatesToCheck.Add(new TemplateMatchInfo(
-                new TemplateInfo()
-                {
-                    Precedence = 10,
-                    Name = "Template1",
-                    Identity = "Template1",
-                    GroupIdentity = "TestGroup"
-                }
-                , null));
+                new MockTemplateInfo("Template1", name: "Template1", identity: "Template1", groupIdentity: "TestGroup", precedence: 10), null));
             templatesToCheck.Add(new TemplateMatchInfo(
-                new TemplateInfo()
-                {
-                    Precedence = 20,
-                    Name = "Template2",
-                    Identity = "Template2",
-                    GroupIdentity = "TestGroup"
-                }
-                , null));
+                new MockTemplateInfo("Template2", name: "Template2", identity: "Template2", groupIdentity: "TestGroup", precedence: 20), null));
             templatesToCheck.Add(new TemplateMatchInfo(
-                new TemplateInfo()
-                {
-                    Precedence = 0,
-                    Name = "Template3",
-                    Identity = "Template3",
-                    GroupIdentity = "TestGroup"
-                }));
+                new MockTemplateInfo("Template3", name: "Template3", identity: "Template3", groupIdentity: "TestGroup", precedence: 0), null));
 
             ITemplateMatchInfo highestPrecedenceTemplate = TemplateResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(templatesToCheck);
             Assert.NotNull(highestPrecedenceTemplate);
@@ -64,23 +46,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         {
             List<ITemplateMatchInfo> templatesToCheck = new List<ITemplateMatchInfo>();
             templatesToCheck.Add(new TemplateMatchInfo(
-                new TemplateInfo()
-                {
-                    Precedence = 10,
-                    Name = "Template1",
-                    Identity = "Template1",
-                    GroupIdentity = "TestGroup"
-                }
-                , null));
+                new MockTemplateInfo("Template1", name: "Template1", identity: "Template1", groupIdentity: "TestGroup", precedence: 10), null));
             templatesToCheck.Add(new TemplateMatchInfo(
-                new TemplateInfo()
-                {
-                    Precedence = 20,
-                    Name = "Template2",
-                    Identity = "Template2",
-                    GroupIdentity = "RealGroup"
-                }
-                , null));
+                new MockTemplateInfo("Template2", name: "Template2", identity: "Template2", groupIdentity: "RealGroup", precedence: 20), null));
+
             ITemplateMatchInfo highestPrecedenceTemplate = TemplateResolver.FindHighestPrecedenceTemplateIfAllSameGroupIdentity(templatesToCheck);
             Assert.Null(highestPrecedenceTemplate);
         }
@@ -89,56 +58,16 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestPerformAllTemplatesInContextQuery()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                Name = "Template1",
-                Identity = "Template1",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project") }
-                },
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                Name = "Template2",
-                Identity = "Template2",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("item") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                Name = "Template3",
-                Identity = "Template3",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("myType") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                Name = "Template4",
-                Identity = "Template4",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "type",ResolutionTestHelper.CreateTestCacheTag("project") }
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                Name = "Template5",
-                Identity = "Template5",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "type", ResolutionTestHelper.CreateTestCacheTag("project") }
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("Template1", name: "Template1", identity: "Template1")
+                                    .WithTag("type", "project"));
+            templatesToSearch.Add(new MockTemplateInfo("Template2", name: "Template2", identity: "Template2")
+                                    .WithTag("type", "item"));
+            templatesToSearch.Add(new MockTemplateInfo("Template3", name: "Template3", identity: "Template3")
+                                    .WithTag("type", "myType"));
+            templatesToSearch.Add(new MockTemplateInfo("Template4", name: "Template4", identity: "Template4")
+                                    .WithTag("type", "project"));
+            templatesToSearch.Add(new MockTemplateInfo("Template5", name: "Template5", identity: "Template5")
+                                     .WithTag("type", "project"));
 
             IHostSpecificDataLoader hostDataLoader = new MockHostSpecificDataLoader();
 
@@ -167,22 +96,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestPerformCoreTemplateQuery_UniqueNameMatchesCorrectly()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "Template1",
-                Name = "Long name of Template1",
-                Identity = "Template1",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "Template2",
-                Name = "Long name of Template2",
-                Identity = "Template2",
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
+            templatesToSearch.Add(new MockTemplateInfo("Template1", name: "Long name of Template1", identity: "Template1"));
+            templatesToSearch.Add(new MockTemplateInfo("Template2", name: "Long name of Template2", identity: "Template2"));
 
             INewCommandInput userInputs = new MockNewCommandInput("Template2");
 
@@ -199,30 +114,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestPerformCoreTemplateQuery_DefaultLanguageDisambiguates()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Description of foo Perl template",
-                Identity = "foo.test.Perl",
-                GroupIdentity = "foo.test.template",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("Perl") }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Description of foo LISP template",
-                Identity = "foo.test.Lisp",
-                GroupIdentity = "foo.test.template",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("LISP") }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Description of foo Perl template", identity: "foo.test.Perl", groupIdentity: "foo.test.template")
+                                      .WithTag("language", "Perl"));
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Description of foo LISP template", identity: "foo.test.Lisp", groupIdentity: "foo.test.template")
+                                      .WithTag("language", "LISP"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo");
 
@@ -237,30 +132,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestPerformCoreTemplateQuery_InputLanguageIsPreferredOverDefault()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Description of foo Perl template",
-                Identity = "foo.test.Perl",
-                GroupIdentity = "foo.test.template",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("Perl") }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Description of foo LISP template",
-                Identity = "foo.test.Lisp",
-                GroupIdentity = "foo.test.template",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "language", ResolutionTestHelper.CreateTestCacheTag("LISP") }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Description of foo Perl template", identity: "foo.test.Perl", groupIdentity: "foo.test.template")
+                                      .WithTag("language", "Perl"));
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Description of foo LISP template", identity: "foo.test.Lisp", groupIdentity: "foo.test.template")
+                                      .WithTag("language", "LISP"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo", "LISP");
 
@@ -276,36 +151,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestPerformCoreTemplateQuery_GroupIsFound()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template old",
-                Identity = "foo.test.old",
-                GroupIdentity = "foo.test.template",
-                Precedence = 100,
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template new",
-                Identity = "foo.test.new",
-                GroupIdentity = "foo.test.template",
-                Precedence = 200,
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "bar",
-                Name = "Bar template",
-                Identity = "bar.test",
-                GroupIdentity = "bar.test.template",
-                Precedence = 100,
-                CacheParameters = new Dictionary<string, ICacheParameter>(),
-                Tags = new Dictionary<string, ICacheTag>()
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template old", identity: "foo.test.old", groupIdentity: "foo.test.template", precedence: 100));
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template new", identity: "foo.test.new", groupIdentity: "foo.test.template", precedence: 200));
+            templatesToSearch.Add(new MockTemplateInfo("bar", name: "Bar template", identity: "bar.test", groupIdentity: "bar.test.template", precedence: 100));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo");
 
@@ -321,30 +169,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestPerformCoreTemplateQuery_ParameterNameDisambiguates()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test.old",
-                GroupIdentity = "foo.test.template",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase),
-                CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "bar", new CacheParameter() },
-                }
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test.new",
-                GroupIdentity = "foo.test.template",
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase),
-                CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "baz", new CacheParameter() },
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template old", identity: "foo.test.old", groupIdentity: "foo.test.template").WithParameters("bar"));
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template new", identity: "foo.test.new", groupIdentity: "foo.test.template").WithParameters("baz"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("baz", "whatever");
 
@@ -358,32 +184,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestPerformCoreTemplateQuery_ParameterValueDisambiguates()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template old",
-                Identity = "foo.test.old",
-                GroupIdentity = "foo.test.template",
-                Precedence = 100,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "framework", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "netcoreapp1.0", "netcoreapp1.1" }) }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template new",
-                Identity = "foo.test.new",
-                GroupIdentity = "foo.test.template",
-                Precedence = 200,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "framework", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "netcoreapp2.0" }) }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template old", identity: "foo.test.old", groupIdentity: "foo.test.template", precedence: 100).WithTag("framework", "netcoreapp1.0", "netcoreapp1.1"));
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template new", identity: "foo.test.new", groupIdentity: "foo.test.template", precedence: 200).WithTag("framework", "netcoreapp2.0"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("framework", "netcoreapp1.0");
 
@@ -397,19 +199,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestPerformCoreTemplateQuery_UnknownParameterNameInvalidatesMatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test",
-                GroupIdentity = "foo.test.template",
-                Precedence = 100,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase),
-                CacheParameters = new Dictionary<string, ICacheParameter>()
-                {
-                    { "bar", new CacheParameter() },
-                }
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test", groupIdentity: "foo.test.template", precedence: 100).WithParameters("bar"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("baz");
 
@@ -428,32 +218,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
         public void TestPerformCoreTemplateQuery_InvalidChoiceValueInvalidatesMatch()
         {
             List<ITemplateInfo> templatesToSearch = new List<ITemplateInfo>();
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test.1x",
-                GroupIdentity = "foo.test.template",
-                Precedence = 100,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "framework", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "netcoreapp1.0", "netcoreapp1.1" }) }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
-            });
-            templatesToSearch.Add(new TemplateInfo()
-            {
-                ShortName = "foo",
-                Name = "Foo template",
-                Identity = "foo.test.2x",
-                GroupIdentity = "foo.test.template",
-                Precedence = 200,
-                Tags = new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase)
-                {
-                    { "framework", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "netcoreapp2.0" }) }
-                },
-                CacheParameters = new Dictionary<string, ICacheParameter>()
-            });
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test.1x", groupIdentity: "foo.test.template", precedence: 100).WithTag("framework", "netcoreapp1.0", "netcoreapp1.1"));
+            templatesToSearch.Add(new MockTemplateInfo("foo", name: "Foo template", identity: "foo.test.2x", groupIdentity: "foo.test.template", precedence: 200).WithTag("framework", "netcoreapp2.0"));
 
             INewCommandInput userInputs = new MockNewCommandInput("foo").WithTemplateOption("framework", "netcoreapp3.0");
 

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCacheTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCacheTests.cs
@@ -26,10 +26,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             MockCliNuGetMetadataSearchSource.SetupMockData(mockTemplateDiscoveryMetadata);
             EngineEnvironmentSettings.SettingsLoader.Components.Register(typeof(MockCliNuGetMetadataSearchSource));
 
-            INewCommandInput commandInput = new MockNewCommandInput()
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput commandInput = new MockNewCommandInput("foo");
 
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(EngineEnvironmentSettings, commandInput, DefaultLanguage);
             SearchResults searchResults = await searchCoordinator.SearchAsync();
@@ -51,15 +48,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             MockCliNuGetMetadataSearchSource.SetupMockData(mockTemplateDiscoveryMetadata);
             EngineEnvironmentSettings.SettingsLoader.Components.Register(typeof(MockCliNuGetMetadataSearchSource));
 
-            // The template symbol is "Framework" (capital "F"). This checks that the host specific override is applied
-            Dictionary<string, string> rawCommandInputs = new Dictionary<string, string>()
-            {
-                { "framework", "netcoreapp2.0" }
-            };
-            INewCommandInput commandInput = new MockNewCommandInput(rawCommandInputs)
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput commandInput = new MockNewCommandInput("foo").WithTemplateOption("framework", "netcoreapp2.0");
 
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(EngineEnvironmentSettings, commandInput, DefaultLanguage);
             SearchResults searchResults = await searchCoordinator.SearchAsync();
@@ -69,15 +58,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.Equal(1, searchResults.MatchesBySource[0].PacksWithMatches.Count);
             Assert.Single(searchResults.MatchesBySource[0].PacksWithMatches[_packTwoInfo].TemplateMatches.Where(t => string.Equals(t.Info.Name, _fooTwoTemplate.Name)));
 
-            // same check, except with the short version of Framework, namely "f"
-            Dictionary<string, string> shortNameCheckRawCommandInputs = new Dictionary<string, string>()
-            {
-                { "f", "netcoreapp2.0" }
-            };
-            INewCommandInput shortNameCommandInput = new MockNewCommandInput(shortNameCheckRawCommandInputs)
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput shortNameCommandInput = new MockNewCommandInput("foo").WithTemplateOption("f", "netcoreapp2.0");
 
             TemplateSearchCoordinator shortNameSearchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(EngineEnvironmentSettings, shortNameCommandInput, DefaultLanguage);
             SearchResults shortNameSearchResults = await searchCoordinator.SearchAsync();
@@ -97,14 +78,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             EngineEnvironmentSettings.SettingsLoader.Components.Register(typeof(MockCliNuGetMetadataSearchSource));
 
             // "tfm" is not a vaild symbol for the "foo" template. So it should not match.
-            Dictionary<string, string> rawCommandInputs = new Dictionary<string, string>()
-            {
-                { "tfm", "netcoreapp2.0" }
-            };
-            INewCommandInput commandInput = new MockNewCommandInput(rawCommandInputs)
-            {
-                TemplateName = "foo"
-            };
+            INewCommandInput commandInput = new MockNewCommandInput("foo").WithTemplateOption("tfm", "netcoreapp2.0");
 
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(EngineEnvironmentSettings, commandInput, DefaultLanguage);
             SearchResults searchResults = await searchCoordinator.SearchAsync();
@@ -122,11 +96,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             EngineEnvironmentSettings.SettingsLoader.Components.Register(typeof(MockCliNuGetMetadataSearchSource));
 
             Dictionary<string, string> rawCommandInputs = new Dictionary<string, string>();
-            MockNewCommandInput commandInput = new MockNewCommandInput(rawCommandInputs)
-            {
-                Language = "F#",
-                TemplateName = "bar"
-            };
+            MockNewCommandInput commandInput = new MockNewCommandInput("bar", "F#");
 
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(EngineEnvironmentSettings, commandInput, DefaultLanguage);
             SearchResults searchResults = await searchCoordinator.SearchAsync();
@@ -147,12 +117,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             MockCliNuGetMetadataSearchSource.SetupMockData(mockTemplateDiscoveryMetadata);
             EngineEnvironmentSettings.SettingsLoader.Components.Register(typeof(MockCliNuGetMetadataSearchSource));
 
-            Dictionary<string, string> rawCommandInputs = new Dictionary<string, string>();
-            MockNewCommandInput commandInput = new MockNewCommandInput(rawCommandInputs)
-            {
-                TemplateName = commandTemplate,
-                AuthorFilter = commandAuthor
-            };
+            MockNewCommandInput commandInput = new MockNewCommandInput(commandTemplate).WithCommandOption("--author", commandAuthor);
 
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(EngineEnvironmentSettings, commandInput, DefaultLanguage);
             SearchResults searchResults = await searchCoordinator.SearchAsync();
@@ -179,12 +144,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             MockCliNuGetMetadataSearchSource.SetupMockData(mockTemplateDiscoveryMetadata);
             EngineEnvironmentSettings.SettingsLoader.Components.Register(typeof(MockCliNuGetMetadataSearchSource));
 
-            Dictionary<string, string> rawCommandInputs = new Dictionary<string, string>();
-            MockNewCommandInput commandInput = new MockNewCommandInput(rawCommandInputs)
-            {
-                TemplateName = commandTemplate,
-                TypeFilter = commandType
-            };
+            MockNewCommandInput commandInput = new MockNewCommandInput(commandTemplate, type: commandType);
 
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(EngineEnvironmentSettings, commandInput, DefaultLanguage);
             SearchResults searchResults = await searchCoordinator.SearchAsync();
@@ -212,12 +172,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             MockCliNuGetMetadataSearchSource.SetupMockData(mockTemplateDiscoveryMetadata);
             EngineEnvironmentSettings.SettingsLoader.Components.Register(typeof(MockCliNuGetMetadataSearchSource));
 
-            Dictionary<string, string> rawCommandInputs = new Dictionary<string, string>();
-            MockNewCommandInput commandInput = new MockNewCommandInput(rawCommandInputs)
-            {
-                TemplateName = commandTemplate,
-                PackageFilter = commandPackage
-            };
+            MockNewCommandInput commandInput = new MockNewCommandInput(commandTemplate).WithCommandOption("--package", commandPackage);
 
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(EngineEnvironmentSettings, commandInput, DefaultLanguage);
             SearchResults searchResults = await searchCoordinator.SearchAsync();
@@ -242,12 +197,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             MockCliNuGetMetadataSearchSource.SetupMockData(mockTemplateDiscoveryMetadata);
             EngineEnvironmentSettings.SettingsLoader.Components.Register(typeof(MockCliNuGetMetadataSearchSource));
 
-            Dictionary<string, string> rawCommandInputs = new Dictionary<string, string>();
-            MockNewCommandInput commandInput = new MockNewCommandInput(rawCommandInputs)
-            {
-                TemplateName = "bar",
-                Language = "VB"
-            };
+            MockNewCommandInput commandInput = new MockNewCommandInput("bar", "VB");
 
             TemplateSearchCoordinator searchCoordinator = CliTemplateSearchCoordinatorFactory.CreateCliTemplateSearchCoordinator(EngineEnvironmentSettings, commandInput, DefaultLanguage);
             SearchResults searchResults = await searchCoordinator.SearchAsync();

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCacheTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCacheTests.cs
@@ -210,79 +210,29 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         private static readonly PackInfo _packTwoInfo = new PackInfo("PackTwo", "1.6.0");
         private static readonly PackInfo _packThreeInfo = new PackInfo("PackThree", "2.1");
 
-        private static readonly ITemplateInfo _fooOneTemplate = new TemplateInfo()
-        {
-            Identity = "Mock.Foo.1",
-            GroupIdentity = "Mock.Foo",
-            Description = "Mock Foo template one",
-            Name = "MockFooTemplateOne",
-            ShortName = "foo1",
-            Author = "TestAuthor",
-            Tags = new Dictionary<string, ICacheTag>(StringComparer.Ordinal)
-            {
-                {
-                    "Framework", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "netcoreapp3.0", "netcoreapp3.1" })
-                },
-                {
-                    "language", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "C#" })
-                },
-                {
-                    "type", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "project" })
-                }
-            },
-            CacheParameters = new Dictionary<string, ICacheParameter>()
-        };
+        private static readonly ITemplateInfo _fooOneTemplate =
+            new MockTemplateInfo("foo1", name: "MockFooTemplateOne", identity: "Mock.Foo.1", groupIdentity: "Mock.Foo", author: "TestAuthor")
+                .WithDescription("Mock Foo template one")
+                .WithTag("Framework", "netcoreapp3.0", "netcoreapp3.1")
+                .WithTag("language", "C#")
+                .WithTag("type", "project");
 
-        private static readonly ITemplateInfo _fooTwoTemplate = new TemplateInfo()
-        {
-            Identity = "Mock.Foo.2",
-            GroupIdentity = "Mock.Foo",
-            Description = "Mock Foo template two",
-            Name = "MockFooTemplateTwo",
-            ShortName = "foo2",
-            Tags = new Dictionary<string, ICacheTag>(StringComparer.Ordinal)
-            {
-                {
-                    "Framework", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "netcoreapp2.0", "netcoreapp2.1", "netcoreapp3.1" })
-                },
-                {
-                    "language", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "C#" })
-                }
-            },
-            CacheParameters = new Dictionary<string, ICacheParameter>()
-        };
+        private static readonly ITemplateInfo _fooTwoTemplate =
+            new MockTemplateInfo("foo2", name: "MockFooTemplateTwo", identity: "Mock.Foo.2", groupIdentity: "Mock.Foo")
+                .WithDescription("Mock Foo template two")
+                .WithTag("Framework", "netcoreapp2.0", "netcoreapp2.1", "netcoreapp3.1")
+                .WithTag("language", "C#");
 
-        private static readonly ITemplateInfo _barCSharpTemplate = new MockTemplateInfo()
-        {
-            Identity = "Mock.Bar.1.Csharp",
-            GroupIdentity = "Mock.Bar",
-            Description = "Mock Bar CSharp template",
-            Name = "MockBarCsharpTemplate",
-            ShortName = "barC",
-            Tags = new Dictionary<string, ICacheTag>(StringComparer.Ordinal)
-            {
-                {
-                    "language", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "C#" })
-                }
-            },
-            CacheParameters = new Dictionary<string, ICacheParameter>()
-        };
 
-        private static readonly ITemplateInfo _barFSharpTemplate = new MockTemplateInfo()
-        {
-            Identity = "Mock.Bar.1.FSharp",
-            GroupIdentity = "Mock.Bar",
-            Description = "Mock Bar FSharp template",
-            Name = "MockBarFSharpTemplate",
-            ShortName = "barF",
-            Tags = new Dictionary<string, ICacheTag>(StringComparer.Ordinal)
-            {
-                {
-                    "language", ResolutionTestHelper.CreateTestCacheTag(new List<string>() { "F#" })
-                }
-            },
-            CacheParameters = new Dictionary<string, ICacheParameter>()
-        };
+        private static readonly ITemplateInfo _barCSharpTemplate =
+            new MockTemplateInfo("barC", name: "MockBarCsharpTemplate", identity: "Mock.Bar.1.Csharp", groupIdentity: "Mock.Bar")
+                .WithDescription("Mock Bar CSharp template")
+                .WithTag("language", "C#");
+
+        private static readonly ITemplateInfo _barFSharpTemplate =
+            new MockTemplateInfo("barF", name: "MockBarFSharpTemplate", identity: "Mock.Bar.1.FSharp", groupIdentity: "Mock.Bar")
+                .WithDescription("Mock Bar FSharp template")
+                .WithTag("language", "F#");
 
         private static TemplateDiscoveryMetadata SetupDiscoveryMetadata(bool includehostData = false)
         {

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearcherTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearcherTests.cs
@@ -76,33 +76,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
 
             List<TemplateNameSearchResult> sourceOneResults = new List<TemplateNameSearchResult>();
 
-            ITemplateInfo sourceOneTemplateOne = new MockTemplateInfo()
-            {
-                Identity = "Mock.Foo.1",
-                Description = "Mock Foo template one",
-                Name = "MockFooTemplateOne",
-                ShortName = "foo1",
-            };
+            ITemplateInfo sourceOneTemplateOne = new MockTemplateInfo("foo1", name: "MockFooTemplateOne", identity: "Mock.Foo.1").WithDescription("Mock Foo template one");
             TemplateNameSearchResult sourceOneResultOne = new TemplateNameSearchResult(sourceOneTemplateOne, _fooPackInfo);
             sourceOneResults.Add(sourceOneResultOne);
 
-            ITemplateInfo sourceOneTemplateTwo = new MockTemplateInfo()
-            {
-                Identity = "Mock.Foo.2",
-                Description = "Mock Foo template two",
-                Name = "MockFooTemplateTwo",
-                ShortName = "foo2"
-            };
+            ITemplateInfo sourceOneTemplateTwo = new MockTemplateInfo("foo2", name: "MockFooTemplateTwo", identity: "Mock.Foo.2").WithDescription("Mock Foo template two");
             TemplateNameSearchResult sourceOneResultTwo = new TemplateNameSearchResult(sourceOneTemplateTwo, _fooPackInfo);
             sourceOneResults.Add(sourceOneResultTwo);
 
-            ITemplateInfo sourceOneTemplateThree = new MockTemplateInfo()
-            {
-                Identity = "Mock.Bar.1",
-                Description = "Mock Bar template one",
-                Name = "MockBarTemplateOne",
-                ShortName = "bar1"
-            };
+            ITemplateInfo sourceOneTemplateThree = new MockTemplateInfo("bar1", name: "MockBarTemplateOne", identity: "Mock.Bar.1").WithDescription("Mock Bar template one");
             TemplateNameSearchResult sourceOneResultThree = new TemplateNameSearchResult(sourceOneTemplateThree, _barPackInfo);
             sourceOneResults.Add(sourceOneResultThree);
 
@@ -110,33 +92,16 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
 
             List<TemplateNameSearchResult> sourceTwoResults = new List<TemplateNameSearchResult>();
 
-            ITemplateInfo sourceTwoTemplateOne = new MockTemplateInfo()
-            {
-                Identity = "Mock.Red.1",
-                Description = "Mock red template",
-                Name = "MockRedTemplate",
-                ShortName = "red",
-            };
+            ITemplateInfo sourceTwoTemplateOne = new MockTemplateInfo("red", name: "MockRedTemplate", identity: "Mock.Red.1").WithDescription("Mock red template");
+
             TemplateNameSearchResult sourceTwoResultOne = new TemplateNameSearchResult(sourceTwoTemplateOne, _redPackInfo);
             sourceTwoResults.Add(sourceTwoResultOne);
 
-            ITemplateInfo sourceTwoTemplateTwo = new MockTemplateInfo()
-            {
-                Identity = "Mock.Blue.1",
-                Description = "Mock blue template",
-                Name = "MockBlueTemplate",
-                ShortName = "blue"
-            };
+            ITemplateInfo sourceTwoTemplateTwo = new MockTemplateInfo("blue", name: "MockBlueTemplate", identity: "Mock.Blue.1").WithDescription("Mock blue template");
             TemplateNameSearchResult sourceTwoResultTwo = new TemplateNameSearchResult(sourceTwoTemplateTwo, _bluePackInfo);
             sourceTwoResults.Add(sourceTwoResultTwo);
 
-            ITemplateInfo sourceTwoTemplateThree = new MockTemplateInfo()
-            {
-                Identity = "Mock.Green.1",
-                Description = "Mock green template",
-                Name = "MockGreenTemplate",
-                ShortName = "green"
-            };
+            ITemplateInfo sourceTwoTemplateThree = new MockTemplateInfo("green", name: "MockGreenTemplate", identity: "Mock.Green.1").WithDescription("Mock green template");
             TemplateNameSearchResult sourceTwoResultThree = new TemplateNameSearchResult(sourceTwoTemplateThree, _greenPackInfo);
             sourceTwoResults.Add(sourceTwoResultThree);
 

--- a/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
+++ b/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
@@ -1,9 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <TargetFrameworks Condition="'$(PackSpecific)' != 'true'">$(NETStandardTargetFramework);$(NETFullTargetFramework)</TargetFrameworks>
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <IsPackable>true</IsPackable>
 		<IsShipping>false</IsShipping>
+        <IsTestProject>false</IsTestProject>
     </PropertyGroup>
 
     <ItemGroup>
@@ -13,4 +14,9 @@
         <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Edge\Microsoft.TemplateEngine.Edge.csproj" />
         <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
     </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="xunit" />
+    </ItemGroup>
+
 </Project>

--- a/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
@@ -1,87 +1,349 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Utils;
+using Newtonsoft.Json;
+using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Mocks
 {
-    public class MockTemplateInfo : ITemplateInfo, IShortNameList
+    public class MockTemplateInfo : ITemplateInfo, IShortNameList, IXunitSerializable
     {
         public MockTemplateInfo()
         {
-            ShortNameList = new List<string>();
-            Classifications = new List<string>();
-            Tags = new Dictionary<string, ICacheTag>(StringComparer.Ordinal);
-            CacheParameters = new Dictionary<string, ICacheParameter>(StringComparer.Ordinal);
-            Parameters = new List<ITemplateParameter>();
-            BaselineInfo = new Dictionary<string, IBaselineInfo>(StringComparer.Ordinal);
         }
 
-        public string Author { get; set; }
+        public MockTemplateInfo(string shortName, string name = null, string identity = null, string groupIdentity = null, int precedence = 0, string author = null)
+            : this(new string[] { shortName }, name, identity, groupIdentity, precedence, author)
+        {
 
-        public string Description { get; set; }
+        }
 
-        public IReadOnlyList<string> Classifications { get; set; }
+        public MockTemplateInfo(string[] shortNames, string name = null, string identity = null, string groupIdentity = null, int precedence = 0, string author = null) : this()
+        {
+            _shortNameList = shortNames;
+            if (string.IsNullOrEmpty(name))
+            {
+                Name = "Template " + shortNames[0];
+            }
+            else
+            {
+                Name = name;
+            }
 
-        public string DefaultName { get; set; }
+            if (string.IsNullOrEmpty(identity))
+            {
+                Identity = shortNames[0];
+            }
+            else
+            {
+                Identity = identity;
+            }
 
-        public string Identity { get; set; }
+            Precedence = precedence;
+            GroupIdentity = groupIdentity;
+            Identity = identity;
+            Author = author;
+        }
 
-        public Guid GeneratorId { get; set; }
+        public MockTemplateInfo WithParameters(params string[] parameters)
+        {
+            if (_cacheParameters.Length == 0)
+            {
+                _cacheParameters = parameters;
+            }
+            else
+            {
+                _cacheParameters = _cacheParameters.Concat(parameters).ToArray();
+            }
+            return this;
+        }
+        public MockTemplateInfo WithTag(string tagName, params string[] values)
+        {
+            _tags.Add(tagName, values);
+            return this;
+        }
 
-        public string GroupIdentity { get; set; }
+        public MockTemplateInfo WithDescription(string description)
+        {
+            Description = description;
+            return this;
+        }
 
-        public int Precedence { get; set; }
+        public MockTemplateInfo WithBaselineInfo(params string[] baseline)
+        {
+            if (_baselineInfo.Length == 0)
+            {
+                _baselineInfo = baseline;
+            }
+            else
+            {
+                _baselineInfo = _baselineInfo.Concat(baseline).ToArray();
+            }
+            return this;
+        }
 
-        public string Name { get; set; }
+        public MockTemplateInfo WithClassifications(params string[] classifications)
+        {
+            if (_classifications.Length == 0)
+            {
+                _classifications = classifications;
+            }
+            else
+            {
+                _classifications = _classifications.Concat(classifications).ToArray();
+            }
+            return this;
+        }
+
+
+        private string[] _cacheParameters = new string[0];
+        private string[] _baselineInfo = new string[0];
+        private string[] _classifications = new string[0];
+        private string[] _shortNameList = new string[0];
+        private Dictionary<string, string[]> _tags = new Dictionary<string, string[]>();
+
+        public string Author { get; private set; }
+
+        public string Description { get; private set; }
+
+        public IReadOnlyList<string> Classifications
+        {
+            get
+            {
+                return _classifications;
+            }
+        }
+
+        public string DefaultName { get; }
+
+        public string Identity { get; private set; }
+
+        public Guid GeneratorId { get; }
+
+        public string GroupIdentity { get; private set; }
+
+        public int Precedence { get; private set; }
+
+        public string Name { get; private set; }
 
         public string ShortName
         {
             get
             {
-                if (ShortNameList.Count > 0)
+                if (_shortNameList.Length > 0)
                 {
-                    return ShortNameList[0];
+                    return _shortNameList[0];
                 }
-
                 return String.Empty;
-            }
-            set
-            {
-                if (ShortNameList.Count > 0)
-                {
-                    throw new Exception("Can't set the short name when the ShortNameList already has entries.");
-                }
-
-                ShortNameList = new List<string>() { value };
             }
         }
 
-        public IReadOnlyList<string> ShortNameList { get; set; }
+        public IReadOnlyList<string> ShortNameList => _shortNameList;
 
-        public IReadOnlyDictionary<string, ICacheTag> Tags { get; set; }
+        public IReadOnlyDictionary<string, ICacheTag> Tags
+        {
+            get
+            {
+                return _tags.ToDictionary(kvp => kvp.Key, kvp => CreateTestCacheTag(kvp.Value));
+            }
+        }
 
-        public IReadOnlyDictionary<string, ICacheParameter> CacheParameters { get; set; }
 
-        public IReadOnlyList<ITemplateParameter> Parameters { get; set; }
+        public IReadOnlyDictionary<string, ICacheParameter> CacheParameters
+        {
+            get
+            {
+                return _cacheParameters.ToDictionary(param => param, kvp => (ICacheParameter)new CacheParameter());
+            }
+        }
 
-        public Guid ConfigMountPointId { get; set; }
+        private IReadOnlyList<ITemplateParameter> _parameters;
+        public IReadOnlyList<ITemplateParameter> Parameters
+        {
+            get
+            {
+                if (_parameters == null)
+                {
+                    List<ITemplateParameter> parameters = new List<ITemplateParameter>();
+                    PopulateParametersFromTags(parameters);
+                    PopulateParametersFromCacheParameters(parameters);
+                    _parameters = parameters;
+                }
+                return _parameters;
+            }
+            set
+            {
+                _parameters = value;
+            }
+        }
 
-        public string ConfigPlace { get; set; }
+        public Guid ConfigMountPointId { get; }
 
-        public Guid LocaleConfigMountPointId { get; set; }
+        public string ConfigPlace { get; }
 
-        public string LocaleConfigPlace { get; set; }
+        public Guid LocaleConfigMountPointId { get; }
 
-        public Guid HostConfigMountPointId { get; set; }
+        public string LocaleConfigPlace { get; }
 
-        public string HostConfigPlace { get; set; }
+        public Guid HostConfigMountPointId { get; }
 
-        public string ThirdPartyNotices { get; set; }
+        public string HostConfigPlace { get; }
 
-        public IReadOnlyDictionary<string, IBaselineInfo> BaselineInfo { get; set; }
+        public string ThirdPartyNotices { get; }
+
+        public IReadOnlyDictionary<string, IBaselineInfo> BaselineInfo
+        {
+            get
+            {
+                return _baselineInfo.ToDictionary(k => k, k => (IBaselineInfo) new BaselineCacheInfo());
+            }
+        }
 
         public bool HasScriptRunningPostActions { get; set; }
 
-        public DateTime? ConfigTimestampUtc { get; set; }
+        public DateTime? ConfigTimestampUtc { get; }
+
+        private static ICacheTag CreateTestCacheTag(IReadOnlyList<string> choiceList, string tagDescription = null, string defaultValue = null, string defaultIfOptionWithoutValue = null)
+        {
+            Dictionary<string, string> choicesDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string choice in choiceList)
+            {
+                choicesDict.Add(choice, null);
+            };
+            return new CacheTag(tagDescription, choicesDict, defaultValue, defaultIfOptionWithoutValue);
+        }
+
+        private void PopulateParametersFromTags (List<ITemplateParameter> parameters)
+        {
+            foreach (KeyValuePair<string, ICacheTag> tagInfo in Tags)
+            {
+                ITemplateParameter param = new TemplateParameter
+                {
+                    Name = tagInfo.Key,
+                    Documentation = tagInfo.Value.Description,
+                    DefaultValue = tagInfo.Value.DefaultValue,
+                    Choices = tagInfo.Value.ChoicesAndDescriptions,
+                    DataType = "choice"
+                };
+
+                if (param is IAllowDefaultIfOptionWithoutValue paramWithNoValueDefault
+                    && tagInfo.Value is IAllowDefaultIfOptionWithoutValue tagWithNoValueDefault)
+                {
+                    paramWithNoValueDefault.DefaultIfOptionWithoutValue = tagWithNoValueDefault.DefaultIfOptionWithoutValue;
+                    parameters.Add(paramWithNoValueDefault as TemplateParameter);
+                }
+                else
+                {
+                    parameters.Add(param);
+                }
+            }
+        }
+
+        private void PopulateParametersFromCacheParameters(List<ITemplateParameter> parameters)
+        {
+            foreach (KeyValuePair<string, ICacheParameter> paramInfo in CacheParameters)
+            {
+                ITemplateParameter param = new TemplateParameter
+                {
+                    Name = paramInfo.Key,
+                    Documentation = paramInfo.Value.Description,
+                    DataType = paramInfo.Value.DataType,
+                    DefaultValue = paramInfo.Value.DefaultValue,
+                };
+
+                if (param is IAllowDefaultIfOptionWithoutValue paramWithNoValueDefault
+                    && paramInfo.Value is IAllowDefaultIfOptionWithoutValue infoWithNoValueDefault)
+                {
+                    paramWithNoValueDefault.DefaultIfOptionWithoutValue = infoWithNoValueDefault.DefaultIfOptionWithoutValue;
+                    parameters.Add(paramWithNoValueDefault as TemplateParameter);
+                }
+                else
+                {
+                    parameters.Add(param);
+                }
+            }
+        }
+
+        #region XUnitSerializable implementation
+        public void Deserialize(IXunitSerializationInfo info)
+        {
+            Name = info.GetValue<string>("template_name");
+            Precedence = info.GetValue<int>("template_precedence");
+            Identity = info.GetValue<string>("template_identity");
+            GroupIdentity = info.GetValue<string>("template_group");
+            Description = info.GetValue<string>("template_description");
+            Author = info.GetValue<string>("template_author");
+            HasScriptRunningPostActions = info.GetValue<bool>("template_hasPostActions");
+
+            _tags = JsonConvert.DeserializeObject<Dictionary<string, string[]>>(info.GetValue<string>("template_tags"));
+            _cacheParameters = JsonConvert.DeserializeObject<string[]>(info.GetValue<string>("template_params"));
+            _baselineInfo = JsonConvert.DeserializeObject<string[]>(info.GetValue<string>("template_baseline"));
+            _classifications = JsonConvert.DeserializeObject<string[]>(info.GetValue<string>("template_classifications"));
+            _shortNameList = JsonConvert.DeserializeObject<string[]>(info.GetValue<string>("template_shortname"));
+        }
+
+        public void Serialize(IXunitSerializationInfo info)
+        {
+            info.AddValue("template_name", Name, typeof(string));
+            info.AddValue("template_shortname", JsonConvert.SerializeObject(_shortNameList), typeof(string));
+            info.AddValue("template_precedence", Precedence, typeof(int));
+            info.AddValue("template_identity", Identity, typeof(string));
+            info.AddValue("template_group", GroupIdentity, typeof(string));
+            info.AddValue("template_description", Description, typeof(string));
+            info.AddValue("template_author", Author, typeof(string));
+            info.AddValue("template_hasPostActions", HasScriptRunningPostActions, typeof(bool));
+
+            info.AddValue("template_tags", JsonConvert.SerializeObject(_tags), typeof(string));
+            info.AddValue("template_params", JsonConvert.SerializeObject(_cacheParameters), typeof(string));
+            info.AddValue("template_baseline", JsonConvert.SerializeObject(_baselineInfo), typeof(string));
+            info.AddValue("template_classifications", JsonConvert.SerializeObject(_classifications), typeof(string));
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+            _ = sb.Append("Short name:" + string.Join(",", _shortNameList) + ";");
+            _ = sb.Append("Identity:" + Identity + ";");
+
+            if (string.IsNullOrEmpty(GroupIdentity))
+            {
+                _ = sb.Append("Group:<not set>;");
+            }
+            else
+            {
+                _ = sb.Append("Group:" + GroupIdentity +";");
+            }
+            if (Precedence != 0)
+            {
+                _ = sb.Append("Precedence:" + Precedence + ";");
+            }
+            if (!string.IsNullOrEmpty(Author))
+            {
+                _ = sb.Append("Author:" + Author + ";");
+            }
+            if (Classifications.Any())
+            {
+                _ = sb.Append("Classifications:" + string.Join(",", _classifications) + ";");
+            }
+            if (_cacheParameters.Any())
+            {
+                _ = sb.Append("Parameters:" + string.Join(",", _cacheParameters) + ";");
+            }
+            if (_baselineInfo.Any())
+            {
+                _ = sb.Append("Baseline:" + string.Join(",", _baselineInfo) + ";");
+            }
+            if (_tags.Any())
+            {
+                _ = sb.Append("Tags:" + string.Join(",", _tags.Select(t => t.Key + "(" + string.Join("|",t.Value) + ")")) + ";");
+            }
+
+            return sb.ToString();
+
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
- refactored `MockTemplateInfo` and `MockNewCommandInput` mock classes 
  - made them ready to be used in data driven tests (`IXUnitSerializable` interface implementation)
  - made construction easier (allowed to reduce the code by 1k+ lines)

Some tests will be converted to data driven tests in next PR