### PR TITLE
fixes dotnet/templating#2456 errors on dotnet new3 first run

### DIFF
--- a/src/Microsoft.TemplateSearch.Common/TemplateEngineHostHelper.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateEngineHostHelper.cs
@@ -45,59 +45,7 @@ namespace Microsoft.TemplateSearch.Common
 
             // use "dotnetcli" as a fallback host so the correct host specific files are read.
             DefaultTemplateEngineHost host = new DefaultTemplateEngineHost(hostIdentifier, hostVersion, CultureInfo.CurrentCulture.Name, preferences, builtIns, new[] { "dotnetcli" });
-
-            // Consider having these around for diagnostic runs.
-            //AddAuthoringLogger(host);
-            //AddInstallLogger(host);
-
             return host;
-        }
-
-        private static void AddAuthoringLogger(DefaultTemplateEngineHost host)
-        {
-            Action<string, string[]> authoringLogger = (message, additionalInfo) =>
-            {
-                Console.WriteLine(string.Format("Authoring: {0}", message));
-            };
-            host.RegisterDiagnosticLogger("Authoring", authoringLogger);
-        }
-
-        private static void AddInstallLogger(DefaultTemplateEngineHost host)
-        {
-            Action<string, string[]> installLogger = (message, additionalInfo) =>
-            {
-                Console.WriteLine(string.Format("Install: {0}", message));
-            };
-            host.RegisterDiagnosticLogger("Install", installLogger);
-        }
-
-
-        // this is mostly a copy of FirstRun() from dotnet_new3.Program.cs
-        public static void FirstRun(IEngineEnvironmentSettings environmentSettings, IInstallerBase installer)
-        {
-            List<string> toInstallList = new List<string>();
-            Paths paths = new Paths(environmentSettings);
-
-            if (paths.FileExists(paths.Global.DefaultInstallPackageList))
-            {
-                toInstallList.AddRange(paths.ReadAllText(paths.Global.DefaultInstallPackageList).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
-            }
-
-            if (paths.FileExists(paths.Global.DefaultInstallTemplateList))
-            {
-                toInstallList.AddRange(paths.ReadAllText(paths.Global.DefaultInstallTemplateList).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
-            }
-
-            if (toInstallList.Count > 0)
-            {
-                for (int i = 0; i < toInstallList.Count; i++)
-                {
-                    toInstallList[i] = toInstallList[i].Replace("\r", "")
-                                                        .Replace('\\', Path.DirectorySeparatorChar);
-                }
-
-                installer.InstallPackages(toInstallList);
-            }
         }
     }
 }

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -107,35 +107,35 @@ namespace dotnet_new3
 
         private static void FirstRun(IEngineEnvironmentSettings environmentSettings, IInstaller installer)
         {
-            string baseDir = Environment.ExpandEnvironmentVariables("%DN3%");
-
-            if (baseDir.Contains('%'))
+            string dn3Path = Environment.GetEnvironmentVariable("DN3");
+            if (string.IsNullOrEmpty(dn3Path))
             {
-                Assembly a = typeof(Program).GetTypeInfo().Assembly;
-                string path = new Uri(a.Location, UriKind.Absolute).LocalPath;
-                path = Path.GetDirectoryName(path);
+                string path = typeof(Program).Assembly.Location;
+                while (path != null && !File.Exists(Path.Combine(path, "Microsoft.TemplateEngine.sln")))
+                {
+                    path = Path.GetDirectoryName(path);
+                }
+                if (path == null)
+                {
+                    environmentSettings.Host.LogDiagnosticMessage("Couldn't the setup package location, because \"Microsoft.TemplateEngine.sln\" is not in any of parent directories.", "Install");
+                    return;
+                }
                 Environment.SetEnvironmentVariable("DN3", path);
             }
 
             List<string> toInstallList = new List<string>();
             Paths paths = new Paths(environmentSettings);
 
-            if (paths.FileExists(paths.Global.DefaultInstallPackageList))
-            {
-                toInstallList.AddRange(paths.ReadAllText(paths.Global.DefaultInstallPackageList).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
-            }
-
             if (paths.FileExists(paths.Global.DefaultInstallTemplateList))
             {
-                toInstallList.AddRange(paths.ReadAllText(paths.Global.DefaultInstallTemplateList).Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
+                toInstallList.AddRange(paths.ReadAllText(paths.Global.DefaultInstallTemplateList).Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries));
             }
 
             if (toInstallList.Count > 0)
             {
                 for (int i = 0; i < toInstallList.Count; i++)
                 {
-                    toInstallList[i] = toInstallList[i].Replace("\r", "")
-                                                        .Replace('\\', Path.DirectorySeparatorChar);
+                    toInstallList[i] = toInstallList[i].Replace('\\', Path.DirectorySeparatorChar);
                 }
 
                 installer.InstallPackages(toInstallList);

--- a/src/dotnet-new3/defaultinstall.package.list
+++ b/src/dotnet-new3/defaultinstall.package.list
@@ -1,5 +1,0 @@
-﻿%DN3%\..\artifacts\packages\Microsoft.TemplateEngine.Abstractions.*
-%DN3%\..\artifacts\packages\Microsoft.TemplateEngine.Core.Contracts.*
-%DN3%\..\artifacts\packages\Microsoft.TemplateEngine.Utils.*
-%DN3%\..\artifacts\packages\Microsoft.TemplateEngine.Core.*
-%DN3%\..\artifacts\packages\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.*

--- a/src/dotnet-new3/defaultinstall.template.list
+++ b/src/dotnet-new3/defaultinstall.template.list
@@ -1,1 +1,1 @@
-%DN3%\..\template_feed\
+%DN3%\template_feed\

--- a/test/dotnet-new3.UnitTests/FirstRunTest.cs
+++ b/test/dotnet-new3.UnitTests/FirstRunTest.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using Microsoft.NET.TestFramework.Assertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace dotnet_new3.UnitTests
+{
+    public class FirstRunTest
+    {
+        private readonly ITestOutputHelper log;
+
+        public FirstRunTest(ITestOutputHelper log)
+        {
+            this.log = log;
+        }
+
+        [Fact]
+        public void FirstRunSuccess()
+        {
+            var home = Helpers.CreateTemporaryFolder("Home");
+            new DotnetNewCommand(log)
+                .WithEnvironmentVariable(Helpers.HomeEnvironmentVariableName, home)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining("Getting ready")
+                .And.NotHaveStdOutContaining("Error");
+
+            new DotnetNewCommand(log, "-u")
+                .WithEnvironmentVariable(Helpers.HomeEnvironmentVariableName, home)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining("template_feed");
+        }
+    }
+}

--- a/test/dotnet-new3.UnitTests/SharedHomeDirectory.cs
+++ b/test/dotnet-new3.UnitTests/SharedHomeDirectory.cs
@@ -39,10 +39,6 @@ namespace dotnet_new3.UnitTests
                 }
                 if (path == null)
                     throw new Exception("Couldn't find repository root, because \"Microsoft.TemplateEngine.sln\" is not in any of parent directories.");
-                // DummyFolder Path just represents folder next to "artifacts" and "template_feed", so paths inside
-                // defaultinstall.package.list correctly finds packages in "../artifacts/"
-                // via %DN3%\..\template_feed\ or %DN3%\..\artifacts\packages\Microsoft.TemplateEngine.Core.*
-                path = Path.Combine(path, "DummyFolder");
                 dn3Path = path;
             }
 


### PR DESCRIPTION
fixes dotnet/templating#2456 

dotnet new3 implementation had a failure in setting DN3 env variable. 
Replaced with the way @DavidKarlas originally suggested for integration tests. 

Fixed paths in default template list to avoid using dummy folder.
Removed default packages list and its handling - installing packages is not used now - the packages to load are hardcoded. Moreover installing packages from local packages is not possible anymore, at least without using dev option (https://github.com/dotnet/templating/issues/2719#issuecomment-749160687)