### PR TITLE
Template discovery: skip templates filter

### DIFF
--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/PreviouslyRejectedPackFilter.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/PreviouslyRejectedPackFilter.cs
@@ -1,0 +1,62 @@
+using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking.Reporting;
+using Microsoft.TemplateSearch.TemplateDiscovery.PackProviders;
+using Microsoft.TemplateSearch.TemplateDiscovery.Results;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.TemplateSearch.TemplateDiscovery.Filters
+{
+    internal sealed class PreviouslyRejectedPackFilter
+    {
+        private static readonly string FilterId = "Previously Seen";
+
+        internal static Func<IInstalledPackInfo, PreFilterResult> SetupPackFilter(HashSet<string> nonTemplatePacks)
+        {
+            Func<IInstalledPackInfo, PreFilterResult> previouslyRejectedPackFilter = (packInfo) =>
+            {
+                if (nonTemplatePacks.Contains(packInfo.Id))
+                {
+                    return new PreFilterResult()
+                    {
+                        FilterId = FilterId,
+                        IsFiltered = true,
+                        Reason = "Package was previously examined, and does not contain templates."
+                    };
+                }
+
+                return new PreFilterResult()
+                {
+                    FilterId = FilterId,
+                    IsFiltered = false,
+                    Reason = string.Empty
+                };
+            };
+
+            return previouslyRejectedPackFilter;
+        }
+
+        internal static bool TryGetPreviouslySkippedPacks(string previousRunBasePath, out HashSet<string> nonTemplatePacks)
+        {
+            if (string.IsNullOrEmpty(previousRunBasePath))
+            {
+                nonTemplatePacks = new HashSet<string>();
+                return true;
+            }
+            else if (Directory.Exists(previousRunBasePath))
+            {
+                string nonTemplatePackDataFile = Path.Combine(previousRunBasePath, PackCheckResultReportWriter.CacheContentDirectory, PackCheckResultReportWriter.NonTemplatePacksFileName);
+                string fileContents = File.ReadAllText(nonTemplatePackDataFile);
+                nonTemplatePacks = JsonConvert.DeserializeObject<HashSet<string>>(fileContents);
+                return true;
+            }
+
+            nonTemplatePacks = null;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/SkipTemplatePacksFilter.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/SkipTemplatePacksFilter.cs
@@ -1,0 +1,52 @@
+using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking.Reporting;
+using Microsoft.TemplateSearch.TemplateDiscovery.PackProviders;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.TemplateSearch.TemplateDiscovery.Filters
+{
+    internal sealed class SkipTemplatePacksFilter
+    {
+        private static readonly List<string> packagesToBeSkipped = new List<string>
+        {
+            "microsoft.dotnet.common.itemtemplates",
+            "microsoft.dotnet.common.projecttemplates",
+            "microsoft.dotnet.test.projecttemplates",
+            "microsoft.dotnet.web.itemtemplates",
+            "microsoft.dotnet.web.projecttemplates",
+            "microsoft.dotnet.web.spa.projecttemplates",
+            "microsoft.dotnet.winforms.projecttemplates",
+            "microsoft.dotnet.wpf.projecttemplates",
+            //NUnit package is included to SDK, however not managed by Microsoft - keep it in to check for updates
+            //"nunit3.dotnetnew.template",
+            "microsoft.aspnetcore.components.webassembly.template"
+        };
+        private static readonly string _FilterId = "Permanent pack blacklist";
+
+        public static Func<IInstalledPackInfo, PreFilterResult> SetupPackFilter()
+        {
+            Func<IInstalledPackInfo, PreFilterResult> filter = (packInfo) =>
+            {
+                foreach (string package in packagesToBeSkipped)
+                {
+                    if (packInfo.Id.StartsWith(package, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new PreFilterResult()
+                        {
+                            FilterId = _FilterId,
+                            IsFiltered = true,
+                            Reason = $"Package {packInfo.Id} is skipped as it matches the package name to be permanently skipped."
+                        };
+                    }
+                }
+                return new PreFilterResult()
+                {
+                    FilterId = _FilterId,
+                    IsFiltered = false
+                };
+            };
+
+            return filter;
+        }
+    }
+}

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/TemplateJsonExistencePackFilter.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/TemplateJsonExistencePackFilter.cs
@@ -9,7 +9,7 @@ using Microsoft.TemplateSearch.Common;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking.Reporting;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackProviders;
 
-namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
+namespace Microsoft.TemplateSearch.TemplateDiscovery.Filters
 {
     internal static class TemplateJsonExistencePackFilter
     {

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackScraper.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackScraper.cs
@@ -1,40 +1,34 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using Microsoft.TemplateSearch.TemplateDiscovery.AdditionalData;
+using Microsoft.TemplateSearch.TemplateDiscovery.Filters;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking.Reporting;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackProviders;
-using Microsoft.TemplateSearch.TemplateDiscovery.Results;
-using Newtonsoft.Json;
 
 namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
 {
     public class NugetPackScraper
     {
-        private static readonly string PreviouslySeenPrefilterId = "Previously Seen";
-
         public static bool TryCreateDefaultNugetPackScraper(ScraperConfig config, out PackSourceChecker packSourceChecker)
         {
             NugetPackProvider packProvider = new NugetPackProvider(config.BasePath, config.PageSize, config.RunOnlyOnePage, config.IncludePreviewPacks);
 
             List<Func<IInstalledPackInfo, PreFilterResult>> preFilterList = new List<Func<IInstalledPackInfo, PreFilterResult>>();
 
-            if (!TryGetPreviouslySkippedPacks(config.PreviousRunBasePath, out HashSet<string> nonTemplatePacks))
+            if (!PreviouslyRejectedPackFilter.TryGetPreviouslySkippedPacks(config.PreviousRunBasePath, out HashSet<string> nonTemplatePacks))
             {
                 Console.WriteLine("Unable to read results from the previous run.");
                 packSourceChecker = null;
                 return false;
             }
-            else
-            {
-                preFilterList.Add(SetupPreviouslyRejectedPackFilter(nonTemplatePacks));
-            }
 
+            preFilterList.Add(PreviouslyRejectedPackFilter.SetupPackFilter(nonTemplatePacks));
             if (!config.DontFilterOnTemplateJson)
             {
                 preFilterList.Add(TemplateJsonExistencePackFilter.SetupPackFilter());
             }
+            preFilterList.Add(SkipTemplatePacksFilter.SetupPackFilter());
 
             PackPreFilterer preFilterer = new PackPreFilterer(preFilterList);
 
@@ -45,50 +39,6 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
 
             packSourceChecker = new PackSourceChecker(packProvider, preFilterer, additionalDataProducers, config.SaveCandidatePacks);
             return true;
-        }
-
-        private static bool TryGetPreviouslySkippedPacks(string previousRunBasePath, out HashSet<string> nonTemplatePacks)
-        {
-            if (string.IsNullOrEmpty(previousRunBasePath))
-            {
-                nonTemplatePacks = new HashSet<string>();
-                return true;
-            }
-            else if (Directory.Exists(previousRunBasePath))
-            {
-                string nonTemplatePackDataFile = Path.Combine(previousRunBasePath, PackCheckResultReportWriter.CacheContentDirectory, PackCheckResultReportWriter.NonTemplatePacksFileName);
-                string fileContents = File.ReadAllText(nonTemplatePackDataFile);
-                nonTemplatePacks = JsonConvert.DeserializeObject<HashSet<string>>(fileContents);
-                return true;
-            }
-
-            nonTemplatePacks = null;
-            return false;
-        }
-
-        private static Func<IInstalledPackInfo, PreFilterResult> SetupPreviouslyRejectedPackFilter(HashSet<string> nonTemplatePacks)
-        {
-            Func<IInstalledPackInfo, PreFilterResult> previouslyRejectedPackFilter = (packInfo) =>
-            {
-                if (nonTemplatePacks.Contains(packInfo.Id))
-                {
-                    return new PreFilterResult()
-                    {
-                        FilterId = PreviouslySeenPrefilterId,
-                        IsFiltered = true,
-                        Reason = "Package was previously examined, and does not contain templates."
-                    };
-                }
-
-                return new PreFilterResult()
-                {
-                    FilterId = PreviouslySeenPrefilterId,
-                    IsFiltered = false,
-                    Reason = string.Empty
-                };
-            };
-
-            return previouslyRejectedPackFilter;
         }
     }
 }


### PR DESCRIPTION
temporarily fixes https://github.com/dotnet/templating/issues/2738 by removing SDK packages from template search cache file.

The permanent fix will be provided together with new template discovery approach as the templates shipped with SDK won't be checked for updates with new approach.