### PR TITLE
Template discovery: do not block async

### DIFF
--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateSearch.TemplateDiscovery.AdditionalData;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking.Reporting;
@@ -26,15 +27,15 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
             _packChecker = new PackChecker();
         }
 
-        public PackSourceCheckResult CheckPackages()
+        public async Task<PackSourceCheckResult> CheckPackagesAsync()
         {
             List<PackCheckResult> checkResultList = new List<PackCheckResult>();
             HashSet<string> alreadySeenTemplateIdentities = new HashSet<string>();
 
             int count = 0;
-            Console.WriteLine($"{_packProvider.CandidatePacksCount} packs discovered, starting processing");
+            Console.WriteLine($"{await _packProvider.GetPackageCountAsync().ConfigureAwait(false)} packs discovered, starting processing");
 
-            foreach (IInstalledPackInfo packInfo in _packProvider.CandidatePacks)
+            await foreach (IInstalledPackInfo packInfo in _packProvider.GetCandidatePacksAsync().ConfigureAwait(false))
             {
                 PackCheckResult preFilterResult = PrefilterPackInfo(packInfo);
                 if (preFilterResult.PreFilterResults.ShouldBeFiltered)

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IPackProvider.cs
@@ -1,12 +1,13 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Microsoft.TemplateSearch.TemplateDiscovery.PackProviders
 {
     public interface IPackProvider
     {
-        IEnumerable<IInstalledPackInfo> CandidatePacks { get; }
+        IAsyncEnumerable<IInstalledPackInfo> GetCandidatePacksAsync();
 
-        int CandidatePacksCount { get; }
+        Task<int> GetPackageCountAsync();
 
         void DeleteDownloadedPacks();
     }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Program.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Program.cs
@@ -56,7 +56,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery
                 throw new NotImplementedException("no checker for the input options");
             }
 
-            PackSourceCheckResult checkResults = packSourceChecker.CheckPackages();
+            PackSourceCheckResult checkResults = packSourceChecker.CheckPackagesAsync().GetAwaiter().GetResult();
             PackCheckResultReportWriter.TryWriteResults(config.BasePath, checkResults);
         }
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Program.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.TemplateSearch.TemplateDiscovery.Nuget;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking.Reporting;
@@ -22,7 +23,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery
         private static readonly string _noTemplateJsonFilterFlag = "--noTemplateJsonFilter";
         private static readonly string _verbose = "-v";
 
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             // setup the config with defaults
             ScraperConfig config = new ScraperConfig()
@@ -56,7 +57,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery
                 throw new NotImplementedException("no checker for the input options");
             }
 
-            PackSourceCheckResult checkResults = packSourceChecker.CheckPackagesAsync().GetAwaiter().GetResult();
+            PackSourceCheckResult checkResults = await packSourceChecker.CheckPackagesAsync().ConfigureAwait(false);
             PackCheckResultReportWriter.TryWriteResults(config.BasePath, checkResults);
         }
 


### PR DESCRIPTION
I was running into the issues with template discovery gets stuck at some point. I guess the main reason was getting in deadlocks due to blocking HttpClient async methods when download.  

I've implemented async methods all the way up to the main, hopefully that fixes the problem.