### PR TITLE
fixes dotnet/templating#2746 when using source modifiers returned file changes are wrong

### DIFF
--- a/src/Microsoft.TemplateEngine.Core.Contracts/IOrchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IOrchestrator.cs
@@ -10,17 +10,6 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 
         void Run(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
 
-        IReadOnlyList<IFileChange> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir);
-
-        IReadOnlyList<IFileChange> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir);
-    }
-
-    public interface IOrchestrator2
-    {
-        void Run(string runSpecPath, IDirectory sourceDir, string targetDir);
-
-        void Run(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
-
         IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir);
 
         IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir);

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IOrchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IOrchestrator.cs
@@ -10,9 +10,9 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 
         void Run(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
 
-        IReadOnlyList<IFileChange> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir);
+        IReadOnlyList<IFileChange> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir);
 
-        IReadOnlyList<IFileChange> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
+        IReadOnlyList<IFileChange> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir);
     }
 
     public interface IOrchestrator2
@@ -21,8 +21,8 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 
         void Run(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
 
-        IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir);
+        IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir);
 
-        IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
+        IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir);
     }
 }

--- a/src/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
@@ -31,7 +31,7 @@ namespace Microsoft.TemplateEngine.Core.Util
             RunInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetDir, spec);
         }
 
-        public IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
+        public IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir)
         {
             IGlobalRunSpec spec;
             using (Stream stream = sourceDir.MountPoint.EnvironmentSettings.Host.FileSystem.OpenRead(runSpecPath))
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateEngine.Core.Util
                 }
             }
 
-            return GetFileChangesInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetDir, spec);
+            return GetFileChangesInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetRoot, targetDir, spec);
         }
 
         public void Run(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
@@ -56,19 +56,19 @@ namespace Microsoft.TemplateEngine.Core.Util
             RunInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetDir, spec);
         }
 
-        public IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
+        public IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir)
         {
-            return GetFileChangesInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetDir, spec);
+            return GetFileChangesInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetRoot, targetDir, spec);
         }
 
-        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
+        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir)
         {
-            return GetFileChanges(runSpecPath, sourceDir, targetDir);
+            return GetFileChanges(runSpecPath, sourceDir, targetRoot, targetDir);
         }
 
-        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
+        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir)
         {
-            return GetFileChanges(spec, sourceDir, targetDir);
+            return GetFileChanges(spec, sourceDir, targetRoot, targetDir);
         }
 
         protected virtual IGlobalRunSpec RunSpecLoader(Stream runSpec)
@@ -107,13 +107,10 @@ namespace Microsoft.TemplateEngine.Core.Util
             return processorList;
         }
 
-        private IReadOnlyList<IFileChange2> GetFileChangesInternal(IEngineEnvironmentSettings environmentSettings, IDirectory sourceDir, string targetDir, IGlobalRunSpec spec)
+        private IReadOnlyList<IFileChange2> GetFileChangesInternal(IEngineEnvironmentSettings environmentSettings, IDirectory sourceDir, string targetRoot, string targetDir, IGlobalRunSpec spec)
         {
-            EngineConfig cfg = new EngineConfig(environmentSettings, EngineConfig.DefaultWhitespaces, EngineConfig.DefaultLineEndings, spec.RootVariableCollection);
-            IProcessor fallback = Processor.Create(cfg, spec.Operations);
-
             List<IFileChange2> changes = new List<IFileChange2>();
-            List<KeyValuePair<IPathMatcher, IProcessor>> fileGlobProcessors = CreateFileGlobProcessors(sourceDir.MountPoint.EnvironmentSettings, spec);
+            string fullTargetPath = Path.Combine(targetRoot, targetDir);
 
             foreach (IFile file in sourceDir.EnumerateFiles("*", SearchOption.AllDirectories))
             {
@@ -148,37 +145,36 @@ namespace Microsoft.TemplateEngine.Core.Util
                                 targetRel = sourceRel;
                             }
 
-                            string targetPath = Path.Combine(targetDir, targetRel);
+                            string targetPath = Path.Combine(fullTargetPath, targetRel);
+                            string targetRelativePath = targetDir.CombinePaths(targetRel).TrimStart('/');
+                            string sourceRelativePath = file.FullPath.CombinePaths().TrimStart('/');
 
                             if (checkingDirWithPlaceholderFile)
                             {
                                 targetPath = Path.GetDirectoryName(targetPath);
-                                targetRel = Path.GetDirectoryName(targetRel);
 
                                 if (environmentSettings.Host.FileSystem.DirectoryExists(targetPath))
                                 {
-                                    changes.Add(new FileChange(sourceRel, targetRel, ChangeKind.Overwrite));
+                                    changes.Add(new FileChange(sourceRelativePath, targetRelativePath, ChangeKind.Overwrite));
                                 }
                                 else
                                 {
-                                    changes.Add(new FileChange(sourceRel, targetRel, ChangeKind.Create));
+                                    changes.Add(new FileChange(sourceRelativePath, targetRelativePath, ChangeKind.Create));
                                 }
                             }
                             else if (environmentSettings.Host.FileSystem.FileExists(targetPath))
                             {
-                                changes.Add(new FileChange(sourceRel, targetRel, ChangeKind.Overwrite));
+                                changes.Add(new FileChange(sourceRelativePath, targetRelativePath, ChangeKind.Overwrite));
                             }
                             else
                             {
-                                changes.Add(new FileChange(sourceRel, targetRel, ChangeKind.Create));
+                                changes.Add(new FileChange(sourceRelativePath, targetRelativePath, ChangeKind.Create));
                             }
                         }
-
                         break;
                     }
                 }
             }
-
             return changes;
         }
 

--- a/src/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
@@ -9,7 +9,7 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Core.Util
 {
-    public class Orchestrator : IOrchestrator, IOrchestrator2
+    public class Orchestrator : IOrchestrator 
     {
         public void Run(string runSpecPath, IDirectory sourceDir, string targetDir)
         {
@@ -59,16 +59,6 @@ namespace Microsoft.TemplateEngine.Core.Util
         public IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir)
         {
             return GetFileChangesInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetRoot, targetDir, spec);
-        }
-
-        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir)
-        {
-            return GetFileChanges(runSpecPath, sourceDir, targetRoot, targetDir);
-        }
-
-        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir)
-        {
-            return GetFileChanges(spec, sourceDir, targetRoot, targetDir);
         }
 
         protected virtual IGlobalRunSpec RunSpecLoader(Stream runSpec)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -36,7 +36,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             IVariableCollection variables = VariableCollection.SetupVariables(environmentSettings, parameters, template.Config.OperationConfig.VariableSetup);
             template.Config.Evaluate(parameters, variables, template.ConfigFile);
 
-            IOrchestrator2 basicOrchestrator = new Core.Util.Orchestrator();
+            IOrchestrator basicOrchestrator = new Core.Util.Orchestrator();
             RunnableProjectOrchestrator orchestrator = new RunnableProjectOrchestrator(basicOrchestrator);
 
             GlobalRunSpec runSpec = new GlobalRunSpec(template.TemplateSourceRoot, componentManager, parameters, variables, template.Config.OperationConfig, template.Config.SpecialOperationConfig, template.Config.LocalizationOperations, template.Config.IgnoreFileNames);
@@ -686,7 +686,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             IVariableCollection variables = VariableCollection.SetupVariables(environmentSettings, parameters, template.Config.OperationConfig.VariableSetup);
             template.Config.Evaluate(parameters, variables, template.ConfigFile);
 
-            IOrchestrator2 basicOrchestrator = new Core.Util.Orchestrator();
+            IOrchestrator basicOrchestrator = new Core.Util.Orchestrator();
             RunnableProjectOrchestrator orchestrator = new RunnableProjectOrchestrator(basicOrchestrator);
 
             GlobalRunSpec runSpec = new GlobalRunSpec(template.TemplateSourceRoot, componentManager, parameters, variables, template.Config.OperationConfig, template.Config.SpecialOperationConfig, template.Config.LocalizationOperations, template.Config.IgnoreFileNames);

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -695,8 +695,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             foreach (FileSourceMatchInfo source in template.Config.Sources)
             {
                 runSpec.SetupFileSource(source);
-                string target = Path.Combine(targetDirectory, source.Target);
-                changes.AddRange(orchestrator.GetFileChanges(runSpec, template.TemplateSourceRoot.DirectoryInfo(source.Source), target));
+                changes.AddRange(orchestrator.GetFileChanges(runSpec, template.TemplateSourceRoot.DirectoryInfo(source.Source), targetDirectory, source.Target));
             }
 
             return new CreationEffects2

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectOrchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectOrchestrator.cs
@@ -1,17 +1,15 @@
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
-using Microsoft.TemplateEngine.Core;
 using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
-    public class RunnableProjectOrchestrator : IOrchestrator, IOrchestrator2
+    public class RunnableProjectOrchestrator : IOrchestrator
     {
-        private readonly IOrchestrator2 _basicOrchestrator;
+        private readonly IOrchestrator _basicOrchestrator;
 
-        public RunnableProjectOrchestrator(IOrchestrator2 basicOrchestrator)
+        public RunnableProjectOrchestrator(IOrchestrator basicOrchestrator)
         {
             _basicOrchestrator = basicOrchestrator;
         }
@@ -24,16 +22,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         public IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir)
         {
             return _basicOrchestrator.GetFileChanges(spec, sourceDir, targetRoot, targetDir);
-        }
-
-        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir)
-        {
-            return GetFileChanges(runSpecPath, sourceDir, targetRoot, targetDir);
-        }
-
-        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir)
-        {
-            return GetFileChanges(spec, sourceDir, targetRoot, targetDir);
         }
 
         public void Run(string runSpecPath, IDirectory sourceDir, string targetDir)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectOrchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectOrchestrator.cs
@@ -16,24 +16,24 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             _basicOrchestrator = basicOrchestrator;
         }
 
-        public IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
+        public IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir)
         {
-            return _basicOrchestrator.GetFileChanges(runSpecPath, sourceDir, targetDir);
+            return _basicOrchestrator.GetFileChanges(runSpecPath, sourceDir, targetRoot, targetDir);
         }
 
-        public IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
+        public IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir)
         {
-            return _basicOrchestrator.GetFileChanges(spec, sourceDir, targetDir);
+            return _basicOrchestrator.GetFileChanges(spec, sourceDir, targetRoot, targetDir);
         }
 
-        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
+        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir)
         {
-            return GetFileChanges(runSpecPath, sourceDir, targetDir);
+            return GetFileChanges(runSpecPath, sourceDir, targetRoot, targetDir);
         }
 
-        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
+        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir)
         {
-            return GetFileChanges(spec, sourceDir, targetDir);
+            return GetFileChanges(spec, sourceDir, targetRoot, targetDir);
         }
 
         public void Run(string runSpecPath, IDirectory sourceDir, string targetDir)

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
@@ -54,60 +54,60 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 
             //tests are not working due to bugs:
             // -file changes are not taking into account source modifiers https://github.com/dotnet/templating/issues/2746
-            //yield return new object[]
-            //{
-            //    "TemplateWithSourceNameAndCustomSourcePath",
-            //    "--name bar",
-            //     new MockCreationEffects()
-            //        .WithPrimaryOutputs("bar.name.txt", "bar/bar.cs")
-            //        .WithFileChange(new MockFileChange("Custom/Path/foo/foo.cs", "bar/bar.cs", ChangeKind.Create))
-            //        .WithFileChange(new MockFileChange("Custom/Path/foo.name.txt", "bar.name.txt", ChangeKind.Create))
-            //        .Without("Custom/Path/")
-            //};
+            yield return new object[]
+            {
+                "TemplateWithSourceNameAndCustomSourcePath",
+                "--name bar",
+                 new MockCreationEffects()
+                    .WithPrimaryOutputs("bar.name.txt", "bar/bar.cs")
+                    .WithFileChange(new MockFileChange("Custom/Path/foo/foo.cs", "bar/bar.cs", ChangeKind.Create))
+                    .WithFileChange(new MockFileChange("Custom/Path/foo.name.txt", "bar.name.txt", ChangeKind.Create))
+                    .Without("Custom/Path/")
+            };
 
-            //yield return new object[]
-            //{
-            //    "TemplateWithSourceNameAndCustomTargetPath",
-            //    "--name bar",
-            //     new MockCreationEffects()
-            //        .WithPrimaryOutputs("Custom/Path/bar.name.txt", "Custom/Path/bar/bar.cs")
-            //        .WithFileChange(new MockFileChange("foo/foo.cs", "Custom/Path/bar/bar.cs", ChangeKind.Create))
-            //        .WithFileChange(new MockFileChange("foo.name.txt", "Custom/Path/bar.name.txt", ChangeKind.Create))
-            //        .Without("foo.name.txt", "foo/")
-            //};
+            yield return new object[]
+            {
+                "TemplateWithSourceNameAndCustomTargetPath",
+                "--name bar",
+                 new MockCreationEffects()
+                    .WithPrimaryOutputs("Custom/Path/bar.name.txt", "Custom/Path/bar/bar.cs")
+                    .WithFileChange(new MockFileChange("foo/foo.cs", "Custom/Path/bar/bar.cs", ChangeKind.Create))
+                    .WithFileChange(new MockFileChange("foo.name.txt", "Custom/Path/bar.name.txt", ChangeKind.Create))
+                    .Without("foo.name.txt", "foo/")
+            };
 
-            //yield return new object[]
-            //{
-            //    "TemplateWithSourceNameAndCustomSourceAndTargetPaths",
-            //    "--name bar",
-            //     new MockCreationEffects()
-            //        .WithPrimaryOutputs("Target/Output/bar/bar.cs", "Target/Output/bar.name.txt")
-            //        .WithFileChange(new MockFileChange("Src/Custom/Path/foo/foo.cs", "Target/Output/bar/bar.cs", ChangeKind.Create))
-            //        .WithFileChange(new MockFileChange("Src/Custom/Path/foo.name.txt", "Target/Output/bar.name.txt", ChangeKind.Create))
-            //        .Without("Src/Custom/Path/")
-            //};
+            yield return new object[]
+            {
+                "TemplateWithSourceNameAndCustomSourceAndTargetPaths",
+                "--name bar",
+                 new MockCreationEffects()
+                    .WithPrimaryOutputs("Target/Output/bar/bar.cs", "Target/Output/bar.name.txt")
+                    .WithFileChange(new MockFileChange("Src/Custom/Path/foo/foo.cs", "Target/Output/bar/bar.cs", ChangeKind.Create))
+                    .WithFileChange(new MockFileChange("Src/Custom/Path/foo.name.txt", "Target/Output/bar.name.txt", ChangeKind.Create))
+                    .Without("Src/Custom/Path/")
+            };
 
-            //yield return new object[]
-            //{
-            //    "TemplateWithSourcePathOutsideConfigRoot",
-            //    "--name baz",
-            //     new MockCreationEffects()
-            //        .WithPrimaryOutputs("blah/MountPointRoot/mount.baz.cs", "blah/MountPointRoot/baz/baz.baz.cs", "blah/MountPointRoot/baz/bar/bar.baz.cs")
-            //        .WithFileChange(new MockFileChange("MountPointRoot/mount.foo.cs", "blah/MountPointRoot/mount.baz.cs", ChangeKind.Create))
-            //        .WithFileChange(new MockFileChange("MountPointRoot/foo/foo.foo.cs", "blah/MountPointRoot/baz/baz.baz.cs", ChangeKind.Create))
-            //        .WithFileChange(new MockFileChange("MountPointRoot/foo/bar/bar.foo.cs", "blah/MountPointRoot/baz/bar/bar.baz.cs", ChangeKind.Create))
-            //        .Without("MountPointRoot/")
-            //};
+            yield return new object[]
+            {
+                "TemplateWithSourcePathOutsideConfigRoot",
+                "--name baz",
+                 new MockCreationEffects()
+                    .WithPrimaryOutputs("blah/MountPointRoot/mount.baz.cs", "blah/MountPointRoot/baz/baz.baz.cs", "blah/MountPointRoot/baz/bar/bar.baz.cs")
+                    .WithFileChange(new MockFileChange("MountPointRoot/mount.foo.cs", "blah/MountPointRoot/mount.baz.cs", ChangeKind.Create))
+                    .WithFileChange(new MockFileChange("MountPointRoot/foo/foo.foo.cs", "blah/MountPointRoot/baz/baz.baz.cs", ChangeKind.Create))
+                    .WithFileChange(new MockFileChange("MountPointRoot/foo/bar/bar.foo.cs", "blah/MountPointRoot/baz/bar/bar.baz.cs", ChangeKind.Create))
+                    .Without("MountPointRoot/")
+            };
 
-            //yield return new object[]
-            //{
-            //    "TemplateWithSourceNameInTargetPathGetsRenamed",
-            //    "--name baz",
-            //     new MockCreationEffects()
-            //        .WithPrimaryOutputs("bar/baz/baz.cs")
-            //        .WithFileChange(new MockFileChange("foo.cs", "bar/baz/baz.cs", ChangeKind.Create))
-            //        .Without("bar/foo/")
-            //};
+            yield return new object[]
+            {
+                "TemplateWithSourceNameInTargetPathGetsRenamed",
+                "--name baz",
+                 new MockCreationEffects()
+                    .WithPrimaryOutputs("bar/baz/baz.cs")
+                    .WithFileChange(new MockFileChange("foo.cs", "bar/baz/baz.cs", ChangeKind.Create))
+                    .Without("bar/foo/")
+            };
 
             yield return new object[]
             {

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TestTemplateSetup.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TestTemplateSetup.cs
@@ -106,7 +106,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             runSpec.RootVariableCollection = variables;
             IDirectory sourceDir = SourceMountPoint.DirectoryInfo("/");
 
-            IOrchestrator2 basicOrchestrator = new Core.Util.Orchestrator();
+            IOrchestrator basicOrchestrator = new Core.Util.Orchestrator();
             RunnableProjectOrchestrator orchestrator = new RunnableProjectOrchestrator(basicOrchestrator);
 
             foreach (FileSourceMatchInfo source in runnableConfig.Sources)
@@ -136,7 +136,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             MockGlobalRunSpec runSpec = new MockGlobalRunSpec();
             IDirectory sourceDir = SourceMountPoint.DirectoryInfo("/");
 
-            IOrchestrator2 basicOrchestrator = new Core.Util.Orchestrator();
+            IOrchestrator basicOrchestrator = new Core.Util.Orchestrator();
             RunnableProjectOrchestrator orchestrator = new RunnableProjectOrchestrator(basicOrchestrator);
 
             Dictionary<string, IReadOnlyList<IFileChange2>> changesByTarget = new Dictionary<string, IReadOnlyList<IFileChange2>>();

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TestTemplateSetup.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TestTemplateSetup.cs
@@ -144,8 +144,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             foreach (FileSourceMatchInfo source in runnableConfig.Sources)
             {
                 TemplateConfigTestHelpers.SetupFileSourceMatchersOnGlobalRunSpec(runSpec, source);
-                string targetDirForSource = Path.Combine(targetBaseDir, source.Target);
-                IReadOnlyList<IFileChange2> changes = orchestrator.GetFileChanges(runSpec, sourceDir, targetDirForSource);
+                IReadOnlyList<IFileChange2> changes = orchestrator.GetFileChanges(runSpec, sourceDir, targetBaseDir, source.Target);
                 changesByTarget[source.Target] = changes;
             }
 


### PR DESCRIPTION
fixes dotnet/templating#2746 when using source modifiers returned file changes are wrong
reenabled disabled tests

