### PR TITLE
F# --- warnon 3390

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-FSharp/Company.ClassLibrary1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-FSharp/Company.ClassLibrary1.fsproj
@@ -5,6 +5,7 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ClassLibrary1</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ConsoleApplication-FSharp/Company.ConsoleApplication1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ConsoleApplication-FSharp/Company.ConsoleApplication1.fsproj
@@ -5,6 +5,7 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net5.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ConsoleApplication1</RootNamespace>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This updates F# templates to add the property:
````
    <WarnOn>3390;$(WarnOn)</WarnOn>
````
This will enable these compiler warnings:
````
xmlDocBadlyFormed,"This XML comment is invalid: '%s'"
xmlDocMissingParameterName,"This XML comment is invalid: missing 'name' attribute for parameter or parameter reference"
xmlDocMissingCrossReference,"This XML comment is invalid: missing 'cref' attribute for cross-reference"
xmlDocInvalidParameterName,"This XML comment is invalid: unknown parameter '%s'"
xmlDocDuplicateParameter,"This XML comment is invalid: multiple documentation entries for parameter '%s'"
xmlDocUnresolvedCrossReference,"This XML comment is invalid: unresolved cross-reference '%s'"
xmlDocMissingParameter,"This XML comment is incomplete: no documentation for parameter '%s'"
````
