### PR TITLE
Corrects a typo in template.json

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
@@ -1087,7 +1087,7 @@
         "properties": {
           "description": {
             "type": "string",
-            "description": "A string to use to indicate the intent of the baesline"
+            "description": "A string to use to indicate the intent of the baseline"
           },
           "defaultOverrides": {
             "description": "A lookup of symbol names to new defaults",


### PR DESCRIPTION
This commit corrects a typo (baesline -> baseline) in template.json.