### PR TITLE
Template Discovery: added support for 2nd search query

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/IPackInfo.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IPackInfo.cs
@@ -1,8 +1,0 @@
-namespace Microsoft.TemplateEngine.Abstractions
-{
-    public interface IPackInfo
-    {
-        string Name { get; }
-        string Version { get; }
-    }
-}

--- a/src/Microsoft.TemplateSearch.Common/PackInfo.cs
+++ b/src/Microsoft.TemplateSearch.Common/PackInfo.cs
@@ -1,9 +1,7 @@
 using System.Collections.Generic;
-using Microsoft.TemplateEngine.Abstractions;
-
 namespace Microsoft.TemplateSearch.Common
 {
-    public class PackInfo : IPackInfo
+    public class PackInfo
     {
         public static PackInfo Empty = new PackInfo(string.Empty, string.Empty);
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/AdditionalData/CliHostDataProducer.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/AdditionalData/CliHostDataProducer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.AdditionalData
 
         public string DataUniqueName => CliHostDataName;
 
-        public void CreateDataForTemplatePack(IInstalledPackInfo packInfo, IReadOnlyList<ITemplateInfo> templateList, IEngineEnvironmentSettings environment)
+        public void CreateDataForTemplatePack(IDownloadedPackInfo packInfo, IReadOnlyList<ITemplateInfo> templateList, IEngineEnvironmentSettings environment)
         {
             IHostSpecificDataLoader hostDataLoader = new HostSpecificDataLoader(environment.SettingsLoader);
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/AdditionalData/IAdditionalDataProducer.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/AdditionalData/IAdditionalDataProducer.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.AdditionalData
     {
         string DataUniqueName { get; }
 
-        void CreateDataForTemplatePack(IInstalledPackInfo packInfo, IReadOnlyList<ITemplateInfo> templates, IEngineEnvironmentSettings environment);
+        void CreateDataForTemplatePack(IDownloadedPackInfo packInfo, IReadOnlyList<ITemplateInfo> templates, IEngineEnvironmentSettings environment);
 
         string Serialized { get; }
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/PreviouslyRejectedPackFilter.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/PreviouslyRejectedPackFilter.cs
@@ -15,9 +15,9 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Filters
     {
         private static readonly string FilterId = "Previously Seen";
 
-        internal static Func<IInstalledPackInfo, PreFilterResult> SetupPackFilter(HashSet<string> nonTemplatePacks)
+        internal static Func<IDownloadedPackInfo, PreFilterResult> SetupPackFilter(HashSet<string> nonTemplatePacks)
         {
-            Func<IInstalledPackInfo, PreFilterResult> previouslyRejectedPackFilter = (packInfo) =>
+            Func<IDownloadedPackInfo, PreFilterResult> previouslyRejectedPackFilter = (packInfo) =>
             {
                 if (nonTemplatePacks.Contains(packInfo.Id))
                 {

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/SkipTemplatePacksFilter.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/SkipTemplatePacksFilter.cs
@@ -23,9 +23,9 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Filters
         };
         private static readonly string _FilterId = "Permanent pack blacklist";
 
-        public static Func<IInstalledPackInfo, PreFilterResult> SetupPackFilter()
+        public static Func<IDownloadedPackInfo, PreFilterResult> SetupPackFilter()
         {
-            Func<IInstalledPackInfo, PreFilterResult> filter = (packInfo) =>
+            Func<IDownloadedPackInfo, PreFilterResult> filter = (packInfo) =>
             {
                 foreach (string package in packagesToBeSkipped)
                 {

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/TemplateJsonExistencePackFilter.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/TemplateJsonExistencePackFilter.cs
@@ -24,9 +24,9 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Filters
             _environemntSettings = new EngineEnvironmentSettings(_host, x => new SettingsLoader(x));
         }
 
-        public static Func<IInstalledPackInfo, PreFilterResult> SetupPackFilter()
+        public static Func<IDownloadedPackInfo, PreFilterResult> SetupPackFilter()
         {
-            Func<IInstalledPackInfo, PreFilterResult> filter = (packInfo) =>
+            Func<IDownloadedPackInfo, PreFilterResult> filter = (packInfo) =>
             {
                 foreach (IMountPointFactory factory in _environemntSettings.SettingsLoader.Components.OfType<IMountPointFactory>())
                 {

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackInfo.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.TemplateSearch.TemplateDiscovery.PackProviders;
+using Microsoft.TemplateSearch.TemplateDiscovery.PackProviders;
 
 namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
 {
@@ -12,6 +12,6 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
 
         public string Path { get; set; }
 
-        public int TotalDownloads { get; set; }
+        public long TotalDownloads { get; set; }
     }
 }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackInfo.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
 {
-    public class NugetPackInfo : IInstalledPackInfo
+    public class NugetPackInfo : IDownloadedPackInfo
     {
         public string VersionedPackageIdentity { get; set; }
 
@@ -12,6 +12,6 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
 
         public string Path { get; set; }
 
-        public long TotalDownloads { get; set; }
+        public int TotalDownloads { get; set; }
     }
 }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
             _pageSize = pageSize;
             _runOnlyOnePage = runOnlyOnePage;
             _packageTempPath = Path.Combine(packageTempBasePath, DownloadedPacksDir, Name);
-            _searchUriFormat = $"https://api-v2v3search-0.nuget.org/query?{query}" + "&skip={0}&take={1}" + $"&prerelease={includePreviewPacks}";
+            _searchUriFormat = $"https://api-v2v3search-0.nuget.org/query?{query}&skip={{0}}&take={{1}}&prerelease={includePreviewPacks}";
 
             if (Directory.Exists(_packageTempPath))
             {
@@ -107,7 +107,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
             }
             catch (Exception e)
             {
-                Console.WriteLine($"Failed to download package {packinfo.Id} {packinfo.Version}, reason: {e.Message}.");
+                Console.WriteLine($"Failed to download package {packinfo.Id} {packinfo.Version}, reason: {e.ToString()}.");
                 return null;
             }
         }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackScraper.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackScraper.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
                 new NugetPackProvider("query-package-type-template", "packageType=Template",  config.BasePath, config.PageSize, config.RunOnlyOnePage, config.IncludePreviewPacks)
             };
 
-            List<Func<IInstalledPackInfo, PreFilterResult>> preFilterList = new List<Func<IInstalledPackInfo, PreFilterResult>>();
+            List<Func<IDownloadedPackInfo, PreFilterResult>> preFilterList = new List<Func<IDownloadedPackInfo, PreFilterResult>>();
 
             if (!PreviouslyRejectedPackFilter.TryGetPreviouslySkippedPacks(config.PreviousRunBasePath, out HashSet<string> nonTemplatePacks))
             {

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackScraper.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackScraper.cs
@@ -12,7 +12,11 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
     {
         public static bool TryCreateDefaultNugetPackScraper(ScraperConfig config, out PackSourceChecker packSourceChecker)
         {
-            NugetPackProvider packProvider = new NugetPackProvider(config.BasePath, config.PageSize, config.RunOnlyOnePage, config.IncludePreviewPacks);
+            List<IPackProvider> providers = new List<IPackProvider>
+            {
+                new NugetPackProvider("query-template", "q=template", config.BasePath, config.PageSize, config.RunOnlyOnePage, config.IncludePreviewPacks),
+                new NugetPackProvider("query-package-type-template", "packageType=Template",  config.BasePath, config.PageSize, config.RunOnlyOnePage, config.IncludePreviewPacks)
+            };
 
             List<Func<IInstalledPackInfo, PreFilterResult>> preFilterList = new List<Func<IInstalledPackInfo, PreFilterResult>>();
 
@@ -37,7 +41,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
                 new CliHostDataProducer()
             };
 
-            packSourceChecker = new PackSourceChecker(packProvider, preFilterer, additionalDataProducers, config.SaveCandidatePacks);
+            packSourceChecker = new PackSourceChecker(providers, preFilterer, additionalDataProducers, config.SaveCandidatePacks);
             return true;
         }
     }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSourceInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSourceInfo.cs
@@ -53,7 +53,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
         public List<string> Authors { get; set; }
 
         [JsonProperty]
-        public int TotalDownloads { get; set; }
+        public long TotalDownloads { get; set; }
 
         [JsonProperty]
         public bool Verified { get; set; }
@@ -72,7 +72,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
 
         public override int GetHashCode()
         {
-            return new { Id, Version }.GetHashCode();
+            return (Id, Version).GetHashCode();
         }
 
         public bool Equals(IPackInfo other)

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSourceInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSourceInfo.cs
@@ -77,6 +77,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
 
         public bool Equals(IPackInfo other)
         {
+            if (other == null) return false;
             return Id.Equals(other.Id, StringComparison.OrdinalIgnoreCase) && Version.Equals(other.Version, StringComparison.OrdinalIgnoreCase);
         }
     }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSourceInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSourceInfo.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
+using Microsoft.TemplateSearch.TemplateDiscovery.PackProviders;
 using Newtonsoft.Json;
 
 namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
 {
-    public class NugetPackageSourceInfo
+    public class NugetPackageSourceInfo : IPackInfo, IEquatable<IPackInfo>
     {
         [JsonIgnore]
         public string VersionedPackageIdentity
@@ -58,5 +60,24 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
 
         [JsonProperty("versions")]
         public List<NugetPackageVersion> PackageVersions { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is NugetPackageSourceInfo info)
+            {
+                return Id.Equals(info.Id, StringComparison.OrdinalIgnoreCase) && Version.Equals(info.Version, StringComparison.OrdinalIgnoreCase);
+            }
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return new { Id, Version }.GetHashCode();
+        }
+
+        public bool Equals(IPackInfo other)
+        {
+            return Id.Equals(other.Id, StringComparison.OrdinalIgnoreCase) && Version.Equals(other.Version, StringComparison.OrdinalIgnoreCase);
+        }
     }
 }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackChecker.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackChecker.cs
@@ -20,7 +20,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
         {
         }
 
-        public PackCheckResult TryGetTemplatesInPack(IInstalledPackInfo packInfo, IReadOnlyList<IAdditionalDataProducer> additionalDataProducers, HashSet<string> alreadySeenTemplateIdentities, bool persistHive = false)
+        public PackCheckResult TryGetTemplatesInPack(IDownloadedPackInfo packInfo, IReadOnlyList<IAdditionalDataProducer> additionalDataProducers, HashSet<string> alreadySeenTemplateIdentities, bool persistHive = false)
         {
             ITemplateEngineHost host = CreateHost(packInfo);
             EngineEnvironmentSettings environment = new EngineEnvironmentSettings(host, x => new SettingsLoader(x));
@@ -84,7 +84,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
             return installedTemplates.Count > 0;
         }
 
-        private static ITemplateEngineHost CreateHost(IInstalledPackInfo packInfo)
+        private static ITemplateEngineHost CreateHost(IDownloadedPackInfo packInfo)
         {
             string hostIdentifier = HostIdentifierBase + packInfo.Id;
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackPrefilterer.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackPrefilterer.cs
@@ -7,18 +7,18 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
 {
     public class PackPreFilterer
     {
-        private readonly IReadOnlyList<Func<IInstalledPackInfo, PreFilterResult>> _preFilters;
+        private readonly IReadOnlyList<Func<IDownloadedPackInfo, PreFilterResult>> _preFilters;
 
-        public PackPreFilterer(IReadOnlyList<Func<IInstalledPackInfo, PreFilterResult>> preFilters)
+        public PackPreFilterer(IReadOnlyList<Func<IDownloadedPackInfo, PreFilterResult>> preFilters)
         {
             _preFilters = preFilters;
         }
 
-        public PreFilterResultList FilterPack(IInstalledPackInfo packInfo)
+        public PreFilterResultList FilterPack(IDownloadedPackInfo packInfo)
         {
             List<PreFilterResult> resultList = new List<PreFilterResult>();
 
-            foreach (Func<IInstalledPackInfo, PreFilterResult> filter in _preFilters)
+            foreach (Func<IDownloadedPackInfo, PreFilterResult> filter in _preFilters)
             {
                 PreFilterResult result = filter(packInfo);
                 resultList.Add(result);

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
@@ -97,7 +97,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
             return new PackSourceCheckResult(checkResultList, _additionalDataProducers);
         }
 
-        private PackCheckResult PrefilterPackInfo(IInstalledPackInfo packInfo)
+        private PackCheckResult PrefilterPackInfo(IDownloadedPackInfo packInfo)
         {
             PreFilterResultList preFilterResult = _packPreFilterer.FilterPack(packInfo);
             return new PackCheckResult(packInfo, preFilterResult);

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
@@ -11,15 +11,15 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
 {
     public class PackSourceChecker
     {
-        private readonly IPackProvider _packProvider;
+        private readonly IEnumerable<IPackProvider> _packProviders;
         private readonly PackPreFilterer _packPreFilterer;
         private readonly PackChecker _packChecker;
         private readonly IReadOnlyList<IAdditionalDataProducer> _additionalDataProducers;
         private readonly bool _saveCandidatePacks;
 
-        public PackSourceChecker(IPackProvider packProvider, PackPreFilterer packPreFilterer, IReadOnlyList<IAdditionalDataProducer> additionalDataProducers, bool saveCandidatePacks)
+        public PackSourceChecker(IEnumerable<IPackProvider> packProviders, PackPreFilterer packPreFilterer, IReadOnlyList<IAdditionalDataProducer> additionalDataProducers, bool saveCandidatePacks)
         {
-            _packProvider = packProvider;
+            _packProviders = packProviders;
             _packPreFilterer = packPreFilterer;
             _additionalDataProducers = additionalDataProducers;
             _saveCandidatePacks = saveCandidatePacks;
@@ -32,58 +32,67 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
             List<PackCheckResult> checkResultList = new List<PackCheckResult>();
             HashSet<string> alreadySeenTemplateIdentities = new HashSet<string>();
 
-            int count = 0;
-            Console.WriteLine($"{await _packProvider.GetPackageCountAsync().ConfigureAwait(false)} packs discovered, starting processing");
-
-            await foreach (IInstalledPackInfo packInfo in _packProvider.GetCandidatePacksAsync().ConfigureAwait(false))
+            foreach (IPackProvider packProvider in _packProviders)
             {
-                PackCheckResult preFilterResult = PrefilterPackInfo(packInfo);
-                if (preFilterResult.PreFilterResults.ShouldBeFiltered)
-                {
-                    Verbose.WriteLine($"{packInfo.Id}::{packInfo.Version} is skipped, {preFilterResult.PreFilterResults.Reason}");
-                    checkResultList.Add(preFilterResult);
-                }
-                else
-                {
-                    PackCheckResult packCheckResult = _packChecker.TryGetTemplatesInPack(packInfo, _additionalDataProducers, alreadySeenTemplateIdentities);
-                    checkResultList.Add(packCheckResult);
+                Console.WriteLine($"Processing provider pack {packProvider.Name}");
+                int count = 0;
+                Console.WriteLine($"{await packProvider.GetPackageCountAsync().ConfigureAwait(false)} packs discovered, starting processing");
 
-
-                    Verbose.WriteLine($"{packCheckResult.PackInfo.Id}::{packCheckResult.PackInfo.Version} was processed");
-                    if (packCheckResult.FoundTemplates.Any())
+                await foreach (IInstalledPackInfo packInfo in packProvider.GetCandidatePacksAsync().ConfigureAwait(false))
+                {
+                    PackCheckResult preFilterResult = PrefilterPackInfo(packInfo);
+                    if (preFilterResult.PreFilterResults.ShouldBeFiltered)
                     {
-                        Verbose.WriteLine("Found templates:");
-                        foreach (ITemplateInfo template in packCheckResult.FoundTemplates)
-                        {
-                            Verbose.WriteLine($"  - {template.Identity} ({template.ShortName}) by {template.Author}, group: {(string.IsNullOrWhiteSpace(template.GroupIdentity) ? "<not set>" : template.GroupIdentity)}, precedence: {template.Precedence}");
-                        }
+                        Verbose.WriteLine($"{packInfo.Id}::{packInfo.Version} is skipped, {preFilterResult.PreFilterResults.Reason}");
+                        checkResultList.Add(preFilterResult);
                     }
                     else
                     {
-                        Verbose.WriteLine("No templates were found");
+                        PackCheckResult packCheckResult = _packChecker.TryGetTemplatesInPack(packInfo, _additionalDataProducers, alreadySeenTemplateIdentities);
+                        checkResultList.Add(packCheckResult);
+
+
+                        Verbose.WriteLine($"{packCheckResult.PackInfo.Id}::{packCheckResult.PackInfo.Version} was processed");
+                        if (packCheckResult.FoundTemplates.Any())
+                        {
+                            Verbose.WriteLine("Found templates:");
+                            foreach (ITemplateInfo template in packCheckResult.FoundTemplates)
+                            {
+                                Verbose.WriteLine($"  - {template.Identity} ({template.ShortName}) by {template.Author}, group: {(string.IsNullOrWhiteSpace(template.GroupIdentity) ? "<not set>" : template.GroupIdentity)}, precedence: {template.Precedence}");
+                            }
+                        }
+                        else
+                        {
+                            Verbose.WriteLine("No templates were found");
+                        }
+
+
+                        // Record the found identities - to skip these templates when checking additional packs.
+                        // Some template identities are the same in multiple packs on nuget.
+                        // For this scraper, first in wins.
+                        alreadySeenTemplateIdentities.UnionWith(packCheckResult.FoundTemplates.Select(t => t.Identity));
                     }
 
-
-                    // Record the found identities - to skip these templates when checking additional packs.
-                    // Some template identities are the same in multiple packs on nuget.
-                    // For this scraper, first in wins.
-                    alreadySeenTemplateIdentities.UnionWith(packCheckResult.FoundTemplates.Select(t => t.Identity));
+                    ++count;
+                    if ((count % 10) == 0)
+                    {
+                        Console.WriteLine($"{count} packs processed");
+                    }
                 }
-
-                ++count;
-                if ((count % 10) == 0)
-                {
-                    Console.WriteLine($"{count} packs processed");
-                }
+                Console.WriteLine($"Processing provider pack {packProvider.Name} finished.");
             }
             Console.WriteLine("All packs processed");
 
             if (!_saveCandidatePacks)
             {
                 Console.WriteLine("Removing downloaded packs");
-                _packProvider.DeleteDownloadedPacks();
+                foreach (IPackProvider provider in _packProviders)
+                {
+                    provider.DeleteDownloadedPacks();
+                }
                 Console.WriteLine("Downloaded packs were removed");
             }
+
 
             return new PackSourceCheckResult(checkResultList, _additionalDataProducers);
         }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
@@ -43,7 +43,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
                 {
                     if (alreadySeenPacks.Contains(sourceInfo))
                     {
-                        Console.WriteLine($"Package {sourceInfo.Id}::{sourceInfo.Version} is already processed.");
+                        Verbose.WriteLine($"Package {sourceInfo.Id}::{sourceInfo.Version} is already processed.");
                         continue;
                     }
                     alreadySeenPacks.Add(sourceInfo);

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
@@ -67,7 +67,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
                         checkResultList.Add(packCheckResult);
 
 
-                        Verbose.WriteLine($"{packCheckResult.PackInfo.Id}::{packCheckResult.PackInfo.Version} was processed");
+                        Verbose.WriteLine($"{packCheckResult.PackInfo.Id}::{packCheckResult.PackInfo.Version} is processed");
                         if (packCheckResult.FoundTemplates.Any())
                         {
                             Verbose.WriteLine("Found templates:");
@@ -91,12 +91,12 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
                     ++count;
                     if ((count % 10) == 0)
                     {
-                        Console.WriteLine($"{count} packs processed");
+                        Console.WriteLine($"{count} packs are processed");
                     }
                 }
-                Console.WriteLine($"All packs from pack provider {packProvider.Name} are processed.");
+                Console.WriteLine($"All packs from pack provider {packProvider.Name} are processed");
             }
-            Console.WriteLine("All packs processed");
+            Console.WriteLine("All packs are processed");
 
             if (!_saveCandidatePacks)
             {

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/Reporting/PackCheckResult.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/Reporting/PackCheckResult.cs
@@ -6,21 +6,21 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking.Reporting
 {
     public class PackCheckResult
     {
-        public PackCheckResult(IInstalledPackInfo packInfo, PreFilterResultList preFilterResults)
+        public PackCheckResult(IDownloadedPackInfo packInfo, PreFilterResultList preFilterResults)
         {
             PackInfo = packInfo;
             PreFilterResults = preFilterResults;
             FoundTemplates = new List<ITemplateInfo>();
         }
 
-        public PackCheckResult(IInstalledPackInfo packInfo, IReadOnlyList<ITemplateInfo> foundTemplates)
+        public PackCheckResult(IDownloadedPackInfo packInfo, IReadOnlyList<ITemplateInfo> foundTemplates)
         {
             PackInfo = packInfo;
             PreFilterResults = new PreFilterResultList();
             FoundTemplates = foundTemplates;
         }
 
-        public IInstalledPackInfo PackInfo { get; }
+        public IDownloadedPackInfo PackInfo { get; }
 
         public PreFilterResultList PreFilterResults { get; }
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IDownloadedPackInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IDownloadedPackInfo.cs
@@ -1,15 +1,11 @@
 namespace Microsoft.TemplateSearch.TemplateDiscovery.PackProviders
 {
-    public interface IInstalledPackInfo
+    public interface IDownloadedPackInfo : IPackInfo
     {
         /// <summary>
         /// The fully qualified Id. Style may vary from source to source.
         /// </summary>
         string VersionedPackageIdentity { get; }
-
-        string Id { get; }
-
-        string Version { get; }
 
         /// <summary>
         /// The path on disk for the pack.

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IPackInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IPackInfo.cs
@@ -1,0 +1,10 @@
+
+namespace Microsoft.TemplateSearch.TemplateDiscovery.PackProviders
+{
+    public interface IPackInfo
+    {
+        string Id { get; }
+        string Version { get; }
+        int TotalDownloads { get; }
+    }
+}

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IPackInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IPackInfo.cs
@@ -5,6 +5,6 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackProviders
     {
         string Id { get; }
         string Version { get; }
-        int TotalDownloads { get; }
+        long TotalDownloads { get; }
     }
 }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IPackProvider.cs
@@ -5,6 +5,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackProviders
 {
     public interface IPackProvider
     {
+        string Name { get; }
+
         IAsyncEnumerable<IInstalledPackInfo> GetCandidatePacksAsync();
 
         Task<int> GetPackageCountAsync();

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IPackProvider.cs
@@ -7,7 +7,9 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackProviders
     {
         string Name { get; }
 
-        IAsyncEnumerable<IInstalledPackInfo> GetCandidatePacksAsync();
+        IAsyncEnumerable<IPackInfo> GetCandidatePacksAsync();
+
+        Task<IDownloadedPackInfo> DownloadPackageAsync(IPackInfo packinfo);
 
         Task<int> GetPackageCountAsync();
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/ScraperConfig.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/ScraperConfig.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Microsoft.TemplateSearch.TemplateDiscovery
 {
     public class ScraperConfig
@@ -15,5 +17,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery
         public string PreviousRunBasePath { get; set; }
 
         public bool DontFilterOnTemplateJson { get; set; }
+
+        public List<string> Providers { get; } = new List<string>();
     }
 }


### PR DESCRIPTION
Template discovery tool: added support for searching packs with `packageType` equal to `Template` 