### PR TITLE
Copied analyzers from dotnet/runtime

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,20 +1,200 @@
-# EditorConfig is awesome: http://EditorConfig.org
+# editorconfig.org
 
 # top-most EditorConfig file
 root = true
 
-# Newline ending every file
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
 [*]
-end_of_line = crlf
+insert_final_newline = true
 indent_style = space
 indent_size = 4
-tab_width = 4
-insert_final_newline = true
 trim_trailing_whitespace = true
+
+[project.json]
+indent_size = 2
+
+# Generated code
+[*{_AssemblyInfo.cs,.notsupported.cs}]
+generated_code = true
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Code quality
+dotnet_style_readonly_field = true:suggestion
+dotnet_code_quality_unused_parameters = non_public:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_constructors = true:silent
+csharp_style_expression_bodied_operators = true:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Analyzers
+dotnet_code_quality.ca1802.api_surface = private, internal
+dotnet_code_quality.ca1822.api_surface = private, internal
+dotnet_code_quality.ca2208.api_surface = public
+
+# License header
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.
+
+# C++ Files
+[*.{cpp,h,in}]
+curly_bracket_next_line = true
+indent_brace_style = Allman
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+[*.{csproj,vbproj,proj,nativeproj,locproj}]
 charset = utf-8
 
-[**/*.sh]
-end_of_line = lf
-
-[**/*.json]
+# Xml build files
+[*.builds]
 indent_size = 2
+
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# YAML config files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd,bat}]
+end_of_line = crlf

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
         <Product>Microsoft .NET Core</Product>
         <Copyright>$(CopyrightNetFoundation)</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <NoWarn>NU5105;NU5128</NoWarn>
+        <NoWarn>NU5105;NU5128;0419,0649</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,4 +31,5 @@
     </PropertyGroup>
 
     <Import Project="Version.props" />
+    <Import Project="$(RepositoryEngineeringDir)Analyzers.props" />
 </Project>

--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleset>
+    <!-- Disable analyzers in sourcebuild -->
+    <EnableAnalyzers Condition="'$(DotNetBuildFromSource)' == 'true'">false</EnableAnalyzers>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -62,7 +62,7 @@
     <Rule Id="CA1502" Action="None" />          <!-- Avoid excessive complexity -->
     <Rule Id="CA1505" Action="None" />          <!-- Avoid unmaintainable code -->
     <Rule Id="CA1506" Action="None" />          <!-- Avoid excessive class coupling -->
-    <Rule Id="CA1507" Action="Warning" />       <!-- Use nameof to express symbol names -->
+    <Rule Id="CA1507" Action="Info" TemporarilyDisabled="true" />       <!-- Use nameof to express symbol names -->
     <Rule Id="CA1508" Action="None" />          <!-- Avoid dead conditional code -->
     <Rule Id="CA1509" Action="None" />          <!-- Invalid entry in code metrics rule specification file -->
     <Rule Id="CA1700" Action="None" />          <!-- Do not name enum values 'Reserved' -->
@@ -79,10 +79,10 @@
     <Rule Id="CA1724" Action="None" />          <!-- Type names should not match namespaces -->
     <Rule Id="CA1725" Action="Info" />          <!-- Parameter names should match base declaration -->
     <Rule Id="CA1801" Action="None" />          <!-- Review unused parameters -->
-    <Rule Id="CA1802" Action="Warning" />       <!-- Use literals where appropriate -->
-    <Rule Id="CA1805" Action="Warning" />       <!-- Do not initialize unnecessarily -->
+    <Rule Id="CA1802" Action="Info" TemporarilyDisabled="true" />       <!-- Use literals where appropriate -->
+    <Rule Id="CA1805" Action="Info" TemporarilyDisabled="true" />       <!-- Do not initialize unnecessarily -->
     <Rule Id="CA1806" Action="None" />          <!-- Do not ignore method results -->
-    <Rule Id="CA1810" Action="Warning" />       <!-- Initialize reference type static fields inline -->
+    <Rule Id="CA1810" Action="Info" TemporarilyDisabled="true" />       <!-- Initialize reference type static fields inline -->
     <Rule Id="CA1812" Action="None" />          <!-- Avoid uninstantiated internal classes -->
     <Rule Id="CA1813" Action="None" />          <!-- Avoid unsealed attributes -->
     <Rule Id="CA1814" Action="None" />          <!-- Prefer jagged arrays over multidimensional -->
@@ -94,23 +94,23 @@
     <Rule Id="CA1822" Action="None" />          <!-- Mark members as static -->
     <Rule Id="CA1823" Action="Warning" />       <!-- Avoid unused private fields -->
     <Rule Id="CA1824" Action="Warning" />       <!-- Mark assemblies with NeutralResourcesLanguageAttribute -->
-    <Rule Id="CA1825" Action="Warning" />       <!-- Avoid zero-length array allocations. -->
-    <Rule Id="CA1826" Action="Warning" />       <!-- Do not use Enumerable methods on indexable collections. Instead use the collection directly -->
+    <Rule Id="CA1825" Action="Info" TemporarilyDisabled="true" />       <!-- Avoid zero-length array allocations. -->
+    <Rule Id="CA1826" Action="Info" TemporarilyDisabled="true" />       <!-- Do not use Enumerable methods on indexable collections. Instead use the collection directly -->
     <Rule Id="CA1827" Action="Warning" />       <!-- Do not use Count() or LongCount() when Any() can be used -->
     <Rule Id="CA1828" Action="Warning" />       <!-- Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used -->
-    <Rule Id="CA1829" Action="Warning" />       <!-- Use Length/Count property instead of Count() when available -->
+    <Rule Id="CA1829" Action="Info" TemporarilyDisabled="true" />       <!-- Use Length/Count property instead of Count() when available -->
     <Rule Id="CA1830" Action="Warning" />       <!-- Prefer strongly-typed Append and Insert method overloads on StringBuilder. -->
     <Rule Id="CA1831" Action="Warning" />       <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
     <Rule Id="CA1832" Action="Warning" />       <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
     <Rule Id="CA1833" Action="Warning" />       <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
-    <Rule Id="CA1834" Action="Warning" />       <!-- Consider using 'StringBuilder.Append(char)' when applicable. -->
+    <Rule Id="CA1834" Action="Info" TemporarilyDisabled="true" />       <!-- Consider using 'StringBuilder.Append(char)' when applicable. -->
     <Rule Id="CA1835" Action="Warning" />       <!-- Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync' -->
     <Rule Id="CA1836" Action="Warning" />       <!-- Prefer IsEmpty over Count -->
     <Rule Id="CA1837" Action="Warning" />       <!-- Use 'Environment.ProcessId' -->
     <Rule Id="CA1838" Action="Warning" />       <!-- Avoid 'StringBuilder' parameters for P/Invokes -->
     <Rule Id="CA2000" Action="None" />          <!-- Dispose objects before losing scope -->
     <Rule Id="CA2002" Action="None" />          <!-- Do not lock on objects with weak identity -->
-    <Rule Id="CA2007" Action="Warning" />       <!-- Consider calling ConfigureAwait on the awaited task -->
+    <Rule Id="CA2007" Action="Info" TemporarilyDisabled="true" />       <!-- Consider calling ConfigureAwait on the awaited task -->
     <Rule Id="CA2008" Action="Warning" />       <!-- Do not create tasks without passing a TaskScheduler -->
     <Rule Id="CA2009" Action="Warning" />       <!-- Do not call ToImmutableCollection on an ImmutableCollection value -->
     <Rule Id="CA2011" Action="Warning" />       <!-- Avoid infinite recursion -->
@@ -118,7 +118,7 @@
     <Rule Id="CA2013" Action="Warning" />       <!-- Do not use ReferenceEquals with value types -->
     <Rule Id="CA2014" Action="Warning" />       <!-- Do not use stackalloc in loops. -->
     <Rule Id="CA2015" Action="Warning" />       <!-- Do not define finalizers for types derived from MemoryManager<T> -->
-    <Rule Id="CA2016" Action="Warning" />       <!-- Forward the 'CancellationToken' parameter to methods that take one -->
+    <Rule Id="CA2016" Action="Info" TemporarilyDisabled="true" />       <!-- Forward the 'CancellationToken' parameter to methods that take one -->
     <Rule Id="CA2100" Action="None" />          <!-- Review SQL queries for security vulnerabilities -->
     <Rule Id="CA2101" Action="None" />          <!-- Specify marshaling for P/Invoke string arguments -->
     <Rule Id="CA2109" Action="None" />          <!-- Review visible event handlers -->
@@ -127,7 +127,7 @@
     <Rule Id="CA2200" Action="Warning" />       <!-- Rethrow to preserve stack details. -->
     <Rule Id="CA2201" Action="None" />          <!-- Do not raise reserved exception types -->
     <Rule Id="CA2207" Action="Warning" />       <!-- Initialize value type static fields inline -->
-    <Rule Id="CA2208" Action="Warning" />       <!-- Instantiate argument exceptions correctly -->
+    <Rule Id="CA2208" Action="Info" TemporarilyDisabled="true" />       <!-- Instantiate argument exceptions correctly -->
     <Rule Id="CA2211" Action="None" />          <!-- Non-constant fields should not be visible -->
     <Rule Id="CA2213" Action="None" />          <!-- Disposable fields should be disposed -->
     <Rule Id="CA2214" Action="None" />          <!-- Do not call overridable methods in constructors -->
@@ -154,7 +154,7 @@
     <Rule Id="CA2246" Action="None" />          <!-- Assigning symbol and its member in the same statement. -->
     <Rule Id="CA2247" Action="Warning" />       <!-- Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum. -->
     <Rule Id="CA2248" Action="Warning" />       <!-- Provide correct 'enum' argument to 'Enum.HasFlag' -->
-    <Rule Id="CA2249" Action="Warning" />       <!-- Consider using 'string.Contains' instead of 'string.IndexOf' -->
+    <Rule Id="CA2249" Action="Info" TemporarilyDisabled="true" />       <!-- Consider using 'string.Contains' instead of 'string.IndexOf' -->
     <Rule Id="CA2300" Action="None" />          <!-- Do not use insecure deserializer BinaryFormatter -->
     <Rule Id="CA2301" Action="None" />          <!-- Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder -->
     <Rule Id="CA2302" Action="None" />          <!-- Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize -->
@@ -250,8 +250,8 @@
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="AD0001" Action="None" />          <!-- Analyzer threw an exception -->
     <Rule Id="SA0001" Action="None" />          <!-- XML comments -->
-    <Rule Id="SA1000" Action="Warning" />       <!-- Spacing around keywords -->
-    <Rule Id="SA1001" Action="Warning" />       <!-- Commas should not be preceded by whitespace -->
+    <Rule Id="SA1000" Action="Info" TemporarilyDisabled="true" />       <!-- Spacing around keywords -->
+    <Rule Id="SA1001" Action="Info" TemporarilyDisabled="true" />       <!-- Commas should not be preceded by whitespace -->
     <Rule Id="SA1002" Action="None" />          <!-- Semicolons should not be preceded by a space -->
     <Rule Id="SA1003" Action="None" />          <!-- Operator should not appear at the end of a line -->
     <Rule Id="SA1004" Action="None" />          <!-- Documentation line should begin with a space -->
@@ -262,7 +262,7 @@
     <Rule Id="SA1011" Action="None" />          <!-- Closing square bracket should be followed by a space -->
     <Rule Id="SA1012" Action="None" />          <!-- Opening brace should be followed by a space -->
     <Rule Id="SA1013" Action="None" />          <!-- Closing brace should be preceded by a space -->
-    <Rule Id="SA1014" Action="Warning" />       <!-- Opening generic brackets should not be preceded by a space -->
+    <Rule Id="SA1014" Action="Info" TemporarilyDisabled="true"  />       <!-- Opening generic brackets should not be preceded by a space -->
     <Rule Id="SA1015" Action="None" />          <!-- Closing generic bracket should not be followed by a space -->
     <Rule Id="SA1018" Action="Warning" />       <!-- Nullable type symbol should not be preceded by a space -->
     <Rule Id="SA1020" Action="Warning" />       <!-- Increment symbol should not be preceded by a space -->
@@ -272,7 +272,7 @@
     <Rule Id="SA1025" Action="None" />          <!-- Code should not contain multiple whitespace characters in a row -->
     <Rule Id="SA1026" Action="Warning" />       <!-- Keyword followed by span or blank line -->
     <Rule Id="SA1027" Action="Warning" />       <!-- Tabs and spaces should be used correctly -->
-    <Rule Id="SA1028" Action="Warning" />       <!-- Code should not contain trailing whitespace -->
+    <Rule Id="SA1028" Action="Info" TemporarilyDisabled="true" />       <!-- Code should not contain trailing whitespace -->
     <Rule Id="SA1100" Action="None" />          <!-- Do not prefix calls with base unless local implementation exists -->
     <Rule Id="SA1101" Action="None" />          <!-- Prefix local calls with this -->
     <Rule Id="SA1102" Action="Warning" />       <!-- Query clause should follow previous clause -->
@@ -282,7 +282,7 @@
     <Rule Id="SA1108" Action="None" />          <!-- Block statements should not contain embedded comments -->
     <Rule Id="SA1110" Action="None" />          <!-- Opening parenthesis or bracket should be on declaration line -->
     <Rule Id="SA1111" Action="None" />          <!-- Closing parenthesis should be on line of last parameter -->
-    <Rule Id="SA1113" Action="Warning" />       <!-- Comma should be on the same line as previous parameter -->
+    <Rule Id="SA1113" Action="Info" TemporarilyDisabled="true" />       <!-- Comma should be on the same line as previous parameter -->
     <Rule Id="SA1114" Action="None" />          <!-- Parameter list should follow declaration -->
     <Rule Id="SA1115" Action="Warning" />       <!-- Parameter should begin on the line after the previous parameter -->
     <Rule Id="SA1116" Action="None" />          <!-- Split parameters should start on line after declaration -->
@@ -290,14 +290,14 @@
     <Rule Id="SA1118" Action="None" />          <!-- Parameter should not span multiple lines -->
     <Rule Id="SA1119" Action="None" />          <!-- Statement should not use unnecessary parenthesis -->
     <Rule Id="SA1120" Action="None" />          <!-- Comments should contain text -->
-    <Rule Id="SA1121" Action="Warning" />       <!-- Use built-in type alias -->
+    <Rule Id="SA1121" Action="Info" TemporarilyDisabled="true" />       <!-- Use built-in type alias -->
     <Rule Id="SA1122" Action="None" />          <!-- Use string.Empty for empty strings -->
     <Rule Id="SA1123" Action="None" />          <!-- Region should not be located within a code element -->
     <Rule Id="SA1124" Action="None" />          <!-- Do not use regions -->
     <Rule Id="SA1125" Action="None" />          <!-- Use shorthand for nullable types -->
     <Rule Id="SA1127" Action="None" />          <!-- Generic type constraints should be on their own line -->
     <Rule Id="SA1128" Action="None" />          <!-- Put constructor initializers on their own line -->
-    <Rule Id="SA1129" Action="Warning" />       <!-- Do not use default value type constructor -->
+    <Rule Id="SA1129" Action="Info" TemporarilyDisabled="true" />       <!-- Do not use default value type constructor -->
     <Rule Id="SA1130" Action="None" />          <!-- Use lambda syntax -->
     <Rule Id="SA1131" Action="None" />          <!-- Constant values should appear on the right-hand side of comparisons -->
     <Rule Id="SA1132" Action="None" />          <!-- Do not combine fields -->
@@ -315,7 +315,7 @@
     <Rule Id="SA1203" Action="None" />          <!-- Constants should appear before fields -->
     <Rule Id="SA1204" Action="None" />          <!-- Static elements should appear before instance elements -->
     <Rule Id="SA1205" Action="Warning" />       <!-- Partial elements should declare an access modifier -->
-    <Rule Id="SA1206" Action="Warning" />       <!-- Keyword ordering -->
+    <Rule Id="SA1206" Action="Info" TemporarilyDisabled="true" />       <!-- Keyword ordering -->
     <Rule Id="SA1208" Action="None" />          <!-- Using directive ordering -->
     <Rule Id="SA1209" Action="None" />          <!-- Using alias directives should be placed after all using namespace directives -->
     <Rule Id="SA1210" Action="None" />          <!-- Using directives should be ordered alphabetically by the namespaces -->
@@ -337,7 +337,7 @@
     <Rule Id="SA1313" Action="None" />          <!-- Parameter should begin with lower-case letter -->
     <Rule Id="SA1314" Action="None" />          <!-- Type parameter names should begin with T -->
     <Rule Id="SA1316" Action="None" />          <!-- Tuple element names should use correct casing -->
-    <Rule Id="SA1400" Action="Warning" />       <!-- Member should declare an access modifer -->
+    <Rule Id="SA1400" Action="Info" TemporarilyDisabled="true" />       <!-- Member should declare an access modifer -->
     <Rule Id="SA1401" Action="None" />          <!-- Fields should be private -->
     <Rule Id="SA1402" Action="None" />          <!-- File may only contain a single type -->
     <Rule Id="SA1403" Action="None" />          <!-- File may only contain a single namespace -->
@@ -365,8 +365,8 @@
     <Rule Id="SA1514" Action="None" />          <!-- Element documentation header should be preceded by blank line -->
     <Rule Id="SA1515" Action="None" />          <!-- Single-line comment should be preceded by blank line -->
     <Rule Id="SA1516" Action="None" />          <!-- Elements should be separated by blank line -->
-    <Rule Id="SA1517" Action="Warning" />       <!-- Code should not contain blank lines at start of file -->
-    <Rule Id="SA1518" Action="Warning" />       <!-- Code should not contain blank lines at the end of the file -->
+    <Rule Id="SA1517" Action="Info" TemporarilyDisabled="true" />       <!-- Code should not contain blank lines at start of file -->
+    <Rule Id="SA1518" Action="Info" TemporarilyDisabled="true" />       <!-- Code should not contain blank lines at the end of the file -->
     <Rule Id="SA1519" Action="None" />          <!-- Braces should not be omitted from multi-line child statement -->
     <Rule Id="SA1520" Action="None" />          <!-- Use braces consistently -->
     <Rule Id="SA1600" Action="None" />          <!-- Elements should be documented -->
@@ -465,7 +465,7 @@
     <Rule Id="IDE0070" Action="Hidden" />       <!-- UseSystemHashCode -->
     <Rule Id="IDE0071" Action="Hidden" />       <!-- SimplifyInterpolation -->
     <Rule Id="IDE0072" Action="Hidden" />       <!-- PopulateSwitchExpression -->
-    <Rule Id="IDE0073" Action="Warning" />      <!-- FileHeaderMismatch -->
+    <Rule Id="IDE0073" Action="Info" TemporarilyDisabled="true" />      <!-- FileHeaderMismatch -->
     <Rule Id="IDE0074" Action="Hidden" />       <!-- UseCoalesceCompoundAssignment -->
     <Rule Id="IDE0075" Action="Hidden" />       <!-- SimplifyConditionalExpression -->
     <Rule Id="IDE0076" Action="Hidden" />       <!-- InvalidSuppressMessageAttribute -->

--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -1,0 +1,497 @@
+<RuleSet Name="Microsoft.Analyzers.ManagedCodeAnalysis" Description="Microsoft.Analyzers.ManagedCodeAnalysis" ToolsVersion="14.0">
+  <Rules AnalyzerId="Microsoft.DotNet.CodeAnalysis" RuleNamespace="Microsoft.DotNet.CodeAnalysis.Analyzers">
+    <Rule Id="BCL0001" Action="Warning" />      <!-- Ensure minimum API surface is respected -->
+    <Rule Id="BCL0010" Action="Warning" />      <!-- AppContext default value expected to be true -->
+    <Rule Id="BCL0011" Action="Warning" />      <!-- AppContext default value defined in if statement with incorrect pattern -->
+    <Rule Id="BCL0012" Action="Warning" />      <!-- AppContext default value defined in if statement at root of switch case -->
+    <Rule Id="BCL0015" Action="None" />         <!-- Invalid P/Invoke call -->
+    <Rule Id="BCL0020" Action="Warning" />      <!-- Invalid SR.Format call -->
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.NetAnalyzers">
+    <Rule Id="CA1000" Action="None" />          <!-- Do not declare static members on generic types -->
+    <Rule Id="CA1001" Action="None" />          <!-- Types that own disposable fields should be disposable -->
+    <Rule Id="CA1002" Action="None" />          <!-- Do not expose generic lists -->
+    <Rule Id="CA1003" Action="None" />          <!-- Use generic event handler instances -->
+    <Rule Id="CA1005" Action="None" />          <!-- Avoid excessive parameters on generic types -->
+    <Rule Id="CA1008" Action="None" />          <!-- Enums should have zero value -->
+    <Rule Id="CA1010" Action="None" />          <!-- Generic interface should also be implemented -->
+    <Rule Id="CA1012" Action="None" />          <!-- Abstract types should not have constructors -->
+    <Rule Id="CA1014" Action="None" />          <!-- Mark assemblies with CLSCompliant -->
+    <Rule Id="CA1016" Action="None" />          <!-- Mark assemblies with assembly version -->
+    <Rule Id="CA1017" Action="None" />          <!-- Mark assemblies with ComVisible -->
+    <Rule Id="CA1018" Action="Warning" />       <!-- Mark attributes with AttributeUsageAttribute -->
+    <Rule Id="CA1019" Action="None" />          <!-- Define accessors for attribute arguments -->
+    <Rule Id="CA1021" Action="None" />          <!-- Avoid out parameters -->
+    <Rule Id="CA1024" Action="None" />          <!-- Use properties where appropriate -->
+    <Rule Id="CA1027" Action="None" />          <!-- Mark enums with FlagsAttribute -->
+    <Rule Id="CA1028" Action="None" />          <!-- Enum Storage should be Int32 -->
+    <Rule Id="CA1030" Action="None" />          <!-- Use events where appropriate -->
+    <Rule Id="CA1031" Action="None" />          <!-- Do not catch general exception types -->
+    <Rule Id="CA1032" Action="None" />          <!-- Implement standard exception constructors -->
+    <Rule Id="CA1033" Action="None" />          <!-- Interface methods should be callable by child types -->
+    <Rule Id="CA1034" Action="None" />          <!-- Nested types should not be visible -->
+    <Rule Id="CA1036" Action="None" />          <!-- Override methods on comparable types -->
+    <Rule Id="CA1040" Action="None" />          <!-- Avoid empty interfaces -->
+    <Rule Id="CA1041" Action="None" />          <!-- Provide ObsoleteAttribute message -->
+    <Rule Id="CA1043" Action="None" />          <!-- Use Integral Or String Argument For Indexers -->
+    <Rule Id="CA1044" Action="None" />          <!-- Properties should not be write only -->
+    <Rule Id="CA1045" Action="None" />          <!-- Do not pass types by reference -->
+    <Rule Id="CA1046" Action="None" />          <!-- Do not overload equality operator on reference types -->
+    <Rule Id="CA1047" Action="Warning" />       <!-- Do not declare protected member in sealed type -->
+    <Rule Id="CA1050" Action="Warning" />       <!-- Declare types in namespaces -->
+    <Rule Id="CA1051" Action="None" />          <!-- Do not declare visible instance fields -->
+    <Rule Id="CA1052" Action="None" />          <!-- Static holder types should be Static or NotInheritable -->
+    <Rule Id="CA1054" Action="None" />          <!-- Uri parameters should not be strings -->
+    <Rule Id="CA1055" Action="None" />          <!-- Uri return values should not be strings -->
+    <Rule Id="CA1056" Action="None" />          <!-- Uri properties should not be strings -->
+    <Rule Id="CA1058" Action="None" />          <!-- Types should not extend certain base types -->
+    <Rule Id="CA1060" Action="None" />          <!-- Move pinvokes to native methods class -->
+    <Rule Id="CA1061" Action="None" />          <!-- Do not hide base class methods -->
+    <Rule Id="CA1062" Action="None" />          <!-- Validate arguments of public methods -->
+    <Rule Id="CA1063" Action="None" />          <!-- Implement IDisposable Correctly -->
+    <Rule Id="CA1064" Action="None" />          <!-- Exceptions should be public -->
+    <Rule Id="CA1065" Action="None" />          <!-- Do not raise exceptions in unexpected locations -->
+    <Rule Id="CA1066" Action="None" />          <!-- Implement IEquatable when overriding Object.Equals -->
+    <Rule Id="CA1067" Action="None" />          <!-- Override Object.Equals(object) when implementing IEquatable<T> -->
+    <Rule Id="CA1068" Action="None" />          <!-- CancellationToken parameters must come last -->
+    <Rule Id="CA1069" Action="None" />          <!-- Enums values should not be duplicated -->
+    <Rule Id="CA1070" Action="Info" />          <!-- Do not declare event fields as virtual -->
+    <Rule Id="CA1200" Action="Warning" />       <!-- Avoid using cref tags with a prefix -->
+    <Rule Id="CA1303" Action="None" />          <!-- Do not pass literals as localized parameters -->
+    <Rule Id="CA1304" Action="None" />          <!-- Specify CultureInfo -->
+    <Rule Id="CA1305" Action="None" />          <!-- Specify IFormatProvider -->
+    <Rule Id="CA1307" Action="None" />          <!-- Specify StringComparison -->
+    <Rule Id="CA1308" Action="None" />          <!-- Normalize strings to uppercase -->
+    <Rule Id="CA1309" Action="None" />          <!-- Use ordinal stringcomparison -->
+    <Rule Id="CA1401" Action="Warning" />       <!-- P/Invokes should not be visible -->
+    <Rule Id="CA1416" Action="Warning" />       <!-- Validate platform compatibility -->
+    <Rule Id="CA1417" Action="Warning" />       <!-- Do not use 'OutAttribute' on string parameters for P/Invokes -->
+    <Rule Id="CA1501" Action="None" />          <!-- Avoid excessive inheritance -->
+    <Rule Id="CA1502" Action="None" />          <!-- Avoid excessive complexity -->
+    <Rule Id="CA1505" Action="None" />          <!-- Avoid unmaintainable code -->
+    <Rule Id="CA1506" Action="None" />          <!-- Avoid excessive class coupling -->
+    <Rule Id="CA1507" Action="Warning" />       <!-- Use nameof to express symbol names -->
+    <Rule Id="CA1508" Action="None" />          <!-- Avoid dead conditional code -->
+    <Rule Id="CA1509" Action="None" />          <!-- Invalid entry in code metrics rule specification file -->
+    <Rule Id="CA1700" Action="None" />          <!-- Do not name enum values 'Reserved' -->
+    <Rule Id="CA1707" Action="None" />          <!-- Identifiers should not contain underscores -->
+    <Rule Id="CA1708" Action="None" />          <!-- Identifiers should differ by more than case -->
+    <Rule Id="CA1710" Action="None" />          <!-- Identifiers should have correct suffix -->
+    <Rule Id="CA1711" Action="None" />          <!-- Identifiers should not have incorrect suffix -->
+    <Rule Id="CA1712" Action="None" />          <!-- Do not prefix enum values with type name -->
+    <Rule Id="CA1713" Action="None" />          <!-- Events should not have 'Before' or 'After' prefix -->
+    <Rule Id="CA1715" Action="None" />          <!-- Identifiers should have correct prefix -->
+    <Rule Id="CA1716" Action="None" />          <!-- Identifiers should not match keywords -->
+    <Rule Id="CA1720" Action="None" />          <!-- Identifier contains type name -->
+    <Rule Id="CA1721" Action="None" />          <!-- Property names should not match get methods -->
+    <Rule Id="CA1724" Action="None" />          <!-- Type names should not match namespaces -->
+    <Rule Id="CA1725" Action="Info" />          <!-- Parameter names should match base declaration -->
+    <Rule Id="CA1801" Action="None" />          <!-- Review unused parameters -->
+    <Rule Id="CA1802" Action="Warning" />       <!-- Use literals where appropriate -->
+    <Rule Id="CA1805" Action="Warning" />       <!-- Do not initialize unnecessarily -->
+    <Rule Id="CA1806" Action="None" />          <!-- Do not ignore method results -->
+    <Rule Id="CA1810" Action="Warning" />       <!-- Initialize reference type static fields inline -->
+    <Rule Id="CA1812" Action="None" />          <!-- Avoid uninstantiated internal classes -->
+    <Rule Id="CA1813" Action="None" />          <!-- Avoid unsealed attributes -->
+    <Rule Id="CA1814" Action="None" />          <!-- Prefer jagged arrays over multidimensional -->
+    <Rule Id="CA1815" Action="None" />          <!-- Override equals and operator equals on value types -->
+    <Rule Id="CA1816" Action="None" />          <!-- Dispose methods should call SuppressFinalize -->
+    <Rule Id="CA1819" Action="None" />          <!-- Properties should not return arrays -->
+    <Rule Id="CA1820" Action="None" />          <!-- Test for empty strings using string length -->
+    <Rule Id="CA1821" Action="Warning" />       <!-- Remove empty Finalizers -->
+    <Rule Id="CA1822" Action="None" />          <!-- Mark members as static -->
+    <Rule Id="CA1823" Action="Warning" />       <!-- Avoid unused private fields -->
+    <Rule Id="CA1824" Action="Warning" />       <!-- Mark assemblies with NeutralResourcesLanguageAttribute -->
+    <Rule Id="CA1825" Action="Warning" />       <!-- Avoid zero-length array allocations. -->
+    <Rule Id="CA1826" Action="Warning" />       <!-- Do not use Enumerable methods on indexable collections. Instead use the collection directly -->
+    <Rule Id="CA1827" Action="Warning" />       <!-- Do not use Count() or LongCount() when Any() can be used -->
+    <Rule Id="CA1828" Action="Warning" />       <!-- Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used -->
+    <Rule Id="CA1829" Action="Warning" />       <!-- Use Length/Count property instead of Count() when available -->
+    <Rule Id="CA1830" Action="Warning" />       <!-- Prefer strongly-typed Append and Insert method overloads on StringBuilder. -->
+    <Rule Id="CA1831" Action="Warning" />       <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
+    <Rule Id="CA1832" Action="Warning" />       <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
+    <Rule Id="CA1833" Action="Warning" />       <!-- Use AsSpan or AsMemory instead of Range-based indexers when appropriate -->
+    <Rule Id="CA1834" Action="Warning" />       <!-- Consider using 'StringBuilder.Append(char)' when applicable. -->
+    <Rule Id="CA1835" Action="Warning" />       <!-- Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync' -->
+    <Rule Id="CA1836" Action="Warning" />       <!-- Prefer IsEmpty over Count -->
+    <Rule Id="CA1837" Action="Warning" />       <!-- Use 'Environment.ProcessId' -->
+    <Rule Id="CA1838" Action="Warning" />       <!-- Avoid 'StringBuilder' parameters for P/Invokes -->
+    <Rule Id="CA2000" Action="None" />          <!-- Dispose objects before losing scope -->
+    <Rule Id="CA2002" Action="None" />          <!-- Do not lock on objects with weak identity -->
+    <Rule Id="CA2007" Action="Warning" />       <!-- Consider calling ConfigureAwait on the awaited task -->
+    <Rule Id="CA2008" Action="Warning" />       <!-- Do not create tasks without passing a TaskScheduler -->
+    <Rule Id="CA2009" Action="Warning" />       <!-- Do not call ToImmutableCollection on an ImmutableCollection value -->
+    <Rule Id="CA2011" Action="Warning" />       <!-- Avoid infinite recursion -->
+    <Rule Id="CA2012" Action="Warning" />       <!-- Use ValueTasks correctly -->
+    <Rule Id="CA2013" Action="Warning" />       <!-- Do not use ReferenceEquals with value types -->
+    <Rule Id="CA2014" Action="Warning" />       <!-- Do not use stackalloc in loops. -->
+    <Rule Id="CA2015" Action="Warning" />       <!-- Do not define finalizers for types derived from MemoryManager<T> -->
+    <Rule Id="CA2016" Action="Warning" />       <!-- Forward the 'CancellationToken' parameter to methods that take one -->
+    <Rule Id="CA2100" Action="None" />          <!-- Review SQL queries for security vulnerabilities -->
+    <Rule Id="CA2101" Action="None" />          <!-- Specify marshaling for P/Invoke string arguments -->
+    <Rule Id="CA2109" Action="None" />          <!-- Review visible event handlers -->
+    <Rule Id="CA2119" Action="None" />          <!-- Seal methods that satisfy private interfaces -->
+    <Rule Id="CA2153" Action="None" />          <!-- Do Not Catch Corrupted State Exceptions -->
+    <Rule Id="CA2200" Action="Warning" />       <!-- Rethrow to preserve stack details. -->
+    <Rule Id="CA2201" Action="None" />          <!-- Do not raise reserved exception types -->
+    <Rule Id="CA2207" Action="Warning" />       <!-- Initialize value type static fields inline -->
+    <Rule Id="CA2208" Action="Warning" />       <!-- Instantiate argument exceptions correctly -->
+    <Rule Id="CA2211" Action="None" />          <!-- Non-constant fields should not be visible -->
+    <Rule Id="CA2213" Action="None" />          <!-- Disposable fields should be disposed -->
+    <Rule Id="CA2214" Action="None" />          <!-- Do not call overridable methods in constructors -->
+    <Rule Id="CA2215" Action="None" />          <!-- Dispose methods should call base class dispose -->
+    <Rule Id="CA2216" Action="None" />          <!-- Disposable types should declare finalizer -->
+    <Rule Id="CA2217" Action="None" />          <!-- Do not mark enums with FlagsAttribute -->
+    <Rule Id="CA2218" Action="None" />          <!-- Override GetHashCode on overriding Equals -->
+    <Rule Id="CA2219" Action="None" />          <!-- Do not raise exceptions in finally clauses -->
+    <Rule Id="CA2224" Action="None" />          <!-- Override Equals on overloading operator equals -->
+    <Rule Id="CA2225" Action="None" />          <!-- Operator overloads have named alternates -->
+    <Rule Id="CA2226" Action="None" />          <!-- Operators should have symmetrical overloads -->
+    <Rule Id="CA2227" Action="None" />          <!-- Collection properties should be read only -->
+    <Rule Id="CA2229" Action="Warning" />       <!-- Implement serialization constructors -->
+    <Rule Id="CA2231" Action="None" />          <!-- Overload operator equals on overriding value type Equals -->
+    <Rule Id="CA2234" Action="None" />          <!-- Pass system uri objects instead of strings -->
+    <Rule Id="CA2235" Action="None" />          <!-- Mark all non-serializable fields -->
+    <Rule Id="CA2237" Action="None" />          <!-- Mark ISerializable types with serializable -->
+    <Rule Id="CA2241" Action="Warning" />       <!-- Provide correct arguments to formatting methods -->
+    <Rule Id="CA2242" Action="Warning" />       <!-- Test for NaN correctly -->
+    <!-- CA2243 temporarily disabled: https://github.com/dotnet/roslyn-analyzers/issues/3635 -->
+    <Rule Id="CA2243" Action="None" />          <!-- Attribute string literals should parse correctly -->
+    <Rule Id="CA2244" Action="None" />          <!-- Do not duplicate indexed element initializations -->
+    <Rule Id="CA2245" Action="Warning" />       <!-- Do not assign a property to itself. -->
+    <Rule Id="CA2246" Action="None" />          <!-- Assigning symbol and its member in the same statement. -->
+    <Rule Id="CA2247" Action="Warning" />       <!-- Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum. -->
+    <Rule Id="CA2248" Action="Warning" />       <!-- Provide correct 'enum' argument to 'Enum.HasFlag' -->
+    <Rule Id="CA2249" Action="Warning" />       <!-- Consider using 'string.Contains' instead of 'string.IndexOf' -->
+    <Rule Id="CA2300" Action="None" />          <!-- Do not use insecure deserializer BinaryFormatter -->
+    <Rule Id="CA2301" Action="None" />          <!-- Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder -->
+    <Rule Id="CA2302" Action="None" />          <!-- Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize -->
+    <Rule Id="CA2305" Action="None" />          <!-- Do not use insecure deserializer LosFormatter -->
+    <Rule Id="CA2310" Action="None" />          <!-- Do not use insecure deserializer NetDataContractSerializer -->
+    <Rule Id="CA2311" Action="None" />          <!-- Do not deserialize without first setting NetDataContractSerializer.Binder -->
+    <Rule Id="CA2312" Action="None" />          <!-- Ensure NetDataContractSerializer.Binder is set before deserializing -->
+    <Rule Id="CA2315" Action="None" />          <!-- Do not use insecure deserializer ObjectStateFormatter -->
+    <Rule Id="CA2321" Action="None" />          <!-- Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver -->
+    <Rule Id="CA2322" Action="None" />          <!-- Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing -->
+    <Rule Id="CA2326" Action="None" />          <!-- Do not use TypeNameHandling values other than None -->
+    <Rule Id="CA2327" Action="None" />          <!-- Do not use insecure JsonSerializerSettings -->
+    <Rule Id="CA2328" Action="None" />          <!-- Ensure that JsonSerializerSettings are secure -->
+    <Rule Id="CA2329" Action="None" />          <!-- Do not deserialize with JsonSerializer using an insecure configuration -->
+    <Rule Id="CA2330" Action="None" />          <!-- Ensure that JsonSerializer has a secure configuration when deserializing -->
+    <Rule Id="CA2350" Action="None" />          <!-- Do not use DataTable.ReadXml() with untrusted data -->
+    <Rule Id="CA2351" Action="None" />          <!-- Do not use DataSet.ReadXml() with untrusted data -->
+    <Rule Id="CA2352" Action="None" />          <!-- Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks -->
+    <Rule Id="CA2353" Action="None" />          <!-- Unsafe DataSet or DataTable in serializable type -->
+    <Rule Id="CA2354" Action="None" />          <!-- Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks -->
+    <Rule Id="CA2355" Action="None" />          <!-- Unsafe DataSet or DataTable type found in deserializable object graph -->
+    <Rule Id="CA2356" Action="None" />          <!-- Unsafe DataSet or DataTable type in web deserializable object graph -->
+    <Rule Id="CA2361" Action="None" />          <!-- Ensure autogenerated class containing DataSet.ReadXml() is not used with untrusted data -->
+    <Rule Id="CA2362" Action="None" />          <!-- Unsafe DataSet or DataTable in autogenerated serializable type can be vulnerable to remote code execution attacks -->
+    <Rule Id="CA3001" Action="None" />          <!-- Review code for SQL injection vulnerabilities -->
+    <Rule Id="CA3002" Action="None" />          <!-- Review code for XSS vulnerabilities -->
+    <Rule Id="CA3003" Action="None" />          <!-- Review code for file path injection vulnerabilities -->
+    <Rule Id="CA3004" Action="None" />          <!-- Review code for information disclosure vulnerabilities -->
+    <Rule Id="CA3005" Action="None" />          <!-- Review code for LDAP injection vulnerabilities -->
+    <Rule Id="CA3006" Action="None" />          <!-- Review code for process command injection vulnerabilities -->
+    <Rule Id="CA3007" Action="None" />          <!-- Review code for open redirect vulnerabilities -->
+    <Rule Id="CA3008" Action="None" />          <!-- Review code for XPath injection vulnerabilities -->
+    <Rule Id="CA3009" Action="None" />          <!-- Review code for XML injection vulnerabilities -->
+    <Rule Id="CA3010" Action="None" />          <!-- Review code for XAML injection vulnerabilities -->
+    <Rule Id="CA3011" Action="None" />          <!-- Review code for DLL injection vulnerabilities -->
+    <Rule Id="CA3012" Action="None" />          <!-- Review code for regex injection vulnerabilities -->
+    <Rule Id="CA3061" Action="Warning" />       <!-- Do Not Add Schema By URL -->
+    <Rule Id="CA3075" Action="Warning" />       <!-- Insecure DTD processing in XML -->
+    <Rule Id="CA3076" Action="Warning" />       <!-- Insecure XSLT script processing. -->
+    <Rule Id="CA3077" Action="Warning" />       <!-- Insecure Processing in API Design, XmlDocument and XmlTextReader -->
+    <Rule Id="CA3147" Action="Warning" />       <!-- Mark Verb Handlers With Validate Antiforgery Token -->
+    <Rule Id="CA5350" Action="Warning" />       <!-- Do Not Use Weak Cryptographic Algorithms -->
+    <Rule Id="CA5351" Action="Warning" />       <!-- Do Not Use Broken Cryptographic Algorithms -->
+    <Rule Id="CA5358" Action="None" />          <!-- Review cipher mode usage with cryptography experts -->
+    <Rule Id="CA5359" Action="Warning" />       <!-- Do Not Disable Certificate Validation -->
+    <Rule Id="CA5360" Action="Warning" />       <!-- Do Not Call Dangerous Methods In Deserialization -->
+    <Rule Id="CA5361" Action="Warning" />       <!-- Do Not Disable SChannel Use of Strong Crypto -->
+    <Rule Id="CA5362" Action="None" />          <!-- Potential reference cycle in deserialized object graph -->
+    <Rule Id="CA5363" Action="Warning" />       <!-- Do Not Disable Request Validation -->
+    <Rule Id="CA5364" Action="Warning" />       <!-- Do Not Use Deprecated Security Protocols -->
+    <Rule Id="CA5365" Action="Warning" />       <!-- Do Not Disable HTTP Header Checking -->
+    <Rule Id="CA5366" Action="None" />          <!-- Use XmlReader For DataSet Read Xml -->
+    <Rule Id="CA5367" Action="None" />          <!-- Do Not Serialize Types With Pointer Fields -->
+    <Rule Id="CA5368" Action="Warning" />       <!-- Set ViewStateUserKey For Classes Derived From Page -->
+    <Rule Id="CA5369" Action="None" />          <!-- Use XmlReader For Deserialize -->
+    <Rule Id="CA5370" Action="Warning" />       <!-- Use XmlReader For Validating Reader -->
+    <Rule Id="CA5371" Action="None" />          <!-- Use XmlReader For Schema Read -->
+    <Rule Id="CA5372" Action="None" />          <!-- Use XmlReader For XPathDocument -->
+    <Rule Id="CA5373" Action="Warning" />       <!-- Do not use obsolete key derivation function -->
+    <Rule Id="CA5374" Action="Warning" />       <!-- Do Not Use XslTransform -->
+    <Rule Id="CA5375" Action="None" />          <!-- Do Not Use Account Shared Access Signature -->
+    <Rule Id="CA5376" Action="Warning" />       <!-- Use SharedAccessProtocol HttpsOnly -->
+    <Rule Id="CA5377" Action="Warning" />       <!-- Use Container Level Access Policy -->
+    <Rule Id="CA5378" Action="Warning" />       <!-- Do not disable ServicePointManagerSecurityProtocols -->
+    <Rule Id="CA5379" Action="Warning" />       <!-- Do Not Use Weak Key Derivation Function Algorithm -->
+    <Rule Id="CA5380" Action="Warning" />       <!-- Do Not Add Certificates To Root Store -->
+    <Rule Id="CA5381" Action="Warning" />       <!-- Ensure Certificates Are Not Added To Root Store -->
+    <Rule Id="CA5382" Action="None" />          <!-- Use Secure Cookies In ASP.Net Core -->
+    <Rule Id="CA5383" Action="None" />          <!-- Ensure Use Secure Cookies In ASP.Net Core -->
+    <Rule Id="CA5384" Action="Warning" />       <!-- Do Not Use Digital Signature Algorithm (DSA) -->
+    <Rule Id="CA5385" Action="Warning" />       <!-- Use Rivest–Shamir–Adleman (RSA) Algorithm With Sufficient Key Size -->
+    <Rule Id="CA5386" Action="None" />          <!-- Avoid hardcoding SecurityProtocolType value -->
+    <Rule Id="CA5387" Action="None" />          <!-- Do Not Use Weak Key Derivation Function With Insufficient Iteration Count -->
+    <Rule Id="CA5388" Action="None" />          <!-- Ensure Sufficient Iteration Count When Using Weak Key Derivation Function -->
+    <Rule Id="CA5389" Action="None" />          <!-- Do Not Add Archive Item's Path To The Target File System Path -->
+    <Rule Id="CA5390" Action="None" />          <!-- Do not hard-code encryption key -->
+    <Rule Id="CA5391" Action="None" />          <!-- Use antiforgery tokens in ASP.NET Core MVC controllers -->
+    <Rule Id="CA5392" Action="None" />          <!-- Use DefaultDllImportSearchPaths attribute for P/Invokes -->
+    <Rule Id="CA5393" Action="None" />          <!-- Do not use unsafe DllImportSearchPath value -->
+    <Rule Id="CA5394" Action="None" />          <!-- Do not use insecure randomness -->
+    <Rule Id="CA5395" Action="None" />          <!-- Miss HttpVerb attribute for action methods -->
+    <Rule Id="CA5396" Action="None" />          <!-- Set HttpOnly to true for HttpCookie -->
+    <Rule Id="CA5397" Action="None" />          <!-- Do not use deprecated SslProtocols values -->
+    <Rule Id="CA5398" Action="None" />          <!-- Avoid hardcoded SslProtocols values -->
+    <Rule Id="CA5399" Action="None" />          <!-- HttpClients should enable certificate revocation list checks -->
+    <Rule Id="CA5400" Action="None" />          <!-- Ensure HttpClient certificate revocation list check is not disabled -->
+    <Rule Id="CA5401" Action="None" />          <!-- Do not use CreateEncryptor with non-default IV -->
+    <Rule Id="CA5402" Action="None" />          <!-- Use CreateEncryptor with the default IV  -->
+    <Rule Id="CA5403" Action="None" />          <!-- Do not hard-code certificate -->
+    <Rule Id="IL3000" Action="None" />          <!-- Avoid using accessing Assembly file path when publishing as a single-file -->
+    <Rule Id="IL3001" Action="None" />          <!-- Avoid using accessing Assembly file path when publishing as a single-file -->
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="AD0001" Action="None" />          <!-- Analyzer threw an exception -->
+    <Rule Id="SA0001" Action="None" />          <!-- XML comments -->
+    <Rule Id="SA1000" Action="Warning" />       <!-- Spacing around keywords -->
+    <Rule Id="SA1001" Action="Warning" />       <!-- Commas should not be preceded by whitespace -->
+    <Rule Id="SA1002" Action="None" />          <!-- Semicolons should not be preceded by a space -->
+    <Rule Id="SA1003" Action="None" />          <!-- Operator should not appear at the end of a line -->
+    <Rule Id="SA1004" Action="None" />          <!-- Documentation line should begin with a space -->
+    <Rule Id="SA1005" Action="None" />          <!-- Single line comment should begin with a space -->
+    <Rule Id="SA1008" Action="None" />          <!-- Opening parenthesis should not be preceded by a space -->
+    <Rule Id="SA1009" Action="None" />          <!-- Closing parenthesis should not be followed by a space -->
+    <Rule Id="SA1010" Action="None" />          <!-- Opening square brackets should not be preceded by a space -->
+    <Rule Id="SA1011" Action="None" />          <!-- Closing square bracket should be followed by a space -->
+    <Rule Id="SA1012" Action="None" />          <!-- Opening brace should be followed by a space -->
+    <Rule Id="SA1013" Action="None" />          <!-- Closing brace should be preceded by a space -->
+    <Rule Id="SA1014" Action="Warning" />       <!-- Opening generic brackets should not be preceded by a space -->
+    <Rule Id="SA1015" Action="None" />          <!-- Closing generic bracket should not be followed by a space -->
+    <Rule Id="SA1018" Action="Warning" />       <!-- Nullable type symbol should not be preceded by a space -->
+    <Rule Id="SA1020" Action="Warning" />       <!-- Increment symbol should not be preceded by a space -->
+    <Rule Id="SA1021" Action="None" />          <!-- Negative sign should be preceded by a space -->
+    <Rule Id="SA1023" Action="None" />          <!-- Dereference symbol '*' should not be preceded by a space." -->
+    <Rule Id="SA1024" Action="None" />          <!-- Colon should be followed by a space -->
+    <Rule Id="SA1025" Action="None" />          <!-- Code should not contain multiple whitespace characters in a row -->
+    <Rule Id="SA1026" Action="Warning" />       <!-- Keyword followed by span or blank line -->
+    <Rule Id="SA1027" Action="Warning" />       <!-- Tabs and spaces should be used correctly -->
+    <Rule Id="SA1028" Action="Warning" />       <!-- Code should not contain trailing whitespace -->
+    <Rule Id="SA1100" Action="None" />          <!-- Do not prefix calls with base unless local implementation exists -->
+    <Rule Id="SA1101" Action="None" />          <!-- Prefix local calls with this -->
+    <Rule Id="SA1102" Action="Warning" />       <!-- Query clause should follow previous clause -->
+    <Rule Id="SA1105" Action="Warning" />       <!-- Query clauses spanning multiple lines should begin on own line -->
+    <Rule Id="SA1106" Action="None" />          <!-- Code should not contain empty statements -->
+    <Rule Id="SA1107" Action="None" />          <!-- Code should not contain multiple statements on one line -->
+    <Rule Id="SA1108" Action="None" />          <!-- Block statements should not contain embedded comments -->
+    <Rule Id="SA1110" Action="None" />          <!-- Opening parenthesis or bracket should be on declaration line -->
+    <Rule Id="SA1111" Action="None" />          <!-- Closing parenthesis should be on line of last parameter -->
+    <Rule Id="SA1113" Action="Warning" />       <!-- Comma should be on the same line as previous parameter -->
+    <Rule Id="SA1114" Action="None" />          <!-- Parameter list should follow declaration -->
+    <Rule Id="SA1115" Action="Warning" />       <!-- Parameter should begin on the line after the previous parameter -->
+    <Rule Id="SA1116" Action="None" />          <!-- Split parameters should start on line after declaration -->
+    <Rule Id="SA1117" Action="None" />          <!-- Parameters should be on same line or separate lines -->
+    <Rule Id="SA1118" Action="None" />          <!-- Parameter should not span multiple lines -->
+    <Rule Id="SA1119" Action="None" />          <!-- Statement should not use unnecessary parenthesis -->
+    <Rule Id="SA1120" Action="None" />          <!-- Comments should contain text -->
+    <Rule Id="SA1121" Action="Warning" />       <!-- Use built-in type alias -->
+    <Rule Id="SA1122" Action="None" />          <!-- Use string.Empty for empty strings -->
+    <Rule Id="SA1123" Action="None" />          <!-- Region should not be located within a code element -->
+    <Rule Id="SA1124" Action="None" />          <!-- Do not use regions -->
+    <Rule Id="SA1125" Action="None" />          <!-- Use shorthand for nullable types -->
+    <Rule Id="SA1127" Action="None" />          <!-- Generic type constraints should be on their own line -->
+    <Rule Id="SA1128" Action="None" />          <!-- Put constructor initializers on their own line -->
+    <Rule Id="SA1129" Action="Warning" />       <!-- Do not use default value type constructor -->
+    <Rule Id="SA1130" Action="None" />          <!-- Use lambda syntax -->
+    <Rule Id="SA1131" Action="None" />          <!-- Constant values should appear on the right-hand side of comparisons -->
+    <Rule Id="SA1132" Action="None" />          <!-- Do not combine fields -->
+    <Rule Id="SA1133" Action="None" />          <!-- Do not combine attributes -->
+    <Rule Id="SA1134" Action="None" />          <!-- Each attribute should be placed on its own line of code -->
+    <Rule Id="SA1135" Action="None" />          <!-- Using directive should be qualified -->
+    <Rule Id="SA1136" Action="None" />          <!-- Enum values should be on separate lines -->
+    <Rule Id="SA1137" Action="None" />          <!-- Elements should have the same indentation -->
+    <Rule Id="SA1139" Action="None" />          <!-- Use literal suffix notation instead of casting -->
+    <Rule Id="SA1141" Action="Warning" />       <!-- Use tuple syntax -->
+    <Rule Id="SA1142" Action="Warning" />       <!-- Refer to tuple elements by name -->
+    <Rule Id="SA1200" Action="None" />          <!-- Using directive should appear within a namespace declaration -->
+    <Rule Id="SA1201" Action="None" />          <!-- Elements should appear in the correct order -->
+    <Rule Id="SA1202" Action="None" />          <!-- Elements should be ordered by access -->
+    <Rule Id="SA1203" Action="None" />          <!-- Constants should appear before fields -->
+    <Rule Id="SA1204" Action="None" />          <!-- Static elements should appear before instance elements -->
+    <Rule Id="SA1205" Action="Warning" />       <!-- Partial elements should declare an access modifier -->
+    <Rule Id="SA1206" Action="Warning" />       <!-- Keyword ordering -->
+    <Rule Id="SA1208" Action="None" />          <!-- Using directive ordering -->
+    <Rule Id="SA1209" Action="None" />          <!-- Using alias directives should be placed after all using namespace directives -->
+    <Rule Id="SA1210" Action="None" />          <!-- Using directives should be ordered alphabetically by the namespaces -->
+    <Rule Id="SA1211" Action="None" />          <!-- Using alias directive ordering -->
+    <Rule Id="SA1212" Action="Warning" />       <!-- A get accessor appears after a set accessor within a property or indexer -->
+    <Rule Id="SA1214" Action="None" />          <!-- Readonly fields should appear before non-readonly fields -->
+    <Rule Id="SA1216" Action="None" />          <!-- Using static directives should be placed at the correct location -->
+    <Rule Id="SA1300" Action="None" />          <!-- Element should begin with an uppercase letter -->
+    <Rule Id="SA1302" Action="Warning" />       <!-- Interface names should begin with I -->
+    <Rule Id="SA1303" Action="None" />          <!-- Const field names should begin with upper-case letter -->
+    <Rule Id="SA1304" Action="None" />          <!-- Non-private readonly fields should begin with upper-case letter -->
+    <Rule Id="SA1306" Action="None" />          <!-- Field should begin with lower-case letter -->
+    <Rule Id="SA1307" Action="None" />          <!-- Field should begin with upper-case letter -->
+    <Rule Id="SA1308" Action="None" />          <!-- Field should not begin with the prefix 's_' -->
+    <Rule Id="SA1309" Action="None" />          <!-- Field names should not begin with underscore -->
+    <Rule Id="SA1310" Action="None" />          <!-- Field should not contain an underscore -->
+    <Rule Id="SA1311" Action="None" />          <!-- Static readonly fields should begin with upper-case letter -->
+    <Rule Id="SA1312" Action="None" />          <!-- Variable should begin with lower-case letter -->
+    <Rule Id="SA1313" Action="None" />          <!-- Parameter should begin with lower-case letter -->
+    <Rule Id="SA1314" Action="None" />          <!-- Type parameter names should begin with T -->
+    <Rule Id="SA1316" Action="None" />          <!-- Tuple element names should use correct casing -->
+    <Rule Id="SA1400" Action="Warning" />       <!-- Member should declare an access modifer -->
+    <Rule Id="SA1401" Action="None" />          <!-- Fields should be private -->
+    <Rule Id="SA1402" Action="None" />          <!-- File may only contain a single type -->
+    <Rule Id="SA1403" Action="None" />          <!-- File may only contain a single namespace -->
+    <Rule Id="SA1404" Action="Warning" />       <!-- Code analysis suppression should have justification -->
+    <Rule Id="SA1405" Action="None" />          <!-- Debug.Assert should provide message text -->
+    <Rule Id="SA1407" Action="None" />          <!-- Arithmetic expressions should declare precedence -->
+    <Rule Id="SA1408" Action="None" />          <!-- Conditional expressions should declare precedence -->
+    <Rule Id="SA1410" Action="Warning" />       <!-- Remove delegate parens when possible -->
+    <Rule Id="SA1411" Action="Warning" />       <!-- Attribute constructor shouldn't use unnecessary parenthesis -->
+    <Rule Id="SA1413" Action="None" />          <!-- Use trailing comma in multi-line initializers -->
+    <Rule Id="SA1414" Action="None" />          <!-- Tuple types in signatures should have element names -->
+    <Rule Id="SA1500" Action="None" />          <!-- Braces for multi-line statements should not share line -->
+    <Rule Id="SA1501" Action="None" />          <!-- Statement should not be on a single line -->
+    <Rule Id="SA1502" Action="None" />          <!-- Element should not be on a single line -->
+    <Rule Id="SA1503" Action="None" />          <!-- Braces should not be omitted -->
+    <Rule Id="SA1504" Action="None" />          <!-- All accessors should be single-line or multi-line -->
+    <Rule Id="SA1505" Action="None" />          <!-- An opening brace should not be followed by a blank line -->
+    <Rule Id="SA1506" Action="None" />          <!-- Element documentation headers should not be followed by blank line -->
+    <Rule Id="SA1507" Action="None" />          <!-- Code should not contain multiple blank lines in a row -->
+    <Rule Id="SA1508" Action="None" />          <!-- A closing brace should not be preceded by a blank line -->
+    <Rule Id="SA1509" Action="None" />          <!-- Opening braces should not be preceded by blank line -->
+    <Rule Id="SA1510" Action="None" />          <!-- 'else' statement should not be preceded by a blank line -->
+    <Rule Id="SA1512" Action="None" />          <!-- Single-line comments should not be followed by blank line -->
+    <Rule Id="SA1513" Action="None" />          <!-- Closing brace should be followed by blank line -->
+    <Rule Id="SA1514" Action="None" />          <!-- Element documentation header should be preceded by blank line -->
+    <Rule Id="SA1515" Action="None" />          <!-- Single-line comment should be preceded by blank line -->
+    <Rule Id="SA1516" Action="None" />          <!-- Elements should be separated by blank line -->
+    <Rule Id="SA1517" Action="Warning" />       <!-- Code should not contain blank lines at start of file -->
+    <Rule Id="SA1518" Action="Warning" />       <!-- Code should not contain blank lines at the end of the file -->
+    <Rule Id="SA1519" Action="None" />          <!-- Braces should not be omitted from multi-line child statement -->
+    <Rule Id="SA1520" Action="None" />          <!-- Use braces consistently -->
+    <Rule Id="SA1600" Action="None" />          <!-- Elements should be documented -->
+    <Rule Id="SA1601" Action="None" />          <!-- Partial elements should be documented -->
+    <Rule Id="SA1602" Action="None" />          <!-- Enumeration items should be documented -->
+    <Rule Id="SA1604" Action="None" />          <!-- Element documentation should have summary -->
+    <Rule Id="SA1605" Action="None" />          <!-- Partial element documentation should have summary -->
+    <Rule Id="SA1606" Action="None" />          <!-- Element documentation should have summary text -->
+    <Rule Id="SA1608" Action="None" />          <!-- Element documentation should not have default summary -->
+    <Rule Id="SA1610" Action="None" />          <!-- Property documentation should have value text -->
+    <Rule Id="SA1611" Action="None" />          <!-- The documentation for parameter 'message' is missing -->
+    <Rule Id="SA1612" Action="None" />          <!-- The parameter documentation is at incorrect position -->
+    <Rule Id="SA1614" Action="None" />          <!-- Element parameter documentation should have text -->
+    <Rule Id="SA1615" Action="None" />          <!-- Element return value should be documented -->
+    <Rule Id="SA1616" Action="None" />          <!-- Element return value documentation should have text -->
+    <Rule Id="SA1618" Action="None" />          <!-- The documentation for type parameter is missing -->
+    <Rule Id="SA1619" Action="None" />          <!-- The documentation for type parameter is missing -->
+    <Rule Id="SA1622" Action="None" />          <!-- Generic type parameter documentation should have text -->
+    <Rule Id="SA1623" Action="None" />          <!-- Property documentation text -->
+    <Rule Id="SA1624" Action="None" />          <!-- Because the property only contains a visible get accessor, the documentation summary text should begin with 'Gets' -->
+    <Rule Id="SA1625" Action="None" />          <!-- Element documentation should not be copied and pasted -->
+    <Rule Id="SA1626" Action="None" />          <!-- Single-line comments should not use documentation style slashes -->
+    <Rule Id="SA1627" Action="None" />          <!-- The documentation text within the \'exception\' tag should not be empty -->
+    <Rule Id="SA1629" Action="None" />          <!-- Documentation text should end with a period -->
+    <Rule Id="SA1633" Action="None" />          <!-- File should have header -->
+    <Rule Id="SA1642" Action="None" />          <!-- Constructor summary documentation should begin with standard text -->
+    <Rule Id="SA1643" Action="None" />          <!-- Destructor summary documentation should begin with standard text -->
+    <Rule Id="SA1649" Action="None" />          <!-- File name should match first type name -->
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.CodeStyle" RuleNamespace="Microsoft.CodeQuality.Analyzers">
+    <Rule Id="IDE0001" Action="Hidden" />       <!-- SimplifyNames -->
+    <Rule Id="IDE0002" Action="Hidden" />       <!-- SimplifyMemberAccess -->
+    <Rule Id="IDE0003" Action="Hidden" />       <!-- RemoveQualification -->
+    <Rule Id="IDE0004" Action="Hidden" />       <!-- RemoveUnnecessaryCast -->
+    <Rule Id="IDE0005" Action="Hidden" />       <!-- RemoveUnnecessaryImports -->
+    <Rule Id="IDE0006" Action="Hidden" />       <!-- IntellisenseBuildFailed -->
+    <Rule Id="IDE0007" Action="Hidden" />       <!-- UseImplicitType -->
+    <Rule Id="IDE0008" Action="Hidden" />       <!-- UseExplicitType -->
+    <Rule Id="IDE0009" Action="Hidden" />       <!-- AddQualification -->
+    <Rule Id="IDE0010" Action="Hidden" />       <!-- PopulateSwitchStatement -->
+    <Rule Id="IDE0011" Action="Hidden" />       <!-- AddBraces -->
+    <Rule Id="IDE0016" Action="Hidden" />       <!-- UseThrowExpression -->
+    <Rule Id="IDE0017" Action="Hidden" />       <!-- UseObjectInitializer -->
+    <Rule Id="IDE0018" Action="Hidden" />       <!-- InlineDeclaration -->
+    <Rule Id="IDE0019" Action="Hidden" />       <!-- InlineAsTypeCheck -->
+    <Rule Id="IDE0020" Action="Hidden" />       <!-- InlineIsTypeCheck -->
+    <Rule Id="IDE0021" Action="Hidden" />       <!-- UseExpressionBodyForConstructors -->
+    <Rule Id="IDE0022" Action="Hidden" />       <!-- UseExpressionBodyForMethods -->
+    <Rule Id="IDE0023" Action="Hidden" />       <!-- UseExpressionBodyForConversionOperators -->
+    <Rule Id="IDE0024" Action="Hidden" />       <!-- UseExpressionBodyForOperators -->
+    <Rule Id="IDE0025" Action="Hidden" />       <!-- UseExpressionBodyForProperties -->
+    <Rule Id="IDE0026" Action="Hidden" />       <!-- UseExpressionBodyForIndexers -->
+    <Rule Id="IDE0027" Action="Hidden" />       <!-- UseExpressionBodyForAccessors -->
+    <Rule Id="IDE0028" Action="Hidden" />       <!-- UseCollectionInitializer -->
+    <Rule Id="IDE0029" Action="Hidden" />       <!-- UseCoalesceExpression -->
+    <Rule Id="IDE0030" Action="Hidden" />       <!-- UseCoalesceExpressionForNullable -->
+    <Rule Id="IDE0031" Action="Hidden" />       <!-- UseNullPropagation -->
+    <Rule Id="IDE0032" Action="Hidden" />       <!-- UseAutoProperty -->
+    <Rule Id="IDE0033" Action="Hidden" />       <!-- UseExplicitTupleName -->
+    <Rule Id="IDE0034" Action="Hidden" />       <!-- UseDefaultLiteral -->
+    <Rule Id="IDE0035" Action="Hidden" />       <!-- RemoveUnreachableCode -->
+    <Rule Id="IDE0036" Action="Hidden" />       <!-- OrderModifiers -->
+    <Rule Id="IDE0037" Action="Hidden" />       <!-- UseInferredMemberName -->
+    <Rule Id="IDE0038" Action="Hidden" />       <!-- InlineIsTypeWithoutNameCheck -->
+    <Rule Id="IDE0039" Action="Hidden" />       <!-- UseLocalFunction -->
+    <Rule Id="IDE0040" Action="Hidden" />       <!-- AddAccessibilityModifiers -->
+    <Rule Id="IDE0041" Action="Warning" />      <!-- UseIsNullCheck -->
+    <Rule Id="IDE0042" Action="Hidden" />       <!-- UseDeconstruction -->
+    <Rule Id="IDE0043" Action="Warning" />      <!-- ValidateFormatString -->
+    <Rule Id="IDE0044" Action="Hidden" />       <!-- MakeFieldReadonly -->
+    <Rule Id="IDE0045" Action="Hidden" />       <!-- UseConditionalExpressionForAssignment -->
+    <Rule Id="IDE0046" Action="Hidden" />       <!-- UseConditionalExpressionForReturn -->
+    <Rule Id="IDE0047" Action="Hidden" />       <!-- RemoveUnnecessaryParentheses -->
+    <Rule Id="IDE0048" Action="Hidden" />       <!-- AddRequiredParentheses -->
+    <Rule Id="IDE0049" Action="Hidden" />       <!-- PreferBuiltInOrFrameworkType -->
+    <Rule Id="IDE0050" Action="Hidden" />       <!-- ConvertAnonymousTypeToTuple -->
+    <Rule Id="IDE0051" Action="Hidden" />       <!-- RemoveUnusedMembers -->
+    <Rule Id="IDE0052" Action="Hidden" />       <!-- RemoveUnreadMembers -->
+    <Rule Id="IDE0053" Action="Hidden" />       <!-- UseExpressionBodyForLambdaExpressions -->
+    <Rule Id="IDE0054" Action="Hidden" />       <!-- UseCompoundAssignment -->
+    <Rule Id="IDE0055" Action="Hidden" />       <!-- Formatting -->
+    <Rule Id="IDE0056" Action="Hidden" />       <!-- UseIndexOperator -->
+    <Rule Id="IDE0057" Action="Hidden" />       <!-- UseRangeOperator -->
+    <Rule Id="IDE0058" Action="Hidden" />       <!-- ExpressionValueIsUnused -->
+    <Rule Id="IDE0059" Action="Hidden" />       <!-- ValueAssignedIsUnused -->
+    <Rule Id="IDE0060" Action="Hidden" />       <!-- UnusedParameter -->
+    <Rule Id="IDE0061" Action="Hidden" />       <!-- UseExpressionBodyForLocalFunctions -->
+    <Rule Id="IDE0062" Action="Warning" />      <!-- MakeLocalFunctionStatic -->
+    <Rule Id="IDE0063" Action="Hidden" />       <!-- UseSimpleUsingStatement -->
+    <Rule Id="IDE0064" Action="Hidden" />       <!-- MakeStructFieldsWritable -->
+    <Rule Id="IDE0065" Action="Hidden" />       <!-- MoveMisplacedUsingDirectives -->
+    <Rule Id="IDE0066" Action="Hidden" />       <!-- ConvertSwitchStatementToExpression -->
+    <Rule Id="IDE0067" Action="Hidden" />       <!-- DisposeObjectsBeforeLosingScope -->
+    <Rule Id="IDE0068" Action="Hidden" />       <!-- UseRecommendedDisposePattern -->
+    <Rule Id="IDE0069" Action="Hidden" />       <!-- DisposableFieldsShouldBeDisposed -->
+    <Rule Id="IDE0070" Action="Hidden" />       <!-- UseSystemHashCode -->
+    <Rule Id="IDE0071" Action="Hidden" />       <!-- SimplifyInterpolation -->
+    <Rule Id="IDE0072" Action="Hidden" />       <!-- PopulateSwitchExpression -->
+    <Rule Id="IDE0073" Action="Warning" />      <!-- FileHeaderMismatch -->
+    <Rule Id="IDE0074" Action="Hidden" />       <!-- UseCoalesceCompoundAssignment -->
+    <Rule Id="IDE0075" Action="Hidden" />       <!-- SimplifyConditionalExpression -->
+    <Rule Id="IDE0076" Action="Hidden" />       <!-- InvalidSuppressMessageAttribute -->
+    <Rule Id="IDE0077" Action="Hidden" />       <!-- LegacyFormatSuppressMessageAttribute -->
+    <Rule Id="IDE0078" Action="Hidden" />       <!-- UsePatternCombinators -->
+    <Rule Id="IDE0079" Action="Hidden" />       <!-- RemoveUnnecessarySuppression -->
+    <Rule Id="IDE0080" Action="Hidden" />       <!-- RemoveConfusingSuppressionForIsExpression -->
+    <Rule Id="IDE0081" Action="Hidden" />       <!-- RemoveUnnecessaryByVal -->
+    <Rule Id="IDE0082" Action="Warning" />      <!-- ConvertTypeOfToNameOf -->
+    <Rule Id="IDE0083" Action="Hidden" />       <!-- UseNotPattern -->
+    <Rule Id="IDE0084" Action="Hidden" />       <!-- UseIsNotExpression -->
+    <Rule Id="IDE1001" Action="Hidden" />       <!-- AnalyzerChanged -->
+    <Rule Id="IDE1002" Action="Hidden" />       <!-- AnalyzerDependencyConflict -->
+    <Rule Id="IDE1003" Action="Hidden" />       <!-- MissingAnalyzerReference -->
+    <Rule Id="IDE1004" Action="Hidden" />       <!-- ErrorReadingRuleset -->
+    <Rule Id="IDE1005" Action="Hidden" />       <!-- InvokeDelegateWithConditionalAccess -->
+    <Rule Id="IDE1006" Action="Hidden" />       <!-- NamingRule -->
+    <Rule Id="IDE1007" Action="Hidden" />       <!-- UnboundIdentifier -->
+    <Rule Id="IDE1008" Action="Hidden" />       <!-- UnboundConstructor -->
+  </Rules>
+</RuleSet>

--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -320,7 +320,7 @@
     <Rule Id="SA1209" Action="None" />          <!-- Using alias directives should be placed after all using namespace directives -->
     <Rule Id="SA1210" Action="None" />          <!-- Using directives should be ordered alphabetically by the namespaces -->
     <Rule Id="SA1211" Action="None" />          <!-- Using alias directive ordering -->
-    <Rule Id="SA1212" Action="Warning" />       <!-- A get accessor appears after a set accessor within a property or indexer -->
+    <Rule Id="SA1212" Action="Info" TemporarilyDisabled="true" />       <!-- A get accessor appears after a set accessor within a property or indexer -->
     <Rule Id="SA1214" Action="None" />          <!-- Readonly fields should appear before non-readonly fields -->
     <Rule Id="SA1216" Action="None" />          <!-- Using static directives should be placed at the correct location -->
     <Rule Id="SA1300" Action="None" />          <!-- Element should begin with an uppercase letter -->

--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -1,12 +1,4 @@
 <RuleSet Name="Microsoft.Analyzers.ManagedCodeAnalysis" Description="Microsoft.Analyzers.ManagedCodeAnalysis" ToolsVersion="14.0">
-  <Rules AnalyzerId="Microsoft.DotNet.CodeAnalysis" RuleNamespace="Microsoft.DotNet.CodeAnalysis.Analyzers">
-    <Rule Id="BCL0001" Action="Warning" />      <!-- Ensure minimum API surface is respected -->
-    <Rule Id="BCL0010" Action="Warning" />      <!-- AppContext default value expected to be true -->
-    <Rule Id="BCL0011" Action="Warning" />      <!-- AppContext default value defined in if statement with incorrect pattern -->
-    <Rule Id="BCL0012" Action="Warning" />      <!-- AppContext default value defined in if statement at root of switch case -->
-    <Rule Id="BCL0015" Action="None" />         <!-- Invalid P/Invoke call -->
-    <Rule Id="BCL0020" Action="Warning" />      <!-- Invalid SR.Format call -->
-  </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.NetAnalyzers" RuleNamespace="Microsoft.CodeAnalysis.NetAnalyzers">
     <Rule Id="CA1000" Action="None" />          <!-- Do not declare static members on generic types -->
     <Rule Id="CA1001" Action="None" />          <!-- Types that own disposable fields should be disposable -->

--- a/src/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
+++ b/src/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
@@ -4,5 +4,6 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>Contracts for extending Template Engine</Description>
         <IsPackable>true</IsPackable>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 </Project>

--- a/src/Microsoft.TemplateEngine.Cli.Localization/Microsoft.TemplateEngine.Cli.Localization.csproj
+++ b/src/Microsoft.TemplateEngine.Cli.Localization/Microsoft.TemplateEngine.Cli.Localization.csproj
@@ -11,6 +11,7 @@
         <IsShipping>false</IsShipping>
         <NoWarn>$(NoWarn);2008;NU5105</NoWarn>
         <PackageId>Microsoft.TemplateEngine.Cli.Localization</PackageId>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -4,6 +4,7 @@
         <Description>Template creation for the dotnet CLI</Description>
         <IsPackable>true</IsPackable>
 		<IsShipping>false</IsShipping>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Core.Contracts/Microsoft.TemplateEngine.Core.Contracts.csproj
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/Microsoft.TemplateEngine.Core.Contracts.csproj
@@ -4,6 +4,7 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>Contracts for extending Microsoft.TemplateEngine.Core</Description>
         <IsPackable>true</IsPackable>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
+++ b/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
@@ -4,6 +4,7 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>Common operations for instantiating templates using forward-only input stream operations</Description>
         <IsPackable>true</IsPackable>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
+++ b/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
@@ -4,6 +4,7 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>Helper package for adding Template Engine to consuming applications</Description>
         <IsPackable>true</IsPackable>
+        <EnableAnalyzers>true</EnableAnalyzers>
         <DefineConstants Condition="'$(TargetFramework)' == '$(NETFullTargetFramework)'">$(DefineConstants);NETFULL</DefineConstants>
     </PropertyGroup>
 

--- a/src/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj
+++ b/src/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj
@@ -4,6 +4,7 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>Helper package for adding Template Engine to IDEs</Description>
         <IsPackable>true</IsPackable>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj
@@ -4,6 +4,7 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>An extension for Template Engine that allows projects that still run to be used as templates</Description>
         <IsPackable>true</IsPackable>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
+++ b/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
@@ -4,6 +4,7 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>Components used by all Template Engine extensions and consumers</Description>
         <IsPackable>true</IsPackable>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateEngine.VisualStudioWizard/Microsoft.TemplateEngine.VisualStudioWizard.csproj
+++ b/src/Microsoft.TemplateEngine.VisualStudioWizard/Microsoft.TemplateEngine.VisualStudioWizard.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>$(NETFullTargetFramework)</TargetFramework>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateSearch.Common/Microsoft.TemplateSearch.Common.csproj
+++ b/src/Microsoft.TemplateSearch.Common/Microsoft.TemplateSearch.Common.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>$(NETStandardTargetFramework)</TargetFramework>
     <Description>Components used by the template discovery tool, and also used for related functionality in the CLI.</Description>
     <IsPackable>true</IsPackable>
+    <EnableAnalyzers>true</EnableAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.TemplateSearch.ScraperOutputComparison/Microsoft.TemplateSearch.ScraperOutputComparison.csproj
+++ b/src/Microsoft.TemplateSearch.ScraperOutputComparison/Microsoft.TemplateSearch.ScraperOutputComparison.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
+    <EnableAnalyzers>true</EnableAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
+    <EnableAnalyzers>true</EnableAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet-new3/dotnet-new3.csproj
+++ b/src/dotnet-new3/dotnet-new3.csproj
@@ -3,6 +3,7 @@
         <Description>Template Instantiation Commands for .NET Core CLI.</Description>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <OutputType>Exe</OutputType>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Cli.IntegrationTests/Microsoft.TemplateEngine.Cli.IntegrationTests.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.IntegrationTests/Microsoft.TemplateEngine.Cli.IntegrationTests.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/Microsoft.TemplateEngine.Core.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/Microsoft.TemplateEngine.Core.UnitTests.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/Microsoft.TemplateEngine.Edge.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/Microsoft.TemplateEngine.Edge.UnitTests.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/Microsoft.TemplateEngine.EndToEndTestHarness.csproj
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/Microsoft.TemplateEngine.EndToEndTestHarness.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Microsoft.TemplateEngine.IDE.IntegrationTests.csproj
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Microsoft.TemplateEngine.IDE.IntegrationTests.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
+++ b/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
@@ -5,6 +5,7 @@
         <IsPackable>true</IsPackable>
 		<IsShipping>false</IsShipping>
         <IsTestProject>false</IsTestProject>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />

--- a/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
@@ -3,6 +3,7 @@
         <TargetFrameworks Condition="'$(PackSpecific)' != 'true'">$(NETStandardTargetFramework);$(NETFullTargetFramework)</TargetFrameworks>
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <IsTestProject>false</IsTestProject>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.TestTemplates/Microsoft.TemplateEngine.TestTemplates.csproj
+++ b/test/Microsoft.TemplateEngine.TestTemplates/Microsoft.TemplateEngine.TestTemplates.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/dotnet-new3.UnitTests/dotnet-new3.UnitTests.csproj
+++ b/test/dotnet-new3.UnitTests/dotnet-new3.UnitTests.csproj
@@ -2,6 +2,7 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
+        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />


### PR DESCRIPTION
Partly delivers https://github.com/dotnet/templating/issues/2767.

This PR the analyzers and the ruleset. All the violated rules are temporarily showing up as "suggestions". We will change them back to warnings once we can refactor the existing code. Refactored files are already available on my local machine, but I will postpone pushing them for now to prevent conflicts with existing PRs.

This should be ready to merge after the reviews.