### PR TITLE
fixes dotnet/templating#2810: corrects source paths returned by GetCreationEffectsAsync method

### DIFF
--- a/src/Microsoft.TemplateEngine.Core.Contracts/IOrchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IOrchestrator.cs
@@ -10,8 +10,19 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 
         void Run(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
 
-        IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir);
+        IReadOnlyList<IFileChange> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir);
 
-        IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir);
+        IReadOnlyList<IFileChange> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
+    }
+
+    public interface IOrchestrator2
+    {
+        void Run(string runSpecPath, IDirectory sourceDir, string targetDir);
+
+        void Run(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
+
+        IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir);
+
+        IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir);
     }
 }

--- a/src/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
@@ -9,7 +9,7 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Core.Util
 {
-    public class Orchestrator : IOrchestrator 
+    public class Orchestrator : IOrchestrator, IOrchestrator2
     {
         public void Run(string runSpecPath, IDirectory sourceDir, string targetDir)
         {
@@ -31,7 +31,7 @@ namespace Microsoft.TemplateEngine.Core.Util
             RunInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetDir, spec);
         }
 
-        public IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir)
+        public IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
         {
             IGlobalRunSpec spec;
             using (Stream stream = sourceDir.MountPoint.EnvironmentSettings.Host.FileSystem.OpenRead(runSpecPath))
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateEngine.Core.Util
                 }
             }
 
-            return GetFileChangesInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetRoot, targetDir, spec);
+            return GetFileChangesInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetDir, spec);
         }
 
         public void Run(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
@@ -56,9 +56,19 @@ namespace Microsoft.TemplateEngine.Core.Util
             RunInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetDir, spec);
         }
 
-        public IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir)
+        public IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
         {
-            return GetFileChangesInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetRoot, targetDir, spec);
+            return GetFileChangesInternal(sourceDir.MountPoint.EnvironmentSettings, sourceDir, targetDir, spec);
+        }
+
+        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
+        {
+            return GetFileChanges(runSpecPath, sourceDir, targetDir);
+        }
+
+        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
+        {
+            return GetFileChanges(spec, sourceDir, targetDir);
         }
 
         protected virtual IGlobalRunSpec RunSpecLoader(Stream runSpec)
@@ -97,10 +107,13 @@ namespace Microsoft.TemplateEngine.Core.Util
             return processorList;
         }
 
-        private IReadOnlyList<IFileChange2> GetFileChangesInternal(IEngineEnvironmentSettings environmentSettings, IDirectory sourceDir, string targetRoot, string targetDir, IGlobalRunSpec spec)
+        private IReadOnlyList<IFileChange2> GetFileChangesInternal(IEngineEnvironmentSettings environmentSettings, IDirectory sourceDir, string targetDir, IGlobalRunSpec spec)
         {
+            EngineConfig cfg = new EngineConfig(environmentSettings, EngineConfig.DefaultWhitespaces, EngineConfig.DefaultLineEndings, spec.RootVariableCollection);
+            IProcessor fallback = Processor.Create(cfg, spec.Operations);
+
             List<IFileChange2> changes = new List<IFileChange2>();
-            string fullTargetPath = Path.Combine(targetRoot, targetDir);
+            List<KeyValuePair<IPathMatcher, IProcessor>> fileGlobProcessors = CreateFileGlobProcessors(sourceDir.MountPoint.EnvironmentSettings, spec);
 
             foreach (IFile file in sourceDir.EnumerateFiles("*", SearchOption.AllDirectories))
             {
@@ -135,36 +148,37 @@ namespace Microsoft.TemplateEngine.Core.Util
                                 targetRel = sourceRel;
                             }
 
-                            string targetPath = Path.Combine(fullTargetPath, targetRel);
-                            string targetRelativePath = targetDir.CombinePaths(targetRel).TrimStart('/');
-                            string sourceRelativePath = file.FullPath.CombinePaths().TrimStart('/');
+                            string targetPath = Path.Combine(targetDir, targetRel);
 
                             if (checkingDirWithPlaceholderFile)
                             {
                                 targetPath = Path.GetDirectoryName(targetPath);
+                                targetRel = Path.GetDirectoryName(targetRel);
 
                                 if (environmentSettings.Host.FileSystem.DirectoryExists(targetPath))
                                 {
-                                    changes.Add(new FileChange(sourceRelativePath, targetRelativePath, ChangeKind.Overwrite));
+                                    changes.Add(new FileChange(sourceRel, targetRel, ChangeKind.Overwrite));
                                 }
                                 else
                                 {
-                                    changes.Add(new FileChange(sourceRelativePath, targetRelativePath, ChangeKind.Create));
+                                    changes.Add(new FileChange(sourceRel, targetRel, ChangeKind.Create));
                                 }
                             }
                             else if (environmentSettings.Host.FileSystem.FileExists(targetPath))
                             {
-                                changes.Add(new FileChange(sourceRelativePath, targetRelativePath, ChangeKind.Overwrite));
+                                changes.Add(new FileChange(sourceRel, targetRel, ChangeKind.Overwrite));
                             }
                             else
                             {
-                                changes.Add(new FileChange(sourceRelativePath, targetRelativePath, ChangeKind.Create));
+                                changes.Add(new FileChange(sourceRel, targetRel, ChangeKind.Create));
                             }
                         }
+
                         break;
                     }
                 }
             }
+
             return changes;
         }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -36,7 +36,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             IVariableCollection variables = VariableCollection.SetupVariables(environmentSettings, parameters, template.Config.OperationConfig.VariableSetup);
             template.Config.Evaluate(parameters, variables, template.ConfigFile);
 
-            IOrchestrator basicOrchestrator = new Core.Util.Orchestrator();
+            IOrchestrator2 basicOrchestrator = new Core.Util.Orchestrator();
             RunnableProjectOrchestrator orchestrator = new RunnableProjectOrchestrator(basicOrchestrator);
 
             GlobalRunSpec runSpec = new GlobalRunSpec(template.TemplateSourceRoot, componentManager, parameters, variables, template.Config.OperationConfig, template.Config.SpecialOperationConfig, template.Config.LocalizationOperations, template.Config.IgnoreFileNames);
@@ -686,7 +686,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             IVariableCollection variables = VariableCollection.SetupVariables(environmentSettings, parameters, template.Config.OperationConfig.VariableSetup);
             template.Config.Evaluate(parameters, variables, template.ConfigFile);
 
-            IOrchestrator basicOrchestrator = new Core.Util.Orchestrator();
+            IOrchestrator2 basicOrchestrator = new Core.Util.Orchestrator();
             RunnableProjectOrchestrator orchestrator = new RunnableProjectOrchestrator(basicOrchestrator);
 
             GlobalRunSpec runSpec = new GlobalRunSpec(template.TemplateSourceRoot, componentManager, parameters, variables, template.Config.OperationConfig, template.Config.SpecialOperationConfig, template.Config.LocalizationOperations, template.Config.IgnoreFileNames);
@@ -695,7 +695,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             foreach (FileSourceMatchInfo source in template.Config.Sources)
             {
                 runSpec.SetupFileSource(source);
-                changes.AddRange(orchestrator.GetFileChanges(runSpec, template.TemplateSourceRoot.DirectoryInfo(source.Source), targetDirectory, source.Target));
+                string target = Path.Combine(targetDirectory, source.Target);
+                changes.AddRange(orchestrator.GetFileChanges(runSpec, template.TemplateSourceRoot.DirectoryInfo(source.Source), target));
             }
 
             return new CreationEffects2

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectOrchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectOrchestrator.cs
@@ -1,27 +1,39 @@
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.Core;
 using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
-    public class RunnableProjectOrchestrator : IOrchestrator
+    public class RunnableProjectOrchestrator : IOrchestrator, IOrchestrator2
     {
-        private readonly IOrchestrator _basicOrchestrator;
+        private readonly IOrchestrator2 _basicOrchestrator;
 
-        public RunnableProjectOrchestrator(IOrchestrator basicOrchestrator)
+        public RunnableProjectOrchestrator(IOrchestrator2 basicOrchestrator)
         {
             _basicOrchestrator = basicOrchestrator;
         }
 
-        public IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetRoot, string targetDir)
+        public IReadOnlyList<IFileChange2> GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
         {
-            return _basicOrchestrator.GetFileChanges(runSpecPath, sourceDir, targetRoot, targetDir);
+            return _basicOrchestrator.GetFileChanges(runSpecPath, sourceDir, targetDir);
         }
 
-        public IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetRoot, string targetDir)
+        public IReadOnlyList<IFileChange2> GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
         {
-            return _basicOrchestrator.GetFileChanges(spec, sourceDir, targetRoot, targetDir);
+            return _basicOrchestrator.GetFileChanges(spec, sourceDir, targetDir);
+        }
+
+        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(string runSpecPath, IDirectory sourceDir, string targetDir)
+        {
+            return GetFileChanges(runSpecPath, sourceDir, targetDir);
+        }
+
+        IReadOnlyList<IFileChange> IOrchestrator.GetFileChanges(IGlobalRunSpec spec, IDirectory sourceDir, string targetDir)
+        {
+            return GetFileChanges(spec, sourceDir, targetDir);
         }
 
         public void Run(string runSpecPath, IDirectory sourceDir, string targetDir)

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
@@ -1,8 +1,10 @@
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Core;
 using Microsoft.TemplateEngine.Edge.Template;
 using Microsoft.TemplateEngine.IDE.IntegrationTests.Utils;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,36 +12,99 @@ using Xunit;
 
 namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 {
-    public class BasicTests
+    public class BasicTests : IClassFixture<PackageManager>
     {
+        private PackageManager _packageManager;
+        public BasicTests(PackageManager packageManager)
+        {
+            _packageManager = packageManager;
+        }
 
         [Fact]
-        internal async Task GetCreationEffectsBasicTest()
+        internal async Task GetCreationEffects_BasicTest_Folder()
         {
             var bootstrapper = BootstrapperFactory.GetBootstrapper();
             bootstrapper.InstallTestTemplate("TemplateWithSourceName");
 
+            string output = TestHelper.CreateTemporaryFolder();
             var template = bootstrapper.ListTemplates(true, WellKnownSearchFilters.NameFilter("TestAssets.TemplateWithSourceName"));
-            var result = await bootstrapper.GetCreationEffectsAsync(template.First().Info, "test", "test", new Dictionary<string, string>(), "").ConfigureAwait(false);
+            var result = await bootstrapper.GetCreationEffectsAsync(template.First().Info, "test", output, new Dictionary<string, string>(), "").ConfigureAwait(false);
             Assert.Equal(2, result.CreationResult.PrimaryOutputs.Count);
             Assert.Equal(0, result.CreationResult.PostActions.Count);
             Assert.Equal(2, result.FileChanges.Count);
 
-            Assert.Single(result.FileChanges.Where(change => change.ChangeKind == ChangeKind.Create && ((IFileChange2)change).SourceRelativePath == "bar.cs" && change.TargetRelativePath == "test.cs"));
-            Assert.Single(result.FileChanges.Where(change => change.ChangeKind == ChangeKind.Create && ((IFileChange2)change).SourceRelativePath == "bar/bar.cs" && change.TargetRelativePath == "test/test.cs"));
+            var expectedFileChanges = new FileChange[]
+            {
+                new FileChange ("bar.cs", "test.cs", ChangeKind.Create),
+                new FileChange ("bar/bar.cs", "test/test.cs", ChangeKind.Create),
+
+            };
+            IFileChangeComparer comparer = new IFileChangeComparer();
+            Assert.Equal(
+                expectedFileChanges.OrderBy(s => s, comparer),
+                result.FileChanges.OrderBy(s => s, comparer),
+                comparer);
+
         }
 
         [Fact]
-        internal async Task CreateBasicTest()
+        internal async Task Create_BasicTest_Folder()
         {
             var bootstrapper = BootstrapperFactory.GetBootstrapper(additionalVirtualLocations: new string[] { "test" });
             bootstrapper.InstallTestTemplate("TemplateWithSourceName");
+
+            string output = TestHelper.CreateTemporaryFolder();
             var template = bootstrapper.ListTemplates(true, WellKnownSearchFilters.NameFilter("TestAssets.TemplateWithSourceName"));
 
-            var result = await bootstrapper.CreateAsync(template.First().Info, "test", "test", new Dictionary<string, string>(), false, "").ConfigureAwait(false);
+            var result = await bootstrapper.CreateAsync(template.First().Info, "test", output, new Dictionary<string, string>(), false, "").ConfigureAwait(false);
 
             Assert.Equal(2, result.PrimaryOutputs.Count);
             Assert.Equal(0, result.PostActions.Count);
+            Assert.True(File.Exists(Path.Combine(output, "test.cs")));
+            Assert.True(File.Exists(Path.Combine(output, "test/test.cs")));
+        }
+
+        [Fact]
+        internal async Task GetCreationEffects_BasicTest_Package()
+        {
+            var bootstrapper = BootstrapperFactory.GetBootstrapper();
+            string packageLocation = _packageManager.PackProjectTemplatesNuGetPackage("microsoft.dotnet.common.projecttemplates.5.0");
+            bootstrapper.InstallTemplate(packageLocation);
+
+            string output = TestHelper.CreateTemporaryFolder();
+            var template = bootstrapper.ListTemplates(true, WellKnownSearchFilters.NameFilter("console"));
+            var result = await bootstrapper.GetCreationEffectsAsync(template.First().Info, "test", output, new Dictionary<string, string>(), "").ConfigureAwait(false);
+            Assert.Equal(2, result.CreationResult.PrimaryOutputs.Count);
+            Assert.Equal(2, result.CreationResult.PostActions.Count);
+            Assert.Equal(2, result.FileChanges.Count);
+
+            var expectedFileChanges = new FileChange[]
+            {
+                new FileChange ("Company.ConsoleApplication1.csproj", "test.csproj", ChangeKind.Create),
+                new FileChange ("Program.cs", "Program.cs", ChangeKind.Create),
+            };
+            IFileChangeComparer comparer = new IFileChangeComparer();
+            Assert.Equal(
+                expectedFileChanges.OrderBy(s => s, comparer),
+                result.FileChanges.OrderBy(s => s, comparer),
+                comparer);
+        }
+
+        [Fact]
+        internal async Task Create_BasicTest_Package()
+        {
+            var bootstrapper = BootstrapperFactory.GetBootstrapper();
+            string packageLocation = _packageManager.PackProjectTemplatesNuGetPackage("microsoft.dotnet.common.projecttemplates.5.0");
+            bootstrapper.InstallTemplate(packageLocation);
+
+            string output = TestHelper.CreateTemporaryFolder();
+            var template = bootstrapper.ListTemplates(true, WellKnownSearchFilters.NameFilter("console"));
+            var result = await bootstrapper.CreateAsync(template.First().Info, "test", output, new Dictionary<string, string>(), false, "").ConfigureAwait(false);
+            Assert.Equal(2, result.PrimaryOutputs.Count);
+            Assert.Equal(2, result.PostActions.Count);
+
+            Assert.True(File.Exists(Path.Combine(output, "Program.cs")));
+            Assert.True(File.Exists(Path.Combine(output, "test.csproj")));
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Utils/BootstrapperExtensions.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Utils/BootstrapperExtensions.cs
@@ -25,5 +25,14 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests.Utils
                 bootStrapper.Install(path);
             }
         }
+
+        internal static void InstallTemplate(this Bootstrapper bootStrapper, params string[] templates)
+        {
+            foreach (string template in templates)
+            {
+                string path = Path.Combine(template);
+                bootStrapper.Install(path);
+            }
+        }
     }
 }

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Utils/PackageManager.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Utils/PackageManager.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.TemplateEngine.IDE.IntegrationTests.Utils
+{
+    public class PackageManager : IDisposable
+    {
+        private string _packageLocation = TestHelper.CreateTemporaryFolder("packages");
+        private ConcurrentDictionary<string, string> _installedPackages = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+
+        public string PackTestTemplatesNuGetPackage()
+        {
+            string dir = Path.GetDirectoryName(typeof(FileRenameTests).GetTypeInfo().Assembly.Location);
+            string projectToPack = Path.Combine(dir, "..", "..", "..", "..", "..", "test", "Microsoft.TemplateEngine.TestTemplates", "Microsoft.TemplateEngine.TestTemplates.csproj");
+            return PackNuGetPackage(projectToPack);
+        }
+
+        public string PackProjectTemplatesNuGetPackage(string templatePackName)
+        {
+            string dir = Path.GetDirectoryName(typeof(FileRenameTests).GetTypeInfo().Assembly.Location);
+            string projectToPack = Path.Combine(dir, "..", "..", "..", "..", "..", "template_feed", templatePackName, $"{templatePackName}.csproj");
+            return PackNuGetPackage(projectToPack);
+        }
+
+        public string PackNuGetPackage(string projectPath)
+        {
+            if (string.IsNullOrWhiteSpace(projectPath))
+            {
+                throw new ArgumentException("projectPath cannot be null", nameof(projectPath));
+            }
+            string absolutePath = Path.GetFullPath(projectPath);
+            if (!File.Exists(projectPath))
+            {
+                throw new ArgumentException($"{projectPath} doesn't exist", nameof(projectPath));
+            }
+            lock (string.Intern(absolutePath.ToLowerInvariant()))
+            {
+                if (_installedPackages.TryGetValue(absolutePath, out string packagePath))
+                {
+                    return packagePath;
+                }
+
+                var _info = new ProcessStartInfo("dotnet", $"pack {absolutePath} -o {_packageLocation}")
+                {
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true
+                };
+                Process p = Process.Start(_info);
+                p.WaitForExit();
+                if (p.ExitCode != 0)
+                {
+                    throw new Exception($"Failed to pack the project {projectPath}");
+                }
+
+                string createdPackagePath = Directory.GetFiles(_packageLocation).Aggregate(
+                    (latest, current) => (latest == null) ? current : File.GetCreationTimeUtc(current) > File.GetCreationTimeUtc(latest) ? current : latest);
+                _installedPackages[absolutePath] = createdPackagePath;
+                return createdPackagePath;
+            }
+        }
+
+
+        public void Dispose()
+        {
+            Directory.Delete(_packageLocation, true);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TestTemplateSetup.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TestTemplateSetup.cs
@@ -106,7 +106,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             runSpec.RootVariableCollection = variables;
             IDirectory sourceDir = SourceMountPoint.DirectoryInfo("/");
 
-            IOrchestrator basicOrchestrator = new Core.Util.Orchestrator();
+            IOrchestrator2 basicOrchestrator = new Core.Util.Orchestrator();
             RunnableProjectOrchestrator orchestrator = new RunnableProjectOrchestrator(basicOrchestrator);
 
             foreach (FileSourceMatchInfo source in runnableConfig.Sources)
@@ -136,7 +136,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             MockGlobalRunSpec runSpec = new MockGlobalRunSpec();
             IDirectory sourceDir = SourceMountPoint.DirectoryInfo("/");
 
-            IOrchestrator basicOrchestrator = new Core.Util.Orchestrator();
+            IOrchestrator2 basicOrchestrator = new Core.Util.Orchestrator();
             RunnableProjectOrchestrator orchestrator = new RunnableProjectOrchestrator(basicOrchestrator);
 
             Dictionary<string, IReadOnlyList<IFileChange2>> changesByTarget = new Dictionary<string, IReadOnlyList<IFileChange2>>();
@@ -144,7 +144,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             foreach (FileSourceMatchInfo source in runnableConfig.Sources)
             {
                 TemplateConfigTestHelpers.SetupFileSourceMatchersOnGlobalRunSpec(runSpec, source);
-                IReadOnlyList<IFileChange2> changes = orchestrator.GetFileChanges(runSpec, sourceDir, targetBaseDir, source.Target);
+                string targetDirForSource = Path.Combine(targetBaseDir, source.Target);
+                IReadOnlyList<IFileChange2> changes = orchestrator.GetFileChanges(runSpec, sourceDir, targetDirForSource);
                 changesByTarget[source.Target] = changes;
             }
 

--- a/test/Microsoft.TemplateEngine.TestTemplates/Microsoft.TemplateEngine.TestTemplates.csproj
+++ b/test/Microsoft.TemplateEngine.TestTemplates/Microsoft.TemplateEngine.TestTemplates.csproj
@@ -2,42 +2,20 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <EnableAnalyzers>true</EnableAnalyzers>
+        <PackageType>Template</PackageType>
+        <PackageId>Microsoft.TemplateEngine.TestTemplates</PackageId>
+        <Authors>Microsoft</Authors>
+        <Description>Test Templates</Description>
+        <IncludeContentInPack>true</IncludeContentInPack>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <ContentTargetFolders>content</ContentTargetFolders>
+        <NoWarn>$(NoWarn);NU5128</NoWarn>
+        <IsPackable>true</IsPackable>
+        <IsShipping>false</IsShipping>
     </PropertyGroup>
-
     <ItemGroup>
-        <None Include="**\*.list" CopyToOutputDirectory="Always" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Compile Remove="test_templates\**\*.cs" />
-        <EmbeddedResource Remove="test_templates/**/*" />
-        <None Remove="test_templates\**\*" />
-        <Page Remove="test_templates\**\*" />
+        <Compile Remove="**\*"  />
+        <Content Include="test_templates\**\*" Exclude="test_templates\**\bin\**;test_templates\**\obj\**" />
         <None Include="test_templates\**\*" CopyToOutputDirectory="Always" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Include="test_templates\ConfigurationKitchenSink\.template.config\template.json">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-        <None Include="test_templates\ConfigurationKitchenSink\Test.css" />
-        <None Include="test_templates\ConfigurationKitchenSink\Test.cs">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-        <None Include="test_templates\ConfigurationKitchenSink\Test.json" />
-        <None Include="test_templates\TemplateWithPortsAndCoalesce\.template.config\template.json" />
-        <None Include="test_templates\TemplateWithPortsAndCoalesce\bar.cs" />
-        <None Include="test_templates\TemplateWithRenames\bar\bar.cs">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-        <None Include="test_templates\TemplateWithSourceName\bar\bar.cs">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </None>
-        <None Include="test_templates\TemplateWithUnspecifiedSourceName\.template.config\template.json" />
-        <None Include="test_templates\TemplateWithUnspecifiedSourceName\bar.cs" />
-        <None Include="test_templates\TemplateWithUnspecifiedSourceName\bar\bar.cs" />
-        <None Include="test_templates\TemplateWithValueForms\.template.config\template.json" />
-        <None Include="test_templates\TemplateWithValueForms\bar.2.cs" />
-        <None Include="test_templates\TemplateWithValueForms\bar.cs" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
fixes dotnet/templating#2810: corrects source paths returned by GetCreationEffectsAsync method

The PR reverts changes done in https://github.com/dotnet/templating/pull/2760 as the fix broke the use case for the templates installed from nupkgs and applies different fix.

- adds the ability to pack the NuGet package to be used in IDE tests
- marked TestTemplates project as packable (non-shipping)
- adds FileRename tests to be run on nupkg additionally to templates installed from folder