### PR TITLE
#2811 implements Logger for ITemplateEngineHost

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
 
 namespace Microsoft.TemplateEngine.Abstractions
@@ -42,5 +43,13 @@ namespace Microsoft.TemplateEngine.Abstractions
         void VirtualizeDirectory(string path);
 
         bool OnConfirmPartialMatch(string name);
+    }
+
+    public interface ITemplateEngineHost2 : ITemplateEngineHost
+    {
+        /// <summary>
+        /// Returns the logger for given template engine host
+        /// </summary>
+        ILogger Logger { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
+++ b/src/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
@@ -6,4 +6,7 @@
         <IsPackable>true</IsPackable>
         <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    </ItemGroup>
 </Project>

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -201,9 +201,6 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                     Create.Option("--debug:version", string.Empty, Accept.NoArguments()),
 
                     Create.Option("--dev:install", string.Empty, Accept.NoArguments()),
-
-                    Create.Option("--trace:authoring", string.Empty, Accept.NoArguments()),
-                    Create.Option("--trace:install", string.Empty, Accept.NoArguments()),
                 };
             }
         }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -195,6 +195,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                     Create.Option("--debug:reset-config", string.Empty, Accept.NoArguments()),
                     Create.Option("--debug:showconfig", string.Empty, Accept.NoArguments()),
                     Create.Option("--debug:emit-timings", string.Empty, Accept.NoArguments()),
+                    Create.Option("--debug:enable-logging", string.Empty, Accept.NoArguments()),
                     Create.Option("--debug:emit-telemetry", string.Empty, Accept.NoArguments()),
                     Create.Option("--debug:custom-hive", string.Empty, Accept.ExactlyOneArgument()),
                     Create.Option("--debug:version", string.Empty, Accept.NoArguments()),

--- a/src/Microsoft.TemplateEngine.Cli/ExtendedTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Cli/ExtendedTemplateEngineHost.cs
@@ -2,12 +2,13 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
 
 namespace Microsoft.TemplateEngine.Cli
 {
-    internal class ExtendedTemplateEngineHost : ITemplateEngineHost
+    internal class ExtendedTemplateEngineHost : ITemplateEngineHost, ITemplateEngineHost2
     {
         private readonly New3Command _new3Command;
         private readonly ITemplateEngineHost _baseHost;
@@ -32,15 +33,21 @@ namespace Microsoft.TemplateEngine.Cli
 
         public virtual IReadOnlyList<KeyValuePair<Guid, Func<Type>>> BuiltInComponents => _baseHost.BuiltInComponents;
 
-        public virtual void LogMessage(string message) => _baseHost.LogMessage(message);
+        public virtual void LogMessage(string message)
+        {
+            Reporter.Output.WriteLine(message);
+            _baseHost.LogMessage(message);
+        }
 
         public virtual void OnCriticalError(string code, string message, string currentFile, long currentPosition)
         {
+            Reporter.Error.WriteLine(string.Format(LocalizableStrings.GenericErrorMessage, message));
             _baseHost.OnCriticalError(code, message, currentFile, currentPosition);
         }
 
         public virtual bool OnNonCriticalError(string code, string message, string currentFile, long currentPosition)
         {
+            Reporter.Error.WriteLine(string.Format(LocalizableStrings.GenericErrorMessage, message));
             return _baseHost.OnNonCriticalError(code, message, currentFile, currentPosition);
         }
 
@@ -150,5 +157,7 @@ namespace Microsoft.TemplateEngine.Cli
                 return found;
             }
         }
+
+        public ILogger Logger => (_baseHost as ITemplateEngineHost2)?.Logger;
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -944,6 +944,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error: {0}..
+        /// </summary>
+        public static string GenericErrorMessage {
+            get {
+                return ResourceManager.GetString("GenericErrorMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot retrieve the type for {0}..
         /// </summary>
         public static string GenericPlaceholderTemplateContextError {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -759,4 +759,7 @@ Examples:
   <data name="AmbiguousLanguageHint" xml:space="preserve">
     <value>Re-run the command specifying the language to use with --language option.</value>
   </data>
+  <data name="GenericErrorMessage" xml:space="preserve">
+    <value>Error: {0}.</value>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
+++ b/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
@@ -6,6 +6,10 @@
         <IsPackable>true</IsPackable>
         <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />

--- a/src/Microsoft.TemplateEngine.Utils/Timing.cs
+++ b/src/Microsoft.TemplateEngine.Utils/Timing.cs
@@ -15,8 +15,6 @@ namespace Microsoft.TemplateEngine.Utils
             return new Timing((x, d) =>
             {
                 host.LogTiming(label, x, d);
-                //string indent = string.Join("", Enumerable.Repeat("  ", d));
-                //Console.WriteLine($"{indent} {label} {x.TotalMilliseconds}");
             });
         }
 


### PR DESCRIPTION
fixes https://github.com/dotnet/templating/issues/2811

- implements `Microsoft.Extensions.ILogger` in `ITemplateEngineHost` implementations
- changed existing methods to use Logger
- added `ILogger` creation for dotnet-new3
- fixed output in `ExtendedTemplateEngineHost` to use `Reporter` instead of `Console`