### PR TITLE
string IMountPoint.MountPointUri 

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPoint.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPoint.cs
@@ -4,16 +4,37 @@ namespace Microsoft.TemplateEngine.Abstractions.Mount
 {
     public interface IMountPoint : IDisposable
     {
-        string AbsoluteUri { get; }
+        /// <summary>
+        /// Returns mount point URI (as received from source = not normalized).
+        /// </summary>
+        string MountPointUri { get; }
 
+        /// <summary>
+        /// Returns root directory of the mount point.
+        /// </summary>
         IDirectory Root { get; }
 
         IEngineEnvironmentSettings EnvironmentSettings { get; }
 
-        IFile FileInfo(string fullPath);
+        /// <summary>
+        /// Gets the file info for the file in the mount point.
+        /// </summary>
+        /// <param name="path">The path to the file relative to mount point root.</param>
+        /// <returns></returns>
+        IFile FileInfo(string path);
 
-        IDirectory DirectoryInfo(string fullPath);
+        /// <summary>
+        /// Gets the directory info for the directory in the mount point.
+        /// </summary>
+        /// <param name="path">The path to the directory relative to mount point root.</param>
+        /// <returns></returns>
+        IDirectory DirectoryInfo(string path);
 
-        IFileSystemInfo FileSystemInfo(string fullPath);
+        /// <summary>
+        /// Gets the file system entry (file or directory) info for the entry in the mount point. 
+        /// </summary>
+        /// <param name="path">The path to the file system entry relative to mount point root.</param>
+        /// <returns></returns>
+        IFileSystemInfo FileSystemInfo(string path);
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Mount/Archive/ZipFileMountPoint.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/Archive/ZipFileMountPoint.cs
@@ -6,13 +6,17 @@ using Microsoft.TemplateEngine.Abstractions.Mount;
 
 namespace Microsoft.TemplateEngine.Edge.Mount.Archive
 {
+    /// <summary>
+    /// Mount point implementation for zip file.
+    /// NuGet packages are zip files, so they are handled by this mount point.
+    /// </summary>
     internal class ZipFileMountPoint : IMountPoint
     {
         private IReadOnlyDictionary<string, IFileSystemInfo> _universe;
 
-        public ZipFileMountPoint(IEngineEnvironmentSettings environmentSettings,  IMountPoint parent, string uri, ZipArchive archive)
+        public ZipFileMountPoint(IEngineEnvironmentSettings environmentSettings, IMountPoint parent, string mountPointUri, ZipArchive archive)
         {
-            AbsoluteUri = uri;
+            MountPointUri = mountPointUri;
             Parent = parent;
             EnvironmentSettings = environmentSettings;
             Archive = archive;
@@ -23,35 +27,35 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
 
         public IDirectory Root { get; }
 
-        public IFile FileInfo(string fullPath)
+        public IFile FileInfo(string path)
         {
-            return new ZipFileFile(this, fullPath, fullPath.Substring(fullPath.LastIndexOf('/') + 1), null);
+            return new ZipFileFile(this, path, path.Substring(path.LastIndexOf('/') + 1), null);
         }
 
-        public IDirectory DirectoryInfo(string fullPath)
+        public IDirectory DirectoryInfo(string path)
         {
-            if(Universe.TryGetValue(fullPath, out IFileSystemInfo info))
+            if (Universe.TryGetValue(path, out IFileSystemInfo info))
             {
                 return info as IDirectory;
             }
-            else if (Universe.TryGetValue(fullPath + "/", out info))
+            else if (Universe.TryGetValue(path + "/", out info))
             {
                 return info as IDirectory;
             }
 
-            return new ZipFileDirectory(this, fullPath, fullPath.Substring(fullPath.LastIndexOf('/') + 1));
+            return new ZipFileDirectory(this, path, path.Substring(path.LastIndexOf('/') + 1));
         }
 
-        public IFileSystemInfo FileSystemInfo(string fullPath)
+        public IFileSystemInfo FileSystemInfo(string path)
         {
-            IFile file = FileInfo(fullPath);
+            IFile file = FileInfo(path);
 
             if (file.Exists)
             {
                 return file;
             }
 
-            return DirectoryInfo(fullPath);
+            return DirectoryInfo(path);
         }
 
         public void Dispose()
@@ -116,6 +120,6 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
 
         public Guid MountPointFactoryId => ZipFileMountPointFactory.FactoryId;
 
-        public string AbsoluteUri { get; }
+        public string MountPointUri { get; } 
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemDirectory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemDirectory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
         {
             return _paths.EnumerateFileSystemEntries(_physicalPath, pattern, searchOption).Select(x =>
             {
-                string baseName = x.Substring(((FileSystemMountPoint)MountPoint).Place.Length).Replace(Path.DirectorySeparatorChar, '/');
+                string baseName = x.Substring(((FileSystemMountPoint)MountPoint).MountPointRootPath.Length).Replace(Path.DirectorySeparatorChar, '/');
 
                 if (baseName.Length == 0)
                 {
@@ -60,7 +60,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
         {
             return _paths.EnumerateDirectories(_physicalPath, pattern, searchOption).Select(x =>
             {
-                string baseName = x.Substring(((FileSystemMountPoint)MountPoint).Place.Length).Replace(Path.DirectorySeparatorChar, '/');
+                string baseName = x.Substring(((FileSystemMountPoint)MountPoint).MountPointRootPath.Length).Replace(Path.DirectorySeparatorChar, '/');
 
                 if (baseName.Length == 0)
                 {
@@ -85,7 +85,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
         {
             return _paths.EnumerateFiles(_physicalPath, pattern, searchOption).Select(x =>
             {
-                string baseName = x.Substring(((FileSystemMountPoint)MountPoint).Place.Length).Replace(Path.DirectorySeparatorChar, '/');
+                string baseName = x.Substring(((FileSystemMountPoint)MountPoint).MountPointRootPath.Length).Replace(Path.DirectorySeparatorChar, '/');
 
                 if (baseName.Length == 0)
                 {

--- a/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemMountPoint.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemMountPoint.cs
@@ -5,51 +5,59 @@ using Microsoft.TemplateEngine.Abstractions.Mount;
 
 namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
 {
+    /// <summary>
+    /// Mount point implementation for file system directory
+    /// </summary>
     public class FileSystemMountPoint : IMountPoint
     {
         private Paths _paths;
-        public string Place { get; }
 
-        public FileSystemMountPoint(IEngineEnvironmentSettings environmentSettings, IMountPoint parent, string place)
+        /// <summary>
+        /// Returns full path of the mounted directory
+        /// </summary>
+        internal string MountPointRootPath { get; } 
+
+        public FileSystemMountPoint(IEngineEnvironmentSettings environmentSettings, IMountPoint parent, string mountPointUri, string mountPointRootPath)
         {
+            MountPointUri = mountPointUri;
+            MountPointRootPath = mountPointRootPath;
             EnvironmentSettings = environmentSettings;
             _paths = new Paths(environmentSettings);
-            Place = place;
-            Root = new FileSystemDirectory(this, "/", "", place);
+            Root = new FileSystemDirectory(this, "/", "", MountPointRootPath);
         }
 
         public IDirectory Root { get; }
 
         public IEngineEnvironmentSettings EnvironmentSettings { get; }
 
-        public IFile FileInfo(string fullPath)
+        public IFile FileInfo(string path)
         {
-            string realPath = Path.Combine(Place, fullPath.TrimStart('/'));
+            string fullPath = Path.Combine(MountPointRootPath, path.TrimStart('/'));
 
-            if (!fullPath.StartsWith("/"))
+            if (!path.StartsWith("/"))
             {
-                fullPath = "/" + fullPath;
+                path = "/" + path;
             }
 
-            return new FileSystemFile(this, fullPath, _paths.Name(realPath), realPath);
+            return new FileSystemFile(this, path, _paths.Name(fullPath), fullPath);
         }
 
-        public IDirectory DirectoryInfo(string fullPath)
+        public IDirectory DirectoryInfo(string path)
         {
-            string realPath = Path.Combine(Place, fullPath.TrimStart('/'));
-            return new FileSystemDirectory(this, fullPath, _paths.Name(realPath), realPath);
+            string fullPath = Path.Combine(MountPointRootPath, path.TrimStart('/'));
+            return new FileSystemDirectory(this, path, _paths.Name(fullPath), fullPath);
         }
 
-        public IFileSystemInfo FileSystemInfo(string fullPath)
+        public IFileSystemInfo FileSystemInfo(string path)
         {
-            string realPath = Path.Combine(Place, fullPath.TrimStart('/'));
+            string fullPath = Path.Combine(MountPointRootPath, path.TrimStart('/'));
 
-            if (EnvironmentSettings.Host.FileSystem.DirectoryExists(realPath))
+            if (EnvironmentSettings.Host.FileSystem.DirectoryExists(fullPath))
             {
-                return new FileSystemDirectory(this, fullPath, _paths.Name(realPath), realPath);
+                return new FileSystemDirectory(this, path, _paths.Name(fullPath), fullPath);
             }
 
-            return new FileSystemFile(this, fullPath, _paths.Name(realPath), realPath);
+            return new FileSystemFile(this, path, _paths.Name(fullPath), fullPath);
         }
 
         public void Dispose()
@@ -61,6 +69,6 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
 
         public Guid MountPointFactoryId => FileSystemMountPointFactory.FactoryId;
 
-        public string AbsoluteUri => Place;
+        public string MountPointUri { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemMountPointFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemMountPointFactory.cs
@@ -33,7 +33,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
                 return false;
             }
 
-            mountPoint = new FileSystemMountPoint(environmentSettings, parent, uri.LocalPath);
+            mountPoint = new FileSystemMountPoint(environmentSettings, parent, mountPointUri, uri.LocalPath);
             return true;
         }
     }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -152,7 +152,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                         ILocalizationLocator locator = new LocalizationLocator()
                         {
                             Locale = locale,
-                            MountPointUri = source.AbsoluteUri,
+                            MountPointUri = source.MountPointUri,
                             ConfigPlace = file.FullPath,
                             Identity = locModel.Identity,
                             Author = locModel.Author,
@@ -280,7 +280,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
                 // Record the timestamp of the template file so we
                 // know to reload it if it changes
-                if (Uri.TryCreate(templateFile.MountPoint.AbsoluteUri, UriKind.Absolute, out var uri) &&
+                if (Uri.TryCreate(templateFile.MountPoint.MountPointUri, UriKind.Absolute, out var uri) &&
                     host.FileSystem.DirectoryExists(uri.LocalPath) &&
                     host.FileSystem is IFileLastWriteTimeSource timeSource)
                 {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
@@ -192,7 +192,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         public IFileSystemInfo Configuration => ConfigFile;
 
-        public string MountPointUri => Configuration.MountPoint.AbsoluteUri;
+        public string MountPointUri => Configuration.MountPoint.MountPointUri;
 
         public string ConfigPlace => Configuration.FullPath;
 

--- a/test/Microsoft.TemplateEngine.Mocks/MockMountPoint.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockMountPoint.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateEngine.Mocks
 
         public IEngineEnvironmentSettings EnvironmentSettings { get; set; }
 
-        public string AbsoluteUri => "/";
+        public string MountPointUri { get; }
 
         public IFileSystemInfo FileSystemInfo(string fullPath)
         {


### PR DESCRIPTION
Check only last commit. 

introduced string IMountPoint.MountPointUri for mount points to ensure that any path normalizations do not affect the value. 
removed FileSystemMountPoint.Place; added string FileSystemMountPoint.MountPointRootPath instead.
also removed string IMountPoint.AbsoluteUri - it's not needed at the moment, however it is easy to bring it back as => ((Uri)MountPointUri).LocalPath if needed.

Questions:
- should we add ITemplatesSource property to MountPoint? (instead of MountPointUri) and get MountPointUri accessible via property?
- should we parse MountPointUri to Uri when reading template sources?