### PR TITLE
Update .gitignore

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -23,6 +23,7 @@ mono_crash.*
 [Rr]eleases/
 x64/
 x86/
+[Ww][Ii][Nn]32/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/
@@ -63,6 +64,9 @@ artifacts/
 
 # Tye
 .tye/
+
+# ASP.NET Scaffolding
+ScaffoldingReadMe.txt
 
 # StyleCop
 StyleCopReport.xml
@@ -141,7 +145,9 @@ _TeamCity*
 !.axoCover/settings.json
 
 # Coverlet is a free, cross platform Code Coverage Tool
-coverage*[.json, .xml, .info]
+coverage*.json
+coverage*.xml
+coverage*.info
 
 # Visual Studio code coverage results
 *.coverage
@@ -305,9 +311,6 @@ paket-files/
 # FAKE - F# Make
 .fake/
 
-# Ionide - VsCode extension for F# Support
-.ionide/
-
 # CodeRush personal settings
 .cr/personal
 
@@ -357,6 +360,9 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Fody - auto-generated XML schema
+FodyWeavers.xsd
 
 ##
 ## Visual studio for Mac


### PR DESCRIPTION
based off https://github.com/github/gitignore/blob/ddf1d121ad79a8011aa95e328326b59d8d310b63/VisualStudio.gitignore

includes:

- https://github.com/github/gitignore/commit/0af689b9886d71df768822874f0fe68aa6b0f6c0
- https://github.com/github/gitignore/commit/811be05b83a2740e20b3b0f9a5c5efb89961fefe
- https://github.com/github/gitignore/commit/2a4de265d37eca626309d8e115218d18985b5435
- https://github.com/github/gitignore/commit/6eff882467cbde7b4e293b4dd6abd7685fc67844
- https://github.com/github/gitignore/commit/ddf1d121ad79a8011aa95e328326b59d8d310b63 ([not yet merged](https://github.com/github/gitignore/pull/3645))

and technically reverts https://github.com/dotnet/templating/commit/98040ace62e08122c90588d85b763969d92a09c4 but it should already covered under https://github.com/dotnet/templating/blob/98040ace62e08122c90588d85b763969d92a09c4/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore#L358-L359