### PR TITLE
Fixes for logging for ExtendedTemplateEngineHost (CLI host)

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/ExtendedTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Cli/ExtendedTemplateEngineHost.cs
@@ -32,16 +32,20 @@ namespace Microsoft.TemplateEngine.Cli
 
         public virtual IReadOnlyList<KeyValuePair<Guid, Func<Type>>> BuiltInComponents => _baseHost.BuiltInComponents;
 
-        public virtual void LogMessage(string message) => _baseHost.LogMessage(message);
+        public virtual void LogMessage(string message)
+        {
+            Reporter.Output.WriteLine(message);
+        }
 
         public virtual void OnCriticalError(string code, string message, string currentFile, long currentPosition)
         {
-            _baseHost.OnCriticalError(code, message, currentFile, currentPosition);
+            Reporter.Error.WriteLine(string.Format(LocalizableStrings.GenericError, message));
         }
 
         public virtual bool OnNonCriticalError(string code, string message, string currentFile, long currentPosition)
         {
-            return _baseHost.OnNonCriticalError(code, message, currentFile, currentPosition);
+            Reporter.Error.WriteLine(string.Format(LocalizableStrings.GenericWarning, message));
+            return false;
         }
 
         public virtual bool OnParameterError(ITemplateParameter parameter, string receivedValue, string message, out string newValue)

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -944,11 +944,29 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error: {0}.
+        /// </summary>
+        public static string GenericError {
+            get {
+                return ResourceManager.GetString("GenericError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot retrieve the type for {0}..
         /// </summary>
         public static string GenericPlaceholderTemplateContextError {
             get {
                 return ResourceManager.GetString("GenericPlaceholderTemplateContextError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Warning: {0}.
+        /// </summary>
+        public static string GenericWarning {
+            get {
+                return ResourceManager.GetString("GenericWarning", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -759,4 +759,10 @@ Examples:
   <data name="AmbiguousLanguageHint" xml:space="preserve">
     <value>Re-run the command specifying the language to use with --language option.</value>
   </data>
+  <data name="GenericError" xml:space="preserve">
+    <value>Error: {0}</value>
+  </data>
+  <data name="GenericWarning" xml:space="preserve">
+    <value>Warning: {0}</value>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Utils/DefaultTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Utils/DefaultTemplateEngineHost.cs
@@ -64,7 +64,6 @@ namespace Microsoft.TemplateEngine.Utils
 
         public virtual void LogMessage(string message)
         {
-            //Console.WriteLine("LogMessage: {0}", message);
             Console.WriteLine(message);
         }
 


### PR DESCRIPTION
Made own implementation of LogMessage, OnNonCriticalError, OnCriticalError for ExtendedTemplateEngineHost (CLI host):
- they use Reporter now and not Console.WriteLine
- proper Output/Error stream selection is made