### PR TITLE
Fixes the issue with showing update available when preview version is installed

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/Installer/CheckUpdateResult.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Installer/CheckUpdateResult.cs
@@ -7,9 +7,9 @@ namespace Microsoft.TemplateEngine.Abstractions.Installer
 {
     public class CheckUpdateResult : Result
     {
-        public string Version { get; private set; }
+        public string LatestVersion { get; private set; }
 
-        public bool IsLatestVersion => Source.Version == Version;
+        public bool IsLatestVersion { get; private set; }
 
         public static CheckUpdateResult CreateSuccessNoUpdate(IManagedTemplatesSource source)
         {
@@ -17,17 +17,18 @@ namespace Microsoft.TemplateEngine.Abstractions.Installer
             {
                 Error = InstallerErrorCode.Success,
                 Source = source,
-                Version = source.Version
+                LatestVersion = source.Version
             };
         }
 
-        public static CheckUpdateResult CreateSuccess(IManagedTemplatesSource source, string version)
+        public static CheckUpdateResult CreateSuccess(IManagedTemplatesSource source, string version, bool isLatest)
         {
             return new CheckUpdateResult()
             {
                 Error = InstallerErrorCode.Success,
                 Source = source,
-                Version = version
+                LatestVersion = version,
+                IsLatestVersion = isLatest,
             };
         }
 

--- a/src/Microsoft.TemplateEngine.Abstractions/Installer/UpdateRequest.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Installer/UpdateRequest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.TemplateEngine.Abstractions.Installer
         public static UpdateRequest FromCheckUpdateResult (CheckUpdateResult request)
         {
             _ = request ?? throw new ArgumentNullException(nameof(request));
-            if (string.IsNullOrWhiteSpace(request.Version))
+            if (string.IsNullOrWhiteSpace(request.LatestVersion))
             {
                 throw new ArgumentException("Version cannot be null or empty", nameof(request));
             }
@@ -23,7 +23,7 @@ namespace Microsoft.TemplateEngine.Abstractions.Installer
             return new UpdateRequest()
             {
                 Source = request.Source,
-                Version = request.Version
+                Version = request.LatestVersion
             };
         }
     }

--- a/src/Microsoft.TemplateEngine.Abstractions/TemplatesSources/IManagedTemplatesSourcesProvider.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/TemplatesSources/IManagedTemplatesSourcesProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TemplateEngine.Abstractions.TemplatesSources
         /// <summary>
         /// Takes list of <see cref="IManagedTemplatesSource"/> as input so it can check for latest versions in batch.
         /// And returns list of <see cref="CheckUpdateResult"/> which contains original <see cref="IManagedTemplatesSource"/>
-        /// so caller can compare <see cref="CheckUpdateResult.Version"/> with <see cref="IManagedTemplatesSource.Version"/>
+        /// so caller can compare <see cref="CheckUpdateResult.LatestVersion"/> with <see cref="IManagedTemplatesSource.Version"/>
         /// </summary>
         /// <param name="managedSources">List of <see cref="IManagedTemplatesSource"/> to get latest version for.</param>
         /// <returns>List of <see cref="ManagedTemplatesSourceUpdate"/></returns>

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -608,7 +608,7 @@ namespace Microsoft.TemplateEngine.Cli
             foreach (var (provider, sources) in managedSourcedGroupedByProvider)
             {
                 IReadOnlyList<CheckUpdateResult> checkUpdateResults = await provider.GetLatestVersionsAsync(sources, CancellationToken.None).ConfigureAwait(false);
-                IEnumerable<CheckUpdateResult> updatesToApply = checkUpdateResults.Where(update => !update.IsLatestVersion && !string.IsNullOrWhiteSpace(update.Version));
+                IEnumerable<CheckUpdateResult> updatesToApply = checkUpdateResults.Where(update => !update.IsLatestVersion && !string.IsNullOrWhiteSpace(update.LatestVersion));
                 if (!updatesToApply.Any())
                 {
                     Reporter.Output.WriteLine("All template packages are up-to-date.");
@@ -620,7 +620,7 @@ namespace Microsoft.TemplateEngine.Cli
                     Reporter.Output.WriteLine("The following template packages will be updated:");
                     foreach (CheckUpdateResult update in updatesToApply)
                     {
-                        Reporter.Output.WriteLine($"  {update.Source.Identifier}, version: {update.Version}");
+                        Reporter.Output.WriteLine($"  {update.Source.Identifier}, version: {update.LatestVersion}");
                     }
                     Reporter.Output.WriteLine();
 
@@ -639,7 +639,7 @@ namespace Microsoft.TemplateEngine.Cli
                     foreach (var updateResult in updatesToApply)
                     {
                         Reporter.Output.WriteLine(string.Format(LocalizableStrings.UpdateAvailable, updateResult.Source.DisplayName));
-                        string installString = $"{updateResult.Source.Identifier}::{updateResult.Version}"; // the package::version that will be installed
+                        string installString = $"{updateResult.Source.Identifier}::{updateResult.LatestVersion}"; // the package::version that will be installed
                         Reporter.Output.WriteLine(string.Format(LocalizableStrings.UpdateCheck_InstallCommand, CommandName, installString));
                     }
                 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
@@ -79,7 +79,7 @@ namespace Microsoft.TemplateEngine.Cli
                 {
                     string displayString = $"{updateResult.Source.Identifier}::{updateResult.Source.Version}";         // the package::version currently installed
                     Reporter.Output.WriteLine(string.Format(LocalizableStrings.UpdateAvailable, displayString));
-                    string installString = $"{updateResult.Source.Identifier}::{updateResult.Version}"; // the package::version that will be installed
+                    string installString = $"{updateResult.Source.Identifier}::{updateResult.LatestVersion}"; // the package::version that will be installed
                     Reporter.Output.WriteLine(string.Format(LocalizableStrings.UpdateCheck_InstallCommand, _commandName, installString));
                 }
             }

--- a/src/Microsoft.TemplateEngine.Edge/GlobalSettingsTemplatesSources/GlobalSettingsTemplatesSourcesProvider.cs
+++ b/src/Microsoft.TemplateEngine.Edge/GlobalSettingsTemplatesSources/GlobalSettingsTemplatesSourcesProvider.cs
@@ -46,14 +46,15 @@ namespace Microsoft.TemplateEngine.Edge
                     _installersByGuid[installerFactory.Id] = installer;
                 }
 
-                settings.SettingsLoader.GlobalSettings.SettingsChanged += SourcesChanged;
+                settings.SettingsLoader.GlobalSettings.SettingsChanged += () => SourcesChanged?.Invoke();
+
             }
 
             public event Action SourcesChanged;
 
             public ITemplatesSourcesProviderFactory Factory { get; }
 
-            public async Task<IReadOnlyList<ITemplatesSource>> GetAllSourcesAsync(CancellationToken cancellationToken)
+            public Task<IReadOnlyList<ITemplatesSource>> GetAllSourcesAsync(CancellationToken cancellationToken)
             {
                 var list = new List<ITemplatesSource>();
                 foreach (TemplatesSourceData entry in _environmentSettings.SettingsLoader.GlobalSettings.UserInstalledTemplatesSources)
@@ -69,7 +70,7 @@ namespace Microsoft.TemplateEngine.Edge
                         list.Add(new TemplatesSource(this, entry.MountPointUri, entry.LastChangeTime));
                     }
                 }
-                return list;
+                return Task.FromResult((IReadOnlyList<ITemplatesSource>)list);
             }
 
             public async Task<IReadOnlyList<CheckUpdateResult>> GetLatestVersionsAsync(IEnumerable<IManagedTemplatesSource> sources, CancellationToken cancellationToken)

--- a/src/Microsoft.TemplateEngine.Edge/Installers/Folder/FolderInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/Folder/FolderInstaller.cs
@@ -42,7 +42,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.Folder
 
         public Task<IReadOnlyList<CheckUpdateResult>> GetLatestVersionAsync(IEnumerable<IManagedTemplatesSource> sources, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IReadOnlyList<CheckUpdateResult>>(sources.Select(s => CheckUpdateResult.CreateSuccess(s, null)).ToList());
+            return Task.FromResult<IReadOnlyList<CheckUpdateResult>>(sources.Select(s => CheckUpdateResult.CreateSuccess(s, null, true)).ToList());
         }
 
         public Task<InstallResult> InstallAsync(InstallRequest installRequest, CancellationToken cancellationToken)

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstaller.cs
@@ -86,11 +86,6 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                 {
                     if (source is NuGetManagedTemplatesSource nugetSource)
                     {
-                        if (nugetSource.LocalPackage)
-                        {
-                            //updates for locally installed packages are not supported
-                            return Task.FromResult(CheckUpdateResult.CreateSuccessNoUpdate(source));
-                        }
                         try
                         {
                             return _updateChecker.GetLatestVersionAsync(nugetSource, CancellationToken.None);

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -59,6 +59,23 @@ namespace dotnet_new3.UnitTests
         }
 
         [Fact]
+        public void CanInstallRemoteNuGetPackageWithPrereleaseVersion()
+        {
+            var home = Helpers.CreateTemporaryFolder("Home");
+            new DotnetNewCommand(_log, "-i", "Take.Blip.Client.Templates::0.6.37-beta", "--quiet", "--nuget-source", "https://api.nuget.org/v3/index.json")
+                .WithWorkingDirectory(Helpers.CreateTemporaryFolder())
+                .WithEnvironmentVariable(Helpers.HomeEnvironmentVariableName, home)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And
+                .NotHaveStdErr()
+                .And.HaveStdOutContaining("The following template packages will be installed:")
+                .And.HaveStdOutMatching($"Success: Take.Blip.Client.Templates::0.6.37-beta installed the following templates:")
+                .And.HaveStdOutContaining("blip-console");
+        }
+
+        [Fact]
         public void CanInstallRemoteNuGetPackageWithNuGetSource()
         {
             var home = Helpers.CreateTemporaryFolder("Home");


### PR DESCRIPTION
If the template package version is preview and it's higher than latest stable, the update notification won't be shown.