### PR TITLE
Added DisplayName to ParameterSymbol and choices

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/ICacheParameter.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ICacheParameter.cs
@@ -7,6 +7,7 @@ namespace Microsoft.TemplateEngine.Abstractions
 {
     /// <summary>
     /// Defines the representation of a parameter in template cache.
+    /// This doesn't include parameters with choices which are represented by <see cref="ICacheTag"/>.
     /// </summary>
     public interface ICacheParameter
     {
@@ -22,11 +23,13 @@ namespace Microsoft.TemplateEngine.Abstractions
 
         /// <summary>
         /// Gets the friendly name of the parameter to be displayed to the user.
+        /// This property is localized if localizations are provided.
         /// </summary>
         string? DisplayName { get; }
 
         /// <summary>
         /// Gets the detailed description of the parameter to be displayed to the user.
+        /// This property is localized if localizations are provided.
         /// </summary>
         string? Description { get; }
     }

--- a/src/Microsoft.TemplateEngine.Abstractions/ICacheParameter.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ICacheParameter.cs
@@ -1,11 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
 namespace Microsoft.TemplateEngine.Abstractions
 {
+    /// <summary>
+    /// Defines the representation of a parameter in template cache.
+    /// </summary>
     public interface ICacheParameter
     {
-        string DataType { get; }
+        /// <summary>
+        /// Gets the type of the parameter.
+        /// </summary>
+        string? DataType { get; }
 
-        string DefaultValue { get; }
+        /// <summary>
+        /// Gets the default value to be used if the user did not provide a value.
+        /// </summary>
+        string? DefaultValue { get; }
 
-        string Description { get; }
+        /// <summary>
+        /// Gets the friendly name of the parameter to be displayed to the user.
+        /// </summary>
+        string? DisplayName { get; }
+
+        /// <summary>
+        /// Gets the detailed description of the parameter to be displayed to the user.
+        /// </summary>
+        string? Description { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/ICacheTag.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ICacheTag.cs
@@ -1,13 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
 using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Abstractions
 {
+    /// <summary>
+    /// Represents a parameter symbol with choices in template cache file.
+    /// </summary>
     public interface ICacheTag
     {
-        string Description { get; }
+        /// <summary>
+        /// Gets the friendly name of the tag to be displayed to the user.
+        /// </summary>
+        string? DisplayName { get; }
 
-        IReadOnlyDictionary<string, string> ChoicesAndDescriptions { get; }
+        /// <summary>
+        /// Gets the description of the tag to be displayed to the user.
+        /// </summary>
+        string? Description { get; }
 
-        string DefaultValue { get; }
+        IReadOnlyDictionary<string, ParameterChoice> Choices { get; }
+
+        string? DefaultValue { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/ICacheTag.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ICacheTag.cs
@@ -22,8 +22,15 @@ namespace Microsoft.TemplateEngine.Abstractions
         /// </summary>
         string? Description { get; }
 
+        /// <summary>
+        /// Gets the dictionary containing the possible choices for this tag or parameter symbol.
+        /// Keys represents the identifiers of the choices.
+        /// </summary>
         IReadOnlyDictionary<string, ParameterChoice> Choices { get; }
 
+        /// <summary>
+        /// Gets the identifier of the default choice to be used when no choice was explicitly selected.
+        /// </summary>
         string? DefaultValue { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/ICacheTag.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ICacheTag.cs
@@ -8,17 +8,17 @@ using System.Collections.Generic;
 namespace Microsoft.TemplateEngine.Abstractions
 {
     /// <summary>
-    /// Represents a parameter symbol with choices in template cache file.
+    /// Represents a tag or a parameter symbol with choices in template cache file.
     /// </summary>
     public interface ICacheTag
     {
         /// <summary>
-        /// Gets the friendly name of the tag to be displayed to the user.
+        /// Gets the friendly name of the choice parameter symbol to be displayed to the user.
         /// </summary>
         string? DisplayName { get; }
 
         /// <summary>
-        /// Gets the description of the tag to be displayed to the user.
+        /// Gets the description of the choice parameter symbol to be displayed to the user.
         /// </summary>
         string? Description { get; }
 

--- a/src/Microsoft.TemplateEngine.Abstractions/IParameterSymbolLocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IParameterSymbolLocalizationModel.cs
@@ -1,4 +1,9 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Abstractions
 {
@@ -6,8 +11,13 @@ namespace Microsoft.TemplateEngine.Abstractions
     {
         string Name { get; }
 
-        string Description { get; }
+        /// <summary>
+        /// Gets the localized friendly name of the symbol to be displayed to the user.
+        /// </summary>
+        string? DisplayName { get; }
 
-        IReadOnlyDictionary<string, string> ChoicesAndDescriptions { get; }
+        string? Description { get; }
+
+        IReadOnlyDictionary<string, ParameterChoiceLocalizationModel> Choices { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/ITemplateParameter.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ITemplateParameter.cs
@@ -18,6 +18,6 @@ namespace Microsoft.TemplateEngine.Abstractions
 
         string DataType { get; }
 
-        IReadOnlyDictionary<string, string> Choices { get; }
+        IReadOnlyDictionary<string, ParameterChoice> Choices { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/ParameterChoice.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ParameterChoice.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.TemplateEngine.Abstractions
+{
+    /// <summary>
+    /// Represents a choice that can be assigned to a parameter.
+    /// </summary>
+    public sealed class ParameterChoice
+    {
+        public ParameterChoice(string? displayName, string? description)
+        {
+            DisplayName = displayName;
+            Description = description;
+        }
+
+        /// <summary>
+        /// Gets or sets the friendly name of the choice to be displayed to the user.
+        /// </summary>
+        public string? DisplayName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description of the choice to be displayed to the user.
+        /// </summary>
+        public string? Description { get; set; }
+
+        /// <summary>
+        /// Localizes the choice with the given localization model.
+        /// </summary>
+        public void Localize(ParameterChoiceLocalizationModel localizationModel)
+        {
+            DisplayName = localizationModel.DisplayName ?? DisplayName;
+            Description = localizationModel.Description ?? Description;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Abstractions/ParameterChoiceLocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ParameterChoiceLocalizationModel.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.TemplateEngine.Abstractions
+{
+    /// <summary>
+    /// Represents the data necessary for the localization of a <see cref="ParameterChoice"/>.
+    /// </summary>
+    public sealed class ParameterChoiceLocalizationModel
+    {
+        public ParameterChoiceLocalizationModel(string? displayName, string? description)
+        {
+            DisplayName = displayName;
+            Description = description;
+        }
+
+        /// <summary>
+        /// Gets the friendly name of the choice to be displayed to the user.
+        /// </summary>
+        public string? DisplayName { get; private set; }
+
+        /// <summary>
+        /// Gets the description of the choice to be displayed to the user.
+        /// </summary>
+        public string? Description { get; private set; }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/InvalidParameterInfo.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/InvalidParameterInfo.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.TemplateEngine.Cli.TemplateResolution;
+﻿using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Cli.TemplateResolution;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -117,7 +118,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             return invalidParamsErrorText.ToString();
         }
 
-        private static void DisplayValidValues(StringBuilder text, string header, IDictionary<string, string> possibleValues, int padWidth)
+        private static void DisplayValidValues(StringBuilder text, string header, IDictionary<string, ParameterChoice> possibleValues, int padWidth)
         {
             text.Append(' ', padWidth).Append(header);
 
@@ -128,13 +129,13 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 
             text.Append(' ').AppendLine(LocalizableStrings.PossibleValuesHeader);
             int longestChoiceLength = possibleValues.Keys.Max(x => x.Length);
-            foreach (KeyValuePair<string, string> choiceInfo in possibleValues)
+            foreach (KeyValuePair<string, ParameterChoice> choiceInfo in possibleValues)
             {
                 text.Append(' ', padWidth * 2).Append(choiceInfo.Key.PadRight(longestChoiceLength + padWidth));
 
-                if (!string.IsNullOrWhiteSpace(choiceInfo.Value))
+                if (!string.IsNullOrWhiteSpace(choiceInfo.Value.Description))
                 {
-                    text.Append("- " + choiceInfo.Value);
+                    text.Append("- " + choiceInfo.Value.Description);
                 }
 
                 text.AppendLine();

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
@@ -124,13 +124,13 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                     {
                         int longestChoiceLength = param.Choices.Keys.Max(x => x.Length);
 
-                        foreach (KeyValuePair<string, string> choiceInfo in param.Choices)
+                        foreach (KeyValuePair<string, ParameterChoice> choiceInfo in param.Choices)
                         {
                             displayValue.Append("    " + choiceInfo.Key.PadRight(longestChoiceLength + 4));
 
-                            if (!string.IsNullOrWhiteSpace(choiceInfo.Value))
+                            if (!string.IsNullOrWhiteSpace(choiceInfo.Value.Description))
                             {
-                                displayValue.Append("- " + choiceInfo.Value);
+                                displayValue.Append("- " + choiceInfo.Value.Description);
                             }
 
                             displayValue.AppendLine();

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateParameterHelpBase.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateParameterHelpBase.cs
@@ -30,11 +30,11 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                     Name = "allow-scripts",
                     DataType = "choice",
                     DefaultValue = "prompt",
-                    Choices = new Dictionary<string, string>()
+                    Choices = new Dictionary<string, ParameterChoice>()
                     {
-                        { "yes", LocalizableStrings.AllowScriptsYesChoice },
-                        { "no", LocalizableStrings.AllowScriptsNoChoice },
-                        { "prompt", LocalizableStrings.AllowScriptsPromptChoice }
+                        { "yes", new ParameterChoice(string.Empty, LocalizableStrings.AllowScriptsYesChoice) },
+                        { "no", new ParameterChoice(string.Empty, LocalizableStrings.AllowScriptsNoChoice) },
+                        { "prompt", new ParameterChoice(string.Empty, LocalizableStrings.AllowScriptsPromptChoice) }
                     }
                 };
 

--- a/src/Microsoft.TemplateEngine.Cli/TemplateGroupParameterSet.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateGroupParameterSet.cs
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateEngine.Cli
                 if (_parameterDefinitions == null)
                 {
                     IDictionary<string, ITemplateParameter> combinedParams = new Dictionary<string, ITemplateParameter>();
-                    IDictionary<string, Dictionary<string, string>> combinedChoices = new Dictionary<string, Dictionary<string, string>>();
+                    IDictionary<string, Dictionary<string, ParameterChoice>> combinedChoices = new Dictionary<string, Dictionary<string, ParameterChoice>>();
 
                     // gather info
                     foreach (IParameterSet paramSet in _parameterSetList)
@@ -40,14 +40,14 @@ namespace Microsoft.TemplateEngine.Cli
                             // build the combined choice lists
                             if (parameter.Choices != null)
                             {
-                                Dictionary<string, string> combinedChoicesForParam;
+                                Dictionary<string, ParameterChoice> combinedChoicesForParam;
                                 if (!combinedChoices.TryGetValue(parameter.Name, out combinedChoicesForParam))
                                 {
-                                    combinedChoicesForParam = new Dictionary<string, string>();
+                                    combinedChoicesForParam = new Dictionary<string, ParameterChoice>();
                                     combinedChoices.Add(parameter.Name, combinedChoicesForParam);
                                 }
 
-                                foreach (KeyValuePair<string, string> choiceAndDescription in parameter.Choices)
+                                foreach (KeyValuePair<string, ParameterChoice> choiceAndDescription in parameter.Choices)
                                 {
                                     if (!combinedChoicesForParam.ContainsKey(choiceAndDescription.Key))
                                     {
@@ -68,10 +68,10 @@ namespace Microsoft.TemplateEngine.Cli
                         }
                         else
                         {
-                            Dictionary<string, string> choicesAndDescriptions;
+                            Dictionary<string, ParameterChoice> choicesAndDescriptions;
                             if (!combinedChoices.TryGetValue(paramInfo.Key, out choicesAndDescriptions))
                             {
-                                choicesAndDescriptions = new Dictionary<string, string>();
+                                choicesAndDescriptions = new Dictionary<string, ParameterChoice>();
                             }
 
                             ITemplateParameter combinedParameter = new TemplateParameter

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -60,7 +60,7 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 _telemetryLogger.TrackEvent(_commandName + TelemetryConstants.CreateEventSuffix, new Dictionary<string, string>
                 {
-                    { TelemetryConstants.Language, language?.ChoicesAndDescriptions.Keys.FirstOrDefault() },
+                    { TelemetryConstants.Language, language?.Choices.Keys.FirstOrDefault() },
                     { TelemetryConstants.ArgError, "True" },
                     { TelemetryConstants.Framework, framework },
                     { TelemetryConstants.TemplateName, templateName },
@@ -104,7 +104,7 @@ namespace Microsoft.TemplateEngine.Cli
                 {
                     _telemetryLogger.TrackEvent(_commandName + TelemetryConstants.CreateEventSuffix, new Dictionary<string, string>
                     {
-                        { TelemetryConstants.Language, language?.ChoicesAndDescriptions.Keys.FirstOrDefault() },
+                        { TelemetryConstants.Language, language?.Choices.Keys.FirstOrDefault() },
                         { TelemetryConstants.ArgError, "False" },
                         { TelemetryConstants.Framework, framework },
                         { TelemetryConstants.TemplateName, templateName },

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateGroup.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateGroup.cs
@@ -1,3 +1,4 @@
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.HelpAndUsage;
 using Microsoft.TemplateEngine.Edge.Template;
 using System;
@@ -235,14 +236,14 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// </summary>
         /// <param name="parameter">parameter canonical name</param>
         /// <returns>the dictionary of valid choices and descriptions</returns>
-        internal IDictionary<string, string> GetValidValuesForChoiceParameter(string parameter)
+        internal IDictionary<string, ParameterChoice> GetValidValuesForChoiceParameter(string parameter)
         {
-            Dictionary<string, string> validChoices = new Dictionary<string, string>();
+            Dictionary<string, ParameterChoice> validChoices = new Dictionary<string, ParameterChoice>();
             foreach (ITemplateMatchInfo template in Templates)
             {
                 if (template.Info.Tags.ContainsKey(parameter))
                 {
-                    foreach (var choice in template.Info.Tags[parameter].ChoicesAndDescriptions)
+                    foreach (var choice in template.Info.Tags[parameter].Choices)
                     {
                         validChoices[choice.Key] = choice.Value;
                     }
@@ -257,14 +258,14 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// <param name="parameter">parameter canonical name</param>
         /// <param name="value">ambiguous value for the parameter to return possible choices for</param>
         /// <returns>the dictionary of possible choices and descriptions that are matching ambiguous input</returns>
-        internal Dictionary<string, string> GetAmbiguousValuesForChoiceParameter(string parameter, string value)
+        internal Dictionary<string, ParameterChoice> GetAmbiguousValuesForChoiceParameter(string parameter, string value)
         {
-            Dictionary<string, string> validChoices = new Dictionary<string, string>();
+            Dictionary<string, ParameterChoice> validChoices = new Dictionary<string, ParameterChoice>();
             foreach (ITemplateMatchInfo template in Templates)
             {
                 if (template.Info.Tags.ContainsKey(parameter))
                 {
-                    foreach (var choice in template.Info.Tags[parameter].ChoicesAndDescriptions)
+                    foreach (var choice in template.Info.Tags[parameter].Choices)
                     {
                         if (choice.Key.StartsWith(value, StringComparison.OrdinalIgnoreCase))
                         {

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
@@ -370,7 +370,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                                     InputParameterFormat = commandInput.TemplateParamInputFormat(paramName)
                                 });
                             }
-                            else if (paramDetails.ChoicesAndDescriptions.ContainsKey(paramValue))
+                            else if (paramDetails.Choices.ContainsKey(paramValue))
                             {
                                 template.AddDisposition(new MatchInfo
                                 {
@@ -383,7 +383,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                             }
                             else
                             {
-                                int startsWithCount = paramDetails.ChoicesAndDescriptions.Count(x => x.Key.StartsWith(paramValue, StringComparison.OrdinalIgnoreCase));
+                                int startsWithCount = paramDetails.Choices.Count(x => x.Key.StartsWith(paramValue, StringComparison.OrdinalIgnoreCase));
                                 if (startsWithCount == 1)
                                 {
                                     template.AddDisposition(new MatchInfo

--- a/src/Microsoft.TemplateEngine.Edge/Settings/SettingsStore.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/SettingsStore.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
     public class SettingsStore
     {
         // NOTE: when the current version changes, a corresponding change in TemplateInfo.cs is needed, to get the correct template cache version reader to fire.
-        public static readonly string CurrentVersion = "1.0.0.3";
+        public static readonly string CurrentVersion = "1.0.0.4";
 
         public SettingsStore()
         {

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -349,40 +349,38 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
             foreach (KeyValuePair<string, ICacheTag> templateTag in templateTags)
             {
-                if (localizedParameterSymbols.TryGetValue(templateTag.Key, out IParameterSymbolLocalizationModel localizationForTag))
-                {   // there is loc for this symbol
-                    Dictionary<string, string> localizedChoicesAndDescriptions = new Dictionary<string, string>();
-
-                    foreach (KeyValuePair<string, string> templateChoice in templateTag.Value.ChoicesAndDescriptions)
-                    {
-                        if (localizationForTag.ChoicesAndDescriptions.TryGetValue(templateChoice.Key, out string localizedDesc) && !string.IsNullOrWhiteSpace(localizedDesc))
-                        {
-                            localizedChoicesAndDescriptions.Add(templateChoice.Key, localizedDesc);
-                        }
-                        else
-                        {
-                            localizedChoicesAndDescriptions.Add(templateChoice.Key, templateChoice.Value);
-                        }
-                    }
-
-                    string tagDescription = localizationForTag.Description ?? templateTag.Value.Description;
-
-                    ICacheTag localizedTag;
-                    if (templateTag.Value is IAllowDefaultIfOptionWithoutValue tagWithNoValueDefault)
-                    {
-                        localizedTag = new CacheTag(tagDescription, localizedChoicesAndDescriptions, templateTag.Value.DefaultValue, tagWithNoValueDefault.DefaultIfOptionWithoutValue);
-                    }
-                    else
-                    {
-                        localizedTag = new CacheTag(tagDescription, localizedChoicesAndDescriptions, templateTag.Value.DefaultValue);
-                    }
-
-                    localizedCacheTags.Add(templateTag.Key, localizedTag);
-                }
-                else
+                if (!localizedParameterSymbols.TryGetValue(templateTag.Key, out IParameterSymbolLocalizationModel localizationForTag))
                 {
+                    // There is no localization for this symbol. Use the symbol as is.
                     localizedCacheTags.Add(templateTag.Key, templateTag.Value);
+                    continue;
                 }
+
+                // There is localization. Create a localized instance, starting with the choices.
+                var localizedChoices = new Dictionary<string, ParameterChoice>();
+
+                foreach (KeyValuePair<string, ParameterChoice> templateChoice in templateTag.Value.Choices)
+                {
+                    ParameterChoice localizedChoice = new ParameterChoice(
+                        templateChoice.Value.DisplayName,
+                        templateChoice.Value.Description);
+
+                    if (localizationForTag.Choices.TryGetValue(templateChoice.Key, out ParameterChoiceLocalizationModel locModel))
+                    {
+                        localizedChoice.Localize(locModel);
+                    }
+
+                    localizedChoices.Add(templateChoice.Key, localizedChoice);
+                }
+
+                ICacheTag localizedTag = new CacheTag(
+                    localizationForTag.DisplayName ?? templateTag.Value.DisplayName,
+                    localizationForTag.Description ?? templateTag.Value.Description,
+                    localizedChoices,
+                    templateTag.Value.DefaultValue,
+                    (templateTag.Value as IAllowDefaultIfOptionWithoutValue)?.DefaultIfOptionWithoutValue);
+
+                localizedCacheTags.Add(templateTag.Key, localizedTag);
             }
 
             return localizedCacheTags;
@@ -409,6 +407,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     {
                         DataType = templateParam.Value.DataType,
                         DefaultValue = templateParam.Value.DefaultValue,
+                        DisplayName = localizationForParam.DisplayName ?? templateParam.Value.DisplayName,
                         Description = localizationForParam.Description ?? templateParam.Value.Description
                     };
 

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
@@ -59,7 +59,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                             Name = tagInfo.Key,
                             Documentation = tagInfo.Value.Description,
                             DefaultValue = tagInfo.Value.DefaultValue,
-                            Choices = tagInfo.Value.ChoicesAndDescriptions,
+                            Choices = tagInfo.Value.Choices,
                             DataType = "choice"
                         };
 

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
@@ -26,6 +26,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             versionReaders.Add("1.0.0.1", TemplateInfoReaderVersion1_0_0_1.FromJObject);
             versionReaders.Add("1.0.0.2", TemplateInfoReaderVersion1_0_0_2.FromJObject);
             versionReaders.Add("1.0.0.3", TemplateInfoReaderVersion1_0_0_3.FromJObject);
+            versionReaders.Add("1.0.0.4", TemplateInfoReaderVersion1_0_0_4.FromJObject);
             _infoVersionReaders = versionReaders;
 
             _defaultReader = TemplateInfoReaderInitialVersion.FromJObject;

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderInitialVersion.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderInitialVersion.cs
@@ -39,14 +39,13 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
             info.Tags = tags;
             foreach (JProperty item in tagsObject.Properties())
             {
-                string tagName = item.Value.ToString();
-                var choices = new Dictionary<string, ParameterChoice>(StringComparer.OrdinalIgnoreCase);
-                choices.Add(tagName, new ParameterChoice(string.Empty, string.Empty));
+                Dictionary<string, ParameterChoice> choicesAndDescriptions = new Dictionary<string, ParameterChoice>(StringComparer.OrdinalIgnoreCase);
+                choicesAndDescriptions.Add(item.Value.ToString(), new ParameterChoice(string.Empty, string.Empty));
                 ICacheTag cacheTag = new CacheTag(
                     displayName: string.Empty,
                     description: string.Empty,
-                    choices,
-                    tagName);
+                    choicesAndDescriptions,
+                    item.Value.ToString());
 
                 tags.Add(item.Name.ToString(), cacheTag);
             }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderInitialVersion.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderInitialVersion.cs
@@ -40,12 +40,12 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
             foreach (JProperty item in tagsObject.Properties())
             {
                 string tagName = item.Value.ToString();
-                var choicesAndDescriptions = new Dictionary<string, ParameterChoice>(StringComparer.OrdinalIgnoreCase);
-                choicesAndDescriptions.Add(tagName, new ParameterChoice(string.Empty, string.Empty));
+                var choices = new Dictionary<string, ParameterChoice>(StringComparer.OrdinalIgnoreCase);
+                choices.Add(tagName, new ParameterChoice(string.Empty, string.Empty));
                 ICacheTag cacheTag = new CacheTag(
                     displayName: string.Empty,
                     description: string.Empty,
-                    choicesAndDescriptions,
+                    choices,
                     tagName);
 
                 tags.Add(item.Name.ToString(), cacheTag);

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderInitialVersion.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderInitialVersion.cs
@@ -39,12 +39,14 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
             info.Tags = tags;
             foreach (JProperty item in tagsObject.Properties())
             {
-                Dictionary<string, string> choicesAndDescriptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                choicesAndDescriptions.Add(item.Value.ToString(), string.Empty);
+                string tagName = item.Value.ToString();
+                var choicesAndDescriptions = new Dictionary<string, ParameterChoice>(StringComparer.OrdinalIgnoreCase);
+                choicesAndDescriptions.Add(tagName, new ParameterChoice(string.Empty, string.Empty));
                 ICacheTag cacheTag = new CacheTag(
-                    string.Empty,       // description
+                    displayName: string.Empty,
+                    description: string.Empty,
                     choicesAndDescriptions,
-                    item.Value.ToString());
+                    tagName);
 
                 tags.Add(item.Name.ToString(), cacheTag);
             }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_0.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_0.cs
@@ -97,20 +97,17 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
 
         protected virtual ICacheTag ReadOneTag(JProperty item)
         {
-            var choices = new Dictionary<string, ParameterChoice>(StringComparer.OrdinalIgnoreCase);
-            JObject cdToken = item.Value.Get<JObject>(nameof(ICacheTag.Choices));
+            Dictionary<string, ParameterChoice> choicesAndDescriptions = new Dictionary<string, ParameterChoice>(StringComparer.OrdinalIgnoreCase);
+            JObject cdToken = item.Value.Get<JObject>("ChoicesAndDescriptions");
             foreach (JProperty cdPair in cdToken.Properties())
             {
-                string choiceName = cdPair.Name.ToString();
-                string displayName = cdPair.Value.ToString("displayName");
-                string description = cdPair.Value.ToString("description");
-                choices.Add(choiceName, new ParameterChoice(displayName, description));
+                choicesAndDescriptions.Add(cdPair.Name.ToString(), new ParameterChoice(null, cdPair.Value.ToString()));
             }
 
             return new CacheTag(
-                item.Value.ToString(nameof(ICacheTag.DisplayName)),
-                item.Value.ToString(nameof(ICacheTag.Description)),
-                choices,
+                displayName: null,
+                description: item.Value.ToString(nameof(ICacheTag.Description)),
+                choicesAndDescriptions,
                 item.Value.ToString(nameof(ICacheTag.DefaultValue)));
         }
 
@@ -136,7 +133,6 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
             {
                 DataType = item.Value.ToString(nameof(ICacheParameter.DataType)),
                 DefaultValue = item.Value.ToString(nameof(ICacheParameter.DefaultValue)),
-                DisplayName = item.Value.ToString(nameof(ICacheParameter.DisplayName)),
                 Description = item.Value.ToString(nameof(ICacheParameter.Description))
             };
         }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_0.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_0.cs
@@ -97,16 +97,20 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
 
         protected virtual ICacheTag ReadOneTag(JProperty item)
         {
-            Dictionary<string, string> choicesAndDescriptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            JObject cdToken = item.Value.Get<JObject>(nameof(ICacheTag.ChoicesAndDescriptions));
+            var choices = new Dictionary<string, ParameterChoice>(StringComparer.OrdinalIgnoreCase);
+            JObject cdToken = item.Value.Get<JObject>(nameof(ICacheTag.Choices));
             foreach (JProperty cdPair in cdToken.Properties())
             {
-                choicesAndDescriptions.Add(cdPair.Name.ToString(), cdPair.Value.ToString());
+                string choiceName = cdPair.Name.ToString();
+                string displayName = cdPair.Value.ToString("displayName");
+                string description = cdPair.Value.ToString("description");
+                choices.Add(choiceName, new ParameterChoice(displayName, description));
             }
 
             return new CacheTag(
+                item.Value.ToString(nameof(ICacheTag.DisplayName)),
                 item.Value.ToString(nameof(ICacheTag.Description)),
-                choicesAndDescriptions,
+                choices,
                 item.Value.ToString(nameof(ICacheTag.DefaultValue)));
         }
 
@@ -132,6 +136,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
             {
                 DataType = item.Value.ToString(nameof(ICacheParameter.DataType)),
                 DefaultValue = item.Value.ToString(nameof(ICacheParameter.DefaultValue)),
+                DisplayName = item.Value.ToString(nameof(ICacheParameter.DisplayName)),
                 Description = item.Value.ToString(nameof(ICacheParameter.Description))
             };
         }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_2.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_2.cs
@@ -58,7 +58,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
             if (cacheTag is IAllowDefaultIfOptionWithoutValue tagWithNoValueDefault)
             {
                 tagWithNoValueDefault.DefaultIfOptionWithoutValue = item.Value.ToString(nameof(IAllowDefaultIfOptionWithoutValue.DefaultIfOptionWithoutValue));
-                return tagWithNoValueDefault as CacheTag;
+                return cacheTag;
             }
 
             return cacheTag;

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_4.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_4.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Utils;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
+{
+    public class TemplateInfoReaderVersion1_0_0_4 : TemplateInfoReaderVersion1_0_0_3
+    {
+        public static new TemplateInfo FromJObject(JObject jObject)
+        {
+            TemplateInfoReaderVersion1_0_0_4 reader = new TemplateInfoReaderVersion1_0_0_4();
+            return reader.Read(jObject);
+        }
+
+        public override TemplateInfo Read(JObject jObject)
+        {
+            TemplateInfo info = base.Read(jObject);
+            info.ConfigTimestampUtc = (DateTime?) jObject["ConfigTimestampUtc"];
+            return info;
+        }
+
+        protected override ICacheTag ReadOneTag(JProperty item)
+        {
+            Dictionary<string, ParameterChoice> choices = new Dictionary<string, ParameterChoice>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (JProperty choiceObject in item.Value.PropertiesOf("Choices"))
+            {
+                choices.Add(choiceObject.Name, new ParameterChoice(
+                    choiceObject.Value.ToString("DisplayName"),
+                    choiceObject.Value.ToString("Description")));
+            }
+
+            CacheTag tag = new CacheTag(
+                displayName: item.Value.ToString("DisplayName"),
+                description: item.Value.ToString("Description"),
+                choices,
+                item.Value.ToString("DefaultValue"));
+
+            tag.DefaultIfOptionWithoutValue = item.Value.ToString("DefaultIfOptionWithoutValue");
+            return tag;
+        }
+
+        protected override ICacheParameter ReadOneParameter(JProperty item)
+        {
+            return new CacheParameter
+            {
+                DataType = item.Value.ToString("DataType"),
+                DefaultValue = item.Value.ToString("DefaultValue"),
+                DisplayName = item.Value.ToString("DisplayName"),
+                Description = item.Value.ToString("Description")
+            };
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CacheParameter.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CacheParameter.cs
@@ -1,3 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
 using Microsoft.TemplateEngine.Abstractions;
 using Newtonsoft.Json;
 
@@ -5,30 +10,34 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
     public class CacheParameter : ICacheParameter, IAllowDefaultIfOptionWithoutValue
     {
-        public CacheParameter(string dataType, string defaultValue, string description)
-            :this(dataType, defaultValue, description, null)
+        public CacheParameter(string dataType, string? defaultValue, string? displayName, string? description)
+            : this(dataType, defaultValue, displayName, description, null)
         {
         }
 
-        public CacheParameter(string dataType, string defaultValue, string description, string defaultIfOptionWithoutValue)
+        public CacheParameter(string dataType, string? defaultValue, string? displayName, string? description, string? defaultIfOptionWithoutValue)
         {
             DataType = dataType;
             DefaultValue = defaultValue;
+            DisplayName = displayName;
             Description = description;
             DefaultIfOptionWithoutValue = defaultIfOptionWithoutValue;
         }
 
         [JsonProperty]
-        public string DataType { get; }
+        public string? DataType { get; }
 
         [JsonProperty]
-        public string DefaultValue { get; }
+        public string? DefaultValue { get; }
 
         [JsonProperty]
-        public string Description { get; }
+        public string? DisplayName { get; }
 
         [JsonProperty]
-        public string DefaultIfOptionWithoutValue { get; set; }
+        public string? Description { get; }
+
+        [JsonProperty]
+        public string? DefaultIfOptionWithoutValue { get; set; }
 
         public bool ShouldSerializeDefaultIfOptionWithoutValue()
         {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/ParameterSymbolLocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/ParameterSymbolLocalizationModel.cs
@@ -10,12 +10,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Localization
 {
     public class ParameterSymbolLocalizationModel : IParameterSymbolLocalizationModel
     {
-        public ParameterSymbolLocalizationModel(string name, string? displayName, string? description, IReadOnlyDictionary<string, ParameterChoiceLocalizationModel> choicesAndDescriptions)
+        public ParameterSymbolLocalizationModel(string name, string? displayName, string? description, IReadOnlyDictionary<string, ParameterChoiceLocalizationModel> choices)
         {
             Name = name;
             DisplayName = displayName;
             Description = description;
-            Choices = choicesAndDescriptions;
+            Choices = choices;
         }
 
         public string Name { get; }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/ParameterSymbolLocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/ParameterSymbolLocalizationModel.cs
@@ -1,21 +1,29 @@
-﻿using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Localization
 {
     public class ParameterSymbolLocalizationModel : IParameterSymbolLocalizationModel
     {
-        public ParameterSymbolLocalizationModel(string name, string description, IReadOnlyDictionary<string, string> choicesAndDescriptions)
+        public ParameterSymbolLocalizationModel(string name, string? displayName, string? description, IReadOnlyDictionary<string, ParameterChoiceLocalizationModel> choicesAndDescriptions)
         {
             Name = name;
+            DisplayName = displayName;
             Description = description;
-            ChoicesAndDescriptions = choicesAndDescriptions;
+            Choices = choicesAndDescriptions;
         }
 
         public string Name { get; }
 
-        public string Description { get; }
+        public string? DisplayName { get; }
 
-        public IReadOnlyDictionary<string, string> ChoicesAndDescriptions { get; }
+        public string? Description { get; }
+
+        public IReadOnlyDictionary<string, ParameterChoiceLocalizationModel> Choices { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Parameter.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Parameter.cs
@@ -44,7 +44,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         public string FileRename { get; set; }
 
         [JsonProperty]
-        public IReadOnlyDictionary<string, string> Choices { get; set; }
+        public IReadOnlyDictionary<string, ParameterChoice> Choices { get; set; }
 
         [JsonProperty]
         public IReadOnlyDictionary<string, IReadOnlyList<string>> Forms { get; set; }
@@ -79,8 +79,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 DefaultIfOptionWithoutValue = value;
             }
         }
-
-        IReadOnlyDictionary<string, string> ITemplateParameter.Choices => Choices;
 
         public override string ToString()
         {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
@@ -143,7 +143,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                             Name = tagInfo.Key,
                             Documentation = tagInfo.Value.Description,
                             DefaultValue = tagInfo.Value.DefaultValue,
-                            Choices = tagInfo.Value.ChoicesAndDescriptions,
+                            Choices = tagInfo.Value.Choices,
                             DataType = "choice"
                         };
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SymbolModel/BaseValueSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SymbolModel/BaseValueSymbol.cs
@@ -12,8 +12,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.SymbolModel
 
         public string DefaultValue { get; set; }
 
-        public string Description { get; set; }
-
         public SymbolValueFormsModel Forms { get; set; }
 
         public bool IsRequired { get; set; }
@@ -35,7 +33,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.SymbolModel
             {
                 Binding = jObject.ToString(nameof(Binding)),
                 DefaultValue = defaultOverride ?? jObject.ToString(nameof(DefaultValue)),
-                Description = localization?.Description ?? jObject.ToString(nameof(Description)) ?? string.Empty,
                 FileRename = jObject.ToString(nameof(FileRename)),
                 IsRequired = jObject.ToBool(nameof(IsRequired)),
                 Type = jObject.ToString(nameof(Type)),

--- a/src/Microsoft.TemplateEngine.Utils/CacheParameter.cs
+++ b/src/Microsoft.TemplateEngine.Utils/CacheParameter.cs
@@ -1,16 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Utils
 {
     public class CacheParameter : ICacheParameter, IAllowDefaultIfOptionWithoutValue
     {
-        public string DataType { get; set; }
+        public string? DataType { get; set; }
 
-        public string DefaultValue { get; set; }
+        public string? DefaultValue { get; set; }
 
-        public string Description { get; set; }
+        public string? DisplayName { get; set; }
 
-        public string DefaultIfOptionWithoutValue { get; set; }
+        public string? Description { get; set; }
+
+        public string? DefaultIfOptionWithoutValue { get; set; }
 
         public bool ShouldSerializeDefaultIfOptionWithoutValue()
         {

--- a/src/Microsoft.TemplateEngine.Utils/CacheTag.cs
+++ b/src/Microsoft.TemplateEngine.Utils/CacheTag.cs
@@ -1,3 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
@@ -6,26 +11,29 @@ namespace Microsoft.TemplateEngine.Utils
 {
     public class CacheTag : ICacheTag, IAllowDefaultIfOptionWithoutValue
     {
-        public CacheTag(string description, IReadOnlyDictionary<string, string> choicesAndDescriptions, string defaultValue)
-            : this(description, choicesAndDescriptions, defaultValue, null)
+        public CacheTag(string? displayName, string? description, IReadOnlyDictionary<string, ParameterChoice> choices, string? defaultValue)
+            : this(displayName, description, choices, defaultValue, null)
         {
         }
 
-        public CacheTag(string description, IReadOnlyDictionary<string, string> choicesAndDescriptions, string defaultValue, string defaultIfOptionWithoutValue)
+        public CacheTag(string? displayName, string? description, IReadOnlyDictionary<string, ParameterChoice> choices, string? defaultValue, string? defaultIfOptionWithoutValue)
         {
+            DisplayName = displayName;
             Description = description;
-            ChoicesAndDescriptions = choicesAndDescriptions.CloneIfDifferentComparer(StringComparer.OrdinalIgnoreCase);
+            Choices = choices.CloneIfDifferentComparer(StringComparer.OrdinalIgnoreCase);
             DefaultValue = defaultValue;
             DefaultIfOptionWithoutValue = defaultIfOptionWithoutValue;
         }
 
-        public string Description { get; }
+        public string? DisplayName { get; }
 
-        public IReadOnlyDictionary<string, string> ChoicesAndDescriptions { get; }
+        public string? Description { get; }
 
-        public string DefaultValue { get; }
+        public IReadOnlyDictionary<string, ParameterChoice> Choices { get; }
 
-        public string DefaultIfOptionWithoutValue { get; set; }
+        public string? DefaultValue { get; }
+
+        public string? DefaultIfOptionWithoutValue { get; set; }
 
         public bool ShouldSerializeDefaultIfOptionWithoutValue()
         {

--- a/src/Microsoft.TemplateEngine.Utils/TemplateInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Utils/TemplateInfoExtensions.cs
@@ -43,7 +43,7 @@ namespace Microsoft.TemplateEngine.Utils
             {
                 return null;
             }
-            return tag.ChoicesAndDescriptions.Keys;
+            return tag.Choices.Keys;
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Utils/TemplateParameter.cs
+++ b/src/Microsoft.TemplateEngine.Utils/TemplateParameter.cs
@@ -22,9 +22,9 @@ namespace Microsoft.TemplateEngine.Utils
 
         public string DefaultIfOptionWithoutValue { get; set; }
 
-        private IReadOnlyDictionary<string, string> _choices;
+        private IReadOnlyDictionary<string, ParameterChoice> _choices;
 
-        public IReadOnlyDictionary<string, string> Choices
+        public IReadOnlyDictionary<string, ParameterChoice> Choices
         {
             get
             {

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CacheUpgradeTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CacheUpgradeTests.cs
@@ -49,8 +49,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
       ""Tags"": {
                 ""type"": {
                     ""Description"": null,
-          ""Choices"": {
-                        ""item"": {}
+          ""ChoicesAndDescriptions"": {
+                        ""item"": """"
           },
           ""DefaultValue"": ""item""
                 }
@@ -80,30 +80,30 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
       ""Tags"": {
         ""language"": {
           ""Description"": null,
-          ""Choices"": {
-            ""C#"": {}
+          ""ChoicesAndDescriptions"": {
+            ""C#"": """"
           },
           ""DefaultValue"": ""C#""
         },
         ""type"": {
           ""Description"": null,
-          ""Choices"": {
-            ""project"": {}
+          ""ChoicesAndDescriptions"": {
+            ""project"": """"
           },
           ""DefaultValue"": ""project""
         },
         ""Framework"": {
           ""Description"": """",
-          ""Choices"": {
-            ""netcoreapp1.0"": { ""description"" : ""Target netcoreapp1.0"" },
-            ""netcoreapp1.1"": { ""description"" : ""Target netcoreapp1.1"" },
-            ""netstandard1.0"": { ""description"" : ""Target netstandard1.0"" },
-            ""netstandard1.1"": { ""description"" : ""Target netstandard1.1"" },
-            ""netstandard1.2"": { ""description"" : ""Target netstandard1.2"" },
-            ""netstandard1.3"": { ""description"" : ""Target netstandard1.3"" },
-            ""netstandard1.4"": { ""description"" : ""Target netstandard1.4"" },
-            ""netstandard1.5"": { ""description"" : ""Target netstandard1.5"" },
-            ""netstandard1.6"": { ""description"" : ""Target netstandard1.6"" }
+          ""ChoicesAndDescriptions"": {
+            ""netcoreapp1.0"": ""Target netcoreapp1.0"",
+            ""netcoreapp1.1"": ""Target netcoreapp1.1"",
+            ""netstandard1.0"": ""Target netstandard1.0"",
+            ""netstandard1.1"": ""Target netstandard1.1"",
+            ""netstandard1.2"": ""Target netstandard1.2"",
+            ""netstandard1.3"": ""Target netstandard1.3"",
+            ""netstandard1.4"": ""Target netstandard1.4"",
+            ""netstandard1.5"": ""Target netstandard1.5"",
+            ""netstandard1.6"": ""Target netstandard1.6""
           },
           ""DefaultValue"": ""netstandard1.4""
         }
@@ -133,15 +133,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
       ""Tags"": {
         ""language"": {
           ""Description"": null,
-          ""Choices"": {
-            ""F#"": {}
+          ""ChoicesAndDescriptions"": {
+            ""F#"": """"
           },
           ""DefaultValue"": ""F#""
         },
         ""type"": {
           ""Description"": null,
-          ""Choices"": {
-            ""project"": {}
+          ""ChoicesAndDescriptions"": {
+            ""project"": """"
           },
           ""DefaultValue"": ""project""
         }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CacheUpgradeTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CacheUpgradeTests.cs
@@ -49,8 +49,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
       ""Tags"": {
                 ""type"": {
                     ""Description"": null,
-          ""ChoicesAndDescriptions"": {
-                        ""item"": """"
+          ""Choices"": {
+                        ""item"": {}
           },
           ""DefaultValue"": ""item""
                 }
@@ -80,30 +80,30 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
       ""Tags"": {
         ""language"": {
           ""Description"": null,
-          ""ChoicesAndDescriptions"": {
-            ""C#"": """"
+          ""Choices"": {
+            ""C#"": {}
           },
           ""DefaultValue"": ""C#""
         },
         ""type"": {
           ""Description"": null,
-          ""ChoicesAndDescriptions"": {
-            ""project"": """"
+          ""Choices"": {
+            ""project"": {}
           },
           ""DefaultValue"": ""project""
         },
         ""Framework"": {
           ""Description"": """",
-          ""ChoicesAndDescriptions"": {
-            ""netcoreapp1.0"": ""Target netcoreapp1.0"",
-            ""netcoreapp1.1"": ""Target netcoreapp1.1"",
-            ""netstandard1.0"": ""Target netstandard1.0"",
-            ""netstandard1.1"": ""Target netstandard1.1"",
-            ""netstandard1.2"": ""Target netstandard1.2"",
-            ""netstandard1.3"": ""Target netstandard1.3"",
-            ""netstandard1.4"": ""Target netstandard1.4"",
-            ""netstandard1.5"": ""Target netstandard1.5"",
-            ""netstandard1.6"": ""Target netstandard1.6""
+          ""Choices"": {
+            ""netcoreapp1.0"": { ""description"" : ""Target netcoreapp1.0"" },
+            ""netcoreapp1.1"": { ""description"" : ""Target netcoreapp1.1"" },
+            ""netstandard1.0"": { ""description"" : ""Target netstandard1.0"" },
+            ""netstandard1.1"": { ""description"" : ""Target netstandard1.1"" },
+            ""netstandard1.2"": { ""description"" : ""Target netstandard1.2"" },
+            ""netstandard1.3"": { ""description"" : ""Target netstandard1.3"" },
+            ""netstandard1.4"": { ""description"" : ""Target netstandard1.4"" },
+            ""netstandard1.5"": { ""description"" : ""Target netstandard1.5"" },
+            ""netstandard1.6"": { ""description"" : ""Target netstandard1.6"" }
           },
           ""DefaultValue"": ""netstandard1.4""
         }
@@ -133,15 +133,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
       ""Tags"": {
         ""language"": {
           ""Description"": null,
-          ""ChoicesAndDescriptions"": {
-            ""F#"": """"
+          ""Choices"": {
+            ""F#"": {}
           },
           ""DefaultValue"": ""F#""
         },
         ""type"": {
           ""Description"": null,
-          ""ChoicesAndDescriptions"": {
-            ""project"": """"
+          ""Choices"": {
+            ""project"": {}
           },
           ""DefaultValue"": ""project""
         }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TelemetryHelperTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TelemetryHelperTests.cs
@@ -51,10 +51,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             ITemplateParameter param = new MockParameter()
             {
                 Name = "TestName",
-                Choices = new Dictionary<string, string>()
+                Choices = new Dictionary<string, ParameterChoice>()
                 {
-                    { "foo", "Foo value" },
-                    { "bar", "Bar value" }
+                    { "foo", new ParameterChoice("Foo", "Foo value") },
+                    { "bar", new ParameterChoice("Bar", "Bar value") }
                 }
             };
             IReadOnlyList<ITemplateParameter> parametersForTemplate = new List<ITemplateParameter>() { param };
@@ -74,10 +74,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             ITemplateParameter param = new MockParameter()
             {
                 Name = "TestName",
-                Choices = new Dictionary<string, string>()
+                Choices = new Dictionary<string, ParameterChoice>()
                 {
-                    { "foo", "Foo value" },
-                    { "bar", "Bar value" }
+                    { "foo", new ParameterChoice("Foo", "Foo value") },
+                    { "bar", new ParameterChoice("Bar", "Bar value") }
                 }
             };
             IReadOnlyList<ITemplateParameter> parametersForTemplate = new List<ITemplateParameter>() { param };
@@ -97,10 +97,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             ITemplateParameter param = new MockParameter()
             {
                 Name = "TestName",
-                Choices = new Dictionary<string, string>()
+                Choices = new Dictionary<string, ParameterChoice>()
                 {
-                    { "foo", "Foo value" },
-                    { "bar", "Bar value" }
+                    { "foo", new ParameterChoice("Foo", "Foo value") },
+                    { "bar", new ParameterChoice("Bar", "Bar value") }
                 }
             };
             IReadOnlyList<ITemplateParameter> parametersForTemplate = new List<ITemplateParameter>() { param };
@@ -120,11 +120,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             ITemplateParameter param = new MockParameter()
             {
                 Name = "TestName",
-                Choices = new Dictionary<string, string>()
+                Choices = new Dictionary<string, ParameterChoice>()
                 {
-                    { "foo", "Foo value" },
-                    { "bar", "Bar value" },
-                    { "foot", "Foot value" }
+                    { "foo", new ParameterChoice("Foo", "Foo value") },
+                    { "bar", new ParameterChoice("Bar", "Bar value") },
+                    { "foot", new ParameterChoice("Foot", "Foot value") }
                 }
             };
             IReadOnlyList<ITemplateParameter> parametersForTemplate = new List<ITemplateParameter>() { param };
@@ -144,10 +144,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             ITemplateParameter param = new MockParameter()
             {
                 Name = "TestName",
-                Choices = new Dictionary<string, string>()
+                Choices = new Dictionary<string, ParameterChoice>()
                 {
-                    { "foo", "Foo value" },
-                    { "bar", "Bar value" }
+                    { "foo", new ParameterChoice("Foo", "Foo value") },
+                    { "bar", new ParameterChoice("Bar", "Bar value") }
                 }
             };
             IReadOnlyList<ITemplateParameter> parametersForTemplate = new List<ITemplateParameter>() { param };
@@ -167,12 +167,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             ITemplateParameter param = new MockParameter()
             {
                 Name = "TestName",
-                Choices = new Dictionary<string, string>()
+                Choices = new Dictionary<string, ParameterChoice>()
                 {
-                    { "foot", "Foo value" },
-                    { "bar", "Bar value" },
-                    { "Football", "Foo value" },
-                    { "FOOTPOUND", "Foo value" }
+                    { "foot", new ParameterChoice("Foo", "Foo value") },
+                    { "bar", new ParameterChoice("Bar", "Bar value") },
+                    { "Football", new ParameterChoice("Football", "Foo value") },
+                    { "FOOTPOUND", new ParameterChoice("Footpound", "Foo value") }
                 }
             };
             IReadOnlyList<ITemplateParameter> parametersForTemplate = new List<ITemplateParameter>() { param };

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/HelpTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/HelpTemplateListResolverTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             Assert.True(matchResult.HasUnambiguousTemplateGroupForDefaultLanguage);
             Assert.Equal("console", matchResult.UnambiguousTemplatesForDefaultLanguage.Single().Info.ShortName);
             Assert.Equal("Console.App.L1", matchResult.UnambiguousTemplatesForDefaultLanguage.Single().Info.Identity);
-            Assert.Equal("L1", matchResult.UnambiguousTemplatesForDefaultLanguage.Single().Info.Tags["language"].ChoicesAndDescriptions.Keys.FirstOrDefault());
+            Assert.Equal("L1", matchResult.UnambiguousTemplatesForDefaultLanguage.Single().Info.Tags["language"].Choices.Keys.FirstOrDefault());
             Assert.Equal(2, matchResult.UnambiguousTemplateGroup.Count);
             Assert.Equal(1, matchResult.UnambiguousTemplatesForDefaultLanguage.Count);
         }
@@ -123,7 +123,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
             Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
             Assert.Equal("Console.App.L2", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
-            Assert.Equal("L2", matchResult.UnambiguousTemplateGroup.Single().Info.Tags["language"].ChoicesAndDescriptions.Keys.FirstOrDefault());
+            Assert.Equal("L2", matchResult.UnambiguousTemplateGroup.Single().Info.Tags["language"].Choices.Keys.FirstOrDefault());
             Assert.Equal(1, matchResult.UnambiguousTemplateGroup.Count);
         }
 

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
             Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
             Assert.Equal("Console.App.L2", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
-            Assert.Equal("L2", matchResult.UnambiguousTemplateGroup.Single().Info.Tags["language"].ChoicesAndDescriptions.Keys.FirstOrDefault());
+            Assert.Equal("L2", matchResult.UnambiguousTemplateGroup.Single().Info.Tags["language"].Choices.Keys.FirstOrDefault());
             Assert.Equal(1, matchResult.UnambiguousTemplateGroup.Count);
         }
 

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/LocalizationTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/LocalizationTests.cs
@@ -23,13 +23,8 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         [InlineData("tr-TR", "name_tr-TR:çÇğĞıIİöÖşŞüÜ")]
         public void TestLocalizedTemplateName(string locale, string expectedName)
         {
-            _ = LoadHostWithLocalizationTemplates(out SettingsLoader settingsLoader);
+            _ = LoadHostWithLocalizationTemplates(locale, out _, out TemplateInfo localizationTemplate);
 
-            IReadOnlyList<TemplateInfo> localizedTemplates = settingsLoader.UserTemplateCache.GetTemplatesForLocale(locale, null);
-
-            Assert.True(localizedTemplates.Count != 0, "Test template couldn't be loaded.");
-            TemplateInfo localizationTemplate = localizedTemplates.FirstOrDefault(t => t.Identity == "TestAssets.TemplateWithLocalization");
-            Assert.NotNull(localizationTemplate);
             Assert.Equal(expectedName, localizationTemplate.Name);
         }
 
@@ -39,14 +34,35 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         [InlineData("tr-TR", "desc_tr-TR:çÇğĞıIİöÖşŞüÜ")]
         public void TestLocalizedTemplateDescription(string locale, string expectedDescription)
         {
-            _ = LoadHostWithLocalizationTemplates(out SettingsLoader settingsLoader);
+            _ = LoadHostWithLocalizationTemplates(locale, out _, out TemplateInfo localizationTemplate);
 
-            IReadOnlyList<TemplateInfo> localizedTemplates = settingsLoader.UserTemplateCache.GetTemplatesForLocale(locale, null);
-
-            Assert.True(localizedTemplates.Count != 0, "Test template couldn't be loaded.");
-            TemplateInfo localizationTemplate = localizedTemplates.FirstOrDefault(t => t.Identity == "TestAssets.TemplateWithLocalization");
-            Assert.NotNull(localizationTemplate);
             Assert.Equal(expectedDescription, localizationTemplate.Description);
+        }
+
+        [Theory]
+        [InlineData(null, "someSymbol", "sym0_displayName")]
+        [InlineData("de-DE", "someSymbol", "sym0_displayName_de-DE:äÄßöÖüÜ")]
+        [InlineData("tr-TR", "someSymbol", "sym0_displayName_tr-TR:çÇğĞıIİöÖşŞüÜ")]
+        public void TestLocalizedSymbolDisplayName(string locale, string symbolName, string expectedDisplayName)
+        {
+            _ = LoadHostWithLocalizationTemplates(locale, out _, out TemplateInfo localizationTemplate);
+
+            KeyValuePair<string, ICacheParameter>? symbol = localizationTemplate.CacheParameters?.FirstOrDefault(p => p.Key == symbolName);
+            Assert.NotNull(symbol);
+            Assert.Equal(expectedDisplayName, symbol.Value.Value?.DisplayName);
+        }
+
+        [Theory]
+        [InlineData(null, "someChoice", "sym1_displayName")]
+        [InlineData("de-DE", "someChoice", "sym1_displayName")]
+        [InlineData("tr-TR", "someChoice", "sym1_displayName")]
+        public void TestLocalizedSymbolChoiceDisplayName(string locale, string symbolName, string expectedDisplayName)
+        {
+            _ = LoadHostWithLocalizationTemplates(locale, out _, out TemplateInfo localizationTemplate);
+
+            KeyValuePair<string, ICacheTag>? symbol = localizationTemplate.Tags?.FirstOrDefault(p => p.Key == symbolName);
+            Assert.NotNull(symbol);
+            Assert.Equal(expectedDisplayName, symbol.Value.Value?.DisplayName);
         }
 
         [Theory]
@@ -55,14 +71,8 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         [InlineData("tr-TR", "sym0_desc_tr-TR:çÇğĞıIİöÖşŞüÜ")]
         public void TestLocalizedSymbolDescription(string locale, string expectedDescription)
         {
-            _ = LoadHostWithLocalizationTemplates(out SettingsLoader settingsLoader);
+            _ = LoadHostWithLocalizationTemplates(locale, out _, out TemplateInfo localizationTemplate);
 
-            IReadOnlyList<TemplateInfo> localizedTemplates = settingsLoader.UserTemplateCache.GetTemplatesForLocale(locale,
-                SettingsStore.CurrentVersion);
-
-            Assert.True(localizedTemplates.Count != 0, "Test template couldn't be loaded.");
-            TemplateInfo localizationTemplate = localizedTemplates.FirstOrDefault(t => t.Identity == "TestAssets.TemplateWithLocalization");
-            Assert.NotNull(localizationTemplate);
             KeyValuePair<string, ICacheParameter>? symbol = localizationTemplate.CacheParameters?.FirstOrDefault(p => p.Key == "someSymbol");
             Assert.NotNull(symbol);
             Assert.Equal(expectedDescription, symbol.Value.Value?.Description);
@@ -79,14 +89,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             string choice1Desc,
             string choice2Desc)
         {
-            _ = LoadHostWithLocalizationTemplates(out SettingsLoader settingsLoader);
-
-            IReadOnlyList<TemplateInfo> localizedTemplates = settingsLoader.UserTemplateCache.GetTemplatesForLocale(locale,
-                SettingsStore.CurrentVersion);
-
-            Assert.True(localizedTemplates.Count != 0, "Test template couldn't be loaded.");
-            TemplateInfo localizationTemplate = localizedTemplates.FirstOrDefault(t => t.Identity == "TestAssets.TemplateWithLocalization");
-            Assert.NotNull(localizationTemplate);
+            _ = LoadHostWithLocalizationTemplates(locale, out _, out TemplateInfo localizationTemplate);
 
             KeyValuePair<string, ICacheTag>? tag = localizationTemplate.Tags?.FirstOrDefault(p => p.Key == "someChoice");
             Assert.NotNull(tag);
@@ -94,14 +97,14 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             Assert.NotNull(tag.Value.Value);
             Assert.Equal(symbolDesc, tag.Value.Value.Description);
 
-            var choices = tag.Value.Value.ChoicesAndDescriptions;
+            var choices = tag.Value.Value.Choices;
             Assert.NotNull(choices);
-            Assert.True(choices.TryGetValue("choice0", out string choice0Description), "Template symbol should contain a choice with name 'choice0'.");
-            Assert.Equal(choice0Desc, choice0Description);
-            Assert.True(choices.TryGetValue("choice1", out string choice1Description), "Template symbol should contain a choice with name 'choice1'.");
-            Assert.Equal(choice1Desc, choice1Description);
-            Assert.True(choices.TryGetValue("choice2", out string choice2Description), "Template symbol should contain a choice with name 'choice2'.");
-            Assert.Equal(choice2Desc, choice2Description);
+            Assert.True(choices.TryGetValue("choice0", out ParameterChoice choice0), "Template symbol should contain a choice with name 'choice0'.");
+            Assert.Equal(choice0Desc, choice0.Description);
+            Assert.True(choices.TryGetValue("choice1", out ParameterChoice choice1), "Template symbol should contain a choice with name 'choice1'.");
+            Assert.Equal(choice1Desc, choice1.Description);
+            Assert.True(choices.TryGetValue("choice2", out ParameterChoice choice2), "Template symbol should contain a choice with name 'choice2'.");
+            Assert.Equal(choice2Desc, choice2.Description);
         }
 
         [Theory]
@@ -117,14 +120,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             string expectedDescription,
             string expectedManualInstructions)
         {
-            _ = LoadHostWithLocalizationTemplates(out SettingsLoader settingsLoader);
-
-            IReadOnlyList<TemplateInfo> localizedTemplates = settingsLoader.UserTemplateCache.GetTemplatesForLocale(locale,
-                SettingsStore.CurrentVersion);
-
-            Assert.True(localizedTemplates.Count != 0, "Test template couldn't be loaded.");
-            TemplateInfo localizationTemplate = localizedTemplates.FirstOrDefault(t => t.Identity == "TestAssets.TemplateWithLocalization");
-            Assert.NotNull(localizationTemplate);
+            _ = LoadHostWithLocalizationTemplates(locale, out SettingsLoader settingsLoader, out TemplateInfo localizationTemplate);
 
             ITemplate template = settingsLoader.LoadTemplate(localizationTemplate, null);
             Assert.NotNull(template);
@@ -146,7 +142,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             Assert.Equal(expectedManualInstructions, effects.CreationResult.PostActions[postActionIndex].ManualInstructions);
         }
 
-        private ITemplateEngineHost LoadHostWithLocalizationTemplates(out SettingsLoader settingsLoaderOut)
+        private ITemplateEngineHost LoadHostWithLocalizationTemplates(string locale, out SettingsLoader settingsLoaderOut, out TemplateInfo localizationTemplate)
         {
             var thisDir = Path.GetDirectoryName(typeof(LocalizationTests).Assembly.Location);
             var testTemplatesFolder = Path.Combine(thisDir, "..", "..", "..", "..", "..",
@@ -165,13 +161,24 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             SettingsLoader settingsLoader = null;
             var envSettings = new EngineEnvironmentSettings(host, x => settingsLoader = new SettingsLoader(x));
 
-            host.VirtualizeDirectory(Path.Combine(Environment.ExpandEnvironmentVariables("%USERPROFILE%"),
-                ".templateengine", "TestRunner"));
+            host.VirtualizeDirectory(Path.Combine(
+                Environment.ExpandEnvironmentVariables("%USERPROFILE%"),
+                ".templateengine",
+                "TestRunner"));
             settingsLoader.Components.Register(typeof(RunnableProjectGenerator));
 
             settingsLoader.UserTemplateCache.Scan(testTemplatesFolder);
             settingsLoader.Save();
             settingsLoaderOut = settingsLoader;
+
+            IReadOnlyList<TemplateInfo> localizedTemplates = settingsLoader.UserTemplateCache.GetTemplatesForLocale(
+                locale,
+                SettingsStore.CurrentVersion);
+
+            Assert.True(localizedTemplates.Count != 0, "Test template couldn't be loaded.");
+            localizationTemplate = localizedTemplates.FirstOrDefault(t => t.Identity == "TestAssets.TemplateWithLocalization");
+            Assert.NotNull(localizationTemplate);
+
             return host;
         }
     }

--- a/test/Microsoft.TemplateEngine.Mocks/MockParameter.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockParameter.cs
@@ -21,6 +21,6 @@ namespace Microsoft.TemplateEngine.Mocks
 
         public string DataType { get; set; }
 
-        public IReadOnlyDictionary<string, string> Choices { get; set; }
+        public IReadOnlyDictionary<string, ParameterChoice> Choices { get; set; }
     }
 }

--- a/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
@@ -208,12 +208,12 @@ namespace Microsoft.TemplateEngine.Mocks
 
         private static ICacheTag CreateTestCacheTag(IReadOnlyList<string> choiceList, string tagDescription = null, string defaultValue = null, string defaultIfOptionWithoutValue = null)
         {
-            Dictionary<string, string> choicesDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, ParameterChoice> choicesDict = new Dictionary<string, ParameterChoice>(StringComparer.OrdinalIgnoreCase);
             foreach (string choice in choiceList)
             {
-                choicesDict.Add(choice, null);
+                choicesDict.Add(choice, new ParameterChoice(string.Empty, string.Empty));
             };
-            return new CacheTag(tagDescription, choicesDict, defaultValue, defaultIfOptionWithoutValue);
+            return new CacheTag(string.Empty, tagDescription, choicesDict, defaultValue, defaultIfOptionWithoutValue);
         }
 
         private void PopulateParametersFromTags (List<ITemplateParameter> parameters)
@@ -225,7 +225,7 @@ namespace Microsoft.TemplateEngine.Mocks
                     Name = tagInfo.Key,
                     Documentation = tagInfo.Value.Description,
                     DefaultValue = tagInfo.Value.DefaultValue,
-                    Choices = tagInfo.Value.ChoicesAndDescriptions,
+                    Choices = tagInfo.Value.Choices,
                     DataType = "choice"
                 };
 

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/de-DE.template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/de-DE.template.json
@@ -4,6 +4,7 @@
     "description": "desc_de-DE:äÄßöÖüÜ",
     "symbols": {
         "someSymbol": {
+            "displayName": "sym0_displayName_de-DE:äÄßöÖüÜ",
             "description": "sym0_desc_de-DE:äÄßöÖüÜ"
         },
         "someChoice": {

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/template.json
@@ -15,6 +15,7 @@
     "description": "desc",
     "symbols": {
         "someSymbol": {
+            "displayName": "sym0_displayName",
             "description": "sym0_desc",
             "type": "parameter",
             "datatype": "string",
@@ -24,6 +25,7 @@
         },
         "someChoice": {
             "type": "parameter",
+            "displayName": "sym1_displayName",
             "description": "sym1_desc",
             "datatype": "choice",
             "choices": [

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/tr-TR.template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/tr-TR.template.json
@@ -4,6 +4,7 @@
     "description": "desc_tr-TR:çÇğĞıIİöÖşŞüÜ",
     "symbols": {
         "someSymbol": {
+            "displayName": "sym0_displayName_tr-TR:çÇğĞıIİöÖşŞüÜ",
             "description": "sym0_desc_tr-TR:çÇğĞıIİöÖşŞüÜ"
         },
         "someChoice": {


### PR DESCRIPTION
### Problem
<!-- Add the issue number if exists. Describe the problem otherwise. -->
Fixes https://github.com/dotnet/templating/issues/2822

### Solution
<!-- Describe the solution. -->
Added `DisplayName` property to `ParameterSymbol`, `ICacheParameter` and `ICacheTag`.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)