### PR TITLE
Remove IManagedTemplatesSource.Installer and add IManagedTemplatesSource.ManagedProvider

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/TemplatesSources/IManagedTemplatesSource.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/TemplatesSources/IManagedTemplatesSource.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using Microsoft.TemplateEngine.Abstractions.Installer;
 
 namespace Microsoft.TemplateEngine.Abstractions.TemplatesSources
 {
@@ -27,10 +26,10 @@ namespace Microsoft.TemplateEngine.Abstractions.TemplatesSources
 
         /// <summary>
         /// Installer that created this source.
-        /// This serves as helper for grouping sources by installer
-        /// so caller doesn't need to keep track of installer->source relation.
+        /// This serves as helper for grouping sources by <see cref="IManagedTemplatesSourcesProvider"/>
+        /// so caller doesn't need to keep track of "managed provider"->"source" relation.
         /// </summary>
-        IInstaller Installer { get; }
+        IManagedTemplatesSourcesProvider ManagedProvider { get; }
 
         /// <summary>
         /// Version of templates source.

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateEngine.Cli
                 return;
             }
 
-            IReadOnlyList<CheckUpdateResult> versionChecks = await managedTemplateSource.Installer.Provider.GetLatestVersions(new[] { managedTemplateSource }).ConfigureAwait(false);
+            IReadOnlyList<CheckUpdateResult> versionChecks = await managedTemplateSource.ManagedProvider.GetLatestVersions(new[] { managedTemplateSource }).ConfigureAwait(false);
             if (versionChecks.Count == 1)
             {
                 var updateResult = versionChecks[0];

--- a/src/Microsoft.TemplateEngine.Edge/Installers/Folder/FolderInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/Folder/FolderInstaller.cs
@@ -36,7 +36,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.Folder
 
         public IManagedTemplatesSource Deserialize(IManagedTemplatesSourcesProvider provider, TemplatesSourceData data)
         {
-            return new FolderManagedTemplatesSource(_settings, this, data.MountPointUri);
+            return new FolderManagedTemplatesSource(_settings, provider, data.MountPointUri);
         }
 
         public Task<IReadOnlyList<CheckUpdateResult>> GetLatestVersionAsync(IEnumerable<IManagedTemplatesSource> sources)
@@ -47,7 +47,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.Folder
         public Task<InstallResult> InstallAsync(InstallRequest installRequest)
         {
             if (Directory.Exists(installRequest.Identifier))
-                return Task.FromResult(InstallResult.CreateSuccess(installRequest, new FolderManagedTemplatesSource(_settings, this, installRequest.Identifier)));
+                return Task.FromResult(InstallResult.CreateSuccess(installRequest, new FolderManagedTemplatesSource(_settings, Provider, installRequest.Identifier)));
             else
                 return Task.FromResult(InstallResult.CreateFailure(installRequest, InstallerErrorCode.GenericError, null));
         }

--- a/src/Microsoft.TemplateEngine.Edge/Installers/Folder/FolderManagedTemplatesSource.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/Folder/FolderManagedTemplatesSource.cs
@@ -13,19 +13,19 @@ namespace Microsoft.TemplateEngine.Edge.Installers.Folder
 {
     internal class FolderManagedTemplatesSource : IManagedTemplatesSource
     {
-        public FolderManagedTemplatesSource(IEngineEnvironmentSettings settings, IInstaller installer, string mountPointUri)
+        public FolderManagedTemplatesSource(IEngineEnvironmentSettings settings, IManagedTemplatesSourcesProvider managedProvider, string mountPointUri)
         {
             MountPointUri = mountPointUri;
-            Installer = installer;
+            ManagedProvider = managedProvider;
             LastChangeTime = (settings.Host.FileSystem as IFileLastWriteTimeSource)?.GetLastWriteTimeUtc(mountPointUri) ?? File.GetLastWriteTime(mountPointUri);
         }
 
         public string DisplayName => Identifier;
         public string Identifier => MountPointUri;
-        public IInstaller Installer { get; }
+        public ITemplatesSourcesProvider Provider => ManagedProvider;
+        public IManagedTemplatesSourcesProvider ManagedProvider { get; }
         public DateTime LastChangeTime { get; }
         public string MountPointUri { get; }
-        public ITemplatesSourcesProvider Provider => Installer.Provider;
         public string Version => null;
         public IReadOnlyDictionary<string, string> GetDisplayDetails() => new Dictionary<string, string>();
     }

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstaller.cs
@@ -76,7 +76,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 
         public IManagedTemplatesSource Deserialize(IManagedTemplatesSourcesProvider provider, TemplatesSourceData data)
         {
-            return new NuGetManagedTemplatesSource(_environmentSettings, this, data.MountPointUri, data.Details);
+            return new NuGetManagedTemplatesSource(_environmentSettings, provider, data.MountPointUri, data.Details);
         }
 
         public async Task<IReadOnlyList<CheckUpdateResult>> GetLatestVersionAsync(IEnumerable<IManagedTemplatesSource> sources)
@@ -139,7 +139,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                 sourceDetails[NuGetManagedTemplatesSource.NuGetSourceKey] = nuGetPackageInfo.NuGetSource;
                 sourceDetails[NuGetManagedTemplatesSource.PackageIdKey] = nuGetPackageInfo.PackageIdentifier;
                 sourceDetails[NuGetManagedTemplatesSource.PackageVersionKey] = nuGetPackageInfo.PackageVersion.ToString();
-                NuGetManagedTemplatesSource source = new NuGetManagedTemplatesSource(_environmentSettings, this, nuGetPackageInfo.FullPath, sourceDetails);
+                NuGetManagedTemplatesSource source = new NuGetManagedTemplatesSource(_environmentSettings, Provider, nuGetPackageInfo.FullPath, sourceDetails);
                 return InstallResult.CreateSuccess(installRequest, source);
             }
             catch (DownloadException e)

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetManagedTemplatesSource.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetManagedTemplatesSource.cs
@@ -20,9 +20,9 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 
         private IEngineEnvironmentSettings _settings;
 
-        public NuGetManagedTemplatesSource(IEngineEnvironmentSettings settings, IInstaller installer, string mountPoint, IReadOnlyDictionary<string, string> details)
+        public NuGetManagedTemplatesSource(IEngineEnvironmentSettings settings, IManagedTemplatesSourcesProvider managedProvider, string mountPoint, IReadOnlyDictionary<string, string> details)
         {
-            Installer = installer;
+            ManagedProvider = managedProvider;
             MountPointUri = mountPoint;
             Details = details;
             _settings = settings;
@@ -31,12 +31,12 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
         public string Author => Details.TryGetValue(AuthorKey, out string author) ? author : null;
         public string DisplayName => string.IsNullOrWhiteSpace(Version) ? Identifier : $"{Identifier}::{Version}";
         public string Identifier => Details.TryGetValue(PackageIdKey, out string identifier) ? identifier : null;
-        public IInstaller Installer { get; }
         public DateTime LastChangeTime => (_settings.Host.FileSystem as IFileLastWriteTimeSource)?.GetLastWriteTimeUtc(MountPointUri) ?? default;
         public bool LocalPackage => Details.TryGetValue(LocalPackageKey, out string isLocalPackage) && bool.TryParse(isLocalPackage, out bool result) ? result : false;
         public string MountPointUri { get; }
         public string NuGetSource => Details.TryGetValue(NuGetSourceKey, out string nugetSource) ? nugetSource : null;
-        public ITemplatesSourcesProvider Provider => Installer.Provider;
+        public ITemplatesSourcesProvider Provider => ManagedProvider;
+        public IManagedTemplatesSourcesProvider ManagedProvider { get; }
         public string Version => Details.TryGetValue(PackageVersionKey, out string version) ? version : null;
         internal IReadOnlyDictionary<string, string> Details { get; }
 

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplatesSourcesManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplatesSourcesManager.cs
@@ -57,7 +57,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             EnsureLoaded();
             var sources = await GetManagedTemplatesSources(force).ConfigureAwait(false);
             var list = new List<(IManagedTemplatesSourcesProvider Provider, IReadOnlyList<IManagedTemplatesSource> ManagedSources)>();
-            foreach (var source in sources.GroupBy(s => s.Installer.Provider))
+            foreach (var source in sources.GroupBy(s => s.ManagedProvider))
             {
                 list.Add((source.Key, source.ToList()));
             }

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/OrchestratorTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/OrchestratorTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             var environmentSettings = new EngineEnvironmentSettings(host, x => null);
             MockMountPoint mnt = new MockMountPoint(environmentSettings);
             mnt.MockRoot.AddDirectory("subdir").AddFile("test.file", new byte[0]);
-            Orchestrator orchestrator = new Orchestrator();
+            Util.Orchestrator orchestrator = new Util.Orchestrator();
             orchestrator.Run(new MockGlobalRunSpec(), mnt.Root, @"c:\temp");
         }
     }


### PR DESCRIPTION
### Problem
Problem with having IInstaller exposed can lead to misusage by enduser of API, since all install/update/uninstall calls must go via Provider since provider needs to update its own data.

### Solution
Replace it with ManagedProvider and keep track of installer that created source inside Provider.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)