### PR TITLE
Add Avalonia UI to the list of templates

### DIFF
--- a/docs/Available-templates-for-dotnet-new.md
+++ b/docs/Available-templates-for-dotnet-new.md
@@ -8,6 +8,7 @@ Here is a list (alpha sorted) of templates which are available for use with `dot
 | [.NET Boxed](https://github.com/Dotnet-Boxed/Templates) | `dotnet new -i "Boxed.Templates::*"`|
 | [Auth0 Templates](https://github.com/auth0-community/auth0-dotnet-templates) | `dotnet new -i "Auth0.Templates::*"` |
 | [AWS Lambda .NET Core Templates](https://github.com/aws/aws-lambda-dotnet/tree/master/Blueprints) | `dotnet new -i "Amazon.Lambda.Templates::*"`|
+| [Avalonia UI Templates](https://github.com/AvaloniaUI/Avalonia) - Avalonia is a framework for creating cross platform UI | `dotnet new -i "Avalonia.Templates::*"`|
 | [Blazor](http://blazor.net) - Full stack web development with C# and WebAssembly | `dotnet new -i "Microsoft.AspNetCore.Blazor.Templates::3.0.0-*"`|
 | [Cake.Frosting](https://github.com/cake-build/cake) | `dotnet new -i "Cake.Frosting.Template::*"` |
 | [Carter](https://github.com/CarterCommunity/Carter) - Carter is a library that allows Nancy-esque routing for use with ASP.Net Core. | `dotnet new -i "CarterTemplate::*"`|


### PR DESCRIPTION
Simply add Avalonia UI (dotnet foundation member) to the list of templates for dotnet new.