### PR TITLE
Source build shouldn't use analyzers

### DIFF
--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <CodeAnalysisRuleset>$(MSBuildThisFileDirectory)CodeAnalysis.ruleset</CodeAnalysisRuleset>
+    <EnableAnalyzers>true</EnableAnalyzers>
     <!-- Disable analyzers in sourcebuild -->
     <EnableAnalyzers Condition="'$(DotNetBuildFromSource)' == 'true'">false</EnableAnalyzers>
   </PropertyGroup>

--- a/src/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
+++ b/src/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
@@ -4,6 +4,5 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>Contracts for extending Template Engine</Description>
         <IsPackable>true</IsPackable>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 </Project>

--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -4,7 +4,6 @@
         <Description>Template creation for the dotnet CLI</Description>
         <IsPackable>true</IsPackable>
         <IsShippingPackage>false</IsShippingPackage>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Core.Contracts/Microsoft.TemplateEngine.Core.Contracts.csproj
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/Microsoft.TemplateEngine.Core.Contracts.csproj
@@ -4,7 +4,6 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>Contracts for extending Microsoft.TemplateEngine.Core</Description>
         <IsPackable>true</IsPackable>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
+++ b/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
@@ -4,7 +4,6 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>Common operations for instantiating templates using forward-only input stream operations</Description>
         <IsPackable>true</IsPackable>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
+++ b/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
@@ -4,7 +4,6 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>Helper package for adding Template Engine to consuming applications</Description>
         <IsPackable>true</IsPackable>
-        <EnableAnalyzers>true</EnableAnalyzers>
         <DefineConstants Condition="'$(TargetFramework)' == '$(NETFullTargetFramework)'">$(DefineConstants);NETFULL</DefineConstants>
     </PropertyGroup>
 

--- a/src/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj
+++ b/src/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj
@@ -4,7 +4,6 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>Helper package for adding Template Engine to IDEs</Description>
         <IsPackable>true</IsPackable>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj
@@ -4,7 +4,6 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>An extension for Template Engine that allows projects that still run to be used as templates</Description>
         <IsPackable>true</IsPackable>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
+++ b/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
@@ -4,7 +4,6 @@
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <Description>Components used by all Template Engine extensions and consumers</Description>
         <IsPackable>true</IsPackable>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Microsoft.TemplateSearch.Common/Microsoft.TemplateSearch.Common.csproj
+++ b/src/Microsoft.TemplateSearch.Common/Microsoft.TemplateSearch.Common.csproj
@@ -3,7 +3,6 @@
     <TargetFramework>$(NETStandardTargetFramework)</TargetFramework>
     <Description>Components used by the template discovery tool, and also used for related functionality in the CLI.</Description>
     <IsPackable>true</IsPackable>
-    <EnableAnalyzers>true</EnableAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.TemplateSearch.ScraperOutputComparison/Microsoft.TemplateSearch.ScraperOutputComparison.csproj
+++ b/src/Microsoft.TemplateSearch.ScraperOutputComparison/Microsoft.TemplateSearch.ScraperOutputComparison.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
-    <EnableAnalyzers>true</EnableAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <SignAssembly>false</SignAssembly>
     <DelaySign>false</DelaySign>
-    <EnableAnalyzers>true</EnableAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet-new3/dotnet-new3.csproj
+++ b/src/dotnet-new3/dotnet-new3.csproj
@@ -3,7 +3,6 @@
         <Description>Template Instantiation Commands for .NET Core CLI.</Description>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <OutputType>Exe</OutputType>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Cli.IntegrationTests/Microsoft.TemplateEngine.Cli.IntegrationTests.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.IntegrationTests/Microsoft.TemplateEngine.Cli.IntegrationTests.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/Microsoft.TemplateEngine.Core.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/Microsoft.TemplateEngine.Core.UnitTests.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/Microsoft.TemplateEngine.Edge.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/Microsoft.TemplateEngine.Edge.UnitTests.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/Microsoft.TemplateEngine.EndToEndTestHarness.csproj
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/Microsoft.TemplateEngine.EndToEndTestHarness.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Microsoft.TemplateEngine.IDE.IntegrationTests.csproj
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Microsoft.TemplateEngine.IDE.IntegrationTests.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
+++ b/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
@@ -5,7 +5,6 @@
         <IsPackable>true</IsPackable>
 		<IsShipping>false</IsShipping>
         <IsTestProject>false</IsTestProject>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />

--- a/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
@@ -3,7 +3,6 @@
         <TargetFrameworks Condition="'$(PackSpecific)' != 'true'">$(NETStandardTargetFramework);$(NETFullTargetFramework)</TargetFrameworks>
         <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
         <IsTestProject>false</IsTestProject>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Microsoft.TemplateEngine.TestTemplates/Microsoft.TemplateEngine.TestTemplates.csproj
+++ b/test/Microsoft.TemplateEngine.TestTemplates/Microsoft.TemplateEngine.TestTemplates.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
-        <EnableAnalyzers>true</EnableAnalyzers>
         <PackageType>Template</PackageType>
         <PackageId>Microsoft.TemplateEngine.TestTemplates</PackageId>
         <Authors>Microsoft</Authors>

--- a/test/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/dotnet-new3.UnitTests/dotnet-new3.UnitTests.csproj
+++ b/test/dotnet-new3.UnitTests/dotnet-new3.UnitTests.csproj
@@ -2,7 +2,6 @@
     <PropertyGroup>
         <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
         <TestProject>true</TestProject>
-        <EnableAnalyzers>true</EnableAnalyzers>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />


### PR DESCRIPTION
### Problem
Fixes #2900 

### Solution
Projects no longer override the value of MSBuild property EnableAnalyzers themselves and it is set to true by default.

### Checks:
- [ ] Added unit tests. **Not applicable**
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) **Not applicable**