### PR TITLE
Updated links and branch names from `master` to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/templating/templating-ci?branchName=master)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=302&branchName=master) [![Join the chat at https://gitter.im/dotnet/templating](https://badges.gitter.im/dotnet/templating.svg)](https://gitter.im/dotnet/templating?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/templating/templating-ci?branchName=main)](https://dev.azure.com/dnceng/public/_build/latest?definitionId=302&branchName=main) [![Join the chat at https://gitter.im/dotnet/templating](https://badges.gitter.im/dotnet/templating.svg)](https://gitter.im/dotnet/templating?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 # Overview
 
@@ -8,9 +8,9 @@ Template Engine is a library for manipulating streams, including operations to r
 regions and process `if`, `else if`, `else` and `end if` style statements.
 
 # Content Repositories
-* [Class Library/Console App](https://github.com/dotnet/templating/tree/master/template_feed)
+* [Class Library/Console App](https://github.com/dotnet/templating/tree/main/template_feed)
 * [Test projects](https://github.com/dotnet/test-templates/tree/master/template_feed)
-* [ASP.NET project and items](https://github.com/aspnet/AspNetCore/tree/master/src/ProjectTemplates)
+* [ASP.NET project and items](https://github.com/aspnet/AspNetCore/tree/main/src/ProjectTemplates)
 
 # Template Samples
 

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -11,7 +11,7 @@ The attached notices are provided for information only.
 License notice for NuGet.Client
 -------------------------------
 
-In reference to: https://github.com/dotnet/templating/blob/master/build/nuget.exe
+In reference to: https://github.com/dotnet/templating/blob/main/build/nuget.exe
 
 https://github.com/NuGet/NuGet.Client/blob/dev/LICENSE.txt
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ trigger:
   branches:
     include:
     - stabilize
-    - master
+    - main
     - release/3*
     - release/5*
     - internal/release/3*
@@ -13,7 +13,7 @@ pr:
   branches:
     include:
     - stabilize
-    - master
+    - main
     - release/3*
     - release/5*
     - feature/*

--- a/docs/Available-Symbols-Generators.md
+++ b/docs/Available-Symbols-Generators.md
@@ -99,7 +99,7 @@ In this sample three symbols are defined:
 
 ### Related
 
-[`Implementation class`](https://github.com/dotnet/templating/blob/master/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CaseChangeMacro.cs)
+[`Implementation class`](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CaseChangeMacro.cs)
 [`Sample`](https://github.com/dotnet/dotnet-template-samples/tree/master/11-change-string-casing)
 
 
@@ -146,7 +146,7 @@ In this sample three symbols are defined:
 ```
 
 ### Related
-[`Implementation class`](https://github.com/dotnet/templating/blob/master/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CoalesceMacro.cs)
+[`Implementation class`](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CoalesceMacro.cs)
 
 ## Constant
 
@@ -178,7 +178,7 @@ Uses constant value.
 
 ### Related
 
-[`Implementation class`](https://github.com/dotnet/templating/blob/master/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ConstantMacro.cs)
+[`Implementation class`](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ConstantMacro.cs)
 [`Sample`](https://github.com/dotnet/dotnet-template-samples/tree/master/13-constant-value)
 
 
@@ -206,7 +206,7 @@ In this sample `IndividualAuth` is `true` if the value of `auth`, another symbol
     },
 ```
 ### Related
-[`Implementation class`](https://github.com/dotnet/templating/blob/master/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/EvaluateMacro.cs)
+[`Implementation class`](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/EvaluateMacro.cs)
 
 
 ## Port
@@ -233,7 +233,7 @@ In this sample `KestrelPortGenerated` is a symbol that return the number of an a
 ```
 
 ### Related
-[`Implementation class`](https://github.com/dotnet/templating/blob/master/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GeneratePortNumberMacro.cs)
+[`Implementation class`](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GeneratePortNumberMacro.cs)
 
 
 ## Guid
@@ -294,7 +294,7 @@ This sample creates different symbols showing the different formatting available
 ```
 
 ### Related 
-[`Implementation class`](https://github.com/dotnet/templating/blob/master/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GuidMacro.cs)
+[`Implementation class`](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GuidMacro.cs)
 [`Guid Format Documentation`](https://msdn.microsoft.com/en-us/library/97af8hh4(v=vs.110).aspx)    
 [`Sample`](https://github.com/dotnet/dotnet-template-samples/tree/master/14-guid)
 
@@ -326,7 +326,7 @@ In this sample a symbol is created showing the current data, and replacing any i
 ```
 
 ### Related
-[`Implementation class`](https://github.com/dotnet/templating/blob/master/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/NowMacro.cs)   
+[`Implementation class`](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/NowMacro.cs)   
 [`DateTime.ToString documentation`](https://msdn.microsoft.com/en-us/library/zdtaw1bw(v=vs.110).aspx)     
 [`Sample`](https://github.com/dotnet/dotnet-template-samples/tree/master/10-symbol-from-date)   
 
@@ -358,7 +358,7 @@ This sample shows a symbol that generates a value from `0` to `10000` excluded, 
 ```
 
 ### Related 
-[`Implementation class`](https://github.com/dotnet/templating/blob/master/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RandomMacro.cs)    
+[`Implementation class`](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RandomMacro.cs)    
 [`Sample`](https://github.com/dotnet/dotnet-template-samples/tree/master/12-random-number)
 
 
@@ -405,7 +405,7 @@ Replacement steps
 ```
 
 ### Related
-[`Implementation class`](https://github.com/dotnet/templating/blob/master/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMacro.cs)
+[`Implementation class`](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMacro.cs)
 [`RegEx.Replace Documentation`](https://msdn.microsoft.com/en-us/library/xwewhkd1(v=vs.110).aspx)     
 
 ## RegexMatch
@@ -435,7 +435,7 @@ Tries to match regex pattern against value of source symbol and returns `True` i
 ```
 
 ### Related
-[`Implementation class`](https://github.com/dotnet/templating/blob/master/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMatchMacro.cs)
+[`Implementation class`](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMatchMacro.cs)
 [`Regex.IsMatch Documentation`](https://docs.microsoft.com/en-us/dotnet/api/system.text.regularexpressions.regex.ismatch)     
 
 ## Switch
@@ -489,7 +489,7 @@ This sample shows how to change the replacement value based on evaluating condit
 In this case, if the user enters the value `123` as the value of the parameter `test`, `abc` in the content will be replaced with `456`, if the user enters `789`, `abc` is replaced with `012` instead.
 
 ### Related
-[`Implementation class`](https://github.com/dotnet/templating/blob/master/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/SwitchMacro.cs)
+[`Implementation class`](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/SwitchMacro.cs)
 
 ## Join
 
@@ -555,4 +555,4 @@ This sample shows how to change the replacement value based on evaluating condit
 This sample will rename folder called `Api` into `Source/Api/Microsoft/Visual Studio`. Notice that File API will automatically change `/` into `\` on Windows.
 
 ### Related
-[`Implementation class`](https://github.com/dotnet/templating/blob/master/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/JoinMacro.cs)
+[`Implementation class`](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/JoinMacro.cs)

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -19,15 +19,15 @@ The steps required are outlined below.
 
 - Fork this repository.
 - Clone the forked repository to your local machine.
-- Checkout *master* and branch off to your feature branch (see: [branching](#branching))
-- Rebase against *master* before submitting your PR.
+- Checkout *main* and branch off to your feature branch (see: [branching](#branching))
+- Rebase against *main* before submitting your PR.
 
 # Build & Run
 
 - Open up a command prompt and navigate to the root of your local repo.
 - Run the build script appropriate for your environment.
-     - **Windows:** [build.cmd](https://github.com/dotnet/templating/blob/master/build.cmd)
-     - **Mac/Linux**: [build.sh](https://github.com/dotnet/templating/blob/master/build.sh) 
+     - **Windows:** [build.cmd](https://github.com/dotnet/templating/blob/main/build.cmd)
+     - **Mac/Linux**: [build.sh](https://github.com/dotnet/templating/blob/main/build.sh) 
 - The changes you build will not change how `dotnet new` behaves. Instead, they will be available through `dotnet new3`. To run `dotnet new3`, run 
   ```
   dotnet <your repo location>\artifacts\bin\dotnet-new3\<configuration>\<target framework>\dotnet-new3.dll
@@ -116,13 +116,13 @@ Some of the analyzer rules are currently being treated as "info/suggestion"s ins
 
 # Branching #
 
-We do development in *master* branch. After a release branch is created, any new changes that should be included in that release are cherry-picked from *master*.
+We do development in *main* branch. After a release branch is created, any new changes that should be included in that release are cherry-picked from *main*.
 
 We follow the same versioning as https://github.com/dotnet/sdk and release branches are named after the version numbers. For instance, `release/5.0.2xx` branch ships with .NET SDK 5.0.2xx.
 
 | Topic | Branch |
 |-------|-------|
-| Development | *master* |
+| Development | *main* |
 | Release | *release/** |
 
 [Top](#top)

--- a/docs/Testing-your-templates.md
+++ b/docs/Testing-your-templates.md
@@ -1,4 +1,4 @@
-dotnet/templating repo includes the test framework (ProjectTestRunner) which allows automated testing for the custom templates. The source code is available in [tools subfolder](https://github.com/dotnet/templating/tree/master/tools/ProjectTestRunner).
+dotnet/templating repo includes the test framework (ProjectTestRunner) which allows automated testing for the custom templates. The source code is available in [tools subfolder](https://github.com/dotnet/templating/tree/main/tools/ProjectTestRunner).
 The default test set includes the templates shipped with dotnet SDK, but tests can be setup for 3rd-party templates as long as the templates can be installed using `dotnet new --install <template pack identifier>`. The framework used to configure these tests makes it easy to setup tests to do any of the following:
 * Install a template pack
 * Instantiate an installed template with parameters specified


### PR DESCRIPTION
### Problem
Some URLs and branch mentions are now outdated.

### Solution
Change from `master` to `main`