### PR TITLE
Fix 2913: Using //-:cnd:noEmit on the first line of *.cs file corrupts file content when templating new project

### DIFF
--- a/src/Microsoft.TemplateEngine.Core.Contracts/IProcessorState.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IProcessorState.cs
@@ -20,7 +20,7 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 
         IEncodingConfig EncodingConfig { get; }
 
-        Encoding Encoding { get; set; }
+        Encoding Encoding { get; }
 
         bool AdvanceBuffer(int bufferPosition);
 

--- a/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
@@ -81,7 +81,6 @@ Microsoft.TemplateEngine.Core.Contracts.IProcessorState.CurrentBufferLength.get 
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.CurrentBufferPosition.get -> int
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.CurrentSequenceNumber.get -> int
 ~Microsoft.TemplateEngine.Core.Contracts.IProcessorState.Encoding.get -> System.Text.Encoding
-~Microsoft.TemplateEngine.Core.Contracts.IProcessorState.Encoding.set -> void
 ~Microsoft.TemplateEngine.Core.Contracts.IProcessorState.EncodingConfig.get -> Microsoft.TemplateEngine.Core.Contracts.IEncodingConfig
 ~Microsoft.TemplateEngine.Core.Contracts.IProcessorState.Inject(System.IO.Stream staged) -> void
 ~Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie match) -> void

--- a/src/Microsoft.TemplateEngine.Core/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Core/PublicAPI.Unshipped.txt
@@ -454,7 +454,6 @@ Microsoft.TemplateEngine.Core.Util.ProcessorState.CurrentBufferLength.get -> int
 Microsoft.TemplateEngine.Core.Util.ProcessorState.CurrentBufferPosition.get -> int
 Microsoft.TemplateEngine.Core.Util.ProcessorState.CurrentSequenceNumber.get -> int
 Microsoft.TemplateEngine.Core.Util.ProcessorState.Encoding.get -> System.Text.Encoding
-Microsoft.TemplateEngine.Core.Util.ProcessorState.Encoding.set -> void
 Microsoft.TemplateEngine.Core.Util.ProcessorState.EncodingConfig.get -> Microsoft.TemplateEngine.Core.Contracts.IEncodingConfig
 Microsoft.TemplateEngine.Core.Util.ProcessorState.Inject(System.IO.Stream staged) -> void
 Microsoft.TemplateEngine.Core.Util.ProcessorState.ProcessorState(System.IO.Stream source, System.IO.Stream target, int bufferSize, int flushThreshold, Microsoft.TemplateEngine.Core.Contracts.IEngineConfig config, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider> operationProviders) -> void

--- a/src/Microsoft.TemplateEngine.Core/Util/ProcessorState.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/ProcessorState.cs
@@ -23,6 +23,26 @@ namespace Microsoft.TemplateEngine.Core.Util
 
         public ProcessorState(Stream source, Stream target, int bufferSize, int flushThreshold, IEngineConfig config, IReadOnlyList<IOperationProvider> operationProviders)
         {
+            if (source == null)
+            {
+                throw new ArgumentNullException(nameof(source));
+            }
+
+            if (target == null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            if (config == null)
+            {
+                throw new ArgumentNullException(nameof(config));
+            }
+
+            if (operationProviders == null)
+            {
+                throw new ArgumentNullException(nameof(operationProviders));
+            }
+
             if (source.CanSeek)
             {
                 try
@@ -125,7 +145,7 @@ namespace Microsoft.TemplateEngine.Core.Util
 
         public IEncodingConfig EncodingConfig { get; }
 
-        public Encoding Encoding { get => EncodingConfig.Encoding; }
+        public Encoding Encoding => EncodingConfig.Encoding;
 
         public bool AdvanceBuffer(int bufferPosition)
         {

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.RazorBlockComments.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.RazorBlockComments.cs
@@ -349,5 +349,30 @@ Trailing stuff";
             IProcessor processor = SetupRazorStyleProcessor(NeitherClauseTrue);
             RunAndVerify(test, expected, processor, 9999);
         }
+
+        [Theory]
+        [InlineData(true, "No Auth")]
+        [InlineData(false, "Auth")]
+        // File encoding is not maintained when first line of file is a conditional statement
+        // https://github.com/dotnet/templating/issues/2217
+        public void BomMentained(bool noAuth, string expected)
+        {
+            IProcessor processor = SetupRazorStyleProcessor(new VariableCollection
+            {
+                ["NoAuth"] = noAuth
+            });
+            RunAndVerify(
+                @"@*#if (NoAuth)
+No Auth
+#else
+Auth
+#endif*@
+Trailing stuff",
+                expected + @"
+Trailing stuff",
+                processor,
+                9999,
+                emitBOM: true);
+        }
     }
 }

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/SetFlagTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/SetFlagTests.cs
@@ -176,11 +176,11 @@ using System;
 #endif
 ";
 
-            VariableCollection vc = new VariableCollection();
+            VariableCollection vc = new();
             IEngineEnvironmentSettings environmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
-            EngineConfig engineConfig = new EngineConfig(environmentSettings, vc);
+            EngineConfig engineConfig = new(environmentSettings, vc);
 
-            ConditionalTokens tokens = new ConditionalTokens
+            ConditionalTokens tokens = new()
             {
                 IfTokens = new[] { "#if" }.TokenConfigs()
             };

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/PostActions/RunScript/Basic/setup.sh
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/PostActions/RunScript/Basic/setup.sh
@@ -1,2 +1,2 @@
-﻿#!/bin/sh
+#!/bin/sh
 echo Hello Unix


### PR DESCRIPTION
### Problem
Issue was that BOM was emitted only in some code path...
Which means that if "operation" was on first character, BOM was emitted after that operation, hence corrupted file...

### Solution
Now I moved BomEmitting outside loop to beginning of Run method... Even if output doesn't have any content, arguably, it still makes sense to emit BOM...

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)