### PR TITLE
Dev/jonms90/class library renaming

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-CSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-FSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-FSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/content/ClassLibrary-CSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/content/ClassLibrary-FSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.2/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.2/content/ClassLibrary-CSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.2/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.2/content/ClassLibrary-FSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.2/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.2/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-FSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ClassLibrary-CSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ClassLibrary-FSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-FSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-FSharp/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Microsoft",
   "classifications": ["Common", "Library"],
-  "name": "Class library",
+  "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CacheUpgradeTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CacheUpgradeTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
       ""GeneratorId"": ""0c434df7-e2cb-4dee-b216-d7c58c8eb4b3"",
       ""GroupIdentity"": ""Microsoft.Common.Library"",
       ""Precedence"": 100,
-      ""Name"": ""Class library"",
+      ""Name"": ""Class Library"",
       ""ShortName"": ""classlib"",
       ""Tags"": {
         ""language"": {
@@ -128,7 +128,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
       ""GeneratorId"": ""0c434df7-e2cb-4dee-b216-d7c58c8eb4b3"",
       ""GroupIdentity"": ""Microsoft.Common.Library"",
       ""Precedence"": 100,
-      ""Name"": ""Class library"",
+      ""Name"": ""Class Library"",
       ""ShortName"": ""classlib"",
       ""Tags"": {
         ""language"": {
@@ -198,7 +198,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
       ""Identity"": ""Microsoft.Common.Library.CSharp"",
       ""GeneratorId"": ""0c434df7-e2cb-4dee-b216-d7c58c8eb4b3"",
       ""GroupIdentity"": ""Microsoft.Common.Library"",
-      ""Name"": ""Class library"",
+      ""Name"": ""Class Library"",
       ""ShortName"": ""classlib"",
       ""Tags"": {
         ""language"": ""C#"",
@@ -220,7 +220,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
       ""Identity"": ""Microsoft.Common.Library.FSharp"",
       ""GeneratorId"": ""0c434df7-e2cb-4dee-b216-d7c58c8eb4b3"",
       ""GroupIdentity"": ""Microsoft.Common.Library"",
-      ""Name"": ""Class library"",
+      ""Name"": ""Class Library"",
       ""ShortName"": ""classlib"",
       ""Tags"": {
         ""language"": ""F#"",


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/2603

### Solution
Renamed the templates named "Class library" to "Class Library".
There were also some tests refering to the name "Class library", so I updated those too.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)