### PR TITLE
Fix randomly failing unit tests

### DIFF
--- a/src/Microsoft.TemplateEngine.Utils/EngineEnvironmentSettings.cs
+++ b/src/Microsoft.TemplateEngine.Utils/EngineEnvironmentSettings.cs
@@ -18,10 +18,15 @@ namespace Microsoft.TemplateEngine.Utils
         }
 
         public EngineEnvironmentSettings(ITemplateEngineHost host, Func<IEngineEnvironmentSettings, ISettingsLoader> settingsLoaderFactory, string hiveLocation)
+            :this(host, settingsLoaderFactory, hiveLocation, null)
+        {
+        }
+
+        public EngineEnvironmentSettings(ITemplateEngineHost host, Func<IEngineEnvironmentSettings, ISettingsLoader> settingsLoaderFactory, string hiveLocation, string engineRoot)
         {
             Host = host;
             Environment = new DefaultEnvironment();
-            Paths = new DefaultPathInfo(this, hiveLocation);
+            Paths = new DefaultPathInfo(this, engineRoot, hiveLocation);
             SettingsLoader = settingsLoaderFactory(this);
         }
 
@@ -45,7 +50,7 @@ namespace Microsoft.TemplateEngine.Utils
 
         private class DefaultPathInfo : IPathInfo
         {
-            public DefaultPathInfo(IEngineEnvironmentSettings parent, string hiveLocation)
+            public DefaultPathInfo(IEngineEnvironmentSettings parent, string hiveLocation, string engineRoot)
             {
                 bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
@@ -53,7 +58,7 @@ namespace Microsoft.TemplateEngine.Utils
                     ? "USERPROFILE"
                     : "HOME");
 
-                TemplateEngineRootDir = Path.Combine(UserProfileDir, ".templateengine");
+                TemplateEngineRootDir = engineRoot ?? Path.Combine(UserProfileDir, ".templateengine");
 
                 BaseDir = hiveLocation ?? Path.Combine(TemplateEngineRootDir, parent.Host.HostIdentifier, parent.Host.Version);
             }

--- a/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateEngine.TestHelper
         {
             if (string.IsNullOrEmpty(locale))
                 locale = "en-US";
-            Environment.SetEnvironmentVariable(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "USERPROFILE" : "HOME", CreateTemporaryFolder());
+
             ITemplateEngineHost host = new TestHost
             {
                 HostIdentifier = "TestRunner",
@@ -40,7 +40,8 @@ namespace Microsoft.TemplateEngine.TestHelper
                 FallbackHostTemplateConfigNames = new[] { "dotnetcli" }
             };
             CultureInfo.CurrentUICulture = new CultureInfo(locale);
-            var engineEnvironmentSettings = new EngineEnvironmentSettings(host, (x) => new SettingsLoader(x));
+            var tempateEngineRoot = Path.Combine(CreateTemporaryFolder(), ".templateengine");
+            var engineEnvironmentSettings = new EngineEnvironmentSettings(host, (x) => new SettingsLoader(x), null, tempateEngineRoot);
             engineEnvironmentToDispose.Add(engineEnvironmentSettings);
             return engineEnvironmentSettings;
         }


### PR DESCRIPTION
### Problem
Unit tests were randomly failing

### Solution
Problem was that we were calling `SetEnvironmentVariable` in parallel which I thought is per-thread, but turns out is per-process, hence it had same path for multiple unit tests