### PR TITLE
Fix NullRferenceException when "ChoicesAndDescriptions" is not defined

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_0.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_0.cs
@@ -4,6 +4,8 @@ using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
 
+#nullable enable
+
 namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
 {
     public class TemplateInfoReaderVersion1_0_0_0
@@ -29,14 +31,17 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
         {
             info.ConfigMountPointId = Guid.Parse(jObject.ToString(nameof(TemplateInfo.ConfigMountPointId)));
             info.Author = jObject.ToString(nameof(TemplateInfo.Author));
-            JArray classificationsArray = jObject.Get<JArray>(nameof(TemplateInfo.Classifications));
+            JArray? classificationsArray = jObject.Get<JArray>(nameof(TemplateInfo.Classifications));
 
             List<string> classifications = new List<string>();
             info.Classifications = classifications;
             //using (Timing.Over("Read classifications"))
-            foreach (JToken item in classificationsArray)
+            if (classificationsArray != null)
             {
-                classifications.Add(item.ToString());
+                foreach (JToken item in classificationsArray)
+                {
+                    classifications.Add(item.ToString());
+                }
             }
 
             info.DefaultName = jObject.ToString(nameof(TemplateInfo.DefaultName));
@@ -57,7 +62,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
             info.HostConfigPlace = jObject.ToString(nameof(TemplateInfo.HostConfigPlace));
             info.ThirdPartyNotices = jObject.ToString(nameof(TemplateInfo.ThirdPartyNotices));
 
-            JObject baselineJObject = jObject.Get<JObject>(nameof(ITemplateInfo.BaselineInfo));
+            JObject? baselineJObject = jObject.Get<JObject>(nameof(ITemplateInfo.BaselineInfo));
             Dictionary<string, IBaselineInfo> baselineInfo = new Dictionary<string, IBaselineInfo>();
             if (baselineJObject != null)
             {
@@ -82,7 +87,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
         protected virtual IReadOnlyDictionary<string, ICacheTag> ReadTags(JObject jObject)
         {
             Dictionary<string, ICacheTag> tags = new Dictionary<string, ICacheTag>();
-            JObject tagsObject = jObject.Get<JObject>(nameof(TemplateInfo.Tags));
+            JObject? tagsObject = jObject.Get<JObject>(nameof(TemplateInfo.Tags));
 
             if (tagsObject != null)
             {
@@ -98,10 +103,13 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
         protected virtual ICacheTag ReadOneTag(JProperty item)
         {
             Dictionary<string, ParameterChoice> choicesAndDescriptions = new Dictionary<string, ParameterChoice>(StringComparer.OrdinalIgnoreCase);
-            JObject cdToken = item.Value.Get<JObject>("ChoicesAndDescriptions");
-            foreach (JProperty cdPair in cdToken.Properties())
+            JObject? cdToken = item.Value.Get<JObject>("ChoicesAndDescriptions");
+            if (cdToken != null)
             {
-                choicesAndDescriptions.Add(cdPair.Name.ToString(), new ParameterChoice(null, cdPair.Value.ToString()));
+                foreach (JProperty cdPair in cdToken.Properties())
+                {
+                    choicesAndDescriptions.Add(cdPair.Name.ToString(), new ParameterChoice(null, cdPair.Value.ToString()));
+                }
             }
 
             return new CacheTag(
@@ -114,7 +122,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
         protected virtual IReadOnlyDictionary<string, ICacheParameter> ReadParameters(JObject jObject)
         {
             Dictionary<string, ICacheParameter> cacheParams = new Dictionary<string, ICacheParameter>();
-            JObject cacheParamsObject = jObject.Get<JObject>(nameof(TemplateInfo.CacheParameters));
+            JObject? cacheParamsObject = jObject.Get<JObject>(nameof(TemplateInfo.CacheParameters));
 
             if (cacheParamsObject != null)
             {

--- a/src/Shared/JExtensions.cs
+++ b/src/Shared/JExtensions.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
 
+#nullable enable
+
 namespace Microsoft.TemplateEngine
 {
     internal static class JExtensions
     {
-        public static string ToString(this JToken token, string key)
+        public static string? ToString(this JToken? token, string? key)
         {
             if (key == null)
             {
@@ -19,7 +21,7 @@ namespace Microsoft.TemplateEngine
                 return token.ToString();
             }
 
-            JObject obj = token as JObject;
+            JObject? obj = token as JObject;
 
             if (obj == null)
             {
@@ -35,7 +37,7 @@ namespace Microsoft.TemplateEngine
             return element.ToString();
         }
 
-        public static bool ToBool(this JToken token, string key = null, bool defaultValue = false)
+        public static bool ToBool(this JToken? token, string? key = null, bool defaultValue = false)
         {
             JToken checkToken;
 
@@ -64,7 +66,7 @@ namespace Microsoft.TemplateEngine
             }
         }
 
-        public static int ToInt32(this JToken token, string key = null, int defaultValue = 0)
+        public static int ToInt32(this JToken? token, string? key = null, int defaultValue = 0)
         {
             int value = defaultValue;
             if (key == null)
@@ -77,7 +79,7 @@ namespace Microsoft.TemplateEngine
                 return value;
             }
 
-            JObject obj = token as JObject;
+            JObject? obj = token as JObject;
 
             if (obj == null)
             {
@@ -101,10 +103,10 @@ namespace Microsoft.TemplateEngine
             return defaultValue;
         }
 
-        public static T ToEnum<T>(this JToken token, string key = null, T defaultValue = default(T))
+        public static T ToEnum<T>(this JToken token, string? key = null, T defaultValue = default(T))
             where T : struct
         {
-            string val = token.ToString(key);
+            string? val = token.ToString(key);
             T result;
             if (val == null || !Enum.TryParse(val, out result))
             {
@@ -114,9 +116,9 @@ namespace Microsoft.TemplateEngine
             return result;
         }
 
-        public static Guid ToGuid(this JToken token, string key = null, Guid defaultValue = default(Guid))
+        public static Guid ToGuid(this JToken token, string? key = null, Guid defaultValue = default(Guid))
         {
-            string val = token.ToString(key);
+            string? val = token.ToString(key);
             Guid result;
             if (val == null || !Guid.TryParse(val, out result))
             {
@@ -126,9 +128,9 @@ namespace Microsoft.TemplateEngine
             return result;
         }
 
-        public static IEnumerable<JProperty> PropertiesOf(this JToken token, string key = null)
+        public static IEnumerable<JProperty> PropertiesOf(this JToken? token, string? key = null)
         {
-            JObject obj = token as JObject;
+            JObject? obj = token as JObject;
 
             if (obj == null)
             {
@@ -154,10 +156,10 @@ namespace Microsoft.TemplateEngine
             return obj.Properties();
         }
 
-        public static T Get<T>(this JToken token, string key)
+        public static T? Get<T>(this JToken? token, string? key)
             where T : JToken
         {
-            JObject obj = token as JObject;
+            JObject? obj = token as JObject;
 
             if (obj == null)
             {
@@ -173,7 +175,7 @@ namespace Microsoft.TemplateEngine
             return res as T;
         }
 
-        public static IReadOnlyDictionary<string, string> ToStringDictionary(this JToken token, StringComparer comparer = null, string propertyName = null)
+        public static IReadOnlyDictionary<string, string> ToStringDictionary(this JToken token, StringComparer? comparer = null, string? propertyName = null)
         {
             Dictionary<string, string> result = new Dictionary<string, string>(comparer ?? StringComparer.Ordinal);
 
@@ -191,7 +193,7 @@ namespace Microsoft.TemplateEngine
         }
 
         // reads a dictionary whose values can either be string literals, or arrays of strings.
-        public static IReadOnlyDictionary<string, IReadOnlyList<string>> ToStringListDictionary(this JToken token, StringComparer comparer = null, string propertyName = null)
+        public static IReadOnlyDictionary<string, IReadOnlyList<string>> ToStringListDictionary(this JToken token, StringComparer? comparer = null, string? propertyName = null)
         {
             Dictionary<string, IReadOnlyList<string>> result = new Dictionary<string, IReadOnlyList<string>>(comparer ?? StringComparer.Ordinal);
 
@@ -215,7 +217,7 @@ namespace Microsoft.TemplateEngine
         }
 
         // Leaves the values as JTokens.
-        public static IReadOnlyDictionary<string, JToken> ToJTokenDictionary(this JToken token, StringComparer comparaer = null, string propertyName = null)
+        public static IReadOnlyDictionary<string, JToken> ToJTokenDictionary(this JToken token, StringComparer? comparaer = null, string? propertyName = null)
         {
             Dictionary<string, JToken> result = new Dictionary<string, JToken>(comparaer ?? StringComparer.Ordinal);
 
@@ -227,14 +229,14 @@ namespace Microsoft.TemplateEngine
             return result;
         }
 
-        public static IReadOnlyList<string> ArrayAsStrings(this JToken token, string propertyName = null)
+        public static IReadOnlyList<string> ArrayAsStrings(this JToken? token, string? propertyName = null)
         {
             if (propertyName != null)
             {
                 token = token.Get<JArray>(propertyName);
             }
 
-            JArray arr = token as JArray;
+            JArray? arr = token as JArray;
 
             if (arr == null)
             {
@@ -254,14 +256,14 @@ namespace Microsoft.TemplateEngine
             return values;
         }
 
-        public static IReadOnlyList<Guid> ArrayAsGuids(this JToken token, string propertyName = null)
+        public static IReadOnlyList<Guid> ArrayAsGuids(this JToken? token, string? propertyName = null)
         {
             if (propertyName != null)
             {
                 token = token.Get<JArray>(propertyName);
             }
 
-            JArray arr = token as JArray;
+            JArray? arr = token as JArray;
 
             if (arr == null)
             {
@@ -285,7 +287,7 @@ namespace Microsoft.TemplateEngine
             return values;
         }
 
-        public static IEnumerable<T> Items<T>(this JToken token, string propertyName = null)
+        public static IEnumerable<T> Items<T>(this JToken? token, string? propertyName = null)
             where T : JToken
         {
             if (propertyName != null)
@@ -293,7 +295,7 @@ namespace Microsoft.TemplateEngine
                 token = token.Get<JArray>(propertyName);
             }
 
-            JArray arr = token as JArray;
+            JArray? arr = token as JArray;
 
             if (arr == null)
             {
@@ -302,7 +304,7 @@ namespace Microsoft.TemplateEngine
 
             foreach (JToken item in arr)
             {
-                T res = item as T;
+                T? res = item as T;
 
                 if (res != null)
                 {


### PR DESCRIPTION
### Problem
In some unit tests on dotnet/sdk repo some tests are failing with NullReferenceException in `TemplateInfoReaderVersion1_0_0_0.ReadOneTag` my conclusion is that its most likely `ChoicesAndDescriptions`.

### Solution
I added `#nullable enable` but it didn't show this as problem, because `JExtensions.cs` didn't have `#nullable enable`... So I added it there too, also caught another potential NRE with `classificationsArray`.

### Checks:
- [ ] Added unit tests(I didn't add because this code will soon be removed.)
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)