### PR TITLE
fixes dotnet/templating#2934 disable publishing template packages on previews and servicing

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/Microsoft.DotNet.Common.ProjectTemplates.1.x.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.1.x/Microsoft.DotNet.Common.ProjectTemplates.1.x.csproj
@@ -6,7 +6,10 @@
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
         <OutputPath>$(TemplatesDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
-        <IsPackable>true</IsPackable>
+        <!-- do not do package for preview and servicing, do package for rtm release-->
+        <!-- if the package should be shipped for preview or servicing, set <IsPackable> to true for explicit version here -->
+        <IsPackable>false</IsPackable>
+        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtm'">true</IsPackable>
         <NoWarn>$(NoWarn);2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ProjectTemplates.1.x</PackageId>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/Microsoft.DotNet.Common.ProjectTemplates.2.0.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.0/Microsoft.DotNet.Common.ProjectTemplates.2.0.csproj
@@ -6,7 +6,10 @@
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
         <OutputPath>$(TemplatesDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
-        <IsPackable>true</IsPackable>
+        <!-- do not do package for preview and servicing, do package for rtm release-->
+        <!-- if the package should be shipped for preview or servicing, set <IsPackable> to true for explicit version here -->
+        <IsPackable>false</IsPackable>
+        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtm'">true</IsPackable>
         <NoWarn>$(NoWarn);2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ProjectTemplates.2.0</PackageId>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/Microsoft.DotNet.Common.ProjectTemplates.2.1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.1/Microsoft.DotNet.Common.ProjectTemplates.2.1.csproj
@@ -6,7 +6,10 @@
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
         <OutputPath>$(TemplatesDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
-        <IsPackable>true</IsPackable>
+        <!-- do not do package for preview and servicing, do package for rtm release-->
+        <!-- if the package should be shipped for preview or servicing, set <IsPackable> to true for explicit version here -->
+        <IsPackable>false</IsPackable>
+        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtm'">true</IsPackable>
         <NoWarn>$(NoWarn);2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ProjectTemplates.2.1</PackageId>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.2/Microsoft.DotNet.Common.ProjectTemplates.2.2.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.2.2/Microsoft.DotNet.Common.ProjectTemplates.2.2.csproj
@@ -6,7 +6,10 @@
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
         <OutputPath>$(TemplatesDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
-        <IsPackable>true</IsPackable>
+        <!-- do not do package for preview and servicing, do package for rtm release-->
+        <!-- if the package should be shipped for preview or servicing, set <IsPackable> to true for explicit version here -->
+        <IsPackable>false</IsPackable>
+        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtm'">true</IsPackable>
         <NoWarn>$(NoWarn);2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ProjectTemplates.2.2</PackageId>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/Microsoft.DotNet.Common.ProjectTemplates.3.0.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.0/Microsoft.DotNet.Common.ProjectTemplates.3.0.csproj
@@ -6,7 +6,10 @@
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
         <OutputPath>$(TemplatesDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
-        <IsPackable>true</IsPackable>
+        <!-- do not do package for preview and servicing, do package for rtm release-->
+        <!-- if the package should be shipped for preview or servicing, set <IsPackable> to true for explicit version here -->
+        <IsPackable>false</IsPackable>
+        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtm'">true</IsPackable>
         <NoWarn>$(NoWarn);2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ProjectTemplates.3.0</PackageId>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/Microsoft.DotNet.Common.ProjectTemplates.3.1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.3.1/Microsoft.DotNet.Common.ProjectTemplates.3.1.csproj
@@ -6,7 +6,10 @@
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
         <OutputPath>$(TemplatesDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
-        <IsPackable>true</IsPackable>
+        <!-- do not do package for preview and servicing, do package for rtm release-->
+        <!-- if the package should be shipped for preview or servicing, set <IsPackable> to true for explicit version here -->
+        <IsPackable>false</IsPackable>
+        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtm'">true</IsPackable>
         <NoWarn>2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ProjectTemplates.3.1</PackageId>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/Microsoft.DotNet.Common.ProjectTemplates.5.0.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.5.0/Microsoft.DotNet.Common.ProjectTemplates.5.0.csproj
@@ -6,7 +6,10 @@
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
         <OutputPath>$(TemplatesDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
-        <IsPackable>true</IsPackable>
+        <!-- do not do package for preview and servicing, do package for rtm release-->
+        <!-- if the package should be shipped for preview or servicing, set <IsPackable> to true for explicit version here -->
+        <IsPackable>false</IsPackable>
+        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtm'">true</IsPackable>
         <NoWarn>2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ProjectTemplates.5.0</PackageId>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/Microsoft.DotNet.Common.ProjectTemplates.6.0.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/Microsoft.DotNet.Common.ProjectTemplates.6.0.csproj
@@ -6,7 +6,12 @@
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
         <OutputPath>$(TemplatesDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
-        <IsPackable>true</IsPackable>
+        <!-- .NET 6 template package is shipped with the preview / RC since .NET 6 is not released yet -->
+        <!-- if the package should be shipped for servicing, set <IsPackable> to true for explicit version here -->
+        <IsPackable>false</IsPackable>
+        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'preview'">true</IsPackable>
+        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rc'">true</IsPackable>
+        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtm'">true</IsPackable>
         <NoWarn>2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ProjectTemplates.6.0</PackageId>

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
         internal async Task GetCreationEffects_BasicTest_Package()
         {
             var bootstrapper = BootstrapperFactory.GetBootstrapper();
-            string packageLocation = _packageManager.PackProjectTemplatesNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
+            string packageLocation = _packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
             await bootstrapper.InstallTemplateAsync(packageLocation).ConfigureAwait(false);
 
             string output = TestUtils.CreateTemporaryFolder();
@@ -99,7 +99,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
         internal async Task Create_BasicTest_Package()
         {
             var bootstrapper = BootstrapperFactory.GetBootstrapper();
-            string packageLocation = _packageManager.PackProjectTemplatesNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
+            string packageLocation = _packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
             await bootstrapper.InstallTemplateAsync(packageLocation).ConfigureAwait(false);
 
             string output = TestUtils.CreateTemporaryFolder();

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/TemplatePackagesTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/TemplatePackagesTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
         internal async Task CanInstall_LocalNuGetPackage()
         {
             Bootstrapper bootstrapper = BootstrapperFactory.GetBootstrapper();
-            string packageLocation = _packageManager.PackProjectTemplatesNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
+            string packageLocation = _packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
 
             InstallRequest installRequest = new InstallRequest(Path.GetFullPath(packageLocation));
 

--- a/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
@@ -15,6 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="NuGet.Protocol" Version="5.9.0"/>
         <PackageReference Include="xunit" />
     </ItemGroup>
 

--- a/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
@@ -3,16 +3,30 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
 
 namespace Microsoft.TemplateEngine.TestHelper
 {
     public class PackageManager : IDisposable
     {
         private string _packageLocation = TestUtils.CreateTemporaryFolder("packages");
+        private readonly ILogger _nugetLogger = NullLogger.Instance;
+        private readonly SourceCacheContext _cacheSettings = new SourceCacheContext()
+        {
+            NoCache = true,
+            DirectDownload = true
+        };
         private ConcurrentDictionary<string, string> _installedPackages = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         public string PackTestTemplatesNuGetPackage()
@@ -22,11 +36,21 @@ namespace Microsoft.TemplateEngine.TestHelper
             return PackNuGetPackage(projectToPack);
         }
 
-        public string PackProjectTemplatesNuGetPackage(string templatePackName)
+        public string GetNuGetPackage(string templatePackName)
         {
-            string dir = Path.GetDirectoryName(typeof(PackageManager).GetTypeInfo().Assembly.Location);
-            string projectToPack = Path.Combine(dir, "..", "..", "..", "..", "..", "template_feed", templatePackName, $"{templatePackName}.csproj");
-            return PackNuGetPackage(projectToPack);
+            lock (string.Intern(templatePackName.ToLowerInvariant()))
+            {
+                if (_installedPackages.TryGetValue(templatePackName, out string packagePath))
+                {
+                    return packagePath;
+                }
+
+                Task<string> downloadTask = DownloadPackageAsync(templatePackName);
+                downloadTask.Wait();
+                string downloadedPackage = downloadTask.Result;
+                _installedPackages[templatePackName] = downloadedPackage;
+                return downloadedPackage;
+            }
         }
 
         public string PackNuGetPackage(string projectPath)
@@ -68,9 +92,213 @@ namespace Microsoft.TemplateEngine.TestHelper
             }
         }
 
-        public void Dispose()
+        public void Dispose() => Directory.Delete(_packageLocation, true);
+
+        private async Task<string> DownloadPackageAsync(string identifier, string version = null, IEnumerable<string> additionalSources = null, CancellationToken cancellationToken = default)
         {
-            Directory.Delete(_packageLocation, true);
+            if (string.IsNullOrWhiteSpace(identifier))
+            {
+                throw new ArgumentException($"{nameof(identifier)} cannot be null or empty", nameof(identifier));
+            }
+
+            IEnumerable<PackageSource> packagesSources = LoadNuGetSources(additionalSources?.ToArray() ?? Array.Empty<string>());
+
+            NuGetVersion packageVersion;
+            PackageSource source;
+            IPackageSearchMetadata packageMetadata;
+
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                (source, packageMetadata) = await GetLatestVersionInternalAsync(identifier, packagesSources, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                packageVersion = new NuGetVersion(version);
+                (source, packageMetadata) = await GetPackageMetadataAsync(identifier, packageVersion, packagesSources, cancellationToken).ConfigureAwait(false);
+            }
+
+            FindPackageByIdResource resource;
+            SourceRepository repository = Repository.Factory.GetCoreV3(source);
+            try
+            {
+                resource = await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Failed to load NuGet source {source.Source}", e);
+            }
+
+            string filePath = Path.Combine(_packageLocation, packageMetadata.Identity.Id + "." + packageMetadata.Identity.Version + ".nupkg");
+            if (File.Exists(filePath))
+            {
+                throw new Exception($"{filePath} already exists");
+            }
+            try
+            {
+                using Stream packageStream = File.Create(filePath);
+                if (await resource.CopyNupkgToStreamAsync(
+                    packageMetadata.Identity.Id,
+                    packageMetadata.Identity.Version,
+                    packageStream,
+                    _cacheSettings,
+                    _nugetLogger,
+                    cancellationToken).ConfigureAwait(false))
+                {
+                    return filePath;
+                }
+                else
+                {
+                    throw new Exception($"Failed to download {packageMetadata.Identity.Id}, version: {packageMetadata.Identity.Version} from {source.Source}");
+                }
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Failed to download {packageMetadata.Identity.Id}, version: {packageMetadata.Identity.Version} from {source.Source}", e);
+            }
+        }
+
+        private async Task<(PackageSource, IPackageSearchMetadata)> GetLatestVersionInternalAsync(string packageIdentifier, IEnumerable<PackageSource> packageSources, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(packageIdentifier))
+            {
+                throw new ArgumentException($"{nameof(packageIdentifier)} cannot be null or empty", nameof(packageIdentifier));
+            }
+            _ = packageSources ?? throw new ArgumentNullException(nameof(packageSources));
+
+            (PackageSource source, IEnumerable<IPackageSearchMetadata> foundPackages)[] foundPackagesBySource =
+                await Task.WhenAll(
+                    packageSources.Select(source => GetPackageMetadataAsync(source, packageIdentifier, includePrerelease: true, cancellationToken)))
+                          .ConfigureAwait(false);
+
+            if (!foundPackagesBySource.Any())
+            {
+                throw new Exception($"Failed to load NuGet sources {string.Join(";", packageSources.Select(source => source.Source))}");
+            }
+
+            var accumulativeSearchResults = foundPackagesBySource
+                .SelectMany(result => result.foundPackages.Select(package => (result.source, package)));
+
+            if (!accumulativeSearchResults.Any())
+            {
+                throw new Exception($"{packageIdentifier} is not found in {string.Join(";", packageSources.Select(source => source.Source))}");
+            }
+
+            (PackageSource, IPackageSearchMetadata) latestVersion = accumulativeSearchResults.Aggregate(
+                (max, current) =>
+                {
+                    if (max == default) return current;
+                    return current.package.Identity.Version > max.package.Identity.Version ? current : max;
+                });
+            return latestVersion;
+        }
+
+        private async Task<(PackageSource, IPackageSearchMetadata)> GetPackageMetadataAsync(string packageIdentifier, NuGetVersion packageVersion, IEnumerable<PackageSource> sources, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(packageIdentifier))
+            {
+                throw new ArgumentException($"{nameof(packageIdentifier)} cannot be null or empty", nameof(packageIdentifier));
+            }
+            _ = packageVersion ?? throw new ArgumentNullException(nameof(packageVersion));
+            _ = sources ?? throw new ArgumentNullException(nameof(sources));
+
+            bool atLeastOneSourceValid = false;
+            using CancellationTokenSource linkedCts =
+                      CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var tasks = sources.Select(source => GetPackageMetadataAsync(source, packageIdentifier, includePrerelease: true, linkedCts.Token)).ToList();
+            while (tasks.Any())
+            {
+                var finishedTask = await Task.WhenAny(tasks).ConfigureAwait(false);
+                tasks.Remove(finishedTask);
+                (PackageSource source, IEnumerable<IPackageSearchMetadata> foundPackages) result = await finishedTask.ConfigureAwait(false);
+                if (result.foundPackages == null)
+                {
+                    continue;
+                }
+                atLeastOneSourceValid = true;
+                IPackageSearchMetadata matchedVersion = result.foundPackages.FirstOrDefault(package => package.Identity.Version == packageVersion);
+                if (matchedVersion != null)
+                {
+                    linkedCts.Cancel();
+                    return (result.source, matchedVersion);
+                }
+            }
+            if (!atLeastOneSourceValid)
+            {
+                throw new Exception($"Failed to load NuGet sources {string.Join(";", sources.Select(source => source.Source))}");
+            }
+            throw new Exception($"{packageIdentifier}, version: {packageVersion} is not found in {string.Join(";", sources.Select(source => source.Source))}");
+        }
+
+        private async Task<(PackageSource source, IEnumerable<IPackageSearchMetadata> foundPackages)> GetPackageMetadataAsync(PackageSource source, string packageIdentifier, bool includePrerelease = false, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(packageIdentifier))
+            {
+                throw new ArgumentException($"{nameof(packageIdentifier)} cannot be null or empty", nameof(packageIdentifier));
+            }
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+
+            SourceRepository repository = Repository.Factory.GetCoreV3(source);
+            PackageMetadataResource resource = await repository.GetResourceAsync<PackageMetadataResource>(cancellationToken).ConfigureAwait(false);
+            IEnumerable<IPackageSearchMetadata> foundPackages = await resource.GetMetadataAsync(
+                packageIdentifier,
+                includePrerelease: includePrerelease,
+                includeUnlisted: false,
+                _cacheSettings,
+                _nugetLogger,
+                cancellationToken).ConfigureAwait(false);
+            return (source, foundPackages);
+        }
+
+        private IEnumerable<PackageSource> LoadNuGetSources(params string[] additionalSources)
+        {
+            IEnumerable<PackageSource> defaultSources;
+            string currentDirectory = string.Empty;
+            try
+            {
+                currentDirectory = Directory.GetCurrentDirectory();
+                ISettings settings = global::NuGet.Configuration.Settings.LoadDefaultSettings(currentDirectory);
+                PackageSourceProvider packageSourceProvider = new PackageSourceProvider(settings);
+                defaultSources = packageSourceProvider.LoadPackageSources().Where(source => source.IsEnabled);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to load NuGet sources configured for the folder {currentDirectory}", ex);
+            }
+
+            if (!additionalSources?.Any() ?? true)
+            {
+                if (!defaultSources.Any())
+                {
+                    throw new Exception("No NuGet sources are defined or enabled");
+                }
+                return defaultSources;
+            }
+
+            List<PackageSource> customSources = new List<PackageSource>();
+            foreach (string source in additionalSources)
+            {
+                if (string.IsNullOrWhiteSpace(source))
+                {
+                    continue;
+                }
+                if (defaultSources.Any(s => s.Source.Equals(source, StringComparison.OrdinalIgnoreCase)))
+                {
+                    continue;
+                }
+                PackageSource packageSource = new PackageSource(source);
+                if (packageSource.TrySourceAsUri == null)
+                {
+                    continue;
+                }
+                customSources.Add(packageSource);
+            }
+
+            IEnumerable<PackageSource> retrievedSources = customSources.Concat(defaultSources);
+            if (!retrievedSources.Any())
+            {
+                throw new Exception("No NuGet sources are defined or enabled");
+            }
+            return retrievedSources;
         }
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -359,7 +359,7 @@ namespace dotnet_new3.IntegrationTests
             var home = TestUtils.CreateTemporaryFolder("Home");
 
             using var packageManager = new PackageManager();
-            string packageLocation = packageManager.PackProjectTemplatesNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
+            string packageLocation = packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
 
             new DotnetNewCommand(_log, "-i", packageLocation)
                 .WithCustomHive(home)


### PR DESCRIPTION
### Problem
fixes dotnet/templating#2934

### Solution
conditionally disabled `<IsPackable>` flag in corresponding csproj files
modified integration tests not to pack projects from /template_feed, download them from NuGet feed instaed.