### PR TITLE
fixes dotnet/templating#2968 Revert explicit --nuget-source in dotnet-new3 tests

### DIFF
--- a/test/dotnet-new3.UnitTests/AllProjectsWork.cs
+++ b/test/dotnet-new3.UnitTests/AllProjectsWork.cs
@@ -81,8 +81,8 @@ namespace dotnet_new3.UnitTests
                 .And
                 .NotHaveStdErr();
 
-            InstallPackage("Microsoft.DotNet.Web.ProjectTemplates.5.0", BaseWorkingDirectory, "https://api.nuget.org/v3/index.json");
-            InstallPackage("Microsoft.DotNet.Web.ProjectTemplates.3.1", BaseWorkingDirectory, "https://api.nuget.org/v3/index.json");
+            InstallPackage("Microsoft.DotNet.Web.ProjectTemplates.5.0", BaseWorkingDirectory);
+            InstallPackage("Microsoft.DotNet.Web.ProjectTemplates.3.1", BaseWorkingDirectory);
         }
 
         internal string BaseWorkingDirectory { get; private set; }


### PR DESCRIPTION
### Problem
fixes dotnet/templating#2968 Revert explicit --nuget-source in dotnet-new3 tests

### Solution
removed explicit nuget source arg in command
