### PR TITLE
make most of public types/members of TemplateEngine.Cli internal

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/AliasSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/AliasSupport.cs
@@ -10,9 +10,9 @@ using Microsoft.TemplateEngine.Edge.Template;
 
 namespace Microsoft.TemplateEngine.Cli
 {
-    public static class AliasSupport
+    internal static class AliasSupport
     {
-        public static CreationResultStatus CoordinateAliasExpansion(INewCommandInput commandInput, AliasRegistry aliasRegistry, ITelemetryLogger telemetryLogger)
+        internal static CreationResultStatus CoordinateAliasExpansion(INewCommandInput commandInput, AliasRegistry aliasRegistry, ITelemetryLogger telemetryLogger)
         {
             AliasExpansionStatus aliasExpansionStatus = AliasSupport.TryExpandAliases(commandInput, aliasRegistry);
             if (aliasExpansionStatus == AliasExpansionStatus.ExpansionError)
@@ -35,7 +35,7 @@ namespace Microsoft.TemplateEngine.Cli
             return CreationResultStatus.Success;
         }
 
-        public static AliasExpansionStatus TryExpandAliases(INewCommandInput commandInput, AliasRegistry aliasRegistry)
+        internal static AliasExpansionStatus TryExpandAliases(INewCommandInput commandInput, AliasRegistry aliasRegistry)
         {
             List<string> inputTokens = commandInput.Tokens.ToList();
             inputTokens.RemoveAt(0);    // remove the command name
@@ -61,7 +61,7 @@ namespace Microsoft.TemplateEngine.Cli
         // TODO: make this test more robust.
         private static readonly Regex ValidFirstTokenRegex = new Regex("^[a-z0-9]", RegexOptions.IgnoreCase);
 
-        public static CreationResultStatus ManipulateAliasIfValid(AliasRegistry aliasRegistry, string aliasName, List<string> inputTokens, HashSet<string> reservedAliasNames)
+        internal static CreationResultStatus ManipulateAliasIfValid(AliasRegistry aliasRegistry, string aliasName, List<string> inputTokens, HashSet<string> reservedAliasNames)
         {
             if (reservedAliasNames.Contains(aliasName))
             {
@@ -157,7 +157,7 @@ namespace Microsoft.TemplateEngine.Cli
             return aliasTokens;
         }
 
-        public static CreationResultStatus DisplayAliasValues(IEngineEnvironmentSettings environment, INewCommandInput commandInput, AliasRegistry aliasRegistry, string commandName)
+        internal static CreationResultStatus DisplayAliasValues(IEngineEnvironmentSettings environment, INewCommandInput commandInput, AliasRegistry aliasRegistry, string commandName)
         {
             IReadOnlyDictionary<string, IReadOnlyList<string>> aliasesToShow;
 

--- a/src/Microsoft.TemplateEngine.Cli/AnsiColorExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/AnsiColorExtensions.cs
@@ -1,47 +1,47 @@
 ﻿namespace Microsoft.TemplateEngine.Cli
 {
-    public static class AnsiColorExtensions
+    internal static class AnsiColorExtensions
     {
-        public static string Black(this string text)
+        internal static string Black(this string text)
         {
             return "\x1B[30m" + text + "\x1B[39m";
         }
 
-        public static string Red(this string text)
+        internal static string Red(this string text)
         {
             return "\x1B[31m" + text + "\x1B[39m";
         }
-        public static string Green(this string text)
+        internal static string Green(this string text)
         {
             return "\x1B[32m" + text + "\x1B[39m";
         }
 
-        public static string Yellow(this string text)
+        internal static string Yellow(this string text)
         {
             return "\x1B[33m" + text + "\x1B[39m";
         }
 
-        public static string Blue(this string text)
+        internal static string Blue(this string text)
         {
             return "\x1B[34m" + text + "\x1B[39m";
         }
 
-        public static string Magenta(this string text)
+        internal static string Magenta(this string text)
         {
             return "\x1B[35m" + text + "\x1B[39m";
         }
 
-        public static string Cyan(this string text)
+        internal static string Cyan(this string text)
         {
             return "\x1B[36m" + text + "\x1B[39m";
         }
 
-        public static string White(this string text)
+        internal static string White(this string text)
         {
             return "\x1B[37m" + text + "\x1B[39m";
         }
 
-        public static string Bold(this string text)
+        internal static string Bold(this string text)
         {
             return "\x1B[1m" + text + "\x1B[22m";
         }

--- a/src/Microsoft.TemplateEngine.Cli/AnsiConsole.cs
+++ b/src/Microsoft.TemplateEngine.Cli/AnsiConsole.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Microsoft.TemplateEngine.Cli
 {
-    public class AnsiConsole
+    internal class AnsiConsole
     {
         private AnsiConsole(TextWriter writer)
         {
@@ -14,19 +14,19 @@ namespace Microsoft.TemplateEngine.Cli
 
         private int _boldRecursion;
 
-        public static AnsiConsole GetOutput()
+        internal static AnsiConsole GetOutput()
         {
             return new AnsiConsole(Console.Out);
         }
 
-        public static AnsiConsole GetError()
+        internal static AnsiConsole GetError()
         {
             return new AnsiConsole(Console.Error);
         }
 
-        public TextWriter Writer { get; }
+        internal TextWriter Writer { get; }
 
-        public ConsoleColor OriginalForegroundColor { get; }
+        internal ConsoleColor OriginalForegroundColor { get; }
 
         private void SetColor(ConsoleColor color)
         {
@@ -51,14 +51,14 @@ namespace Microsoft.TemplateEngine.Cli
             SetColor(Console.ForegroundColor);
         }
 
-        public void WriteLine(string message)
+        internal void WriteLine(string message)
         {
             Write(message);
             Writer.WriteLine();
         }
 
 
-        public void Write(string message)
+        internal void Write(string message)
         {
             var escapeScan = 0;
             for (;;)

--- a/src/Microsoft.TemplateEngine.Cli/AppExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/AppExtensions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TemplateEngine.Cli
 {
     internal static class AppExtensions
     {
-        public static IReadOnlyList<string> CreateArgListFromAdditionalFiles(IList<string> extraArgFileNames)
+        internal static IReadOnlyList<string> CreateArgListFromAdditionalFiles(IList<string> extraArgFileNames)
         {
             IReadOnlyDictionary<string, IReadOnlyList<string>> argsDict = ParseArgsFromFile(extraArgFileNames);
 
@@ -29,7 +29,7 @@ namespace Microsoft.TemplateEngine.Cli
             return argsFlattened;
         }
 
-        public static IReadOnlyDictionary<string, IReadOnlyList<string>> ParseArgsFromFile(IList<string> extraArgFileNames)
+        internal static IReadOnlyDictionary<string, IReadOnlyList<string>> ParseArgsFromFile(IList<string> extraArgFileNames)
         {
             Dictionary<string, IReadOnlyList<string>> parameters = new Dictionary<string, IReadOnlyList<string>>();
 

--- a/src/Microsoft.TemplateEngine.Cli/ArgumentEscaper.cs
+++ b/src/Microsoft.TemplateEngine.Cli/ArgumentEscaper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.TemplateEngine.Cli
         /// </summary>
         /// <param name="args"></param>
         /// <returns></returns>
-        public static string EscapeAndConcatenateArgArrayForProcessStart(IEnumerable<string> args)
+        internal static string EscapeAndConcatenateArgArrayForProcessStart(IEnumerable<string> args)
         {
             return string.Join(" ", EscapeArgArray(args));
         }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParserException.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParserException.cs
@@ -1,8 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
 using System;
 
 namespace Microsoft.TemplateEngine.Cli
 {
-    internal class CommandParserException : Exception
+    public class CommandParserException : Exception
     {
         internal CommandParserException(string message, string argument)
             : base(message)
@@ -16,6 +21,6 @@ namespace Microsoft.TemplateEngine.Cli
             Argument = argument;
         }
 
-        internal string Argument { get; }
+        public string Argument { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParserException.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParserException.cs
@@ -2,20 +2,20 @@ using System;
 
 namespace Microsoft.TemplateEngine.Cli
 {
-    public class CommandParserException : Exception
+    internal class CommandParserException : Exception
     {
-        public CommandParserException(string message, string argument)
+        internal CommandParserException(string message, string argument)
             : base(message)
         {
             Argument = argument;
         }
 
-        public CommandParserException(string message, string argument, Exception innerException)
+        internal CommandParserException(string message, string argument, Exception innerException)
             : base(message, innerException)
         {
             Argument = argument;
         }
 
-        public string Argument { get; }
+        internal string Argument { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/AliasAssignmentCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/AliasAssignmentCoordinator.cs
@@ -4,7 +4,7 @@ using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Cli.CommandParsing
 {
-    public class AliasAssignmentCoordinator
+    internal class AliasAssignmentCoordinator
     {
         private IReadOnlyList<ITemplateParameter> _parameterDefinitions;
         private IDictionary<string, string> _longNameOverrides;
@@ -15,7 +15,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         private HashSet<string> _invalidParams;
         private bool _calculatedAssignments;
 
-        public AliasAssignmentCoordinator(IReadOnlyList<ITemplateParameter> parameterDefinitions, IDictionary<string, string> longNameOverrides, IDictionary<string, string> shortNameOverrides, HashSet<string> takenAliases)
+        internal AliasAssignmentCoordinator(IReadOnlyList<ITemplateParameter> parameterDefinitions, IDictionary<string, string> longNameOverrides, IDictionary<string, string> shortNameOverrides, HashSet<string> takenAliases)
         {
             _parameterDefinitions = parameterDefinitions;
             _longNameOverrides = longNameOverrides;
@@ -27,7 +27,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             _calculatedAssignments = false;
         }
 
-        public IReadOnlyDictionary<string, string> LongNameAssignments
+        internal IReadOnlyDictionary<string, string> LongNameAssignments
         {
             get
             {
@@ -36,7 +36,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             }
         }
 
-        public IReadOnlyDictionary<string, string> ShortNameAssignments
+        internal IReadOnlyDictionary<string, string> ShortNameAssignments
         {
             get
             {
@@ -45,7 +45,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             }
         }
 
-        public HashSet<string> InvalidParams
+        internal HashSet<string> InvalidParams
         {
             get
             {
@@ -54,7 +54,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             }
         }
 
-        public HashSet<string> TakenAliases
+        internal HashSet<string> TakenAliases
         {
             get
             {

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandAliasAssigner.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandAliasAssigner.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Cli.CommandParsing
 {
-    public static class CommandAliasAssigner
+    internal static class CommandAliasAssigner
     {
-        public static bool TryAssignAliasesForParameter(Func<string, bool> isAliasTaken, string parameterName, string longNameOverride, string shortNameOverride, out IReadOnlyList<string> assignedAliases)
+        internal static bool TryAssignAliasesForParameter(Func<string, bool> isAliasTaken, string parameterName, string longNameOverride, string shortNameOverride, out IReadOnlyList<string> assignedAliases)
         {
             List<string> aliasAssignments = new List<string>();
             HashSet<string> invalidParams = new HashSet<string>();

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -7,9 +7,9 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli.CommandParsing
 {
-    public static class CommandParserSupport
+    internal static class CommandParserSupport
     {
-        public static Command CreateNewCommandWithoutTemplateInfo(string commandName) => GetNewCommand(commandName, NewCommandVisibleArgs, NewCommandHiddenArgs, DebuggingCommandArgs);
+        internal static Command CreateNewCommandWithoutTemplateInfo(string commandName) => GetNewCommand(commandName, NewCommandVisibleArgs, NewCommandHiddenArgs, DebuggingCommandArgs);
 
         private static Command GetNewCommand(string commandName, params Option[][] args)
         {
@@ -23,7 +23,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         // Final parser for when there is no template name provided.
         // Unmatched args are errors.
-        public static Command CreateNewCommandForNoTemplateName(string commandName)
+        internal static Command CreateNewCommandForNoTemplateName(string commandName)
         {
             Option[] combinedArgs = ArrayExtensions.CombineArrays(NewCommandVisibleArgs, NewCommandHiddenArgs, DebuggingCommandArgs);
 
@@ -44,7 +44,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                            combinedArgs);
         }
 
-        public static HashSet<string> ArgsForBuiltInCommands
+        internal static HashSet<string> ArgsForBuiltInCommands
         {
             get
             {
@@ -62,7 +62,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         private static HashSet<string> _argsForBuiltInCommands = null;
 
         // Creates a command setup with the args for "new", plus args for the input template parameters.
-        public static Command CreateNewCommandWithArgsForTemplate(string commandName, string templateName,
+        internal static Command CreateNewCommandWithArgsForTemplate(string commandName, string templateName,
                     IReadOnlyList<ITemplateParameter> parameterDefinitions,
                     IDictionary<string, string> longNameOverrides,
                     IDictionary<string, string> shortNameOverrides,

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
@@ -9,7 +9,7 @@ using Microsoft.TemplateEngine.Edge.Template;
 
 namespace Microsoft.TemplateEngine.Cli.CommandParsing
 {
-    public interface INewCommandInput
+    internal interface INewCommandInput
     {
         string Alias { get; }
         string AllowScriptsToRun { get; }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -12,7 +12,7 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli.CommandParsing
 {
-    public class NewCommandInputCli : INewCommandInput
+    internal class NewCommandInputCli : INewCommandInput
     {
         internal const string AuthorColumnFilter = "author";
         internal const string LanguageColumnFilter = "language";
@@ -39,7 +39,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         private IReadOnlyDictionary<string, string> _templateParamValues;
         private IReadOnlyDictionary<string, string> _templateParamVariantToCanonicalMap;
 
-        public NewCommandInputCli(string commandName)
+        internal NewCommandInputCli(string commandName)
         {
             _commandName = commandName;
             _noTemplateCommand = CommandParserSupport.CreateNewCommandWithoutTemplateInfo(_commandName);

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/ParseResultExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/ParseResultExtensions.cs
@@ -4,9 +4,9 @@ using Microsoft.DotNet.Cli.CommandLine;
 
 namespace Microsoft.TemplateEngine.Cli.CommandParsing
 {
-    public static class ParseResultExtensions
+    internal static class ParseResultExtensions
     {
-        public static bool HasAppliedOption(this ParseResult parseResult, params string[] optionPath)
+        internal static bool HasAppliedOption(this ParseResult parseResult, params string[] optionPath)
         {
             if (optionPath.Length == 0)
             {
@@ -37,7 +37,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         // If the argument has a value, set it to the out param.
         // This allows checking for args existence whose type is not known, which makes it safe to check for bool flags without values
         // in addition to checking for string value args.
-        public static bool TryGetArgumentValueAtPath(this ParseResult parseResult, out string argValue, params string[] optionsPath)
+        internal static bool TryGetArgumentValueAtPath(this ParseResult parseResult, out string argValue, params string[] optionsPath)
         {
             if (parseResult.TryTraversePath(out AppliedOption option, optionsPath))
             {
@@ -57,7 +57,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             return false;
         }
 
-        public static string GetArgumentValueAtPath(this ParseResult parseResult, params string[] optionsPath)
+        internal static string GetArgumentValueAtPath(this ParseResult parseResult, params string[] optionsPath)
         {
             if (parseResult.TryTraversePath(out AppliedOption option, optionsPath) && (option.Arguments.Count > 0))
             {
@@ -67,7 +67,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             return null;
         }
 
-        public static IReadOnlyCollection<string> GetArgumentListAtPath(this ParseResult parseResult, params string[] optionPath)
+        internal static IReadOnlyCollection<string> GetArgumentListAtPath(this ParseResult parseResult, params string[] optionPath)
         {
             if (parseResult.TryTraversePath(out AppliedOption option, optionPath))
             {

--- a/src/Microsoft.TemplateEngine.Cli/Dotnet.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Dotnet.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,81 +9,45 @@ using System.Text;
 
 namespace Microsoft.TemplateEngine.Cli
 {
-    public class Dotnet
+    internal class Dotnet
     {
         private ProcessStartInfo _info;
-        private DataReceivedEventHandler? _errorDataReceived;
-        private StringBuilder? _stderr;
-        private StringBuilder? _stdout;
-        private DataReceivedEventHandler? _outputDataReceived;
+        private DataReceivedEventHandler _errorDataReceived;
+        private StringBuilder _stderr;
+        private StringBuilder _stdout;
+        private DataReceivedEventHandler _outputDataReceived;
         private bool _anyNonEmptyStderrWritten;
 
-        private Dotnet(ProcessStartInfo info)
-        {
-            _info = info;
-        }
-
         internal string Command => string.Concat(_info.FileName, " ", _info.Arguments);
-        public Result Execute()
-        {
-            Process p = Process.Start(_info);
-            p.BeginOutputReadLine();
-            p.BeginErrorReadLine();
-            p.ErrorDataReceived += OnErrorDataReceived;
-            p.OutputDataReceived += OnOutputDataReceived;
-            p.WaitForExit();
-
-            return new Result(_stdout?.ToString(), _stderr?.ToString(), p.ExitCode);
-        }
-
-        public static Dotnet Version()
-        {
-            return new Dotnet(new ProcessStartInfo("dotnet", "--version")
-            {
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardError = true,
-                RedirectStandardOutput = true
-            });
-        }
-
-        public Dotnet CaptureStdOut()
-        {
-            _stdout = new StringBuilder();
-            _outputDataReceived += CaptureStreamStdOut;
-            return this;
-        }
-
-        public Dotnet CaptureStdErr()
-        {
-            _stderr = new StringBuilder();
-            _errorDataReceived += CaptureStreamStdErr;
-            return this;
-        }
-
         internal static Dotnet Restore(params string[] args)
         {
-            return new Dotnet (new ProcessStartInfo("dotnet", ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(new[] { "restore" }.Concat(args)))
+            return new Dotnet
             {
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardError = true,
-                RedirectStandardOutput = true
-            });
+                _info = new ProcessStartInfo("dotnet", ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(new[] { "restore" }.Concat(args)))
+                {
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true
+                }
+            };
         }
 
         internal static Dotnet AddProjectToProjectReference(string projectFile, params string[] args)
         {
-            return new Dotnet(new ProcessStartInfo("dotnet", ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(new[] { "add", projectFile, "reference" }.Concat(args)))
+            return new Dotnet
             {
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardError = true,
-                RedirectStandardOutput = true
-            });
+                _info = new ProcessStartInfo("dotnet", ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(new[] { "add", projectFile, "reference" }.Concat(args)))
+                {
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true
+                }
+            };
         }
 
-        internal static Dotnet AddPackageReference(string projectFile, string packageName, string? version = null)
+        internal static Dotnet AddPackageReference(string projectFile, string packageName, string version = null)
         {
             string argString;
             if (version == null)
@@ -97,13 +59,16 @@ namespace Microsoft.TemplateEngine.Cli
                 argString = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(new[] { "add", projectFile, "package", packageName, "--version", version });
             }
 
-            return new Dotnet(new ProcessStartInfo("dotnet", argString)
+            return new Dotnet
             {
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardError = true,
-                RedirectStandardOutput = true
-            });
+                _info = new ProcessStartInfo("dotnet", argString)
+                {
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true
+                }
+            };
         }
 
         internal static Dotnet AddProjectsToSolution(string solutionFile, IReadOnlyList<string> projects, string solutionFolder = "")
@@ -124,13 +89,16 @@ namespace Microsoft.TemplateEngine.Cli
             allArgs.AddRange(projects);
             string argString = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(allArgs);
 
-            return new Dotnet(new ProcessStartInfo("dotnet", argString)
+            return new Dotnet
             {
-                UseShellExecute = false,
-                CreateNoWindow = true,
-                RedirectStandardError = true,
-                RedirectStandardOutput = true
-            });
+                _info = new ProcessStartInfo("dotnet", argString)
+                {
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true
+                }
+            };
         }
 
         internal Dotnet ForwardStdErr()
@@ -165,14 +133,40 @@ namespace Microsoft.TemplateEngine.Cli
             Console.Error.WriteLine(e.Data);
         }
 
+        internal Dotnet CaptureStdOut()
+        {
+            _stdout = new StringBuilder();
+            _outputDataReceived += CaptureStreamStdOut;
+            return this;
+        }
+
         private void CaptureStreamStdOut(object sender, DataReceivedEventArgs e)
         {
-            _stdout?.AppendLine(e.Data);
+            _stdout.AppendLine(e.Data);
+        }
+
+        internal Dotnet CaptureStdErr()
+        {
+            _stderr = new StringBuilder();
+            _errorDataReceived += CaptureStreamStdErr;
+            return this;
         }
 
         private void CaptureStreamStdErr(object sender, DataReceivedEventArgs e)
         {
-            _stderr?.AppendLine(e.Data);
+            _stderr.AppendLine(e.Data);
+        }
+
+        internal Result Execute()
+        {
+            Process p = Process.Start(_info);
+            p.BeginOutputReadLine();
+            p.BeginErrorReadLine();
+            p.ErrorDataReceived += OnErrorDataReceived;
+            p.OutputDataReceived += OnOutputDataReceived;
+            p.WaitForExit();
+
+            return new Result(_stdout?.ToString(), _stderr?.ToString(), p.ExitCode);
         }
 
         private void OnOutputDataReceived(object sender, DataReceivedEventArgs e)
@@ -185,20 +179,34 @@ namespace Microsoft.TemplateEngine.Cli
             _errorDataReceived?.Invoke(sender, e);
         }
 
-        public class Result
+        internal class Result
         {
-            internal Result(string? stdout, string? stderr, int exitCode)
+            internal Result(string stdout, string stderr, int exitCode)
             {
                 StdErr = stderr;
                 StdOut = stdout;
                 ExitCode = exitCode;
             }
 
-            public string? StdErr { get; }
+            internal string StdErr { get; }
 
-            public string? StdOut { get; }
+            internal string StdOut { get; }
 
-            public int ExitCode { get; }
+            internal int ExitCode { get; }
+        }
+
+        internal static Dotnet Version()
+        {
+            return new Dotnet
+            {
+                _info = new ProcessStartInfo("dotnet", "--version")
+                {
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true
+                }
+            };
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/ExtendedTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Cli/ExtendedTemplateEngineHost.cs
@@ -12,7 +12,7 @@ namespace Microsoft.TemplateEngine.Cli
         private readonly New3Command _new3Command;
         private readonly ITemplateEngineHost _baseHost;
 
-        public ExtendedTemplateEngineHost(ITemplateEngineHost baseHost, New3Command new3Command)
+        internal ExtendedTemplateEngineHost(ITemplateEngineHost baseHost, New3Command new3Command)
         {
             _baseHost = baseHost;
             _new3Command = new3Command;
@@ -50,7 +50,7 @@ namespace Microsoft.TemplateEngine.Cli
         }
 
         public virtual void OnSymbolUsed(string symbol, object value) => _baseHost.OnSymbolUsed(symbol, value);
-        
+
         public virtual bool TryGetHostParamDefault(string paramName, out string value)
         {
             switch (paramName)

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 {
     internal static class HelpForTemplateResolution
     {
-        public static CreationResultStatus CoordinateHelpAndUsageDisplay(TemplateListResolutionResult templateResolutionResult, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, ITelemetryLogger telemetryLogger, TemplateCreator templateCreator, string defaultLanguage, bool showUsageHelp = true)
+        internal static CreationResultStatus CoordinateHelpAndUsageDisplay(TemplateListResolutionResult templateResolutionResult, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, ITelemetryLogger telemetryLogger, TemplateCreator templateCreator, string defaultLanguage, bool showUsageHelp = true)
         {
             if (showUsageHelp)
             {
@@ -364,7 +364,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             reporter.WriteLine(formatter.Layout());
         }
 
-        public static void DisplayInvalidParameters(IReadOnlyList<string> invalidParams)
+        internal static void DisplayInvalidParameters(IReadOnlyList<string> invalidParams)
         {
             if (invalidParams.Count > 0)
             {
@@ -425,7 +425,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
         }
 
         // Returns a list of the parameter names that are invalid for every template in the input group.
-        public static void GetParametersInvalidForTemplatesInList(IReadOnlyCollection<ITemplateMatchInfo> templateList, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates)
+        internal static void GetParametersInvalidForTemplatesInList(IReadOnlyCollection<ITemplateMatchInfo> templateList, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates)
         {
             IDictionary<string, int> invalidCounts = new Dictionary<string, int>();
 
@@ -458,7 +458,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             }
         }
 
-        public static void ShowUsageHelp(INewCommandInput commandInput, ITelemetryLogger telemetryLogger)
+        internal static void ShowUsageHelp(INewCommandInput commandInput, ITelemetryLogger telemetryLogger)
         {
             if (commandInput.IsHelpFlagSpecified)
             {
@@ -469,7 +469,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             Reporter.Output.WriteLine();
         }
 
-        public static CreationResultStatus HandleParseError(INewCommandInput commandInput, ITelemetryLogger telemetryLogger)
+        internal static CreationResultStatus HandleParseError(INewCommandInput commandInput, ITelemetryLogger telemetryLogger)
         {
             TemplateResolver.ValidateRemainingParameters(commandInput, out IReadOnlyList<string> invalidParams);
             DisplayInvalidParameters(invalidParams);

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/InvalidParameterInfo.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/InvalidParameterInfo.cs
@@ -66,7 +66,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
         /// <param name="invalidParameterList">the invalid parameters collection to prepare output for</param>
         /// <param name="templateGroup">the template group to use to get more information about parameters. Optional - if not provided the possible value for the parameters won't be included to the output.</param>
         /// <returns>the error string for the output</returns>
-        public static string InvalidParameterListToString(IEnumerable<InvalidParameterInfo> invalidParameterList, TemplateGroup templateGroup = null)
+        internal static string InvalidParameterListToString(IEnumerable<InvalidParameterInfo> invalidParameterList, TemplateGroup templateGroup = null)
         {
             if (!invalidParameterList.Any())
             {

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
@@ -13,9 +13,9 @@ using Microsoft.TemplateEngine.Cli.TemplateResolution;
 
 namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 {
-    public static class TemplateDetailsDisplay
+    internal static class TemplateDetailsDisplay
     {
-        public static void ShowTemplateGroupHelp(IReadOnlyCollection<ITemplateMatchInfo> templateGroup, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, TemplateCreator templateCreator, bool showImplicitlyHiddenParams = false)
+        internal static void ShowTemplateGroupHelp(IReadOnlyCollection<ITemplateMatchInfo> templateGroup, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, TemplateCreator templateCreator, bool showImplicitlyHiddenParams = false)
         {
             if (templateGroup.Count == 0 || !TemplateResolver.AreAllTemplatesSameGroupIdentity(templateGroup))
             {
@@ -393,14 +393,14 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 
         private struct TemplateGroupParameterDetails
         {
-            public IParameterSet AllParams;
-            public string AdditionalInfo;       // TODO: rename (probably)
-            public IReadOnlyList<string> InvalidParams;
-            public HashSet<string> ExplicitlyHiddenParams;
-            public IReadOnlyDictionary<string, IReadOnlyList<string>> GroupVariantsForCanonicals;
-            public HashSet<string> GroupUserParamsWithDefaultValues;
-            public bool HasPostActionScriptRunner;
-            public HashSet<string> ParametersToAlwaysShow;
+            internal IParameterSet AllParams;
+            internal string AdditionalInfo;       // TODO: rename (probably)
+            internal IReadOnlyList<string> InvalidParams;
+            internal HashSet<string> ExplicitlyHiddenParams;
+            internal IReadOnlyDictionary<string, IReadOnlyList<string>> GroupVariantsForCanonicals;
+            internal HashSet<string> GroupUserParamsWithDefaultValues;
+            internal bool HasPostActionScriptRunner;
+            internal HashSet<string> ParametersToAlwaysShow;
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateParameterHelpBase.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateParameterHelpBase.cs
@@ -9,10 +9,10 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 {
-    public static class TemplateParameterHelpBase
+    internal static class TemplateParameterHelpBase
     {
         // Note: This method explicitly filters out "type" and "language", in addition to other filtering.
-        public static IEnumerable<ITemplateParameter> FilterParamsForHelp(IEnumerable<ITemplateParameter> parameterDefinitions, HashSet<string> hiddenParams, bool showImplicitlyHiddenParams = false, bool hasPostActionScriptRunner = false, HashSet<string> parametersToAlwaysShow = null)
+        internal static IEnumerable<ITemplateParameter> FilterParamsForHelp(IEnumerable<ITemplateParameter> parameterDefinitions, HashSet<string> hiddenParams, bool showImplicitlyHiddenParams = false, bool hasPostActionScriptRunner = false, HashSet<string> parametersToAlwaysShow = null)
         {
             IList<ITemplateParameter> filteredParams = parameterDefinitions
                 .Where(x => x.Priority != TemplateParameterPriority.Implicit

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
@@ -12,9 +12,9 @@ using Microsoft.TemplateEngine.Edge.Template;
 
 namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 {
-    public static class TemplateUsageHelp
+    internal static class TemplateUsageHelp
     {
-        public static void ShowInvocationExamples(TemplateListResolutionResult templateResolutionResult, IHostSpecificDataLoader hostDataLoader, string commandName)
+        internal static void ShowInvocationExamples(TemplateListResolutionResult templateResolutionResult, IHostSpecificDataLoader hostDataLoader, string commandName)
         {
             const int ExamplesToShow = 2;
             IReadOnlyList<string> preferredNameList = new List<string>() { "mvc" };

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageInformation.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageInformation.cs
@@ -8,11 +8,11 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 {
     internal struct TemplateUsageInformation
     {
-        public IReadOnlyList<InvalidParameterInfo> InvalidParameters;
-        public IParameterSet AllParameters;
-        public IReadOnlyList<string> UserParametersWithInvalidValues;
-        public HashSet<string> UserParametersWithDefaultValues;
-        public IReadOnlyDictionary<string, IReadOnlyList<string>> VariantsForCanonicals;
-        public bool HasPostActionScriptRunner;
+        internal IReadOnlyList<InvalidParameterInfo> InvalidParameters;
+        internal IParameterSet AllParameters;
+        internal IReadOnlyList<string> UserParametersWithInvalidValues;
+        internal HashSet<string> UserParametersWithDefaultValues;
+        internal IReadOnlyDictionary<string, IReadOnlyList<string>> VariantsForCanonicals;
+        internal bool HasPostActionScriptRunner;
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/HiveSynchronizationException.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HiveSynchronizationException.cs
@@ -5,20 +5,20 @@ using System;
 
 namespace Microsoft.TemplateEngine.Cli
 {
-    public sealed class HiveSynchronizationException : Exception
+    internal sealed class HiveSynchronizationException : Exception
     {
-        public HiveSynchronizationException(string message, string version)
+        internal HiveSynchronizationException(string message, string version)
             : base(message)
         {
             SdkVersion = version;
         }
 
-        public HiveSynchronizationException(string message, string version, Exception innerException)
+        internal HiveSynchronizationException(string message, string version, Exception innerException)
             : base(message, innerException)
         {
             SdkVersion = version;
         }
 
-        public string SdkVersion { get; }
+        internal string SdkVersion { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/HostSpecificDataLoader.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HostSpecificDataLoader.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System.IO;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
@@ -10,12 +13,11 @@ namespace Microsoft.TemplateEngine.Cli
 {
     public class HostSpecificDataLoader : IHostSpecificDataLoader
     {
+        private readonly ISettingsLoader _settingsLoader;
         public HostSpecificDataLoader(ISettingsLoader settingsLoader)
         {
             _settingsLoader = settingsLoader;
         }
-
-        private ISettingsLoader _settingsLoader;
 
         public HostSpecificTemplateData ReadHostSpecificTemplateData(ITemplateInfo templateInfo)
         {

--- a/src/Microsoft.TemplateEngine.Cli/HostSpecificTemplateData.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HostSpecificTemplateData.cs
@@ -1,5 +1,7 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -9,28 +11,25 @@ namespace Microsoft.TemplateEngine.Cli
 {
     public class HostSpecificTemplateData
     {
-        private static readonly string IsHiddenKey = "isHidden";
-        private static readonly string LongNameKey = "longName";
-        private static readonly string ShortNameKey = "shortName";
-        private static readonly string AlwaysShowKey = "alwaysShow";
+        private const string IsHiddenKey = "isHidden";
+        private const string LongNameKey = "longName";
+        private const string ShortNameKey = "shortName";
+        private const string AlwaysShowKey = "alwaysShow";
 
-        public static HostSpecificTemplateData Default { get; } = new HostSpecificTemplateData();
+        private readonly Dictionary<string, IReadOnlyDictionary<string, string>> _symbolInfo;
 
-        protected readonly Dictionary<string, IReadOnlyDictionary<string, string>> _symbolInfo;
-
-        public HostSpecificTemplateData()
+        internal HostSpecificTemplateData()
         {
             _symbolInfo = new Dictionary<string, IReadOnlyDictionary<string, string>>();
         }
 
-        // for unit tests
-        protected HostSpecificTemplateData(Dictionary<string, IReadOnlyDictionary<string, string>> symbolInfo)
+        internal HostSpecificTemplateData(Dictionary<string, IReadOnlyDictionary<string, string>> symbolInfo)
         {
             _symbolInfo = symbolInfo;
         }
 
         [JsonProperty]
-        public List<string> UsageExamples { get; set; }
+        public List<string>? UsageExamples { get; set; }
 
         [JsonProperty]
         public IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> SymbolInfo => _symbolInfo;
@@ -64,7 +63,7 @@ namespace Microsoft.TemplateEngine.Cli
                 HashSet<string> parametersToAlwaysShow = new HashSet<string>(StringComparer.Ordinal);
                 foreach (KeyValuePair<string, IReadOnlyDictionary<string, string>> paramInfo in SymbolInfo)
                 {
-                    if(paramInfo.Value.TryGetValue(AlwaysShowKey, out string alwaysShowValue)
+                    if (paramInfo.Value.TryGetValue(AlwaysShowKey, out string alwaysShowValue)
                         && bool.TryParse(alwaysShowValue, out bool alwaysShowBoolValue)
                         && alwaysShowBoolValue)
                     {
@@ -112,7 +111,9 @@ namespace Microsoft.TemplateEngine.Cli
             }
         }
 
-        public string DisplayNameForParameter(string parameterName)
+        internal static HostSpecificTemplateData Default { get; } = new HostSpecificTemplateData();
+
+        internal string DisplayNameForParameter(string parameterName)
         {
             if (SymbolInfo.TryGetValue(parameterName, out IReadOnlyDictionary<string, string> configForParam)
                 && configForParam.TryGetValue(LongNameKey, out string longName))

--- a/src/Microsoft.TemplateEngine.Cli/IHostSpecificDataLoader.cs
+++ b/src/Microsoft.TemplateEngine.Cli/IHostSpecificDataLoader.cs
@@ -1,3 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Cli

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.TemplateEngine.Cli {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class LocalizableStrings {
+    internal class LocalizableStrings {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace Microsoft.TemplateEngine.Cli {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Resources.ResourceManager ResourceManager {
+        internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Microsoft.TemplateEngine.Cli.LocalizableStrings", typeof(LocalizableStrings).Assembly);
@@ -51,7 +51,7 @@ namespace Microsoft.TemplateEngine.Cli {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        public static global::System.Globalization.CultureInfo Culture {
+        internal static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Action would have been taken automatically:.
         /// </summary>
-        public static string ActionWouldHaveBeenTakenAutomatically {
+        internal static string ActionWouldHaveBeenTakenAutomatically {
             get {
                 return ResourceManager.GetString("ActionWouldHaveBeenTakenAutomatically", resourceCulture);
             }
@@ -72,7 +72,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Failed to add project(s) {0} to solution file {1}, solution folder {2}..
         /// </summary>
-        public static string AddProjToSlnPostActionFailed {
+        internal static string AddProjToSlnPostActionFailed {
             get {
                 return ResourceManager.GetString("AddProjToSlnPostActionFailed", resourceCulture);
             }
@@ -81,7 +81,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Add project reference to solution action is not configured correctly in the template. Unable to determine the project files to add..
         /// </summary>
-        public static string AddProjToSlnPostActionNoProjFiles {
+        internal static string AddProjToSlnPostActionNoProjFiles {
             get {
                 return ResourceManager.GetString("AddProjToSlnPostActionNoProjFiles", resourceCulture);
             }
@@ -90,7 +90,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Adding project reference(s) to solution file. Running {0}.
         /// </summary>
-        public static string AddProjToSlnPostActionRunning {
+        internal static string AddProjToSlnPostActionRunning {
             get {
                 return ResourceManager.GetString("AddProjToSlnPostActionRunning", resourceCulture);
             }
@@ -102,7 +102,7 @@ namespace Microsoft.TemplateEngine.Cli {
         ///    to solution file: {1}
         ///    solution folder: {2}.
         /// </summary>
-        public static string AddProjToSlnPostActionSucceeded {
+        internal static string AddProjToSlnPostActionSucceeded {
             get {
                 return ResourceManager.GetString("AddProjToSlnPostActionSucceeded", resourceCulture);
             }
@@ -111,7 +111,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Unable to determine which solution file to add the reference to..
         /// </summary>
-        public static string AddProjToSlnPostActionUnresolvedSlnFile {
+        internal static string AddProjToSlnPostActionUnresolvedSlnFile {
             get {
                 return ResourceManager.GetString("AddProjToSlnPostActionUnresolvedSlnFile", resourceCulture);
             }
@@ -120,7 +120,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Adding a package reference. Running dotnet add {0} package {1}.
         /// </summary>
-        public static string AddRefPostActionAddPackageRef {
+        internal static string AddRefPostActionAddPackageRef {
             get {
                 return ResourceManager.GetString("AddRefPostActionAddPackageRef", resourceCulture);
             }
@@ -129,7 +129,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Adding a package reference. Running dotnet add {0} package {1} --version {2}.
         /// </summary>
-        public static string AddRefPostActionAddPackageRefWithVersion {
+        internal static string AddRefPostActionAddPackageRefWithVersion {
             get {
                 return ResourceManager.GetString("AddRefPostActionAddPackageRefWithVersion", resourceCulture);
             }
@@ -138,7 +138,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Adding a project reference. Running dotnet add {0} reference {1}.
         /// </summary>
-        public static string AddRefPostActionAddProjectRef {
+        internal static string AddRefPostActionAddProjectRef {
             get {
                 return ResourceManager.GetString("AddRefPostActionAddProjectRef", resourceCulture);
             }
@@ -147,7 +147,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Failed to add reference {0} to project file {1}.
         /// </summary>
-        public static string AddRefPostActionFailed {
+        internal static string AddRefPostActionFailed {
             get {
                 return ResourceManager.GetString("AddRefPostActionFailed", resourceCulture);
             }
@@ -156,7 +156,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Unable to automatically add the framework reference {0} to the project. Manually edit the project file to add it..
         /// </summary>
-        public static string AddRefPostActionFrameworkNotSupported {
+        internal static string AddRefPostActionFrameworkNotSupported {
             get {
                 return ResourceManager.GetString("AddRefPostActionFrameworkNotSupported", resourceCulture);
             }
@@ -165,7 +165,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Add reference action is not configured correctly in the template..
         /// </summary>
-        public static string AddRefPostActionMisconfigured {
+        internal static string AddRefPostActionMisconfigured {
             get {
                 return ResourceManager.GetString("AddRefPostActionMisconfigured", resourceCulture);
             }
@@ -174,7 +174,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Project files found:.
         /// </summary>
-        public static string AddRefPostActionProjFileListHeader {
+        internal static string AddRefPostActionProjFileListHeader {
             get {
                 return ResourceManager.GetString("AddRefPostActionProjFileListHeader", resourceCulture);
             }
@@ -185,7 +185,7 @@ namespace Microsoft.TemplateEngine.Cli {
         ///    reference: {0}
         ///    to project file: {1}.
         /// </summary>
-        public static string AddRefPostActionSucceeded {
+        internal static string AddRefPostActionSucceeded {
             get {
                 return ResourceManager.GetString("AddRefPostActionSucceeded", resourceCulture);
             }
@@ -194,7 +194,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Unable to determine which project file to add the reference to..
         /// </summary>
-        public static string AddRefPostActionUnresolvedProjFile {
+        internal static string AddRefPostActionUnresolvedProjFile {
             get {
                 return ResourceManager.GetString("AddRefPostActionUnresolvedProjFile", resourceCulture);
             }
@@ -203,7 +203,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Adding reference type {0} is not supported..
         /// </summary>
-        public static string AddRefPostActionUnsupportedRefType {
+        internal static string AddRefPostActionUnsupportedRefType {
             get {
                 return ResourceManager.GetString("AddRefPostActionUnsupportedRefType", resourceCulture);
             }
@@ -212,7 +212,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Alias &apos;{0}&apos; is a template short name, and therefore cannot be aliased..
         /// </summary>
-        public static string AliasCannotBeShortName {
+        internal static string AliasCannotBeShortName {
             get {
                 return ResourceManager.GetString("AliasCannotBeShortName", resourceCulture);
             }
@@ -222,7 +222,7 @@ namespace Microsoft.TemplateEngine.Cli {
         ///   Looks up a localized string similar to After expanding aliases, the command is:
         ///    dotnet {0}.
         /// </summary>
-        public static string AliasCommandAfterExpansion {
+        internal static string AliasCommandAfterExpansion {
             get {
                 return ResourceManager.GetString("AliasCommandAfterExpansion", resourceCulture);
             }
@@ -231,7 +231,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Successfully created alias named &apos;{0}&apos; with value &apos;{1}&apos;.
         /// </summary>
-        public static string AliasCreated {
+        internal static string AliasCreated {
             get {
                 return ResourceManager.GetString("AliasCreated", resourceCulture);
             }
@@ -240,7 +240,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Alias not created. It would have created an alias cycle, resulting in infinite expansion..
         /// </summary>
-        public static string AliasCycleError {
+        internal static string AliasCycleError {
             get {
                 return ResourceManager.GetString("AliasCycleError", resourceCulture);
             }
@@ -249,7 +249,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Command is invalid after expanding aliases..
         /// </summary>
-        public static string AliasExpandedCommandParseError {
+        internal static string AliasExpandedCommandParseError {
             get {
                 return ResourceManager.GetString("AliasExpandedCommandParseError", resourceCulture);
             }
@@ -258,7 +258,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Error expanding aliases on input params..
         /// </summary>
-        public static string AliasExpansionError {
+        internal static string AliasExpansionError {
             get {
                 return ResourceManager.GetString("AliasExpansionError", resourceCulture);
             }
@@ -267,7 +267,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Alias Name.
         /// </summary>
-        public static string AliasName {
+        internal static string AliasName {
             get {
                 return ResourceManager.GetString("AliasName", resourceCulture);
             }
@@ -276,7 +276,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Alias names can only contain letters, numbers, underscores, and periods..
         /// </summary>
-        public static string AliasNameContainsInvalidCharacters {
+        internal static string AliasNameContainsInvalidCharacters {
             get {
                 return ResourceManager.GetString("AliasNameContainsInvalidCharacters", resourceCulture);
             }
@@ -285,7 +285,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Alias not created. The input was invalid..
         /// </summary>
-        public static string AliasNotCreatedInvalidInput {
+        internal static string AliasNotCreatedInvalidInput {
             get {
                 return ResourceManager.GetString("AliasNotCreatedInvalidInput", resourceCulture);
             }
@@ -294,7 +294,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Successfully removed alias named &apos;{0}&apos; whose value was &apos;{1}&apos;..
         /// </summary>
-        public static string AliasRemoved {
+        internal static string AliasRemoved {
             get {
                 return ResourceManager.GetString("AliasRemoved", resourceCulture);
             }
@@ -303,7 +303,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Unable to remove alias &apos;{0}&apos;. It did not exist..
         /// </summary>
-        public static string AliasRemoveNonExistentFailed {
+        internal static string AliasRemoveNonExistentFailed {
             get {
                 return ResourceManager.GetString("AliasRemoveNonExistentFailed", resourceCulture);
             }
@@ -312,7 +312,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to All Aliases:.
         /// </summary>
-        public static string AliasShowAllAliasesHeader {
+        internal static string AliasShowAllAliasesHeader {
             get {
                 return ResourceManager.GetString("AliasShowAllAliasesHeader", resourceCulture);
             }
@@ -322,7 +322,7 @@ namespace Microsoft.TemplateEngine.Cli {
         ///   Looks up a localized string similar to Unknown alias name &apos;{0}&apos;.
         ///Run &apos;dotnet {1} --show-aliases&apos; with no args to show all aliases..
         /// </summary>
-        public static string AliasShowErrorUnknownAlias {
+        internal static string AliasShowErrorUnknownAlias {
             get {
                 return ResourceManager.GetString("AliasShowErrorUnknownAlias", resourceCulture);
             }
@@ -331,7 +331,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Successfully updated alias named &apos;{0}&apos; to value &apos;{1}&apos;..
         /// </summary>
-        public static string AliasUpdated {
+        internal static string AliasUpdated {
             get {
                 return ResourceManager.GetString("AliasUpdated", resourceCulture);
             }
@@ -340,7 +340,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Alias Value.
         /// </summary>
-        public static string AliasValue {
+        internal static string AliasValue {
             get {
                 return ResourceManager.GetString("AliasValue", resourceCulture);
             }
@@ -349,7 +349,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to First argument of an alias value must begin with a letter or digit..
         /// </summary>
-        public static string AliasValueFirstArgError {
+        internal static string AliasValueFirstArgError {
             get {
                 return ResourceManager.GetString("AliasValueFirstArgError", resourceCulture);
             }
@@ -358,7 +358,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Do not allow scripts to run.
         /// </summary>
-        public static string AllowScriptsNoChoice {
+        internal static string AllowScriptsNoChoice {
             get {
                 return ResourceManager.GetString("AllowScriptsNoChoice", resourceCulture);
             }
@@ -367,7 +367,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Ask before running each script.
         /// </summary>
-        public static string AllowScriptsPromptChoice {
+        internal static string AllowScriptsPromptChoice {
             get {
                 return ResourceManager.GetString("AllowScriptsPromptChoice", resourceCulture);
             }
@@ -376,7 +376,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Allow scripts to run.
         /// </summary>
-        public static string AllowScriptsYesChoice {
+        internal static string AllowScriptsYesChoice {
             get {
                 return ResourceManager.GetString("AllowScriptsYesChoice", resourceCulture);
             }
@@ -385,7 +385,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Re-run the command specifying the language to use with --language option..
         /// </summary>
-        public static string AmbiguousLanguageHint {
+        internal static string AmbiguousLanguageHint {
             get {
                 return ResourceManager.GetString("AmbiguousLanguageHint", resourceCulture);
             }
@@ -394,7 +394,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{1}&apos; is ambiguous for option {0}..
         /// </summary>
-        public static string AmbiguousParameterDetail {
+        internal static string AmbiguousParameterDetail {
             get {
                 return ResourceManager.GetString("AmbiguousParameterDetail", resourceCulture);
             }
@@ -403,7 +403,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Unable to resolve the template to instantiate, these templates matched your input:.
         /// </summary>
-        public static string AmbiguousTemplateGroupListHeader {
+        internal static string AmbiguousTemplateGroupListHeader {
             get {
                 return ResourceManager.GetString("AmbiguousTemplateGroupListHeader", resourceCulture);
             }
@@ -412,7 +412,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Re-run the command using the template&apos;s exact short name..
         /// </summary>
-        public static string AmbiguousTemplateGroupListHint {
+        internal static string AmbiguousTemplateGroupListHint {
             get {
                 return ResourceManager.GetString("AmbiguousTemplateGroupListHint", resourceCulture);
             }
@@ -421,7 +421,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Unable to resolve the template to instantiate, the following installed templates are conflicting:.
         /// </summary>
-        public static string AmbiguousTemplatesHeader {
+        internal static string AmbiguousTemplatesHeader {
             get {
                 return ResourceManager.GetString("AmbiguousTemplatesHeader", resourceCulture);
             }
@@ -430,7 +430,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Uninstall the templates or the packages to keep only one template from the list..
         /// </summary>
-        public static string AmbiguousTemplatesMultiplePackagesHint {
+        internal static string AmbiguousTemplatesMultiplePackagesHint {
             get {
                 return ResourceManager.GetString("AmbiguousTemplatesMultiplePackagesHint", resourceCulture);
             }
@@ -439,7 +439,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The package {0} is not correct, uninstall it and report the issue to the package author..
         /// </summary>
-        public static string AmbiguousTemplatesSamePackageHint {
+        internal static string AmbiguousTemplatesSamePackageHint {
             get {
                 return ResourceManager.GetString("AmbiguousTemplatesSamePackageHint", resourceCulture);
             }
@@ -448,7 +448,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The specified extra args file does not exist: {0}..
         /// </summary>
-        public static string ArgsFileNotFound {
+        internal static string ArgsFileNotFound {
             get {
                 return ResourceManager.GetString("ArgsFileNotFound", resourceCulture);
             }
@@ -457,7 +457,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Extra args file {0} is not formatted properly..
         /// </summary>
-        public static string ArgsFileWrongFormat {
+        internal static string ArgsFileWrongFormat {
             get {
                 return ResourceManager.GetString("ArgsFileWrongFormat", resourceCulture);
             }
@@ -466,7 +466,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Assembly.
         /// </summary>
-        public static string Assembly {
+        internal static string Assembly {
             get {
                 return ResourceManager.GetString("Assembly", resourceCulture);
             }
@@ -475,7 +475,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Author: {0}.
         /// </summary>
-        public static string Author {
+        internal static string Author {
             get {
                 return ResourceManager.GetString("Author", resourceCulture);
             }
@@ -484,7 +484,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Equal highest precedence values among the best template matches prevented unambiguously choosing a template to invoke..
         /// </summary>
-        public static string Authoring_AmbiguousBestPrecedence {
+        internal static string Authoring_AmbiguousBestPrecedence {
             get {
                 return ResourceManager.GetString("Authoring_AmbiguousBestPrecedence", resourceCulture);
             }
@@ -493,7 +493,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to An ambiguous choice parameter value prevented unambiguously choosing a template to invoke..
         /// </summary>
-        public static string Authoring_AmbiguousChoiceParameterValue {
+        internal static string Authoring_AmbiguousChoiceParameterValue {
             get {
                 return ResourceManager.GetString("Authoring_AmbiguousChoiceParameterValue", resourceCulture);
             }
@@ -502,7 +502,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Change.
         /// </summary>
-        public static string Change {
+        internal static string Change {
             get {
                 return ResourceManager.GetString("Change", resourceCulture);
             }
@@ -511,7 +511,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Author.
         /// </summary>
-        public static string ColumnNameAuthor {
+        internal static string ColumnNameAuthor {
             get {
                 return ResourceManager.GetString("ColumnNameAuthor", resourceCulture);
             }
@@ -520,7 +520,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Identity.
         /// </summary>
-        public static string ColumnNameIdentity {
+        internal static string ColumnNameIdentity {
             get {
                 return ResourceManager.GetString("ColumnNameIdentity", resourceCulture);
             }
@@ -529,7 +529,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Language.
         /// </summary>
-        public static string ColumnNameLanguage {
+        internal static string ColumnNameLanguage {
             get {
                 return ResourceManager.GetString("ColumnNameLanguage", resourceCulture);
             }
@@ -538,7 +538,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Package.
         /// </summary>
-        public static string ColumnNamePackage {
+        internal static string ColumnNamePackage {
             get {
                 return ResourceManager.GetString("ColumnNamePackage", resourceCulture);
             }
@@ -547,7 +547,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Precedence.
         /// </summary>
-        public static string ColumnNamePrecedence {
+        internal static string ColumnNamePrecedence {
             get {
                 return ResourceManager.GetString("ColumnNamePrecedence", resourceCulture);
             }
@@ -556,7 +556,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The column {0} is/are not supported, the supported columns are: {1}..
         /// </summary>
-        public static string ColumnNamesAreNotSupported {
+        internal static string ColumnNamesAreNotSupported {
             get {
                 return ResourceManager.GetString("ColumnNamesAreNotSupported", resourceCulture);
             }
@@ -565,7 +565,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Short Name.
         /// </summary>
-        public static string ColumnNameShortName {
+        internal static string ColumnNameShortName {
             get {
                 return ResourceManager.GetString("ColumnNameShortName", resourceCulture);
             }
@@ -574,7 +574,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Tags.
         /// </summary>
-        public static string ColumnNameTags {
+        internal static string ColumnNameTags {
             get {
                 return ResourceManager.GetString("ColumnNameTags", resourceCulture);
             }
@@ -583,7 +583,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Template Name.
         /// </summary>
-        public static string ColumnNameTemplateName {
+        internal static string ColumnNameTemplateName {
             get {
                 return ResourceManager.GetString("ColumnNameTemplateName", resourceCulture);
             }
@@ -592,7 +592,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Downloads.
         /// </summary>
-        public static string ColumnNameTotalDownloads {
+        internal static string ColumnNameTotalDownloads {
             get {
                 return ResourceManager.GetString("ColumnNameTotalDownloads", resourceCulture);
             }
@@ -601,7 +601,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Type.
         /// </summary>
-        public static string ColumnNameType {
+        internal static string ColumnNameType {
             get {
                 return ResourceManager.GetString("ColumnNameType", resourceCulture);
             }
@@ -610,7 +610,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Template Instantiation Commands for .NET Core CLI.
         /// </summary>
-        public static string CommandDescription {
+        internal static string CommandDescription {
             get {
                 return ResourceManager.GetString("CommandDescription", resourceCulture);
             }
@@ -619,7 +619,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Command failed..
         /// </summary>
-        public static string CommandFailed {
+        internal static string CommandFailed {
             get {
                 return ResourceManager.GetString("CommandFailed", resourceCulture);
             }
@@ -629,7 +629,7 @@ namespace Microsoft.TemplateEngine.Cli {
         ///   Looks up a localized string similar to Output from command:
         ///{0}.
         /// </summary>
-        public static string CommandOutput {
+        internal static string CommandOutput {
             get {
                 return ResourceManager.GetString("CommandOutput", resourceCulture);
             }
@@ -638,7 +638,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Command succeeded..
         /// </summary>
-        public static string CommandSucceeded {
+        internal static string CommandSucceeded {
             get {
                 return ResourceManager.GetString("CommandSucceeded", resourceCulture);
             }
@@ -647,7 +647,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Commit Hash:.
         /// </summary>
-        public static string CommitHash {
+        internal static string CommitHash {
             get {
                 return ResourceManager.GetString("CommitHash", resourceCulture);
             }
@@ -656,7 +656,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Configured Value: {0}.
         /// </summary>
-        public static string ConfiguredValue {
+        internal static string ConfiguredValue {
             get {
                 return ResourceManager.GetString("ConfiguredValue", resourceCulture);
             }
@@ -665,7 +665,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Couldn&apos;t determine files to restore..
         /// </summary>
-        public static string CouldntDetermineFilesToRestore {
+        internal static string CouldntDetermineFilesToRestore {
             get {
                 return ResourceManager.GetString("CouldntDetermineFilesToRestore", resourceCulture);
             }
@@ -675,7 +675,7 @@ namespace Microsoft.TemplateEngine.Cli {
         ///   Looks up a localized string similar to Template &quot;{0}&quot; could not be created.
         ///{1}.
         /// </summary>
-        public static string CreateFailed {
+        internal static string CreateFailed {
             get {
                 return ResourceManager.GetString("CreateFailed", resourceCulture);
             }
@@ -684,7 +684,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The template &quot;{0}&quot; was created successfully..
         /// </summary>
-        public static string CreateSuccessful {
+        internal static string CreateSuccessful {
             get {
                 return ResourceManager.GetString("CreateSuccessful", resourceCulture);
             }
@@ -693,7 +693,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Current configuration:.
         /// </summary>
-        public static string CurrentConfiguration {
+        internal static string CurrentConfiguration {
             get {
                 return ResourceManager.GetString("CurrentConfiguration", resourceCulture);
             }
@@ -702,7 +702,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Default if option is provided without a value: {0}.
         /// </summary>
-        public static string DefaultIfOptionWithoutValue {
+        internal static string DefaultIfOptionWithoutValue {
             get {
                 return ResourceManager.GetString("DefaultIfOptionWithoutValue", resourceCulture);
             }
@@ -711,7 +711,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Default: {0}.
         /// </summary>
-        public static string DefaultValue {
+        internal static string DefaultValue {
             get {
                 return ResourceManager.GetString("DefaultValue", resourceCulture);
             }
@@ -720,7 +720,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Delete.
         /// </summary>
-        public static string Delete {
+        internal static string Delete {
             get {
                 return ResourceManager.GetString("Delete", resourceCulture);
             }
@@ -729,7 +729,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Description: {0}.
         /// </summary>
-        public static string Description {
+        internal static string Description {
             get {
                 return ResourceManager.GetString("Description", resourceCulture);
             }
@@ -738,7 +738,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Creating this template will make changes to existing files:.
         /// </summary>
-        public static string DestructiveChangesNotification {
+        internal static string DestructiveChangesNotification {
             get {
                 return ResourceManager.GetString("DestructiveChangesNotification", resourceCulture);
             }
@@ -747,7 +747,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Displays help for this command..
         /// </summary>
-        public static string DisplaysHelp {
+        internal static string DisplaysHelp {
             get {
                 return ResourceManager.GetString("DisplaysHelp", resourceCulture);
             }
@@ -756,7 +756,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Displays a summary of what would happen if the given command line were run if it would result in a template creation..
         /// </summary>
-        public static string DryRunDescription {
+        internal static string DryRunDescription {
             get {
                 return ResourceManager.GetString("DryRunDescription", resourceCulture);
             }
@@ -766,7 +766,7 @@ namespace Microsoft.TemplateEngine.Cli {
         ///   Looks up a localized string similar to After expanding the extra args files, the command is:
         ///    dotnet {0}.
         /// </summary>
-        public static string ExtraArgsCommandAfterExpansion {
+        internal static string ExtraArgsCommandAfterExpansion {
             get {
                 return ResourceManager.GetString("ExtraArgsCommandAfterExpansion", resourceCulture);
             }
@@ -775,7 +775,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to File actions would have been taken:.
         /// </summary>
-        public static string FileActionsWouldHaveBeenTaken {
+        internal static string FileActionsWouldHaveBeenTaken {
             get {
                 return ResourceManager.GetString("FileActionsWouldHaveBeenTaken", resourceCulture);
             }
@@ -784,7 +784,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Forces content to be generated even if it would change existing files..
         /// </summary>
-        public static string ForcesTemplateCreation {
+        internal static string ForcesTemplateCreation {
             get {
                 return ResourceManager.GetString("ForcesTemplateCreation", resourceCulture);
             }
@@ -793,7 +793,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Generators.
         /// </summary>
-        public static string Generators {
+        internal static string Generators {
             get {
                 return ResourceManager.GetString("Generators", resourceCulture);
             }
@@ -802,7 +802,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Error: {0}.
         /// </summary>
-        public static string GenericError {
+        internal static string GenericError {
             get {
                 return ResourceManager.GetString("GenericError", resourceCulture);
             }
@@ -811,7 +811,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Warning: {0}.
         /// </summary>
-        public static string GenericWarning {
+        internal static string GenericWarning {
             get {
                 return ResourceManager.GetString("GenericWarning", resourceCulture);
             }
@@ -820,7 +820,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Getting ready....
         /// </summary>
-        public static string GettingReady {
+        internal static string GettingReady {
             get {
                 return ResourceManager.GetString("GettingReady", resourceCulture);
             }
@@ -829,7 +829,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Installs a source or a template package..
         /// </summary>
-        public static string InstallHelp {
+        internal static string InstallHelp {
             get {
                 return ResourceManager.GetString("InstallHelp", resourceCulture);
             }
@@ -838,7 +838,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Allows the internal dotnet restore command to stop and wait for user input or action (for example to complete authentication)..
         /// </summary>
-        public static string InteractiveHelp {
+        internal static string InteractiveHelp {
             get {
                 return ResourceManager.GetString("InteractiveHelp", resourceCulture);
             }
@@ -847,7 +847,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Invalid input switch:.
         /// </summary>
-        public static string InvalidInputSwitch {
+        internal static string InvalidInputSwitch {
             get {
                 return ResourceManager.GetString("InvalidInputSwitch", resourceCulture);
             }
@@ -856,7 +856,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Name cannot contain any of the following characters {0} or character codes {1}.
         /// </summary>
-        public static string InvalidNameParameter {
+        internal static string InvalidNameParameter {
             get {
                 return ResourceManager.GetString("InvalidNameParameter", resourceCulture);
             }
@@ -865,7 +865,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The default value &apos;{1}&apos; is not a valid value for {0}..
         /// </summary>
-        public static string InvalidParameterDefault {
+        internal static string InvalidParameterDefault {
             get {
                 return ResourceManager.GetString("InvalidParameterDefault", resourceCulture);
             }
@@ -874,7 +874,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to &apos;{1}&apos; is not a valid value for {0}..
         /// </summary>
-        public static string InvalidParameterDetail {
+        internal static string InvalidParameterDetail {
             get {
                 return ResourceManager.GetString("InvalidParameterDetail", resourceCulture);
             }
@@ -883,7 +883,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid option.
         /// </summary>
-        public static string InvalidParameterNameDetail {
+        internal static string InvalidParameterNameDetail {
             get {
                 return ResourceManager.GetString("InvalidParameterNameDetail", resourceCulture);
             }
@@ -892,7 +892,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to For more information, run &apos;{0}&apos;..
         /// </summary>
-        public static string InvalidParameterTemplateHint {
+        internal static string InvalidParameterTemplateHint {
             get {
                 return ResourceManager.GetString("InvalidParameterTemplateHint", resourceCulture);
             }
@@ -901,7 +901,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Error: Invalid option(s):.
         /// </summary>
-        public static string InvalidTemplateParameterValues {
+        internal static string InvalidTemplateParameterValues {
             get {
                 return ResourceManager.GetString("InvalidTemplateParameterValues", resourceCulture);
             }
@@ -910,7 +910,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Filters templates based on language and specifies the language of the template to create..
         /// </summary>
-        public static string LanguageParameter {
+        internal static string LanguageParameter {
             get {
                 return ResourceManager.GetString("LanguageParameter", resourceCulture);
             }
@@ -919,7 +919,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Lists templates containing the specified template name. If no name is specified, lists all templates..
         /// </summary>
-        public static string ListsTemplates {
+        internal static string ListsTemplates {
             get {
                 return ResourceManager.GetString("ListsTemplates", resourceCulture);
             }
@@ -928,7 +928,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to To list installed templates, run &apos;dotnet {0} --list&apos;..
         /// </summary>
-        public static string ListTemplatesCommand {
+        internal static string ListTemplatesCommand {
             get {
                 return ResourceManager.GetString("ListTemplatesCommand", resourceCulture);
             }
@@ -937,7 +937,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Mandatory option {0} missing for template {1}..
         /// </summary>
-        public static string MissingRequiredParameter {
+        internal static string MissingRequiredParameter {
             get {
                 return ResourceManager.GetString("MissingRequiredParameter", resourceCulture);
             }
@@ -946,7 +946,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Unable to locate the specified template content, the template cache may be corrupted. Try running &apos;dotnet {0} --debug:reinit&apos; to fix the issue..
         /// </summary>
-        public static string MissingTemplateContentDetected {
+        internal static string MissingTemplateContentDetected {
             get {
                 return ResourceManager.GetString("MissingTemplateContentDetected", resourceCulture);
             }
@@ -955,7 +955,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Mount Point Factories.
         /// </summary>
-        public static string MountPointFactories {
+        internal static string MountPointFactories {
             get {
                 return ResourceManager.GetString("MountPointFactories", resourceCulture);
             }
@@ -964,7 +964,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The name for the output being created. If no name is specified, the name of the output directory is used..
         /// </summary>
-        public static string NameOfOutput {
+        internal static string NameOfOutput {
             get {
                 return ResourceManager.GetString("NameOfOutput", resourceCulture);
             }
@@ -973,7 +973,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to (No Items).
         /// </summary>
-        public static string NoItems {
+        internal static string NoItems {
             get {
                 return ResourceManager.GetString("NoItems", resourceCulture);
             }
@@ -982,7 +982,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to     (No Parameters).
         /// </summary>
-        public static string NoParameters {
+        internal static string NoParameters {
             get {
                 return ResourceManager.GetString("NoParameters", resourceCulture);
             }
@@ -991,7 +991,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to No Primary Outputs to restore..
         /// </summary>
-        public static string NoPrimaryOutputsToRestore {
+        internal static string NoPrimaryOutputsToRestore {
             get {
                 return ResourceManager.GetString("NoPrimaryOutputsToRestore", resourceCulture);
             }
@@ -1000,7 +1000,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to No templates found matching: {0}..
         /// </summary>
-        public static string NoTemplatesMatchingInputParameters {
+        internal static string NoTemplatesMatchingInputParameters {
             get {
                 return ResourceManager.GetString("NoTemplatesMatchingInputParameters", resourceCulture);
             }
@@ -1009,7 +1009,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Specifies a NuGet source to use during install..
         /// </summary>
-        public static string NuGetSourceHelp {
+        internal static string NuGetSourceHelp {
             get {
                 return ResourceManager.GetString("NuGetSourceHelp", resourceCulture);
             }
@@ -1018,7 +1018,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Error during synchronization with the Optional SDK Workloads..
         /// </summary>
-        public static string OptionalWorkloadsSyncFailed {
+        internal static string OptionalWorkloadsSyncFailed {
             get {
                 return ResourceManager.GetString("OptionalWorkloadsSyncFailed", resourceCulture);
             }
@@ -1027,7 +1027,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Filters the templates based on the template author. Applicable only with --search or --list | -l option..
         /// </summary>
-        public static string OptionDescriptionAuthorFilter {
+        internal static string OptionDescriptionAuthorFilter {
             get {
                 return ResourceManager.GetString("OptionDescriptionAuthorFilter", resourceCulture);
             }
@@ -1037,7 +1037,7 @@ namespace Microsoft.TemplateEngine.Cli {
         ///   Looks up a localized string similar to Comma separated list of columns to display in --list and --search output. 
         ///The supported columns are: language, tags, author, type..
         /// </summary>
-        public static string OptionDescriptionColumns {
+        internal static string OptionDescriptionColumns {
             get {
                 return ResourceManager.GetString("OptionDescriptionColumns", resourceCulture);
             }
@@ -1046,7 +1046,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Display all columns in --list and --search output..
         /// </summary>
-        public static string OptionDescriptionColumnsAll {
+        internal static string OptionDescriptionColumnsAll {
             get {
                 return ResourceManager.GetString("OptionDescriptionColumnsAll", resourceCulture);
             }
@@ -1055,7 +1055,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Filters the templates based on NuGet package ID. Applies to --search..
         /// </summary>
-        public static string OptionDescriptionPackageFilter {
+        internal static string OptionDescriptionPackageFilter {
             get {
                 return ResourceManager.GetString("OptionDescriptionPackageFilter", resourceCulture);
             }
@@ -1064,7 +1064,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Searches for the templates on NuGet.org..
         /// </summary>
-        public static string OptionDescriptionSearch {
+        internal static string OptionDescriptionSearch {
             get {
                 return ResourceManager.GetString("OptionDescriptionSearch", resourceCulture);
             }
@@ -1073,7 +1073,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Filters the templates based on the tag. Applies to --search and --list..
         /// </summary>
-        public static string OptionDescriptionTagFilter {
+        internal static string OptionDescriptionTagFilter {
             get {
                 return ResourceManager.GetString("OptionDescriptionTagFilter", resourceCulture);
             }
@@ -1082,7 +1082,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Options:.
         /// </summary>
-        public static string Options {
+        internal static string Options {
             get {
                 return ResourceManager.GetString("Options", resourceCulture);
             }
@@ -1091,7 +1091,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Location to place the generated output..
         /// </summary>
-        public static string OutputPath {
+        internal static string OutputPath {
             get {
                 return ResourceManager.GetString("OutputPath", resourceCulture);
             }
@@ -1100,7 +1100,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Overwrite.
         /// </summary>
-        public static string Overwrite {
+        internal static string Overwrite {
             get {
                 return ResourceManager.GetString("Overwrite", resourceCulture);
             }
@@ -1109,7 +1109,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Some partially matched templates may not support these input switches:.
         /// </summary>
-        public static string PartialTemplateMatchSwitchesNotValidForAllMatches {
+        internal static string PartialTemplateMatchSwitchesNotValidForAllMatches {
             get {
                 return ResourceManager.GetString("PartialTemplateMatchSwitchesNotValidForAllMatches", resourceCulture);
             }
@@ -1118,7 +1118,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The possible values are:.
         /// </summary>
-        public static string PossibleValuesHeader {
+        internal static string PossibleValuesHeader {
             get {
                 return ResourceManager.GetString("PossibleValuesHeader", resourceCulture);
             }
@@ -1127,7 +1127,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Actual command: {0}.
         /// </summary>
-        public static string PostActionCommand {
+        internal static string PostActionCommand {
             get {
                 return ResourceManager.GetString("PostActionCommand", resourceCulture);
             }
@@ -1136,7 +1136,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Description: {0}.
         /// </summary>
-        public static string PostActionDescription {
+        internal static string PostActionDescription {
             get {
                 return ResourceManager.GetString("PostActionDescription", resourceCulture);
             }
@@ -1145,7 +1145,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Post action failed..
         /// </summary>
-        public static string PostActionFailedInstructionHeader {
+        internal static string PostActionFailedInstructionHeader {
             get {
                 return ResourceManager.GetString("PostActionFailedInstructionHeader", resourceCulture);
             }
@@ -1154,7 +1154,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Manual instructions: {0}.
         /// </summary>
-        public static string PostActionInstructions {
+        internal static string PostActionInstructions {
             get {
                 return ResourceManager.GetString("PostActionInstructions", resourceCulture);
             }
@@ -1163,7 +1163,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Invalid input &quot;{0}&quot;. Please enter one of [{1}(yes)|{2}(no)]..
         /// </summary>
-        public static string PostActionInvalidInputRePrompt {
+        internal static string PostActionInvalidInputRePrompt {
             get {
                 return ResourceManager.GetString("PostActionInvalidInputRePrompt", resourceCulture);
             }
@@ -1172,7 +1172,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Template is configured to run the following action:.
         /// </summary>
-        public static string PostActionPromptHeader {
+        internal static string PostActionPromptHeader {
             get {
                 return ResourceManager.GetString("PostActionPromptHeader", resourceCulture);
             }
@@ -1181,7 +1181,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Do you want to run this action [{0}(yes)|{1}(no)]?.
         /// </summary>
-        public static string PostActionPromptRequest {
+        internal static string PostActionPromptRequest {
             get {
                 return ResourceManager.GetString("PostActionPromptRequest", resourceCulture);
             }
@@ -1190,7 +1190,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Processing post-creation actions....
         /// </summary>
-        public static string ProcessingPostActions {
+        internal static string ProcessingPostActions {
             get {
                 return ResourceManager.GetString("ProcessingPostActions", resourceCulture);
             }
@@ -1199,7 +1199,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Rerun the command and pass --force to accept and create..
         /// </summary>
-        public static string RerunCommandAndPassForceToCreateAnyway {
+        internal static string RerunCommandAndPassForceToCreateAnyway {
             get {
                 return ResourceManager.GetString("RerunCommandAndPassForceToCreateAnyway", resourceCulture);
             }
@@ -1208,7 +1208,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Restore failed..
         /// </summary>
-        public static string RestoreFailed {
+        internal static string RestoreFailed {
             get {
                 return ResourceManager.GetString("RestoreFailed", resourceCulture);
             }
@@ -1217,7 +1217,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Restore succeeded..
         /// </summary>
-        public static string RestoreSucceeded {
+        internal static string RestoreSucceeded {
             get {
                 return ResourceManager.GetString("RestoreSucceeded", resourceCulture);
             }
@@ -1226,7 +1226,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Run dotnet {0} --help for usage information..
         /// </summary>
-        public static string RunHelpForInformationAboutAcceptedParameters {
+        internal static string RunHelpForInformationAboutAcceptedParameters {
             get {
                 return ResourceManager.GetString("RunHelpForInformationAboutAcceptedParameters", resourceCulture);
             }
@@ -1235,7 +1235,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Running command &apos;{0}&apos;....
         /// </summary>
-        public static string RunningCommand {
+        internal static string RunningCommand {
             get {
                 return ResourceManager.GetString("RunningCommand", resourceCulture);
             }
@@ -1244,7 +1244,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Running &apos;dotnet restore&apos; on {0}....
         /// </summary>
-        public static string RunningDotnetRestoreOn {
+        internal static string RunningDotnetRestoreOn {
             get {
                 return ResourceManager.GetString("RunningDotnetRestoreOn", resourceCulture);
             }
@@ -1258,7 +1258,7 @@ namespace Microsoft.TemplateEngine.Cli {
         ///        dotnet {1} --search --author Microsoft
         ///        dotnet {1} &lt;template name&gt; --search --author Microsoft.
         /// </summary>
-        public static string SearchOnlineErrorNoTemplateNameOrFilter {
+        internal static string SearchOnlineErrorNoTemplateNameOrFilter {
             get {
                 return ResourceManager.GetString("SearchOnlineErrorNoTemplateNameOrFilter", resourceCulture);
             }
@@ -1267,7 +1267,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Search failed: template name is too short, minimum 2 characters are required..
         /// </summary>
-        public static string SearchOnlineErrorTemplateNameIsTooShort {
+        internal static string SearchOnlineErrorTemplateNameIsTooShort {
             get {
                 return ResourceManager.GetString("SearchOnlineErrorTemplateNameIsTooShort", resourceCulture);
             }
@@ -1276,7 +1276,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to No remoted sources defined to search for the templates..
         /// </summary>
-        public static string SearchOnlineNoSources {
+        internal static string SearchOnlineNoSources {
             get {
                 return ResourceManager.GetString("SearchOnlineNoSources", resourceCulture);
             }
@@ -1285,7 +1285,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Searching for the templates....
         /// </summary>
-        public static string SearchOnlineNotification {
+        internal static string SearchOnlineNotification {
             get {
                 return ResourceManager.GetString("SearchOnlineNotification", resourceCulture);
             }
@@ -1294,7 +1294,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Template &apos;{0}&apos; was not found..
         /// </summary>
-        public static string SearchOnlineTemplateNotFound {
+        internal static string SearchOnlineTemplateNotFound {
             get {
                 return ResourceManager.GetString("SearchOnlineTemplateNotFound", resourceCulture);
             }
@@ -1303,7 +1303,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to         dotnet {0} -i {1}.
         /// </summary>
-        public static string SearchResultInstallCommand {
+        internal static string SearchResultInstallCommand {
             get {
                 return ResourceManager.GetString("SearchResultInstallCommand", resourceCulture);
             }
@@ -1312,7 +1312,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to To use the template, run the following command to install the package: dotnet {0} -i &lt;package&gt;.
         /// </summary>
-        public static string SearchResultInstallHeader {
+        internal static string SearchResultInstallHeader {
             get {
                 return ResourceManager.GetString("SearchResultInstallHeader", resourceCulture);
             }
@@ -1321,7 +1321,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Matches from template source: {0}.
         /// </summary>
-        public static string SearchResultSourceIndicator {
+        internal static string SearchResultSourceIndicator {
             get {
                 return ResourceManager.GetString("SearchResultSourceIndicator", resourceCulture);
             }
@@ -1330,7 +1330,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to To search for the templates on NuGet.org, run &apos;dotnet {0} {1} --search&apos;..
         /// </summary>
-        public static string SearchTemplatesCommand {
+        internal static string SearchTemplatesCommand {
             get {
                 return ResourceManager.GetString("SearchTemplatesCommand", resourceCulture);
             }
@@ -1339,7 +1339,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Error reading the installed configuration, file may be corrupted. If this problem persists, try resetting with the `--debug:reinit&apos; flag.
         /// </summary>
-        public static string SettingsReadError {
+        internal static string SettingsReadError {
             get {
                 return ResourceManager.GetString("SettingsReadError", resourceCulture);
             }
@@ -1348,7 +1348,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Shows all templates..
         /// </summary>
-        public static string ShowsAllTemplates {
+        internal static string ShowsAllTemplates {
             get {
                 return ResourceManager.GetString("ShowsAllTemplates", resourceCulture);
             }
@@ -1357,7 +1357,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Filters templates based on available types. Predefined values are &quot;project&quot; and &quot;item&quot;..
         /// </summary>
-        public static string ShowsFilteredTemplates {
+        internal static string ShowsFilteredTemplates {
             get {
                 return ResourceManager.GetString("ShowsFilteredTemplates", resourceCulture);
             }
@@ -1366,7 +1366,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The following option(s) or their value(s) are not valid in combination with other supplied options or their values:.
         /// </summary>
-        public static string SingleTemplateGroupPartialMatchSwitchesNotValidForAllMatches {
+        internal static string SingleTemplateGroupPartialMatchSwitchesNotValidForAllMatches {
             get {
                 return ResourceManager.GetString("SingleTemplateGroupPartialMatchSwitchesNotValidForAllMatches", resourceCulture);
             }
@@ -1375,7 +1375,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Templates.
         /// </summary>
-        public static string Templates {
+        internal static string Templates {
             get {
                 return ResourceManager.GetString("Templates", resourceCulture);
             }
@@ -1384,7 +1384,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to These templates matched your input: {0}..
         /// </summary>
-        public static string TemplatesFoundMatchingInputParameters {
+        internal static string TemplatesFoundMatchingInputParameters {
             get {
                 return ResourceManager.GetString("TemplatesFoundMatchingInputParameters", resourceCulture);
             }
@@ -1393,7 +1393,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to {0} template(s) partially matched, but failed on {1}..
         /// </summary>
-        public static string TemplatesNotValidGivenTheSpecifiedFilter {
+        internal static string TemplatesNotValidGivenTheSpecifiedFilter {
             get {
                 return ResourceManager.GetString("TemplatesNotValidGivenTheSpecifiedFilter", resourceCulture);
             }
@@ -1402,7 +1402,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Could not find the template package containing template &apos;{0}&apos;.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Error_PackageForTemplateNotFound {
+        internal static string TemplatesPackageCoordinator_Error_PackageForTemplateNotFound {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Error_PackageForTemplateNotFound", resourceCulture);
             }
@@ -1411,7 +1411,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to   {0} (contains {1} templates).
         /// </summary>
-        public static string TemplatesPackageCoordinator_Error_PackageNameContainsTemplates {
+        internal static string TemplatesPackageCoordinator_Error_PackageNameContainsTemplates {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Error_PackageNameContainsTemplates", resourceCulture);
             }
@@ -1420,7 +1420,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The template package &apos;{0}&apos; is not found.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Error_PackageNotFound {
+        internal static string TemplatesPackageCoordinator_Error_PackageNotFound {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Error_PackageNotFound", resourceCulture);
             }
@@ -1429,7 +1429,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The template &apos;{0}&apos; is included to the packages:.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Error_TemplateIncludedToPackages {
+        internal static string TemplatesPackageCoordinator_Error_TemplateIncludedToPackages {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Error_TemplateIncludedToPackages", resourceCulture);
             }
@@ -1438,7 +1438,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to   {0}.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Info_PackageName {
+        internal static string TemplatesPackageCoordinator_Info_PackageName {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Info_PackageName", resourceCulture);
             }
@@ -1447,7 +1447,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to   {0}, version: {1}.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Info_PackageNameVersion {
+        internal static string TemplatesPackageCoordinator_Info_PackageNameVersion {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Info_PackageNameVersion", resourceCulture);
             }
@@ -1456,7 +1456,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Found no template packages to install.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall {
+        internal static string TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall", resourceCulture);
             }
@@ -1465,7 +1465,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The command is attempting to install the template package &apos;{0}&apos; twice, check the arguments and retry..
         /// </summary>
-        public static string TemplatesPackageCoordinator_Install_Error_SameInstallRequests {
+        internal static string TemplatesPackageCoordinator_Install_Error_SameInstallRequests {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Install_Error_SameInstallRequests", resourceCulture);
             }
@@ -1474,7 +1474,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The following template packages will be installed:.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled {
+        internal static string TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled", resourceCulture);
             }
@@ -1483,7 +1483,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to {0} is already installed.
         /// </summary>
-        public static string TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled {
+        internal static string TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled", resourceCulture);
             }
@@ -1492,7 +1492,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to {0} could not be installed, download failed.
         /// </summary>
-        public static string TemplatesPackageCoordinator_lnstall_Error_DownloadFailed {
+        internal static string TemplatesPackageCoordinator_lnstall_Error_DownloadFailed {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_DownloadFailed", resourceCulture);
             }
@@ -1501,7 +1501,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to {0} could not be installed.
         /// </summary>
-        public static string TemplatesPackageCoordinator_lnstall_Error_GenericError {
+        internal static string TemplatesPackageCoordinator_lnstall_Error_GenericError {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_GenericError", resourceCulture);
             }
@@ -1510,7 +1510,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to {0} could not be installed, no NuGet feeds are configured or they are invalid.
         /// </summary>
-        public static string TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds {
+        internal static string TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds", resourceCulture);
             }
@@ -1519,7 +1519,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Failed to install {0}, failed to uninstall previous version of the template package.
         /// </summary>
-        public static string TemplatesPackageCoordinator_lnstall_Error_InvalidPackage {
+        internal static string TemplatesPackageCoordinator_lnstall_Error_InvalidPackage {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_InvalidPackage", resourceCulture);
             }
@@ -1528,7 +1528,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to {0} could not be installed, the package does not exist.
         /// </summary>
-        public static string TemplatesPackageCoordinator_lnstall_Error_PackageNotFound {
+        internal static string TemplatesPackageCoordinator_lnstall_Error_PackageNotFound {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_PackageNotFound", resourceCulture);
             }
@@ -1537,7 +1537,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Failed to install {0}, the template package is invalid.
         /// </summary>
-        public static string TemplatesPackageCoordinator_lnstall_Error_UninstallFailed {
+        internal static string TemplatesPackageCoordinator_lnstall_Error_UninstallFailed {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_UninstallFailed", resourceCulture);
             }
@@ -1546,7 +1546,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to {0} is not supported.
         /// </summary>
-        public static string TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest {
+        internal static string TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest", resourceCulture);
             }
@@ -1555,7 +1555,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Success: {0} installed the following templates:.
         /// </summary>
-        public static string TemplatesPackageCoordinator_lnstall_Info_Success {
+        internal static string TemplatesPackageCoordinator_lnstall_Info_Success {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Info_Success", resourceCulture);
             }
@@ -1564,7 +1564,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Failed to uninstall {0}, reason: {1}..
         /// </summary>
-        public static string TemplatesPackageCoordinator_Uninstall_Error_GenericError {
+        internal static string TemplatesPackageCoordinator_Uninstall_Error_GenericError {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Error_GenericError", resourceCulture);
             }
@@ -1573,7 +1573,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to To list installed template packages, use dotnet {0} -u.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint {
+        internal static string TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint", resourceCulture);
             }
@@ -1582,7 +1582,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to To uninstall the template package, use dotnet {0} -u {1}.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint {
+        internal static string TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint", resourceCulture);
             }
@@ -1591,7 +1591,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Details:.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader {
+        internal static string TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader", resourceCulture);
             }
@@ -1600,7 +1600,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Currently installed items:.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Uninstall_Info_InstalledItems {
+        internal static string TemplatesPackageCoordinator_Uninstall_Info_InstalledItems {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Info_InstalledItems", resourceCulture);
             }
@@ -1609,7 +1609,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Success: {0} was uninstalled..
         /// </summary>
-        public static string TemplatesPackageCoordinator_Uninstall_Info_Success {
+        internal static string TemplatesPackageCoordinator_Uninstall_Info_Success {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Info_Success", resourceCulture);
             }
@@ -1618,7 +1618,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Uninstall Command:.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint {
+        internal static string TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint", resourceCulture);
             }
@@ -1627,7 +1627,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Failed to check update for {0}: {1}..
         /// </summary>
-        public static string TemplatesPackageCoordinator_Update_Error_GenericError {
+        internal static string TemplatesPackageCoordinator_Update_Error_GenericError {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Error_GenericError", resourceCulture);
             }
@@ -1636,7 +1636,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Failed to check update for {0}: no NuGet feeds are configured or they are invalid..
         /// </summary>
-        public static string TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds {
+        internal static string TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds", resourceCulture);
             }
@@ -1645,7 +1645,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Failed to check update for {0}: the package is not available in configured NuGet feeds..
         /// </summary>
-        public static string TemplatesPackageCoordinator_Update_Error_PackageNotFound {
+        internal static string TemplatesPackageCoordinator_Update_Error_PackageNotFound {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Error_PackageNotFound", resourceCulture);
             }
@@ -1654,7 +1654,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Failed to check update for {0}: the package is not supported..
         /// </summary>
-        public static string TemplatesPackageCoordinator_Update_Error_PackageNotSupported {
+        internal static string TemplatesPackageCoordinator_Update_Error_PackageNotSupported {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Error_PackageNotSupported", resourceCulture);
             }
@@ -1663,7 +1663,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to All template packages are up-to-date..
         /// </summary>
-        public static string TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate {
+        internal static string TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate", resourceCulture);
             }
@@ -1672,7 +1672,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to     install command: dotnet {0} -i {1}.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Update_Info_InstallCommand {
+        internal static string TemplatesPackageCoordinator_Update_Info_InstallCommand {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Info_InstallCommand", resourceCulture);
             }
@@ -1681,7 +1681,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to The following template packages will be updated:.
         /// </summary>
-        public static string TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated {
+        internal static string TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated", resourceCulture);
             }
@@ -1690,7 +1690,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to An update for template package &apos;{0}&apos; is available..
         /// </summary>
-        public static string TemplatesPackageCoordinator_Update_Info_UpdateAvailable {
+        internal static string TemplatesPackageCoordinator_Update_Info_UpdateAvailable {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Info_UpdateAvailable", resourceCulture);
             }
@@ -1699,7 +1699,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Failed to initialize NuGet credential service, details: {0}..
         /// </summary>
-        public static string TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError {
+        internal static string TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError {
             get {
                 return ResourceManager.GetString("TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError", resourceCulture);
             }
@@ -1708,7 +1708,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to This template contains technologies from parties other than Microsoft, see {0} for details..
         /// </summary>
-        public static string ThirdPartyNotices {
+        internal static string ThirdPartyNotices {
             get {
                 return ResourceManager.GetString("ThirdPartyNotices", resourceCulture);
             }
@@ -1717,7 +1717,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Type.
         /// </summary>
-        public static string Type {
+        internal static string Type {
             get {
                 return ResourceManager.GetString("Type", resourceCulture);
             }
@@ -1726,7 +1726,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Unable to apply permissions {0} to &quot;{1}&quot;..
         /// </summary>
-        public static string UnableToSetPermissions {
+        internal static string UnableToSetPermissions {
             get {
                 return ResourceManager.GetString("UnableToSetPermissions", resourceCulture);
             }
@@ -1735,7 +1735,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Uninstalls a source or a template package..
         /// </summary>
-        public static string UninstallHelp {
+        internal static string UninstallHelp {
             get {
                 return ResourceManager.GetString("UninstallHelp", resourceCulture);
             }
@@ -1744,7 +1744,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Unknown Change.
         /// </summary>
-        public static string UnknownChangeKind {
+        internal static string UnknownChangeKind {
             get {
                 return ResourceManager.GetString("UnknownChangeKind", resourceCulture);
             }
@@ -1753,7 +1753,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Check the currently installed template packages for update, and install the updates..
         /// </summary>
-        public static string UpdateApplyCommandHelp {
+        internal static string UpdateApplyCommandHelp {
             get {
                 return ResourceManager.GetString("UpdateApplyCommandHelp", resourceCulture);
             }
@@ -1762,7 +1762,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Check the currently installed template packages for updates..
         /// </summary>
-        public static string UpdateCheckCommandHelp {
+        internal static string UpdateCheckCommandHelp {
             get {
                 return ResourceManager.GetString("UpdateCheckCommandHelp", resourceCulture);
             }
@@ -1771,7 +1771,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Version:.
         /// </summary>
-        public static string Version {
+        internal static string Version {
             get {
                 return ResourceManager.GetString("Version", resourceCulture);
             }
@@ -1780,7 +1780,7 @@ namespace Microsoft.TemplateEngine.Cli {
         /// <summary>
         ///   Looks up a localized string similar to Specify if post action scripts should run..
         /// </summary>
-        public static string WhetherToAllowScriptsToRun {
+        internal static string WhetherToAllowScriptsToRun {
             get {
                 return ResourceManager.GetString("WhetherToAllowScriptsToRun", resourceCulture);
             }

--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -35,7 +35,7 @@
 
     <ItemGroup>
         <EmbeddedResource Update="LocalizableStrings.resx">
-            <Generator>PublicResXFileCodeGenerator</Generator>
+            <Generator>ResXFileCodeGenerator</Generator>
             <LastGenOutput>LocalizableStrings.Designer.cs</LastGenOutput>
         </EmbeddedResource>
     </ItemGroup>

--- a/src/Microsoft.TemplateEngine.Cli/New3Callbacks.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Callbacks.cs
@@ -10,16 +10,16 @@ namespace Microsoft.TemplateEngine.Cli
     /// These callbacks provide a mechanism for the template engine to invoke these operations without
     /// requiring a built-time dependency on the actual implementation.
     /// </summary>
-    public sealed class New3Callbacks
+    internal sealed class New3Callbacks
     {
         /// <summary>
         /// Callback to be executed on first run of the template engine.
         /// </summary>
-        public Action<IEngineEnvironmentSettings> OnFirstRun { get; set; }
+        internal Action<IEngineEnvironmentSettings> OnFirstRun { get; set; }
 
         /// <summary>
         /// Callback to be executed to restore a project.
         /// </summary>
-        public Func<string, bool> RestoreProject { get; set; }
+        internal Func<string, bool> RestoreProject { get; set; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/New3Callbacks.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Callbacks.cs
@@ -1,25 +1,26 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Cli
 {
     /// <summary>
-    /// The set of callbacks that should be implemented by callers of <code>New3Command.Run</code>.
+    /// The set of callbacks that should be implemented by callers of <c>New3Command.Run</c>.
     /// These callbacks provide a mechanism for the template engine to invoke these operations without
     /// requiring a built-time dependency on the actual implementation.
     /// </summary>
-    internal sealed class New3Callbacks
+    public sealed class New3Callbacks
     {
         /// <summary>
         /// Callback to be executed on first run of the template engine.
         /// </summary>
-        internal Action<IEngineEnvironmentSettings> OnFirstRun { get; set; }
+        public Action<IEngineEnvironmentSettings> OnFirstRun { get; set; }
 
         /// <summary>
         /// Callback to be executed to restore a project.
         /// </summary>
-        internal Func<string, bool> RestoreProject { get; set; }
+        public Func<string, bool> RestoreProject { get; set; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -86,22 +86,6 @@ namespace Microsoft.TemplateEngine.Cli
         /// <param name="host">The <see cref="ITemplateEngineHost"/> that executes the command.</param>
         /// <param name="telemetryLogger"><see cref="ITelemetryLogger"/> to use to track events.</param>
         /// <param name="onFirstRun">actions to be run on the first run.</param>
-        /// <param name="args">arguments to be run using template engine.</param>
-        /// <param name="hivePath">(optional) the path to template engine settings to use.</param>
-        /// <returns>exit code: 0 on success, other on error.</returns>
-        /// <exception cref="CommandParserException">when <paramref name="args"/> cannot be parsed.</exception>
-        public static int Run(string commandName, ITemplateEngineHost host, ITelemetryLogger telemetryLogger, Action<IEngineEnvironmentSettings> onFirstRun, string[] args, string? hivePath = null)
-        {
-            return Run(commandName, host, telemetryLogger, new New3Callbacks() { OnFirstRun = onFirstRun }, args, hivePath);
-        }
-
-        /// <summary>
-        /// Runs the command using <paramref name="host"/> and <paramref name="args"/>.
-        /// </summary>
-        /// <param name="commandName">Command name that is being executed.</param>
-        /// <param name="host">The <see cref="ITemplateEngineHost"/> that executes the command.</param>
-        /// <param name="telemetryLogger"><see cref="ITelemetryLogger"/> to use to track events.</param>
-        /// <param name="onFirstRun">actions to be run on the first run.</param>
         /// <param name="callbacks">set of callbacks to be used, <see cref="New3Callbacks"/> for more details.</param>
         /// <param name="args">arguments to be run using template engine.</param>
         /// <param name="hivePath">(optional) the path to template engine settings to use.</param>

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -79,12 +79,18 @@ namespace Microsoft.TemplateEngine.Cli
 
         internal EngineEnvironmentSettings EnvironmentSettings { get; private set; }
 
-        public static int Run(string commandName, ITemplateEngineHost host, ITelemetryLogger telemetryLogger, Action<IEngineEnvironmentSettings> onFirstRun, string[] args)
-        {
-            return Run(commandName, host, telemetryLogger, new New3Callbacks() { OnFirstRun = onFirstRun }, args, null);
-        }
-
-        public static int Run(string commandName, ITemplateEngineHost host, ITelemetryLogger telemetryLogger, Action<IEngineEnvironmentSettings> onFirstRun, string[] args, string? hivePath)
+        /// <summary>
+        /// Runs the command using <paramref name="host"/> and <paramref name="args"/>.
+        /// </summary>
+        /// <param name="commandName">Command name that is being executed.</param>
+        /// <param name="host">The <see cref="ITemplateEngineHost"/> that executes the command.</param>
+        /// <param name="telemetryLogger"><see cref="ITelemetryLogger"/> to use to track events.</param>
+        /// <param name="onFirstRun">actions to be run on the first run.</param>
+        /// <param name="args">arguments to be run using template engine.</param>
+        /// <param name="hivePath">(optional) the path to template engine settings to use.</param>
+        /// <returns>exit code: 0 on success, other on error.</returns>
+        /// <exception cref="CommandParserException">when <paramref name="args"/> cannot be parsed.</exception>
+        public static int Run(string commandName, ITemplateEngineHost host, ITelemetryLogger telemetryLogger, Action<IEngineEnvironmentSettings> onFirstRun, string[] args, string? hivePath = null)
         {
             return Run(commandName, host, telemetryLogger, new New3Callbacks() { OnFirstRun = onFirstRun }, args, hivePath);
         }

--- a/src/Microsoft.TemplateEngine.Cli/OptionalWorkloadProvider.cs
+++ b/src/Microsoft.TemplateEngine.Cli/OptionalWorkloadProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateEngine.Utils
         {
             private IEngineEnvironmentSettings EnvironmentSettings;
 
-            public OptionalWorkloadProvider(ITemplatePackageProviderFactory factory, IEngineEnvironmentSettings settings)
+            internal OptionalWorkloadProvider(ITemplatePackageProviderFactory factory, IEngineEnvironmentSettings settings)
             {
                 this.Factory = factory;
                 this.EnvironmentSettings = settings;

--- a/src/Microsoft.TemplateEngine.Cli/OptionalWorkloadProviderFactory.cs
+++ b/src/Microsoft.TemplateEngine.Cli/OptionalWorkloadProviderFactory.cs
@@ -1,6 +1,5 @@
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
-using Microsoft.TemplateEngine.Edge.Mount.Archive;
 using System;
 
 namespace Microsoft.TemplateEngine.Utils

--- a/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
@@ -6,14 +6,14 @@ using Microsoft.TemplateEngine.Edge.Template;
 
 namespace Microsoft.TemplateEngine.Cli
 {
-    public enum AllowPostActionsSetting
+    internal enum AllowPostActionsSetting
     {
         No,
         Yes,
         Prompt
     };
 
-    public class PostActionDispatcher
+    internal class PostActionDispatcher
     {
         private readonly TemplateCreationResult _creationResult;
         private readonly IEngineEnvironmentSettings _environment;
@@ -21,7 +21,7 @@ namespace Microsoft.TemplateEngine.Cli
         private readonly AllowPostActionsSetting _canRunScripts;
         private readonly bool _isDryRun;
 
-        public PostActionDispatcher(IEngineEnvironmentSettings environment, New3Callbacks callbacks, TemplateCreationResult creationResult, AllowPostActionsSetting canRunStatus, bool isDryRun)
+        internal PostActionDispatcher(IEngineEnvironmentSettings environment, New3Callbacks callbacks, TemplateCreationResult creationResult, AllowPostActionsSetting canRunStatus, bool isDryRun)
         {
             _environment = environment;
             _callbacks = callbacks;
@@ -30,7 +30,7 @@ namespace Microsoft.TemplateEngine.Cli
             _isDryRun = isDryRun;
         }
 
-        public void Process(Func<string> inputGetter)
+        internal void Process(Func<string> inputGetter)
         {
             IReadOnlyList<IPostAction> postActions = _creationResult.ResultInfo?.PostActions ?? _creationResult.CreationEffects.CreationResult.PostActions;
             if (postActions.Count > 0)

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddProjectsToSolutionPostAction.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddProjectsToSolutionPostAction.cs
@@ -9,9 +9,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 {
-    public class AddProjectsToSolutionPostAction : PostActionProcessor2Base, IPostActionProcessor, IPostActionProcessor2
+    internal class AddProjectsToSolutionPostAction : PostActionProcessor2Base, IPostActionProcessor, IPostActionProcessor2
     {
-        public static readonly Guid ActionProcessorId = new Guid("D396686C-DE0E-4DE6-906D-291CD29FC5DE");
+        internal static readonly Guid ActionProcessorId = new Guid("D396686C-DE0E-4DE6-906D-291CD29FC5DE");
 
         public Guid Id => ActionProcessorId;
 

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddReferencePostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddReferencePostActionProcessor.cs
@@ -8,9 +8,9 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 {
-    public class AddReferencePostActionProcessor : PostActionProcessor2Base, IPostActionProcessor, IPostActionProcessor2
+    internal class AddReferencePostActionProcessor : PostActionProcessor2Base, IPostActionProcessor, IPostActionProcessor2
     {
-        public static readonly Guid ActionProcessorId = new Guid("B17581D1-C5C9-4489-8F0A-004BE667B814");
+        internal static readonly Guid ActionProcessorId = new Guid("B17581D1-C5C9-4489-8F0A-004BE667B814");
 
         public Guid Id => ActionProcessorId;
 

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/ChmodPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/ChmodPostActionProcessor.cs
@@ -6,13 +6,13 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 {
-    public class ChmodPostActionProcessor : IPostActionProcessor
+    internal class ChmodPostActionProcessor : IPostActionProcessor
     {
         private static readonly Guid ActionProcessorId = new Guid("cb9a6cf3-4f5c-4860-b9d2-03a574959774");
 
         public Guid Id => ActionProcessorId;
 
-        public ChmodPostActionProcessor()
+        internal ChmodPostActionProcessor()
         {
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/DotnetRestorePostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/DotnetRestorePostActionProcessor.cs
@@ -7,13 +7,13 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 {
-    public class DotnetRestorePostActionProcessor : PostActionProcessor2Base, IPostActionProcessor, IPostActionProcessor2
+    internal class DotnetRestorePostActionProcessor : PostActionProcessor2Base, IPostActionProcessor, IPostActionProcessor2
     {
         private static readonly Guid ActionProcessorId = new Guid("210D431B-A78B-4D2F-B762-4ED3E3EA9025");
 
         public Guid Id => ActionProcessorId;
 
-        public DotnetRestorePostActionProcessor()
+        internal DotnetRestorePostActionProcessor()
         {
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/IPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/IPostActionProcessor.cs
@@ -2,12 +2,12 @@ using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 {
-    public interface IPostActionProcessor : IIdentifiedComponent
+    internal interface IPostActionProcessor : IIdentifiedComponent
     {
         bool Process(IEngineEnvironmentSettings environment, IPostAction action, ICreationResult templateCreationResult, string outputBasePath);
     }
 
-    public interface IPostActionProcessor2 : IIdentifiedComponent
+    internal interface IPostActionProcessor2 : IIdentifiedComponent
     {
         bool Process(IEngineEnvironmentSettings environment, IPostAction action, ICreationEffects2 creationEffects, ICreationResult templateCreationResult, string outputBasePath);
     }

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/InstructionDisplayPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/InstructionDisplayPostActionProcessor.cs
@@ -3,13 +3,13 @@ using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 {
-    public class InstructionDisplayPostActionProcessor : IPostActionProcessor
+    internal class InstructionDisplayPostActionProcessor : IPostActionProcessor
     {
         private static readonly Guid ActionProcessorId = new Guid("AC1156F7-BB77-4DB8-B28F-24EEBCCA1E5C");
 
         public Guid Id => ActionProcessorId;
 
-        public InstructionDisplayPostActionProcessor()
+        internal InstructionDisplayPostActionProcessor()
         {
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/PostActionProcessorBase.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/PostActionProcessorBase.cs
@@ -7,7 +7,7 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 {
-    public abstract class PostActionProcessor2Base
+    internal abstract class PostActionProcessor2Base
     {
         protected internal New3Callbacks Callbacks { get; set; }
 

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/ProcessStartPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/ProcessStartPostActionProcessor.cs
@@ -7,9 +7,9 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 {
-    public class ProcessStartPostActionProcessor : IPostActionProcessor
+    internal class ProcessStartPostActionProcessor : IPostActionProcessor
     {
-        public static readonly Guid ActionProcessorId = PostActionInfo.ProcessStartPostActionProcessorId;
+        internal static readonly Guid ActionProcessorId = PostActionInfo.ProcessStartPostActionProcessorId;
 
         public Guid Id => ActionProcessorId;
 

--- a/src/Microsoft.TemplateEngine.Cli/Reporter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Reporter.cs
@@ -19,14 +19,14 @@ namespace Microsoft.TemplateEngine.Cli
             _console = console;
         }
 
-        public static Reporter Output { get; private set; }
-        public static Reporter Error { get; private set; }
-        public static Reporter Verbose { get; private set; }
+        internal static Reporter Output { get; private set; }
+        internal static Reporter Error { get; private set; }
+        internal static Reporter Verbose { get; private set; }
 
         /// <summary>
         /// Resets the Reporters to write to the current Console Out/Error.
         /// </summary>
-        public static void Reset()
+        internal static void Reset()
         {
             lock (_lock)
             {
@@ -38,7 +38,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
         }
 
-        public void WriteLine(string message)
+        internal void WriteLine(string message)
         {
             lock (_lock)
             {
@@ -53,7 +53,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
         }
 
-        public void WriteLine()
+        internal void WriteLine()
         {
             lock (_lock)
             {
@@ -61,7 +61,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
         }
 
-        public void Write(string message)
+        internal void Write(string message)
         {
             lock (_lock)
             {

--- a/src/Microsoft.TemplateEngine.Cli/TableFormatter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TableFormatter.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TemplateEngine.Cli
 {
     internal class TableFormatter
     {
-        public static void Print<T>(IEnumerable<T> items, string noItemsMessage, string columnPad, char header, Dictionary<string, Func<T, object>> dictionary)
+        internal static void Print<T>(IEnumerable<T> items, string noItemsMessage, string columnPad, char header, Dictionary<string, Func<T, object>> dictionary)
         {
             List<string>[] columns = new List<string>[dictionary.Count];
 

--- a/src/Microsoft.TemplateEngine.Cli/TableOutput/HelpFormatter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TableOutput/HelpFormatter.cs
@@ -11,15 +11,15 @@ using Microsoft.TemplateEngine.Cli.CommandParsing;
 
 namespace Microsoft.TemplateEngine.Cli
 {
-    public class HelpFormatter
+    internal class HelpFormatter
     {
-        public static HelpFormatter<T> For<T>(IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IEnumerable<T> rows, int columnPadding, char? headerSeparator = null, bool blankLineBetweenRows = false)
+        internal static HelpFormatter<T> For<T>(IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IEnumerable<T> rows, int columnPadding, char? headerSeparator = null, bool blankLineBetweenRows = false)
         {
             return new HelpFormatter<T>(environmentSettings, commandInput, rows, columnPadding, headerSeparator, blankLineBetweenRows);
         }
     }
 
-    public class HelpFormatter<T>
+    internal class HelpFormatter<T>
     {
         private readonly bool _blankLineBetweenRows;
         private readonly int _columnPadding;
@@ -31,7 +31,7 @@ namespace Microsoft.TemplateEngine.Cli
         private const string ShrinkReplacement = "...";
         private readonly INewCommandInput _commandInput;
 
-        public HelpFormatter(IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IEnumerable<T> rows, int columnPadding, char? headerSeparator, bool blankLineBetweenRows)
+        internal HelpFormatter(IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IEnumerable<T> rows, int columnPadding, char? headerSeparator, bool blankLineBetweenRows)
         {
             _rowDataItems = rows ?? Enumerable.Empty<T>();
             _columnPadding = columnPadding;
@@ -41,12 +41,12 @@ namespace Microsoft.TemplateEngine.Cli
             _commandInput = commandInput;
         }
 
-        public HelpFormatter<T> DefineColumn(Func<T, string> binder,  string header = null, string columnName = null, bool shrinkIfNeeded = false, int minWidth = 2, bool showAlways = false, bool defaultColumn = true, bool rightAlign = false)
+        internal HelpFormatter<T> DefineColumn(Func<T, string> binder,  string header = null, string columnName = null, bool shrinkIfNeeded = false, int minWidth = 2, bool showAlways = false, bool defaultColumn = true, bool rightAlign = false)
         {
             return DefineColumn(binder, out object c,  header, columnName, shrinkIfNeeded, minWidth, showAlways, defaultColumn, rightAlign);
         }
 
-        public HelpFormatter<T> DefineColumn(Func<T, string> binder, out object column, string header = null, string columnName = null, bool shrinkIfNeeded = false, int minWidth = 2, bool showAlways = false, bool defaultColumn = true, bool rightAlign = false)
+        internal HelpFormatter<T> DefineColumn(Func<T, string> binder, out object column, string header = null, string columnName = null, bool shrinkIfNeeded = false, int minWidth = 2, bool showAlways = false, bool defaultColumn = true, bool rightAlign = false)
         {
             column = null;
             if ((_commandInput.Columns.Count == 0  && defaultColumn) || showAlways || (!string.IsNullOrWhiteSpace(columnName) && _commandInput.Columns.Contains(columnName)) || _commandInput.ShowAllColumns)
@@ -69,7 +69,7 @@ namespace Microsoft.TemplateEngine.Cli
             return text.Substring(0, Math.Max(0, maxLength - ShrinkReplacement.Length)) + ShrinkReplacement;
         }
 
-        public string Layout()
+        internal string Layout()
         {
             Dictionary<int, int> columnWidthLookup = new Dictionary<int, int>();
             Dictionary<int, int> rowHeightForRow = new Dictionary<int, int>();
@@ -280,7 +280,7 @@ namespace Microsoft.TemplateEngine.Cli
             private readonly Func<T, string> _binder;
             private readonly IEngineEnvironmentSettings _environmentSettings;
 
-            public ColumnDefinition(IEngineEnvironmentSettings environmentSettings, string header, Func<T, string> binder, int minWidth = 2, int maxWidth = -1, bool shrinkIfNeeded = false, bool rightAlign = false)
+            internal ColumnDefinition(IEngineEnvironmentSettings environmentSettings, string header, Func<T, string> binder, int minWidth = 2, int maxWidth = -1, bool shrinkIfNeeded = false, bool rightAlign = false)
             {
                 Header = header;
                 MaxWidth = maxWidth > 0 ? maxWidth : int.MaxValue;
@@ -291,19 +291,19 @@ namespace Microsoft.TemplateEngine.Cli
                 RightAlign = rightAlign;
             }
 
-            public string Header { get; }
+            internal string Header { get; }
 
-            public int CalculatedWidth { get; set; }
+            internal int CalculatedWidth { get; set; }
 
-            public int MinWidth { get; }
+            internal int MinWidth { get; }
 
-            public int MaxWidth { get; }
+            internal int MaxWidth { get; }
 
-            public bool ShrinkIfNeeded { get; }
+            internal bool ShrinkIfNeeded { get; }
 
-            public bool RightAlign { get; }
+            internal bool RightAlign { get; }
 
-            public TextWrapper GetCell(T value)
+            internal TextWrapper GetCell(T value)
             {
                 return new TextWrapper(_environmentSettings, _binder(value), MaxWidth);
             }
@@ -313,7 +313,7 @@ namespace Microsoft.TemplateEngine.Cli
         {
             private readonly IReadOnlyList<string> _lines;
 
-            public TextWrapper(IEngineEnvironmentSettings environmentSettings, string text, int maxWidth)
+            internal TextWrapper(IEngineEnvironmentSettings environmentSettings, string text, int maxWidth)
             {
                 List<string> lines = new List<string>();
                 int position = 0;
@@ -351,11 +351,11 @@ namespace Microsoft.TemplateEngine.Cli
                 RawText = text;
             }
 
-            public int LineCount => _lines.Count;
+            internal int LineCount => _lines.Count;
 
-            public int MaxWidth { get; }
+            internal int MaxWidth { get; }
 
-            public string GetTextWithPadding(int line, int maxColumnWidth, bool rightAlign = false)
+            internal string GetTextWithPadding(int line, int maxColumnWidth, bool rightAlign = false)
             {
                 var text = _lines.Count > line ? _lines[line] : string.Empty;
                 var abbreviatedText = ShrinkTextToLength(text, maxColumnWidth);
@@ -399,10 +399,10 @@ namespace Microsoft.TemplateEngine.Cli
                 }
             }
 
-            public string RawText { get; }
+            internal string RawText { get; }
         }
 
-        public HelpFormatter<T> OrderBy(object columnToken, IComparer<string> comparer = null)
+        internal HelpFormatter<T> OrderBy(object columnToken, IComparer<string> comparer = null)
         {
             comparer = comparer ?? StringComparer.Ordinal;
             int index = _columns.IndexOf(columnToken as ColumnDefinition);
@@ -416,7 +416,7 @@ namespace Microsoft.TemplateEngine.Cli
             return this;
         }
 
-        public HelpFormatter<T> OrderByDescending(object columnToken, IComparer<string> comparer = null)
+        internal HelpFormatter<T> OrderByDescending(object columnToken, IComparer<string> comparer = null)
         {
             comparer = comparer ?? StringComparer.Ordinal;
             int index = _columns.IndexOf(columnToken as ColumnDefinition);

--- a/src/Microsoft.TemplateEngine.Cli/TelemetryConstants.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TelemetryConstants.cs
@@ -6,21 +6,21 @@ namespace Microsoft.TemplateEngine.Cli
     internal static class TelemetryConstants
     {
         // event name suffixes
-        public static readonly string InstallEventSuffix = "-install";
-        public static readonly string HelpEventSuffix = "-help";
-        public static readonly string CreateEventSuffix = "-create-template";
-        public static readonly string CalledWithNoArgsEventSuffix = "-called-with-no-args";
+        internal static readonly string InstallEventSuffix = "-install";
+        internal static readonly string HelpEventSuffix = "-help";
+        internal static readonly string CreateEventSuffix = "-create-template";
+        internal static readonly string CalledWithNoArgsEventSuffix = "-called-with-no-args";
 
         // install event args
-        public static readonly string ToInstallCount = "CountOfThingsToInstall";
+        internal static readonly string ToInstallCount = "CountOfThingsToInstall";
 
         // create event args
-        public static readonly string Language = "language";
-        public static readonly string ArgError = "argument-error";
-        public static readonly string Framework = "framework";
-        public static readonly string TemplateName = "template-name";
-        public static readonly string IsTemplateThirdParty = "is-template-3rd-party";
-        public static readonly string Auth = "auth";
-        public static readonly string CreationResult = "create-success";
+        internal static readonly string Language = "language";
+        internal static readonly string ArgError = "argument-error";
+        internal static readonly string Framework = "framework";
+        internal static readonly string TemplateName = "template-name";
+        internal static readonly string IsTemplateThirdParty = "is-template-3rd-party";
+        internal static readonly string Auth = "auth";
+        internal static readonly string CreationResult = "create-success";
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TelemetryHelper.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TelemetryHelper.cs
@@ -10,14 +10,14 @@ using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Cli
 {
-    public static class TelemetryHelper
+    internal static class TelemetryHelper
     {
         // Checks if the input parameter value is a valid choice for the parameter, and returns the canonical value, or defaultValue if there is no appropriate canonical value.
         // If the parameter or value is null, return defaultValue.
         // For this to return other than the defaultValue, one of these must occur:
         //  - the input value must either exactly match one of the choices (case-insensitive)
         //  - there must be exactly one choice value starting with the input value (case-insensitive).
-        public static string GetCanonicalValueForChoiceParamOrDefault(ITemplateInfo template, string paramName, string inputParamValue, string defaultValue = null)
+        internal static string GetCanonicalValueForChoiceParamOrDefault(ITemplateInfo template, string paramName, string inputParamValue, string defaultValue = null)
         {
             if (string.IsNullOrEmpty(paramName) || string.IsNullOrEmpty(inputParamValue))
             {
@@ -49,13 +49,13 @@ namespace Microsoft.TemplateEngine.Cli
         /// <summary>
         /// // The hashed mac address needs to be the same hashed value as produced by the other distinct sources given the same input. (e.g. VsCode)
         /// </summary>
-        public static string Hash(string text)
+        internal static string Hash(string text)
         {
             var sha256 = SHA256.Create();
             return HashInFormat(sha256, text);
         }
 
-        public static string HashWithNormalizedCasing(string text)
+        internal static string HashWithNormalizedCasing(string text)
         {
             if (text == null)
             {

--- a/src/Microsoft.TemplateEngine.Cli/TemplateGroupParameterSet.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateGroupParameterSet.cs
@@ -6,11 +6,11 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli
 {
-    public class TemplateGroupParameterSet : IParameterSet
+    internal class TemplateGroupParameterSet : IParameterSet
     {
         private readonly IReadOnlyList<IParameterSet> _parameterSetList;
 
-        public TemplateGroupParameterSet(IReadOnlyList<IParameterSet> parameterSetList)
+        internal TemplateGroupParameterSet(IReadOnlyList<IParameterSet> parameterSetList)
         {
             _parameterSetList = parameterSetList;
         }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
@@ -21,7 +21,7 @@ namespace Microsoft.TemplateEngine.Cli
         private readonly Func<string> _inputGetter;
         private readonly New3Callbacks _callbacks;
 
-        public TemplateInvocationCoordinator(ISettingsLoader settingsLoader, INewCommandInput commandInput, ITelemetryLogger telemetryLogger,  string commandName, Func<string> inputGetter, New3Callbacks callbacks)
+        internal TemplateInvocationCoordinator(ISettingsLoader settingsLoader, INewCommandInput commandInput, ITelemetryLogger telemetryLogger,  string commandName, Func<string> inputGetter, New3Callbacks callbacks)
         {
             _settingsLoader = settingsLoader;
             _environment = _settingsLoader.EnvironmentSettings;
@@ -32,7 +32,7 @@ namespace Microsoft.TemplateEngine.Cli
             _callbacks = callbacks;
         }
 
-        public async Task<CreationResultStatus> CoordinateInvocationOrAcquisitionAsync(ITemplateMatchInfo templateToInvoke, CancellationToken cancellationToken)
+        internal async Task<CreationResultStatus> CoordinateInvocationOrAcquisitionAsync(ITemplateMatchInfo templateToInvoke, CancellationToken cancellationToken)
         {
             // invoke and then check for updates
             CreationResultStatus creationResult = await InvokeTemplateAsync(templateToInvoke).ConfigureAwait(false);

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -25,7 +25,7 @@ namespace Microsoft.TemplateEngine.Cli
         private readonly TemplateCreator _templateCreator;
         private readonly IHostSpecificDataLoader _hostDataLoader;
 
-        public TemplateInvoker(IEngineEnvironmentSettings environment, INewCommandInput commandInput, ITelemetryLogger telemetryLogger, string commandName, Func<string> inputGetter, New3Callbacks callbacks)
+        internal TemplateInvoker(IEngineEnvironmentSettings environment, INewCommandInput commandInput, ITelemetryLogger telemetryLogger, string commandName, Func<string> inputGetter, New3Callbacks callbacks)
         {
             _environment = environment;
             _commandInput = commandInput;
@@ -38,7 +38,7 @@ namespace Microsoft.TemplateEngine.Cli
             _hostDataLoader = new HostSpecificDataLoader(_environment.SettingsLoader);
         }
 
-        public async Task<CreationResultStatus> InvokeTemplate(ITemplateMatchInfo templateToInvoke)
+        internal async Task<CreationResultStatus> InvokeTemplate(ITemplateMatchInfo templateToInvoke)
         {
             templateToInvoke.Info.Tags.TryGetValue("language", out ICacheTag language);
             bool isMicrosoftAuthored = string.Equals(templateToInvoke.Info.Author, "Microsoft", StringComparison.OrdinalIgnoreCase);
@@ -118,7 +118,7 @@ namespace Microsoft.TemplateEngine.Cli
             }
         }
 
-        public static bool CheckForArgsError(ITemplateMatchInfo template, out string commandParseFailureMessage)
+        internal static bool CheckForArgsError(ITemplateMatchInfo template, out string commandParseFailureMessage)
         {
             bool argsError;
 

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateListResolutionResult.cs
@@ -13,9 +13,9 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
     /// The class represents the template resolution result for listing purposes.
     /// The resolution result is the list of templates to use.
     /// </summary>
-    public sealed class TemplateListResolutionResult
+    internal sealed class TemplateListResolutionResult
     {
-        public TemplateListResolutionResult(IReadOnlyCollection<ITemplateMatchInfo> coreMatchedTemplates)
+        internal TemplateListResolutionResult(IReadOnlyCollection<ITemplateMatchInfo> coreMatchedTemplates)
         {
             _coreMatchedTemplates = coreMatchedTemplates;
         }
@@ -29,7 +29,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// <summary>
         /// Returns list of exact or partially matched templates by name and exact match by language, filter, baseline (if specified in command paramaters).
         /// </summary>
-        public IReadOnlyCollection<ITemplateMatchInfo> ExactMatchedTemplates
+        internal IReadOnlyCollection<ITemplateMatchInfo> ExactMatchedTemplates
         {
             get
             {
@@ -71,7 +71,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// <summary>
         /// Returns list of exact or partially matched templates by name and mismatch in any of the following: language, filter, baseline (if specified in command paramaters).
         /// </summary>
-        public IReadOnlyCollection<ITemplateMatchInfo> PartiallyMatchedTemplates
+        internal IReadOnlyCollection<ITemplateMatchInfo> PartiallyMatchedTemplates
         {
             get
             {
@@ -108,22 +108,22 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// <summary>
         /// Returns true when at least one template in unambiguous matches default language.
         /// </summary>
-        public bool HasUnambiguousTemplateGroupForDefaultLanguage => UnambiguousTemplatesForDefaultLanguage.Any();
+        internal bool HasUnambiguousTemplateGroupForDefaultLanguage => UnambiguousTemplatesForDefaultLanguage.Any();
 
         /// <summary>
         /// Returns collecion of templates from unamgibuous group that matches default language.
         /// </summary>
-        public IReadOnlyCollection<ITemplateMatchInfo> UnambiguousTemplatesForDefaultLanguage => UnambiguousTemplateGroup.Where(t => t.HasDefaultLanguageMatch()).ToList();
+        internal IReadOnlyCollection<ITemplateMatchInfo> UnambiguousTemplatesForDefaultLanguage => UnambiguousTemplateGroup.Where(t => t.HasDefaultLanguageMatch()).ToList();
 
         /// <summary>
         /// Returns true when at least one template exactly or partially matched templates by name and exactly matched language, filter, baseline (if specified in command paramaters).
         /// </summary>
-        public bool HasExactMatches => ExactMatchedTemplates.Any();
+        internal bool HasExactMatches => ExactMatchedTemplates.Any();
 
         /// <summary>
         /// Returns true when at least one template exactly or partially matched templates by name but has mismatch in any of the following: language, filter, baseline (if specified in command paramaters).
         /// </summary>
-        public bool HasPartialMatches => PartiallyMatchedTemplates.Any();
+        internal bool HasPartialMatches => PartiallyMatchedTemplates.Any();
 
         /// <summary>
         /// Returns true when at least one template has mismatch in language.
@@ -131,42 +131,42 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         // as we need to count errors per template group: for language we need to check template groups as templates in single group may have different language
         // and if one of them can match the filter, then the whole group matches the filter
         // if all templates in the group has language mismatch, then group has language mismatch
-        public bool HasLanguageMismatch => PartiallyMatchedTemplateGroups.Any(g => g.Templates.All(t => t.HasLanguageMismatch()));
+        internal bool HasLanguageMismatch => PartiallyMatchedTemplateGroups.Any(g => g.Templates.All(t => t.HasLanguageMismatch()));
 
         /// <summary>
         /// Returns true when at least one template has mismatch in context (type).
         /// </summary>
-        public bool HasContextMismatch => PartiallyMatchedTemplates.Any(t => t.HasContextMismatch());
+        internal bool HasContextMismatch => PartiallyMatchedTemplates.Any(t => t.HasContextMismatch());
 
         /// <summary>
         /// Returns true when at least one template has mismatch in baseline.
         /// </summary>
-        public bool HasBaselineMismatch => PartiallyMatchedTemplates.Any(t => t.HasBaselineMismatch());
+        internal bool HasBaselineMismatch => PartiallyMatchedTemplates.Any(t => t.HasBaselineMismatch());
 
         /// <summary>
         /// Returns true when at least one template has mismatch in author.
         /// </summary>
-        public bool HasAuthorMismatch => PartiallyMatchedTemplates.Any(t => t.HasAuthorMismatch());
+        internal bool HasAuthorMismatch => PartiallyMatchedTemplates.Any(t => t.HasAuthorMismatch());
 
         /// <summary>
         /// Returns true when at least one template has mismatch in tags.
         /// </summary>
-        public bool HasTagsMismatch => PartiallyMatchedTemplates.Any(t => t.HasTagsMismatch());
+        internal bool HasTagsMismatch => PartiallyMatchedTemplates.Any(t => t.HasTagsMismatch());
 
         /// <summary>
         /// Returns true when one and only one template has exact match.
         /// </summary>
-        public bool HasUnambiguousTemplateGroup => ExactMatchedTemplateGroups.Count == 1;
+        internal bool HasUnambiguousTemplateGroup => ExactMatchedTemplateGroups.Count == 1;
 
         /// <summary>
         /// Returns list of templates for unambiguous template group, otherwise empty list.
         /// </summary>
-        public IReadOnlyCollection<ITemplateMatchInfo> UnambiguousTemplateGroup => HasUnambiguousTemplateGroup ? ExactMatchedTemplates : new List<ITemplateMatchInfo>();
+        internal IReadOnlyCollection<ITemplateMatchInfo> UnambiguousTemplateGroup => HasUnambiguousTemplateGroup ? ExactMatchedTemplates : new List<ITemplateMatchInfo>();
 
         /// <summary>
         /// Returns true if all the templates in unambiguous group have templates in same language.
         /// </summary>
-        public bool AllTemplatesInUnambiguousTemplateGroupAreSameLanguage
+        internal bool AllTemplatesInUnambiguousTemplateGroupAreSameLanguage
         {
             get
             {

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateMatchInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateMatchInfoExtensions.cs
@@ -7,62 +7,62 @@ using Microsoft.TemplateEngine.Edge.Template;
 
 namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 {
-    public static class TemplateMatchInfoExtensions
+    internal static class TemplateMatchInfoExtensions
     {
         // True if name is explicitly mismatched.
         // Partial matches are ok. No disposition on name is also ok.
-        public static bool HasNameMismatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasNameMismatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.Name && x.Kind == MatchKind.Mismatch);
         }
 
-        public static bool HasParameterMismatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasParameterMismatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter
                                        && x.Kind != MatchKind.Exact && x.Kind != MatchKind.AmbiguousParameterValue && x.Kind != MatchKind.SingleStartsWith);
         }
 
-        public static bool HasContextMismatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasContextMismatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.Context && x.Kind == MatchKind.Mismatch);
         }
 
-        public static bool HasLanguageMismatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasLanguageMismatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.Language && x.Kind == MatchKind.Mismatch);
         }
 
-        public static bool HasDefaultLanguageMatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasDefaultLanguageMatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.DispositionOfDefaults.Any(x => x.Location == MatchLocation.DefaultLanguage && x.Kind == MatchKind.Exact);
         }
 
-        public static bool HasInvalidParameterName(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasInvalidParameterName(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.InvalidParameterName);
         }
 
-        public static bool HasBaselineMismatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasBaselineMismatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.Baseline && x.Kind == MatchKind.Mismatch);
         }
 
-        public static bool HasAuthorMismatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasAuthorMismatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.Author && x.Kind == MatchKind.Mismatch);
         }
 
-        public static bool HasTagsMismatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasTagsMismatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.Classification && x.Kind == MatchKind.Mismatch);
         }
 
-        public static bool HasAmbiguousParameterValueMatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasAmbiguousParameterValueMatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.OtherParameter && x.Kind == MatchKind.AmbiguousParameterValue);
         }
 
-        public static bool IsInvokableMatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool IsInvokableMatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Count > 0
                             && templateMatchInfo.MatchDisposition.All(x =>
@@ -79,48 +79,48 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                             );
         }
 
-        public static IReadOnlyList<string> GetInvalidParameterNames(this ITemplateMatchInfo templateMatchInfo)
+        internal static IReadOnlyList<string> GetInvalidParameterNames(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Where(x => x.Kind == MatchKind.InvalidParameterName)
                                                    .Select(x => x.InputParameterName).ToList();
         }
 
-        public static bool HasParseError(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasParseError(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(x => x.Kind == MatchKind.Unspecified);
         }
 
-        public static string GetParseError(this ITemplateMatchInfo templateMatchInfo)
+        internal static string GetParseError(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Where(x => x.Kind == MatchKind.Unspecified).Select(x => x.AdditionalInformation).FirstOrDefault();
         }
 
         // This is analogous to INewCommandInput.InputTemplateParams
-        public static IReadOnlyDictionary<string, string> GetValidTemplateParameters(this ITemplateMatchInfo templateMatchInfo)
+        internal static IReadOnlyDictionary<string, string> GetValidTemplateParameters(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Where(x => x.Location == MatchLocation.OtherParameter && (x.Kind == MatchKind.Exact || x.Kind == MatchKind.SingleStartsWith))
                                     .ToDictionary(x => x.InputParameterName, x => x.ParameterValue);
         }
 
-        public static bool IsContextOnlyMatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool IsContextOnlyMatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.All(x => x.Location == MatchLocation.Context && x.Kind == MatchKind.Exact
                                                                 || x.Kind == MatchKind.Mismatch);
         }
 
-        public static bool IsNameOnlyMatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool IsNameOnlyMatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.All(x => x.Location == MatchLocation.Name && x.Kind == MatchKind.Exact
                                                                 || x.Kind == MatchKind.Mismatch);
         }
 
-        public static bool IsNameOrContextMatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool IsNameOrContextMatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(x => x.Location == MatchLocation.Name && x.Kind == MatchKind.Exact
                                                                 || x.Location == MatchLocation.Context && x.Kind == MatchKind.Exact);
         }
 
-        public static bool IsMatchExceptContext(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool IsMatchExceptContext(this ITemplateMatchInfo templateMatchInfo)
         {
             if (templateMatchInfo.MatchDisposition.Count == 0)
             {
@@ -151,7 +151,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             return hasContextMismatch;
         }
 
-        public static bool IsMatchExceptLanguage(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool IsMatchExceptLanguage(this ITemplateMatchInfo templateMatchInfo)
         {
             if (templateMatchInfo.MatchDisposition.Count == 0)
             {
@@ -184,7 +184,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 
         // Returns true if there is a context mismatch and no other mismatches, false otherwise.
         // Note: there must be at least one disposition that is not mismatch, in addition to the context mismatch.
-        public static bool IsPartialMatchExceptContext(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool IsPartialMatchExceptContext(this ITemplateMatchInfo templateMatchInfo)
         {
             if (templateMatchInfo.MatchDisposition.Count == 0)
             {
@@ -216,12 +216,12 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             return hasOtherThanMismatch && hasContextMismatch;
         }
 
-        public static bool HasNameOrClassificationMatchOrPartialMatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasNameOrClassificationMatchOrPartialMatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any((x => (x.Location == MatchLocation.Name || x.Location == MatchLocation.ShortName || x.Location == MatchLocation.Classification) && (x.Kind == MatchKind.Exact || x.Kind == MatchKind.Partial)));
         }
 
-        public static bool HasAnyMismatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool HasAnyMismatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Any(m => m.Kind == MatchKind.Mismatch);
         }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolutionResult.cs
@@ -28,7 +28,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
     /// --- in case at least one template in the group has more than 1 choice value which starts with specified value in the command<br/>
     /// --- in case at least two templates in the group have 1 choice value which starts with specified value in the command.<br/>
     /// </summary>
-    public class TemplateResolutionResult
+    internal class TemplateResolutionResult
     {
         private readonly IReadOnlyCollection<ITemplateMatchInfo> _coreMatchedTemplates;
 
@@ -44,7 +44,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 
         private UnambiguousTemplateGroupStatus _unambigiousTemplateGroupStatus = UnambiguousTemplateGroupStatus.NotEvaluated;
 
-        public TemplateResolutionResult(string userInputLanguage, IReadOnlyCollection<ITemplateMatchInfo> coreMatchedTemplates)
+        internal TemplateResolutionResult(string userInputLanguage, IReadOnlyCollection<ITemplateMatchInfo> coreMatchedTemplates)
         {
             _hasUserInputLanguage = !string.IsNullOrEmpty(userInputLanguage);
             _coreMatchedTemplates = coreMatchedTemplates;
@@ -53,7 +53,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// <summary>
         /// Enum defines possible statuses for resolving template to invoke.<br />
         /// </summary>
-        public enum Status
+        internal enum Status
         {
             /// <summary>
             /// the status is not evaluated yet

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
@@ -12,7 +12,7 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 {
-    public static class TemplateResolver
+    internal static class TemplateResolver
     {
         private static readonly IReadOnlyCollection<MatchLocation> NameFields = new HashSet<MatchLocation>
         {
@@ -20,13 +20,13 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             MatchLocation.ShortName
         };
 
-        public static void ParseTemplateArgs(ITemplateInfo templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput)
+        internal static void ParseTemplateArgs(ITemplateInfo templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput)
         {
             HostSpecificTemplateData hostData = hostDataLoader.ReadHostSpecificTemplateData(templateInfo);
             commandInput.ReparseForTemplate(templateInfo, hostData);
         }
 
-        public static bool AreAllTemplatesSameGroupIdentity(IEnumerable<ITemplateMatchInfo> templateList)
+        internal static bool AreAllTemplatesSameGroupIdentity(IEnumerable<ITemplateMatchInfo> templateList)
         {
             if (!templateList.Any())
             {
@@ -46,7 +46,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         // for what wants to be validated, either:
         //  - not in the context of any template
         //  - in the context of a specific template.
-        public static bool ValidateRemainingParameters(INewCommandInput commandInput, out IReadOnlyList<string> invalidParams)
+        internal static bool ValidateRemainingParameters(INewCommandInput commandInput, out IReadOnlyList<string> invalidParams)
         {
             List<string> badParams = new List<string>();
 
@@ -63,7 +63,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         }
 
         // This version is preferred, its clear which template the results are in the context of.
-        public static bool ValidateRemainingParameters(ITemplateMatchInfo template, out IReadOnlyList<string> invalidParams)
+        internal static bool ValidateRemainingParameters(ITemplateMatchInfo template, out IReadOnlyList<string> invalidParams)
         {
             invalidParams = template.GetInvalidParameterNames();
 
@@ -71,7 +71,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         }
 
         // Lists all the templates, unfiltered - except the ones hidden by their host file.
-        public static IReadOnlyCollection<ITemplateMatchInfo> PerformAllTemplatesQuery(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader)
+        internal static IReadOnlyCollection<ITemplateMatchInfo> PerformAllTemplatesQuery(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader)
         {
             IReadOnlyList<FilterableTemplateInfo> filterableTemplateInfo = SetupFilterableTemplateInfoFromTemplateInfo(templateInfo);
 
@@ -85,13 +85,13 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             return templates;
         }
 
-        public static TemplateResolutionResult GetTemplateResolutionResult(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string defaultLanguage)
+        internal static TemplateResolutionResult GetTemplateResolutionResult(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string defaultLanguage)
         {
             IReadOnlyCollection<ITemplateMatchInfo> coreMatchedTemplates = PerformCoreTemplateQuery(templateInfo, hostDataLoader, commandInput, defaultLanguage);
             return new TemplateResolutionResult(commandInput.Language, coreMatchedTemplates);
         }
 
-        public static TemplateListResolutionResult GetTemplateResolutionResultForListOrHelp(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string defaultLanguage)
+        internal static TemplateListResolutionResult GetTemplateResolutionResultForListOrHelp(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string defaultLanguage)
         {
             IReadOnlyCollection<ITemplateMatchInfo> coreMatchedTemplates;
 
@@ -109,7 +109,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             return new TemplateListResolutionResult(coreMatchedTemplates);
         }
 
-        public static IReadOnlyCollection<ITemplateMatchInfo> PerformCoreTemplateQueryForList(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string defaultLanguage)
+        internal static IReadOnlyCollection<ITemplateMatchInfo> PerformCoreTemplateQueryForList(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string defaultLanguage)
         {
             IReadOnlyList<FilterableTemplateInfo> filterableTemplateInfo = SetupFilterableTemplateInfoFromTemplateInfo(templateInfo);
 
@@ -135,7 +135,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             return coreMatchedTemplates;
         }
 
-        public static IReadOnlyCollection<ITemplateMatchInfo> PerformCoreTemplateQueryForHelp(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string defaultLanguage)
+        internal static IReadOnlyCollection<ITemplateMatchInfo> PerformCoreTemplateQueryForHelp(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string defaultLanguage)
         {
             IReadOnlyList<FilterableTemplateInfo> filterableTemplateInfo = SetupFilterableTemplateInfoFromTemplateInfo(templateInfo);
             IReadOnlyList<ITemplateMatchInfo> coreMatchedTemplates = TemplateListFilter.GetTemplateMatchInfo(
@@ -173,7 +173,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// <param name="hostDataLoader">data of the host.</param>
         /// <param name="commandInput">new command data used in CLI.</param>
         /// <returns>filtered list of templates.</returns>
-        public static IReadOnlyCollection<ITemplateMatchInfo> PerformCoreTemplateQueryForSearch(IEnumerable<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput)
+        internal static IReadOnlyCollection<ITemplateMatchInfo> PerformCoreTemplateQueryForSearch(IEnumerable<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput)
         {
             IReadOnlyList<FilterableTemplateInfo> filterableTemplateInfo = SetupFilterableTemplateInfoFromTemplateInfo(templateInfo.ToList());
             List<Func<ITemplateInfo, MatchInfo?>> searchFilters = new List<Func<ITemplateInfo, MatchInfo?>>()
@@ -201,7 +201,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// <param name="commandInput">new command data used in CLI.</param>
         /// <param name="defaultLanguage"></param>
         /// <returns>the collection of the templates with their match dispositions (<seealso cref="ITemplateMatchInfo"/>). The templates that do not match are not added to the collection.</returns>
-        public static IReadOnlyCollection<ITemplateMatchInfo> PerformCoreTemplateQuery(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string defaultLanguage)
+        internal static IReadOnlyCollection<ITemplateMatchInfo> PerformCoreTemplateQuery(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string defaultLanguage)
         {
             IReadOnlyList<FilterableTemplateInfo> filterableTemplateInfo = SetupFilterableTemplateInfoFromTemplateInfo(templateInfo);
 

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliHostSpecificDataMatchFilter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliHostSpecificDataMatchFilter.cs
@@ -8,16 +8,16 @@ using Microsoft.TemplateSearch.Common;
 
 namespace Microsoft.TemplateEngine.Cli.TemplateSearch
 {
-    public class CliHostSpecificDataMatchFilterFactory
+    internal class CliHostSpecificDataMatchFilterFactory
     {
-        public CliHostSpecificDataMatchFilterFactory(INewCommandInput commandInput)
+        internal CliHostSpecificDataMatchFilterFactory(INewCommandInput commandInput)
         {
             _commandInput = commandInput;
         }
 
         private readonly INewCommandInput _commandInput;
 
-        public Func<IReadOnlyList<ITemplateNameSearchResult>, IReadOnlyList<ITemplateMatchInfo>> MatchFilter => (foundPackages) =>
+        internal Func<IReadOnlyList<ITemplateNameSearchResult>, IReadOnlyList<ITemplateMatchInfo>> MatchFilter => (foundPackages) =>
         {
             Dictionary<string, HostSpecificTemplateData> hostDataLookup = new Dictionary<string, HostSpecificTemplateData>();
             foreach (ITemplateNameSearchResult result in foundPackages)

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliNuGetMetadataSearchSource.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliNuGetMetadataSearchSource.cs
@@ -6,11 +6,6 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
 {
     internal class CliNuGetMetadataSearchSource : NuGetMetadataSearchSource
     {
-        public CliNuGetMetadataSearchSource()
-            : base()
-        {
-        }
-
         public override Guid Id => new Guid("6EA368C4-8A56-444C-91D1-55150B296BF2");
 
         protected override IFileMetadataTemplateSearchCache CreateSearchCache(IEngineEnvironmentSettings environmentSettings)

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliNuGetMetadataTemplateSearchCache.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliNuGetMetadataTemplateSearchCache.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
     {
         protected IReadOnlyDictionary<string, HostSpecificTemplateData> _cliHostSpecificData;
 
-        public CliNuGetMetadataTemplateSearchCache(IEngineEnvironmentSettings environmentSettings, string pathToMetadata)
+        internal CliNuGetMetadataTemplateSearchCache(IEngineEnvironmentSettings environmentSettings, string pathToMetadata)
             : base(environmentSettings, pathToMetadata)
         {
         }
@@ -49,7 +49,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
             _cliHostSpecificData = new Dictionary<string, HostSpecificTemplateData>();
         }
 
-        public IReadOnlyDictionary<string, HostSpecificTemplateData> GetHostDataForTemplateIdentities(IReadOnlyList<string> identities)
+        internal IReadOnlyDictionary<string, HostSpecificTemplateData> GetHostDataForTemplateIdentities(IReadOnlyList<string> identities)
         {
             EnsureInitialized();
 
@@ -66,7 +66,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
             return map;
         }
 
-        public bool TryGetHostDataForTemplateIdentity(string identity, out HostSpecificTemplateData hostData)
+        internal bool TryGetHostDataForTemplateIdentity(string identity, out HostSpecificTemplateData hostData)
         {
             EnsureInitialized();
 

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliNuGetSearchCacheConfig.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliNuGetSearchCacheConfig.cs
@@ -7,9 +7,9 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
 {
     internal class CliNuGetSearchCacheConfig : NuGetSearchCacheConfig
     {
-        public static readonly string CliHostDataName = "cliHostData";
+        internal static readonly string CliHostDataName = "cliHostData";
 
-        public CliNuGetSearchCacheConfig(string templateDiscoveryFileName)
+        internal CliNuGetSearchCacheConfig(string templateDiscoveryFileName)
             : base(templateDiscoveryFileName)
         {
             _additionalDataReaders[CliHostDataName] = CliHostDataReader;

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateNameSearchResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateNameSearchResult.cs
@@ -3,14 +3,14 @@ using Microsoft.TemplateSearch.Common;
 
 namespace Microsoft.TemplateEngine.Cli.TemplateSearch
 {
-    public class CliTemplateNameSearchResult : TemplateNameSearchResult
+    internal class CliTemplateNameSearchResult : TemplateNameSearchResult
     {
-        public CliTemplateNameSearchResult(ITemplateInfo template, PackInfo packInfo, HostSpecificTemplateData hostSpecificData)
+        internal CliTemplateNameSearchResult(ITemplateInfo template, PackInfo packInfo, HostSpecificTemplateData hostSpecificData)
             : base(template, packInfo)
         {
             HostSpecificTemplateData = hostSpecificData;
         }
 
-        public HostSpecificTemplateData HostSpecificTemplateData { get; }
+        internal HostSpecificTemplateData HostSpecificTemplateData { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinatorFactory.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinatorFactory.cs
@@ -6,7 +6,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
 {
     internal static class CliTemplateSearchCoordinatorFactory
     {
-        public static TemplateSearchCoordinator CreateCliTemplateSearchCoordinator(IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, string defaultLanguage)
+        internal static TemplateSearchCoordinator CreateCliTemplateSearchCoordinator(IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, string defaultLanguage)
         {
             return new TemplateSearchCoordinator(environmentSettings,
                                             commandInput.TemplateName,

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/InMemoryHostSpecificDataLoader.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/InMemoryHostSpecificDataLoader.cs
@@ -5,7 +5,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
 {
     internal class InMemoryHostSpecificDataLoader : IHostSpecificDataLoader
     {
-        public InMemoryHostSpecificDataLoader(IReadOnlyDictionary<string, HostSpecificTemplateData> hostSpecificData)
+        internal InMemoryHostSpecificDataLoader(IReadOnlyDictionary<string, HostSpecificTemplateData> hostSpecificData)
         {
             _hostSpecificData = hostSpecificData;
         }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/ParameterMatchDisposition.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/ParameterMatchDisposition.cs
@@ -5,15 +5,15 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
 {
     internal class ParameterMatchDisposition
     {
-        public string Name { get; private set; }
+        internal string Name { get; private set; }
 
-        public string Value { get; private set; }
+        internal string Value { get; private set; }
 
-        public ParameterNameDisposition NameDisposition { get; private set; }
+        internal ParameterNameDisposition NameDisposition { get; private set; }
 
-        public ParameterValueDisposition ValueDisposition { get; private set; }
+        internal ParameterValueDisposition ValueDisposition { get; private set; }
 
-        public static IReadOnlyList<ParameterMatchDisposition> FromTemplateMatchInfo(ITemplateMatchInfo templateMatchInfo)
+        internal static IReadOnlyList<ParameterMatchDisposition> FromTemplateMatchInfo(ITemplateMatchInfo templateMatchInfo)
         {
             List<ParameterMatchDisposition> parameterMatchDispositions = new List<ParameterMatchDisposition>();
 

--- a/src/Microsoft.TemplateSearch.Common/NuGetMetadataSearchSource.cs
+++ b/src/Microsoft.TemplateSearch.Common/NuGetMetadataSearchSource.cs
@@ -13,12 +13,7 @@ namespace Microsoft.TemplateSearch.Common
     {
         protected static readonly string _templateDiscoveryMetadataFile = "nugetTemplateSearchInfo.json";
 
-        private readonly ISearchInfoFileProvider _searchInfoFileProvider;
-
-        public NuGetMetadataSearchSource()
-        {
-            _searchInfoFileProvider = new BlobStoreSourceFileProvider();
-        }
+        private readonly ISearchInfoFileProvider _searchInfoFileProvider = new BlobStoreSourceFileProvider();
 
         public override string DisplayName => "NuGet.org";
 

--- a/src/Microsoft.TemplateSearch.Common/TemplateSearchCoordinator.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateSearchCoordinator.cs
@@ -29,8 +29,7 @@ namespace Microsoft.TemplateSearch.Common
 
         public async Task<SearchResults> SearchAsync()
         {
-            await EnsureSearchResultsAsync();
-
+            await EnsureSearchResultsAsync().ConfigureAwait(false);
             return _searchResults;
         }
 
@@ -53,7 +52,7 @@ namespace Microsoft.TemplateSearch.Common
                 existingTemplatePackage = new List<IManagedTemplatePackage>();
             }
 
-            _searchResults = await searcher.SearchForTemplatesAsync(existingTemplatePackage, _inputTemplateName);
+            _searchResults = await searcher.SearchForTemplatesAsync(existingTemplatePackage, _inputTemplateName).ConfigureAwait(false);
 
             _isSearchPerformed = true;
         }

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -47,7 +47,11 @@ namespace dotnet_new3
                 AddInstallLogger(host);
             }
 
-            return New3Command.Run(CommandName, host, new TelemetryLogger(null, debugTelemetry), FirstRun, args);
+            var callbacks = new New3Callbacks
+            {
+                OnFirstRun = FirstRun
+            };
+            return New3Command.Run(CommandName, host, new TelemetryLogger(null, debugTelemetry), callbacks, args);
         }
 
         private static DefaultTemplateEngineHost CreateHost(bool emitTimings)

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -6,13 +6,10 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli;
-using Microsoft.TemplateEngine.Cli.PostActionProcessors;
 using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects;
 using Microsoft.TemplateEngine.Utils;
@@ -59,7 +56,7 @@ namespace dotnet_new3
 
             try
             {
-                string versionString = Dotnet.Version().CaptureStdOut().Execute().StdOut;
+                string? versionString = Dotnet.Version().CaptureStdOut().Execute().StdOut;
                 if (!string.IsNullOrWhiteSpace(versionString))
                 {
                     preferences["dotnet-cli-version"] = versionString.Trim();
@@ -75,9 +72,7 @@ namespace dotnet_new3
                 // for assembly: Microsoft.TemplateEngine.Edge
                 typeof(Microsoft.TemplateEngine.Edge.Paths).GetTypeInfo().Assembly,
                 // for assembly: Microsoft.TemplateEngine.Cli
-                typeof(DotnetRestorePostActionProcessor).GetTypeInfo().Assembly,
-                // for assembly: Microsoft.TemplateSearch.Common
-                typeof(Microsoft.TemplateSearch.Common.TemplateToPackMap).GetTypeInfo().Assembly,
+                typeof(Microsoft.TemplateEngine.Cli.New3Command).GetTypeInfo().Assembly,
                 // for this assembly
                 typeof(Program).GetTypeInfo().Assembly
             });

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockHostSpecificDataLoader.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockHostSpecificDataLoader.cs
@@ -2,7 +2,7 @@ using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 {
-    public class MockHostSpecificDataLoader : IHostSpecificDataLoader
+    internal class MockHostSpecificDataLoader : IHostSpecificDataLoader
     {
         // If needed, extend to return mock data.
         public HostSpecificTemplateData ReadHostSpecificTemplateData(ITemplateInfo templateInfo)

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockHostSpecificTemplateData.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockHostSpecificTemplateData.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 {
-    public class MockHostSpecificTemplateData : HostSpecificTemplateData
+    internal class MockHostSpecificTemplateData : HostSpecificTemplateData
     {
         public MockHostSpecificTemplateData(Dictionary<string, IReadOnlyDictionary<string, string>> symbolInfo)
             : base(symbolInfo)

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateInstallTests/NupkgInstallTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateInstallTests/NupkgInstallTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateInstallTests
             Assert.NotNull(host);
 
             ITelemetryLogger telemetryLogger = new TelemetryLogger(null, false);
-            int initializeResult = New3Command.Run(CommandName, host, telemetryLogger, null, new string[] { });
+            int initializeResult = New3Command.Run(CommandName, host, telemetryLogger, new New3Callbacks(), Array.Empty<string>());
             Assert.Equal(0, initializeResult);
 
             string codebase = typeof(NupkgInstallTests).GetTypeInfo().Assembly.Location;
@@ -53,7 +53,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateInstallTests
             };
 
             // install the test pack
-            int firstInstallResult = New3Command.Run(CommandName, host, telemetryLogger, null, installArgs);
+            int firstInstallResult = New3Command.Run(CommandName, host, telemetryLogger, new New3Callbacks(), installArgs);
             Assert.Equal(0, firstInstallResult);
 
             EngineEnvironmentSettings environemnt = new EngineEnvironmentSettings(host, x => new SettingsLoader(x));
@@ -65,7 +65,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateInstallTests
             Assert.Contains(checkTemplateName, allTemplates.Select(t => t.Info.ShortName));
 
             // install the same test pack again
-            int secondInstallResult = New3Command.Run(CommandName, host, telemetryLogger, null, installArgs);
+            int secondInstallResult = New3Command.Run(CommandName, host, telemetryLogger, new New3Callbacks(), installArgs);
             Assert.NotEqual(0, secondInstallResult);
 
             // check that the template is still installed after the second install.

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
@@ -61,7 +61,7 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
             host.VirtualizeDirectory(hivePath);
             host.VirtualizeDirectory(outputPath);
 
-            int result = New3Command.Run(CommandName, host, new TelemetryLogger(null), new Action<IEngineEnvironmentSettings>((x) => {}), passthroughArgs, hivePath);
+            int result = New3Command.Run(CommandName, host, new TelemetryLogger(null), null, passthroughArgs, hivePath);
             bool verificationsPassed = false;
 
             for (int i = 0; i < batteryCount; ++i)

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
@@ -204,7 +204,7 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
             {
                 typeof(RunnableProjectGenerator).GetTypeInfo().Assembly,            // for assembly: Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 typeof(Microsoft.TemplateEngine.Edge.Paths).GetTypeInfo().Assembly,   // for assembly: Microsoft.TemplateEngine.Edge
-                typeof(DotnetRestorePostActionProcessor).GetTypeInfo().Assembly,    // for assembly: Microsoft.TemplateEngine.Cli
+                typeof(New3Command).GetTypeInfo().Assembly,    // for assembly: Microsoft.TemplateEngine.Cli
                 typeof(Microsoft.TemplateSearch.Common.NuGetSearchCacheConfig).GetTypeInfo().Assembly,// for assembly: Microsoft.TemplateSearch.Common
                 typeof(Program).GetTypeInfo().Assembly
             });


### PR DESCRIPTION
### Problem
fixes https://github.com/dotnet/templating/issues/2997

### Solution
Made most of types/members of Cli internal.
remained public types and methods:
- `NewCommand.Run` 
- `HostSpecificDataLoader, HostSpecificDataLoader, HostSpecificTemplateData` - they are used in tools, and I consider them useful to keep public. They used to read host-specific template.json.
- `CommandParserException` - the caller might want to catch it.

### Checks:
- [ ] Added unit tests - NA
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - for classes remained public