### PR TITLE
Fix #2992 of Creating new solution using "dotnet new sln" in .NET 5.0.201 SDK has wrong/invalid solution version number

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30114.105
-MinimumVisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
@@ -1,7 +1,7 @@
 
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 15.0.26124.0
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30114.105

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
@@ -1,8 +1,8 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.6.30114.105
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio Version 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
### Fix #2992 of Creating new solution using "dotnet new sln" in .NET 5.0.201 SDK has wrong/invalid solution version number.

### Problem
I already detailed the problems in issue #2992

### Solution
Use valid solution version number for VS 2019 that always use this scheme of `16.0.xxxx.xxxx` instead of having invalid solution version number of `16.6.xxx.xx` as this breaks actual valid solution's minimum version. See also this comment: https://github.com/dotnet/templating/issues/2992#issuecomment-815281973
Please review. The detailed reasons why I submit this in issue #2992 

FYI, I'm using the version that reverted back to original solution version in the initial history of this file, based on this commit in this branch:  
https://github.com/dotnet/templating/commit/95d19ea6e0d10fc839f273223a736279464b3d38#diff-59d7a44760febde566cb20d6692d2a810281017b42d23841dd1e33eafa6275b1

![image](https://user-images.githubusercontent.com/8773147/114096717-4f4a3f80-98e9-11eb-9c71-2ae0dcc586b1.png)

### Checks:
- [ ] Added unit tests (_I think it is N/A as this is to fix to use correct solution's version number_)
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)