### PR TITLE
made IShortNameList interface obsolete

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/IShortNameList.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IShortNameList.cs
@@ -1,9 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Abstractions
 {
+    [Obsolete("The ShortNameList is added to ITemplateInfo instead")]
     public interface IShortNameList
     {
+        [Obsolete("Use ITemplateInfo.ShortNameList instead")]
         IReadOnlyList<string> ShortNameList { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/ITemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ITemplateInfo.cs
@@ -1,3 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 
@@ -23,6 +28,7 @@ namespace Microsoft.TemplateEngine.Abstractions
 
         string Name { get; }
 
+        [Obsolete("Templates support multiple short names, use ShortNameList instead")]
         string ShortName { get; }
 
         IReadOnlyDictionary<string, ICacheTag> Tags { get; }
@@ -44,5 +50,10 @@ namespace Microsoft.TemplateEngine.Abstractions
         IReadOnlyDictionary<string, IBaselineInfo> BaselineInfo { get; }
 
         bool HasScriptRunningPostActions { get; set; }
+
+        /// <summary>
+        /// Gets the list of short names defined for the template.
+        /// </summary>
+        IReadOnlyList<string> ShortNameList { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -233,7 +233,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 Reporter.Error.WriteLine(string.Format(InvalidParameterInfo.InvalidParameterListToString(invalidParameters, unambiguousTemplateGroup).Bold().Red()));
             }
             Reporter.Error.WriteLine(
-                    string.Format(LocalizableStrings.InvalidParameterTemplateHint, GetTemplateHelpCommand(commandInput.CommandName, unambiguousTemplateGroup.ShortName)).Bold().Red());
+                    string.Format(LocalizableStrings.InvalidParameterTemplateHint, GetTemplateHelpCommand(commandInput.CommandName, unambiguousTemplateGroup.ShortName.First())).Bold().Red());
             return CreationResultStatus.InvalidParamValues;
         }
 
@@ -241,7 +241,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
         {
             internal string TemplateIdentity;
             internal string TemplateName;
-            internal string TemplateShortName;
+            internal IReadOnlyList<string> TemplateShortNames;
             internal string TemplateLanguage;
             internal int TemplatePrecedence;
             internal string TemplateAuthor;
@@ -273,7 +273,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 {
                     TemplateIdentity = template.Info.Identity,
                     TemplateName = template.Info.Name,
-                    TemplateShortName = template.Info.ShortName,
+                    TemplateShortNames = template.Info.ShortNameList,
                     TemplateLanguage = template.Info.GetLanguage(),
                     TemplatePrecedence = template.Info.Precedence,
                     TemplateAuthor = template.Info.Author,
@@ -292,7 +292,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                         blankLineBetweenRows: false)
                     .DefineColumn(t => t.TemplateIdentity, LocalizableStrings.ColumnNameIdentity, showAlways: true)
                     .DefineColumn(t => t.TemplateName, LocalizableStrings.ColumnNameTemplateName, shrinkIfNeeded: true, minWidth: 15, showAlways: true)
-                    .DefineColumn(t => t.TemplateShortName, LocalizableStrings.ColumnNameShortName, showAlways: true)
+                    .DefineColumn(t => string.Join(",", t.TemplateShortNames), LocalizableStrings.ColumnNameShortName, showAlways: true)
                     .DefineColumn(t => t.TemplateLanguage, LocalizableStrings.ColumnNameLanguage, showAlways: true)
                     .DefineColumn(t => t.TemplatePrecedence.ToString(), out object prcedenceColumn, LocalizableStrings.ColumnNamePrecedence, showAlways: true)
                     .DefineColumn(t => t.TemplateAuthor, LocalizableStrings.ColumnNameAuthor, showAlways: true, shrinkIfNeeded: true, minWidth: 10)
@@ -494,7 +494,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 
         internal static string GetTemplateHelpCommand(string commandName, ITemplateInfo template)
         {
-            return GetTemplateHelpCommand(commandName, template.ShortName);
+            return GetTemplateHelpCommand(commandName, template.ShortNameList.First());
         }
 
         internal static string GetTemplateHelpCommand(string commandName, string shortName)

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -1,23 +1,25 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.TemplateEngine.Edge.Template;
-using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Cli.CommandParsing;
-using Microsoft.TemplateEngine.Utils;
-using Microsoft.TemplateEngine.Cli.TemplateResolution;
-using Microsoft.TemplateEngine.Cli.TableOutput;
-using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 using System.Threading.Tasks;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
+using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Cli.TableOutput;
+using Microsoft.TemplateEngine.Cli.TemplateResolution;
+using Microsoft.TemplateEngine.Edge.Template;
+using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 {
     internal static class HelpForTemplateResolution
     {
-        internal static CreationResultStatus CoordinateHelpAndUsageDisplay(TemplateListResolutionResult templateResolutionResult, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, ITelemetryLogger telemetryLogger, TemplateCreator templateCreator, string defaultLanguage, bool showUsageHelp = true)
+        internal static CreationResultStatus CoordinateHelpAndUsageDisplay(TemplateListResolutionResult templateResolutionResult, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, ITelemetryLogger telemetryLogger, TemplateCreator templateCreator, string? defaultLanguage, bool showUsageHelp = true)
         {
             if (showUsageHelp)
             {
@@ -63,7 +65,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             TemplateResolutionResult resolutionResult,
             IEngineEnvironmentSettings environmentSettings,
             INewCommandInput commandInput,
-            string defaultLanguage)
+            string? defaultLanguage)
         {
             switch (resolutionResult.ResolutionStatus)
             {
@@ -95,7 +97,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             return Task.FromResult(CreationResultStatus.CreateFailed);
         }
 
-        private static CreationResultStatus DisplayHelpForUnambiguousTemplateGroup(TemplateListResolutionResult templateResolutionResult, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, TemplateCreator templateCreator, ITelemetryLogger telemetryLogger, string defaultLanguage)
+        private static CreationResultStatus DisplayHelpForUnambiguousTemplateGroup(TemplateListResolutionResult templateResolutionResult, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, TemplateCreator templateCreator, ITelemetryLogger telemetryLogger, string? defaultLanguage)
         {
             // sanity check: should never happen; as condition for unambiguous template group is checked above
             if (!templateResolutionResult.UnambiguousTemplateGroup.Any())
@@ -150,8 +152,12 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             }
             else
             {
-                Reporter.Error.WriteLine(
-                    string.Format(LocalizableStrings.InvalidParameterTemplateHint, GetTemplateHelpCommand(commandInput.CommandName, unambiguousTemplateGroup.First().Info)).Bold().Red());
+                string? templateHelpCommand = GetTemplateHelpCommand(commandInput.CommandName, unambiguousTemplateGroup.First().Info);
+                if (!string.IsNullOrWhiteSpace(templateHelpCommand))
+                {
+                    Reporter.Error.WriteLine(
+                        string.Format(LocalizableStrings.InvalidParameterTemplateHint, templateHelpCommand).Bold().Red());
+                }
             }
 
             return invalidForAllTemplates.Count > 0 || invalidForSomeTemplates.Count > 0
@@ -159,7 +165,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 : CreationResultStatus.Success;
         }
 
-        private static CreationResultStatus DisplayListOrHelpForAmbiguousTemplateGroup(TemplateListResolutionResult templateResolutionResult, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, ITelemetryLogger telemetryLogger, string defaultLanguage)
+        private static CreationResultStatus DisplayListOrHelpForAmbiguousTemplateGroup(TemplateListResolutionResult templateResolutionResult, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, IHostSpecificDataLoader hostDataLoader, ITelemetryLogger telemetryLogger, string? defaultLanguage)
         {
             // The following occurs when:
             //      --alias <value> is specifed
@@ -232,8 +238,14 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             {
                 Reporter.Error.WriteLine(string.Format(InvalidParameterInfo.InvalidParameterListToString(invalidParameters, unambiguousTemplateGroup).Bold().Red()));
             }
-            Reporter.Error.WriteLine(
-                    string.Format(LocalizableStrings.InvalidParameterTemplateHint, GetTemplateHelpCommand(commandInput.CommandName, unambiguousTemplateGroup.ShortName.First())).Bold().Red());
+
+            if (unambiguousTemplateGroup.ShortNames.Any())
+            {
+                Reporter.Error.WriteLine(
+                        string.Format(
+                            LocalizableStrings.InvalidParameterTemplateHint,
+                            GetTemplateHelpCommand(commandInput.CommandName, unambiguousTemplateGroup.ShortNames[0])).Bold().Red());
+            }
             return CreationResultStatus.InvalidParamValues;
         }
 
@@ -245,7 +257,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             internal string TemplateLanguage;
             internal int TemplatePrecedence;
             internal string TemplateAuthor;
-            internal IManagedTemplatePackage TemplatePackage;
+            internal IManagedTemplatePackage? TemplatePackage;
         }
 
         /// <summary>
@@ -303,7 +315,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             string hintMessage = LocalizableStrings.AmbiguousTemplatesMultiplePackagesHint;
             if (unambiguousTemplateGroup.Templates.AllAreTheSame(t => t.Info.MountPointUri))
             {
-                IManagedTemplatePackage templatePackage = await unambiguousTemplateGroup.Templates.First().Info.GetTemplatePackageAsync(environmentSettings).ConfigureAwait(false) as IManagedTemplatePackage;
+                IManagedTemplatePackage? templatePackage = await unambiguousTemplateGroup.Templates.First().Info.GetTemplatePackageAsync(environmentSettings).ConfigureAwait(false) as IManagedTemplatePackage;
                 if (templatePackage != null)
                 {
                     hintMessage = string.Format(LocalizableStrings.AmbiguousTemplatesSamePackageHint, templatePackage.Identifier);
@@ -323,7 +335,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
         // - Short Name: displays the first short name from the highest precedence template in the group.
         // - Language: All languages supported by any template in the group are displayed, with the default language in brackets, e.g.: [C#]
         // - Tags
-        internal static void DisplayTemplateList(IReadOnlyCollection<TemplateGroup> templateGroups, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, string defaultLanguage, bool useErrorOutput = false)
+        internal static void DisplayTemplateList(IReadOnlyCollection<TemplateGroup> templateGroups, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, string? defaultLanguage, bool useErrorOutput = false)
         {
             IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay = TemplateGroupDisplay.GetTemplateGroupsForListDisplay(templateGroups, commandInput.Language, defaultLanguage);
             DisplayTemplateList(groupsForDisplay, environmentSettings, commandInput, useErrorOutput);
@@ -445,17 +457,13 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             }
 
             IEnumerable<IGrouping<string, string>> countGroups = invalidCounts.GroupBy(x => x.Value == templateList.Count ? "all" : "some", x => x.Key);
-            invalidForAllTemplates = countGroups.FirstOrDefault(x => string.Equals(x.Key, "all", StringComparison.Ordinal))?.ToList();
-            if (invalidForAllTemplates == null)
-            {
-                invalidForAllTemplates = new List<string>();
-            }
+            invalidForAllTemplates =
+                countGroups.FirstOrDefault(x => string.Equals(x.Key, "all", StringComparison.Ordinal))?.ToList()
+                ?? new List<string>();
 
-            invalidForSomeTemplates = countGroups.FirstOrDefault(x => string.Equals(x.Key, "some", StringComparison.Ordinal))?.ToList();
-            if (invalidForSomeTemplates == null)
-            {
-                invalidForSomeTemplates = new List<string>();
-            }
+            invalidForSomeTemplates =
+                countGroups.FirstOrDefault(x => string.Equals(x.Key, "some", StringComparison.Ordinal))?.ToList()
+                ?? new List<string>();
         }
 
         internal static void ShowUsageHelp(INewCommandInput commandInput, ITelemetryLogger telemetryLogger)
@@ -492,13 +500,35 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             return CreationResultStatus.InvalidParamValues;
         }
 
-        internal static string GetTemplateHelpCommand(string commandName, ITemplateInfo template)
+        /// <summary>
+        /// Returns the help command for given template; or null in case template does not have short name defined.
+        /// </summary>
+        /// <param name="commandName"></param>
+        /// <param name="template"></param>
+        /// <returns>the help command or null in case template does not have short name defined.</returns>
+        internal static string? GetTemplateHelpCommand(string commandName, ITemplateInfo template)
         {
-            return GetTemplateHelpCommand(commandName, template.ShortNameList.First());
+            if (template.ShortNameList.Any())
+            {
+                return GetTemplateHelpCommand(commandName, template.ShortNameList[0]);
+            }
+            return null;
         }
 
-        internal static string GetTemplateHelpCommand(string commandName, string shortName)
+        /// <summary>
+        /// Returns the help command for given command name and short name.
+        /// </summary>
+        private static string GetTemplateHelpCommand(string commandName, string shortName)
         {
+            if (string.IsNullOrWhiteSpace(commandName))
+            {
+                throw new ArgumentException($"{nameof(commandName)} should not be null or empty", nameof(commandName));
+            }
+            if (string.IsNullOrWhiteSpace(shortName))
+            {
+                throw new ArgumentException($"{nameof(shortName)} should not be null or empty", nameof(shortName));
+            }
+
             return $"dotnet {commandName} {shortName} --help";
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
@@ -33,7 +33,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 
             foreach (string preferredName in preferredNameList)
             {
-                ITemplateInfo template = templateList.FirstOrDefault(x => string.Equals(x.ShortName, preferredName, StringComparison.OrdinalIgnoreCase));
+                ITemplateInfo template = templateList.FirstOrDefault(x => x.ShortNameList.Contains(preferredName, StringComparer.OrdinalIgnoreCase));
 
                 if (template != null)
                 {
@@ -82,11 +82,11 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                     return false;
                 }
 
-                Reporter.Output.WriteLine($"    dotnet {commandName} {templateInfo.ShortName} {hostTemplateData.UsageExamples[0]}");
+                Reporter.Output.WriteLine($"    dotnet {commandName} {templateInfo.ShortNameList.First()} {hostTemplateData.UsageExamples[0]}");
                 return true;
             }
 
-            Reporter.Output.Write($"    dotnet {commandName} {templateInfo.ShortName}");
+            Reporter.Output.Write($"    dotnet {commandName} {templateInfo.ShortNameList.First()}");
             IReadOnlyList<ITemplateParameter> allParameterDefinitions = templateInfo.Parameters;
             IEnumerable<ITemplateParameter> filteredParams = TemplateParameterHelpBase.FilterParamsForHelp(allParameterDefinitions, hostTemplateData.HiddenParameterNames, parametersToAlwaysShow: hostTemplateData.ParametersToAlwaysShow);
 

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
@@ -1,5 +1,7 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -43,9 +45,8 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                         GenerateUsageForTemplate(template, hostDataLoader, commandName);
                         numShown++;
                     }
+                    templateList.Remove(template);  // remove it so it won't get chosen again
                 }
-
-                templateList.Remove(template);  // remove it so it won't get chosen again
             }
 
             // show up to 2 examples (total, including the above)
@@ -67,8 +68,11 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             Reporter.Output.WriteLine($"    dotnet {commandName} --help");
 
             // show a help example for template
-            Reporter.Output.WriteLine($"    {HelpForTemplateResolution.GetTemplateHelpCommand(commandName, bestMatchedTemplates.First().Info)}");
-            
+            string? templateHelpCommand = HelpForTemplateResolution.GetTemplateHelpCommand(commandName, bestMatchedTemplates.First().Info);
+            if (!string.IsNullOrWhiteSpace(templateHelpCommand))
+            {
+                Reporter.Output.WriteLine($"    {templateHelpCommand}");
+            }
         }
 
         private static bool GenerateUsageForTemplate(ITemplateInfo templateInfo, IHostSpecificDataLoader hostDataLoader, string commandName)

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -423,14 +423,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             foreach (ITemplateMatchInfo templateMatchInfo in allTemplates)
             {
-                if (templateMatchInfo.Info is IShortNameList templateWithShortNameList)
-                {
-                    allShortNames.UnionWith(templateWithShortNameList.ShortNameList);
-                }
-                else
-                {
-                    allShortNames.Add(templateMatchInfo.Info.ShortName);
-                }
+                allShortNames.UnionWith(templateMatchInfo.Info.ShortNameList);
             }
 
             return allShortNames;

--- a/src/Microsoft.TemplateEngine.Cli/TableOutput/TemplateGroupDisplay.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TableOutput/TemplateGroupDisplay.cs
@@ -93,9 +93,7 @@ namespace Microsoft.TemplateEngine.Cli.TableOutput
             }
 
             ITemplateInfo highestPrecedenceTemplate = templateGroup.OrderByDescending(x => x.Precedence).First();
-            string shortName = highestPrecedenceTemplate is IShortNameList highestWithShortNameList
-                                ? highestWithShortNameList.ShortNameList[0]
-                                : highestPrecedenceTemplate.ShortName;
+            string shortName = highestPrecedenceTemplate.ShortNameList[0];
 
             TemplateGroupTableRow groupDisplayInfo = new TemplateGroupTableRow
             {

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -419,14 +419,7 @@ namespace Microsoft.TemplateEngine.Cli
             IReadOnlyList<ITemplateInfo> templates = await _engineEnvironmentSettings.SettingsLoader.GetTemplatesAsync(cancellationToken).ConfigureAwait(false);
             var templatesWithMatchedShortName = templates.Where(template =>
             {
-                if (template is IShortNameList t1)
-                {
-                    return t1.ShortNameList.Contains(sourceIdentifier, StringComparer.OrdinalIgnoreCase);
-                }
-                else
-                {
-                    return template.ShortName.Equals(sourceIdentifier, StringComparison.OrdinalIgnoreCase);
-                }
+                return template.ShortNameList.Contains(sourceIdentifier, StringComparer.OrdinalIgnoreCase);
             });
 
             var templatePackages = await Task.WhenAll(
@@ -448,14 +441,7 @@ namespace Microsoft.TemplateEngine.Cli
             IReadOnlyList<ITemplateInfo> templates = await _engineEnvironmentSettings.SettingsLoader.GetTemplatesAsync(cancellationToken).ConfigureAwait(false);
             return templates.Any(template =>
             {
-                if (template is IShortNameList t1)
-                {
-                    return t1.ShortNameList.Contains(sourceIdentifier, StringComparer.OrdinalIgnoreCase);
-                }
-                else
-                {
-                    return template.ShortName.Equals(sourceIdentifier, StringComparison.OrdinalIgnoreCase);
-                }
+                return template.ShortNameList.Contains(sourceIdentifier, StringComparer.OrdinalIgnoreCase);
             });
         }
 
@@ -551,13 +537,14 @@ namespace Microsoft.TemplateEngine.Cli
                     foreach (TemplateInfo info in templates)
                     {
                         string templateLanguage = info.GetLanguage();
+                        string shortNames = string.Join(",", info.ShortNameList);
                         if (!string.IsNullOrWhiteSpace(templateLanguage))
                         {
-                            Reporter.Output.WriteLine($"      {info.Name} ({info.ShortName}) {templateLanguage}");
+                            Reporter.Output.WriteLine($"      {info.Name} ({shortNames}) {templateLanguage}");
                         }
                         else
                         {
-                            Reporter.Output.WriteLine($"      {info.Name} ({info.ShortName})");
+                            Reporter.Output.WriteLine($"      {info.Name} ({shortNames})");
                         }
                     }
                 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateGroup.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateGroup.cs
@@ -54,7 +54,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// Default shortname.
         /// In theory, template group templates can have different short names but they are treated equally
         /// </summary>
-        internal string ShortName => Templates.First().Info.ShortName;
+        internal IReadOnlyList<string> ShortName => Templates.First().Info.ShortNameList;
 
         /// <summary>
         /// Returns true when <see cref="GroupIdentity"/> is not <see cref="null"/> or emply

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateGroup.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateGroup.cs
@@ -51,10 +51,25 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         internal string GroupIdentity { get; private set; }
 
         /// <summary>
-        /// Default shortname.
-        /// In theory, template group templates can have different short names but they are treated equally
+        /// Returns the list of short names defined for templates in the group.
+        /// In theory, template group templates can have different short names but they are treated equally.
         /// </summary>
-        internal IReadOnlyList<string> ShortName => Templates.First().Info.ShortNameList;
+        internal IReadOnlyList<string> ShortNames
+        {
+            get
+            {
+                if (HasSingleTemplate)
+                {
+                    return Templates.First().Info.ShortNameList;
+                }
+                HashSet<string> shortNames = new HashSet<string>();
+                foreach (ITemplateMatchInfo template in Templates)
+                {
+                    shortNames.UnionWith(template.Info.ShortNameList);
+                }
+                return shortNames.ToList();
+            }
+        }
 
         /// <summary>
         /// Returns true when <see cref="GroupIdentity"/> is not <see cref="null"/> or emply

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
@@ -469,15 +469,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                     shortNames = new HashSet<string>();
                     shortNamesByGroup[effectiveGroupIdentity] = shortNames;
                 }
-
-                if (template is IShortNameList templateWithShortNameList)
-                {
-                    shortNames.UnionWith(templateWithShortNameList.ShortNameList);
-                }
-                else
-                {
-                    shortNames.Add(template.ShortName);
-                }
+                shortNames.UnionWith(template.ShortNameList);
             }
 
             // create the TemplateInfoWithGroupShortNames with the group short names
@@ -553,7 +545,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// In addition to <see cref="ITemplateInfo"/> the class contains <see cref="TemplateInfoWithGroupShortNames.GroupShortNameList"/> property which contains the short names of other templates in the template group.
         /// The class is used for template filtering using specific <see cref="CliNameFilter(string)"/> filter which takes into account the short names of template group when matching names.
         /// </summary>
-        private class TemplateInfoWithGroupShortNames : ITemplateInfo, IShortNameList
+        private class TemplateInfoWithGroupShortNames : ITemplateInfo
         {
             private ITemplateInfo _parent;
             internal TemplateInfoWithGroupShortNames (ITemplateInfo source, IEnumerable<string> groupShortNameList)
@@ -580,19 +572,10 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 
             public string Name => _parent.Name;
 
+            [Obsolete]
             public string ShortName => _parent.ShortName;
 
-            public IReadOnlyList<string> ShortNameList
-            {
-                get
-                {
-                    if (_parent is IShortNameList sourceWithShortNameList)
-                    {
-                        return sourceWithShortNameList.ShortNameList;
-                    }
-                    return new List<string>();
-                }
-            }
+            public IReadOnlyList<string> ShortNameList => _parent.ShortNameList;
 
             public IReadOnlyList<string> GroupShortNameList { get; } = new List<string>();
 

--- a/src/Microsoft.TemplateEngine.Edge/FilterableTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/FilterableTemplateInfo.cs
@@ -30,13 +30,9 @@ namespace Microsoft.TemplateEngine.Edge
                 HostConfigPlace = source.HostConfigPlace,
                 ThirdPartyNotices = source.ThirdPartyNotices,
                 BaselineInfo = source.BaselineInfo,
-                HasScriptRunningPostActions = source.HasScriptRunningPostActions
+                HasScriptRunningPostActions = source.HasScriptRunningPostActions,
+                ShortNameList = source.ShortNameList
             };
-
-            if (source is IShortNameList sourceWithShortNameList)
-            {
-                filterableTemplate.ShortNameList = sourceWithShortNameList.ShortNameList;
-            }
 
             return filterableTemplate;
         }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -219,7 +219,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 Name = localizationInfo?.Name ?? template.Name,
                 Tags = LocalizeCacheTags(template, localizationInfo),
                 CacheParameters = LocalizeCacheParameters(template, localizationInfo),
+#pragma warning disable CS0618 // Type or member is obsolete
                 ShortName = template.ShortName,
+#pragma warning restore CS0618 // Type or member is obsolete
                 Classifications = template.Classifications,
                 Author = localizationInfo?.Author ?? template.Author,
                 Description = localizationInfo?.Description ?? template.Description,
@@ -231,13 +233,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 HostConfigPlace = template.HostConfigPlace,
                 ThirdPartyNotices = template.ThirdPartyNotices,
                 BaselineInfo = template.BaselineInfo,
-                HasScriptRunningPostActions = template.HasScriptRunningPostActions
+                HasScriptRunningPostActions = template.HasScriptRunningPostActions,
+                ShortNameList = template.ShortNameList
             };
-
-            if (template is IShortNameList templateWithShortNameList)
-            {
-                localizedTemplate.ShortNameList = templateWithShortNameList.ShortNameList;
-            }
 
             return localizedTemplate;
         }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
@@ -8,7 +8,7 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Edge.Settings
 {
-    public class TemplateInfo : ITemplateInfo, IShortNameList
+    public class TemplateInfo : ITemplateInfo
     {
         public static readonly string CurrentVersion = "1.0.0.5";
 

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_2.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_2.cs
@@ -17,22 +17,16 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
 
         protected override void ReadShortNameInfo(JObject jObject, TemplateInfo info)
         {
-            if (info is IShortNameList)
-            {
-                JToken shortNameToken = jObject.Get<JToken>(nameof(TemplateInfo.ShortNameList));
-                info.ShortNameList = JTokenStringOrArrayToCollection(shortNameToken, new string[0]);
+            JToken shortNameToken = jObject.Get<JToken>(nameof(TemplateInfo.ShortNameList));
+            info.ShortNameList = JTokenStringOrArrayToCollection(shortNameToken, new string[0]);
 
-                if (info.ShortNameList.Count == 0)
-                {
-                    // template.json stores the short name(s) in ShortName
-                    // but the cache will store it in ShortNameList
-                    base.ReadShortNameInfo(jObject, info);
-                }
-            }
-            else
+            if (info.ShortNameList.Count == 0)
             {
+                // template.json stores the short name(s) in ShortName
+                // but the cache will store it in ShortNameList
                 base.ReadShortNameInfo(jObject, info);
             }
+
         }
 
         private static IReadOnlyList<string> JTokenStringOrArrayToCollection(JToken token, string[] defaultSet)

--- a/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
@@ -30,24 +30,17 @@ namespace Microsoft.TemplateEngine.Edge.Template
 
                 bool hasShortNamePartialMatch = false;
 
-                int shortNameIndex = template.ShortName.IndexOf(name, StringComparison.OrdinalIgnoreCase);
-
-                if (shortNameIndex == 0 && string.Equals(template.ShortName, name, StringComparison.OrdinalIgnoreCase))
+                foreach (string shortName in template.ShortNameList)
                 {
-                    foreach (string shortName in template.ShortNameList)
+                    int shortNameIndex = shortName.IndexOf(name, StringComparison.OrdinalIgnoreCase);
+
+                    if (shortNameIndex == 0 && shortName.Length == name.Length)
                     {
-                        int shortNameIndex = shortName.IndexOf(name, StringComparison.OrdinalIgnoreCase);
-
-                        if (shortNameIndex == 0 && shortName.Length == name.Length)
-                        {
-                            return new MatchInfo { Location = MatchLocation.ShortName, Kind = MatchKind.Exact };
-                        }
-
-                        hasShortNamePartialMatch |= shortNameIndex > -1;
+                        return new MatchInfo { Location = MatchLocation.ShortName, Kind = MatchKind.Exact };
                     }
-                }
 
-                hasShortNamePartialMatch = shortNameIndex > -1;
+                    hasShortNamePartialMatch |= shortNameIndex > -1;
+                }
 
                 if (nameIndex > -1)
                 {

--- a/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
@@ -23,7 +23,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
 
                 int nameIndex = template.Name.IndexOf(name, StringComparison.OrdinalIgnoreCase);
 
-                if (nameIndex == 0 && string.Equals(template.Name, name, StringComparison.OrdinalIgnoreCase))
+                if (nameIndex == 0 && template.Name.Length == name.Length)
                 {
                     return new MatchInfo { Location = MatchLocation.Name, Kind = MatchKind.Exact };
                 }
@@ -38,7 +38,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                     {
                         int shortNameIndex = shortName.IndexOf(name, StringComparison.OrdinalIgnoreCase);
 
-                        if (shortNameIndex == 0 && string.Equals(shortName, name, StringComparison.OrdinalIgnoreCase))
+                        if (shortNameIndex == 0 && shortName.Length == name.Length)
                         {
                             return new MatchInfo { Location = MatchLocation.ShortName, Kind = MatchKind.Exact };
                         }

--- a/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/WellKnownSearchFilters.cs
@@ -34,7 +34,17 @@ namespace Microsoft.TemplateEngine.Edge.Template
 
                 if (shortNameIndex == 0 && string.Equals(template.ShortName, name, StringComparison.OrdinalIgnoreCase))
                 {
-                    return new MatchInfo { Location = MatchLocation.ShortName, Kind = MatchKind.Exact };
+                    foreach (string shortName in template.ShortNameList)
+                    {
+                        int shortNameIndex = shortName.IndexOf(name, StringComparison.OrdinalIgnoreCase);
+
+                        if (shortNameIndex == 0 && string.Equals(shortName, name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return new MatchInfo { Location = MatchLocation.ShortName, Kind = MatchKind.Exact };
+                        }
+
+                        hasShortNamePartialMatch |= shortNameIndex > -1;
+                    }
                 }
 
                 hasShortNamePartialMatch = shortNameIndex > -1;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
-    internal class RunnableProjectTemplate : ITemplate, IShortNameList
+    internal class RunnableProjectTemplate : ITemplate
     {
         private readonly JObject _raw;
 

--- a/src/Microsoft.TemplateSearch.Common/FileMetadataTemplateSearchCache.cs
+++ b/src/Microsoft.TemplateSearch.Common/FileMetadataTemplateSearchCache.cs
@@ -55,8 +55,10 @@ namespace Microsoft.TemplateSearch.Common
                 return _templateDiscoveryMetadata.TemplateCache;
             }
 
-            return _templateDiscoveryMetadata.TemplateCache.Where(template => template.Name.IndexOf(searchName, StringComparison.OrdinalIgnoreCase) >= 0
-                                                    || template.ShortName.IndexOf(searchName, StringComparison.OrdinalIgnoreCase) >= 0).ToList();
+            return _templateDiscoveryMetadata.TemplateCache.Where(
+                template => template.Name.IndexOf(searchName, StringComparison.OrdinalIgnoreCase) >= 0
+                || template.ShortNameList.Any(shortName => shortName.IndexOf(searchName, StringComparison.OrdinalIgnoreCase) >= 0))
+                .ToList();
         }
 
         public IReadOnlyDictionary<string, PackInfo> GetTemplateToPackMapForTemplateIdentities(IReadOnlyList<string> identities)

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
@@ -73,7 +73,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
                             Verbose.WriteLine("Found templates:");
                             foreach (ITemplateInfo template in packCheckResult.FoundTemplates)
                             {
-                                Verbose.WriteLine($"  - {template.Identity} ({template.ShortName}) by {template.Author}, group: {(string.IsNullOrWhiteSpace(template.GroupIdentity) ? "<not set>" : template.GroupIdentity)}, precedence: {template.Precedence}");
+                                string shortNames = string.Join(",", template.ShortNameList);
+                                Verbose.WriteLine($"  - {template.Identity} ({shortNames}) by {template.Author}, group: {(string.IsNullOrWhiteSpace(template.GroupIdentity) ? "<not set>" : template.GroupIdentity)}, precedence: {template.Precedence}");
                             }
                         }
                         else

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockTemplateSearchSource.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockTemplateSearchSource.cs
@@ -97,7 +97,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 
             foreach (ITemplateNameSearchResult candidate in possibleSearchResults)
             {
-                if (candidate.Template.Name.Contains(templateName) || candidate.Template.ShortName.Contains(templateName))
+                if (candidate.Template.Name.Contains(templateName) || candidate.Template.ShortNameList.Any(shortName => shortName.Contains(templateName)))
                 {
                     if (!_packFilter.ShouldPackBeFiltered(candidate.Template.Name, candidate.PackInfo.Version))
                     {

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateInstallTests/NupkgInstallTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateInstallTests/NupkgInstallTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateInstallTests
 
             // check that the template was installed from the first install.
             IReadOnlyCollection<ITemplateMatchInfo> allTemplates = TemplateResolver.PerformAllTemplatesQuery(await settingsLoader.GetTemplatesAsync(default), hostDataLoader);
-            Assert.Contains(checkTemplateName, allTemplates.Select(t => t.Info.ShortName));
+            Assert.Contains(checkTemplateName, allTemplates.SelectMany(t => t.Info.ShortNameList));
 
             // install the same test pack again
             int secondInstallResult = New3Command.Run(CommandName, host, telemetryLogger, new New3Callbacks(), installArgs);
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateInstallTests
 
             // check that the template is still installed after the second install.
             IReadOnlyCollection<ITemplateMatchInfo> allTemplatesAfterSecondInstall = TemplateResolver.PerformAllTemplatesQuery(await settingsLoader.GetTemplatesAsync(default), hostDataLoader);
-            Assert.Contains(checkTemplateName, allTemplatesAfterSecondInstall.Select(t => t.Info.ShortName));
+            Assert.Contains(checkTemplateName, allTemplatesAfterSecondInstall.SelectMany(t => t.Info.ShortNameList));
         }
 
         private static ITemplateEngineHost CreateHostWithVirtualizedHive(string hostIdentifier, string hostVersion)

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/HelpTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/HelpTemplateListResolverTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
-            Assert.Equal("console2", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
+            Assert.Equal("console2", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
             Assert.Equal("Console.App2", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
             Assert.Equal(1, matchResult.UnambiguousTemplateGroup.Count);
         }
@@ -47,7 +47,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
-            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
+            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
             Assert.Equal("Console.App", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
             Assert.Equal(1, matchResult.UnambiguousTemplateGroup.Count);
         }
@@ -102,7 +102,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
             Assert.True(matchResult.HasUnambiguousTemplateGroupForDefaultLanguage);
-            Assert.Equal("console", matchResult.UnambiguousTemplatesForDefaultLanguage.Single().Info.ShortName);
+            Assert.Equal("console", matchResult.UnambiguousTemplatesForDefaultLanguage.Single().Info.ShortNameList.Single());
             Assert.Equal("Console.App.L1", matchResult.UnambiguousTemplatesForDefaultLanguage.Single().Info.Identity);
             Assert.Equal("L1", matchResult.UnambiguousTemplatesForDefaultLanguage.Single().Info.Tags["language"].Choices.Keys.FirstOrDefault());
             Assert.Equal(2, matchResult.UnambiguousTemplateGroup.Count);
@@ -121,7 +121,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "L1");
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
-            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
+            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
             Assert.Equal("Console.App.L2", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
             Assert.Equal("L2", matchResult.UnambiguousTemplateGroup.Single().Info.Tags["language"].Choices.Keys.FirstOrDefault());
             Assert.Equal(1, matchResult.UnambiguousTemplateGroup.Count);

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
-            Assert.Equal("console2", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
+            Assert.Equal("console2", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
             Assert.Equal("Console.App2", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
             Assert.Equal(1, matchResult.UnambiguousTemplateGroup.Count);
         }
@@ -117,7 +117,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "L1");
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
-            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
+            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
             Assert.Equal("Console.App.L2", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
             Assert.Equal("L2", matchResult.UnambiguousTemplateGroup.Single().Info.Tags["language"].Choices.Keys.FirstOrDefault());
             Assert.Equal(1, matchResult.UnambiguousTemplateGroup.Count);
@@ -299,7 +299,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             Assert.False(matchResult.HasLanguageMismatch);
             Assert.False(matchResult.HasContextMismatch);
             Assert.False(matchResult.HasBaselineMismatch);
-            Assert.Equal("console1", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
+            Assert.Equal("console1", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
             Assert.Equal("Console.App.T1", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
         }
 
@@ -329,7 +329,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             Assert.False(matchResult.HasLanguageMismatch);
             Assert.False(matchResult.HasContextMismatch);
             Assert.False(matchResult.HasBaselineMismatch);
-            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
+            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
             Assert.Equal("Console.App.T1", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
         }
 

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
@@ -209,7 +209,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 
 
             var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
-            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortNameList.Contains($"TestAssets.{templateName}").Info;
+            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortNameList.Contains($"TestAssets.{templateName}")).Info;
             ICreationEffects result = await bootstrapper.GetCreationEffectsAsync(template, name, output, parametersDict, "").ConfigureAwait(false);
 
             Assert.Equal(expectedResult.CreationResult.PrimaryOutputs.Count, result.CreationResult.PrimaryOutputs.Count);

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
@@ -209,7 +209,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 
 
             var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
-            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName == $"TestAssets.{templateName}").Info;
+            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortNameList.Contains($"TestAssets.{templateName}").Info;
             ICreationEffects result = await bootstrapper.GetCreationEffectsAsync(template, name, output, parametersDict, "").ConfigureAwait(false);
 
             Assert.Equal(expectedResult.CreationResult.PrimaryOutputs.Count, result.CreationResult.PrimaryOutputs.Count);
@@ -239,7 +239,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
             var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
-            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName == $"TestAssets.{templateName}").Info;
+            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortNameList.Contains($"TestAssets.{templateName}")).Info;
             var result = await bootstrapper.CreateAsync(template, name, output, parametersDict, false, "").ConfigureAwait(false);
 
             Assert.Equal(expectedResult.CreationResult.PrimaryOutputs.Count, result.PrimaryOutputs.Count);
@@ -285,7 +285,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
             var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
-            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName == $"TestAssets.{templateName}").Info;
+            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortNameList.Contains($"TestAssets.{templateName}")).Info;
             ICreationEffects result = await bootstrapper.GetCreationEffectsAsync(template, name, output, parametersDict, "").ConfigureAwait(false);
 
             Assert.Equal(expectedResult.CreationResult.PrimaryOutputs.Count, result.CreationResult.PrimaryOutputs.Count);
@@ -316,7 +316,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
             var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
-            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName == $"TestAssets.{templateName}").Info;
+            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortNameList.Contains($"TestAssets.{templateName}")).Info;
             var result = await bootstrapper.CreateAsync(template, name, output, parametersDict, false, "").ConfigureAwait(false);
 
             Assert.Equal(expectedResult.CreationResult.PrimaryOutputs.Count, result.PrimaryOutputs.Count);

--- a/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Mocks
 {
-    public class MockTemplateInfo : ITemplateInfo, IShortNameList, IXunitSerializable
+    public class MockTemplateInfo : ITemplateInfo, IXunitSerializable
     {
         public MockTemplateInfo()
         {


### PR DESCRIPTION
### Problem
Part of public API delivery. 
Templates can have multiple short names, and this feature was delivered via IShortNameList interface. 
This way of doing it contributes to a lot of bugs:
- most implementations still uses ITemplateInfo.ShortName and ignore other short names of templates
- multiple short names are not available for IDE (it uses ITemplateInfo and most of users are not aware of IShortNameList)

### Solution
IShortNameList interface is made obsolete - to be removed in next release
Added ShortNameList property to ITemplateInfo.
ITemplateInfo.ShortName is made obsolete - to be removed in next release

### Checks:
- [ ] Added unit tests - not needed
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - added to ITemplateInfo