### PR TITLE
made IFilteredTemplateInfo obsolete

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Settings/FilteredTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/FilteredTemplateInfo.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
@@ -8,6 +9,7 @@ using Microsoft.TemplateEngine.Edge.Template;
 
 namespace Microsoft.TemplateEngine.Edge.Settings
 {
+    [Obsolete("Use ITemplateMatchInfo instead")]
     public class FilteredTemplateInfo : IFilteredTemplateInfo
     {
         public FilteredTemplateInfo(ITemplateInfo info, IReadOnlyList<MatchInfo> matchDisposition)

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -46,13 +46,6 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         [JsonProperty]
         public Dictionary<string, DateTime> MountPointsInfo { get; set; }
 
-        // This method is getting obsolted soon. It's getting replaced by TemplateListFilter.FilterTemplates, which does the same thing,
-        // except that the template list to act on is passed in.
-        public IReadOnlyCollection<IFilteredTemplateInfo> List(bool exactMatchesOnly, params Func<ITemplateInfo, MatchInfo?>[] filters)
-        {
-            return TemplateListFilter.FilterTemplates(TemplateInfo, exactMatchesOnly, filters);
-        }
-
         private Scanner InstallScanner
         {
             get

--- a/src/Microsoft.TemplateEngine.Edge/Template/FilteredTemplateEqualityComparer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/FilteredTemplateEqualityComparer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Edge.Template
 {
+    [Obsolete("IFilteredTemplateInfo is obsolete")]
     public class FilteredTemplateEqualityComparer : IEqualityComparer<IFilteredTemplateInfo>
     {
         public static IEqualityComparer<IFilteredTemplateInfo> Default { get; } = new FilteredTemplateEqualityComparer();

--- a/src/Microsoft.TemplateEngine.Edge/Template/IFilteredTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/IFilteredTemplateInfo.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Edge.Template
 {
+    [Obsolete("Use ITemplateMatchInfo instead")]
     public interface IFilteredTemplateInfo
     {
         ITemplateInfo Info { get; }

--- a/src/Microsoft.TemplateEngine.Edge/TemplateListFilter.cs
+++ b/src/Microsoft.TemplateEngine.Edge/TemplateListFilter.cs
@@ -1,5 +1,7 @@
-// Copyright (c) .NET Foundation and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
 
 using System;
 using System.Collections.Generic;
@@ -14,7 +16,19 @@ namespace Microsoft.TemplateEngine.Edge
 {
     public static class TemplateListFilter
     {
-        // Deprecating. ITemplateMatchInfo will eventually fully replace IFilteredTemplateInfo
+        /// <summary>
+        /// Exact match criteria - the templates should match all filters.
+        /// </summary>
+        /// <seealso cref="GetTemplateMatchInfo"/>
+        public static Func<ITemplateMatchInfo, bool> ExactMatchFilter => x => x.IsMatch;
+
+        /// <summary>
+        /// Partial match criteria - the templates should match one of the filters.
+        /// </summary>
+        /// <seealso cref="GetTemplateMatchInfo"/>
+        public static Func<ITemplateMatchInfo, bool> PartialMatchFilter => x => x.IsPartialMatch;
+
+        [Obsolete("Use GetTemplateMatchInfo instead")]
         public static IReadOnlyCollection<IFilteredTemplateInfo> FilterTemplates(IReadOnlyList<ITemplateInfo> templateList, bool exactMatchesOnly, params Func<ITemplateInfo, MatchInfo?>[] filters)
         {
             HashSet<IFilteredTemplateInfo> matchingTemplates = new HashSet<IFilteredTemplateInfo>(FilteredTemplateEqualityComparer.Default);
@@ -48,6 +62,18 @@ namespace Microsoft.TemplateEngine.Edge
 #endif
         }
 
+        /// <summary>
+        /// Gets matching information for templates for provided filters.
+        /// </summary>
+        /// <param name="templateList">The templates to be filtered.</param>
+        /// <param name="matchFilter">The criteria of template to be filtered.</param>
+        /// <param name="filters">The list of filters to be applied.</param>
+        /// <returns>The filtered list of templates with matches information.</returns>
+        /// <remarks>
+        /// Usage examples:<br/>
+        /// <c>GetTemplateMatchInfo(templates, TemplateListFilter.ExactMatchFilter, WellKnownSearchFilters.NameFilter("myname")</c> - returns the templates which name or short name contains "myname". <br/>
+        /// <c>GetTemplateMatchInfo(templates, TemplateListFilter.PartialMatchFilter, WellKnownSearchFilters.NameFilter("myname"), WellKnownSearchFilters.NameFilter("othername")</c> - returns the templates which name or short name contains "myname" or "othername".<br/>
+        /// </remarks>
         public static IReadOnlyCollection<ITemplateMatchInfo> GetTemplateMatchInfo(IReadOnlyList<ITemplateInfo> templateList, Func<ITemplateMatchInfo, bool> matchFilter, params Func<ITemplateInfo, MatchInfo?>[] filters)
         {
             HashSet<ITemplateMatchInfo> matchingTemplates = new HashSet<ITemplateMatchInfo>(TemplateMatchInfoEqualityComparer.Default);
@@ -79,9 +105,5 @@ namespace Microsoft.TemplateEngine.Edge
             return matchingTemplates.ToList();
 #endif
         }
-
-        public static Func<ITemplateMatchInfo, bool> ExactMatchFilter = x => x.IsMatch;
-
-        public static Func<ITemplateMatchInfo, bool> PartialMatchFilter = x => x.IsPartialMatch;
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/TemplateListFilter.cs
+++ b/src/Microsoft.TemplateEngine.Edge/TemplateListFilter.cs
@@ -23,7 +23,7 @@ namespace Microsoft.TemplateEngine.Edge
         public static Func<ITemplateMatchInfo, bool> ExactMatchFilter => x => x.IsMatch;
 
         /// <summary>
-        /// Partial match criteria - the templates should match one of the filters.
+        /// Partial match criteria - the templates should match at least one of the filters.
         /// </summary>
         /// <seealso cref="GetTemplateMatchInfo"/>
         public static Func<ITemplateMatchInfo, bool> PartialMatchFilter => x => x.IsPartialMatch;
@@ -69,11 +69,10 @@ namespace Microsoft.TemplateEngine.Edge
         /// <param name="matchFilter">The criteria of template to be filtered.</param>
         /// <param name="filters">The list of filters to be applied.</param>
         /// <returns>The filtered list of templates with matches information.</returns>
-        /// <remarks>
-        /// Usage examples:<br/>
+        /// <example>
         /// <c>GetTemplateMatchInfo(templates, TemplateListFilter.ExactMatchFilter, WellKnownSearchFilters.NameFilter("myname")</c> - returns the templates which name or short name contains "myname". <br/>
         /// <c>GetTemplateMatchInfo(templates, TemplateListFilter.PartialMatchFilter, WellKnownSearchFilters.NameFilter("myname"), WellKnownSearchFilters.NameFilter("othername")</c> - returns the templates which name or short name contains "myname" or "othername".<br/>
-        /// </remarks>
+        /// </example>
         public static IReadOnlyCollection<ITemplateMatchInfo> GetTemplateMatchInfo(IReadOnlyList<ITemplateInfo> templateList, Func<ITemplateMatchInfo, bool> matchFilter, params Func<ITemplateInfo, MatchInfo?>[] filters)
         {
             HashSet<ITemplateMatchInfo> matchingTemplates = new HashSet<ITemplateMatchInfo>(TemplateMatchInfoEqualityComparer.Default);

--- a/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs
+++ b/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs
@@ -59,7 +59,7 @@ namespace Microsoft.TemplateEngine.IDE
             EnvironmentSettings.SettingsLoader.Components.RegisterMany(assembly.GetTypes());
         }
 
-        [Obsolete("Use GetTemplates instead")]
+        [Obsolete("Use " + nameof(GetTemplatesAsync) + "instead")]
         public async Task<IReadOnlyCollection<IFilteredTemplateInfo>> ListTemplates(bool exactMatchesOnly, params Func<ITemplateInfo, MatchInfo?>[] filters)
         {
             EnsureInitialized();
@@ -69,17 +69,19 @@ namespace Microsoft.TemplateEngine.IDE
         /// <summary>
         /// Gets list of available templates, if <paramref name="filters"/> are provided returns only matching templates.
         /// </summary>
-        /// <param name="exactMatchesOnly">
-        /// true: templates should match all filters;
-        /// false:  templates should match any filter.
-        /// </param>
         /// <param name="filters">List of filters to apply. See <see cref="WellKnownSearchFilters"/> for predefined filters.</param>
+        /// <param name="exactMatchesOnly">
+        /// true: templates should match all filters; false: templates should match any filter.
+        /// </param>
+        /// <param name="cancellationToken"></param>
         /// <returns>Filtered list of available templates with details on the applied filters matches.</returns>
-        public async Task<IReadOnlyCollection<ITemplateMatchInfo>> GetTemplates(bool exactMatchesOnly = true, params Func<ITemplateInfo, MatchInfo?>[] filters)
+        public async Task<IReadOnlyCollection<ITemplateMatchInfo>> GetTemplatesAsync(IEnumerable<Func<ITemplateInfo, MatchInfo?>> filters = null, bool exactMatchesOnly = true, CancellationToken cancellationToken = default)
         {
-            var criteria = exactMatchesOnly ? TemplateListFilter.ExactMatchFilter : TemplateListFilter.PartialMatchFilter;
+            Func<ITemplateMatchInfo, bool> criteria = exactMatchesOnly ? TemplateListFilter.ExactMatchFilter : TemplateListFilter.PartialMatchFilter;
+            Func<ITemplateInfo, MatchInfo?>[] filtersArray = filters?.ToArray() ?? Array.Empty<Func<ITemplateInfo, MatchInfo?>>();
+
             EnsureInitialized();
-            return TemplateListFilter.GetTemplateMatchInfo(await EnvironmentSettings.SettingsLoader.GetTemplatesAsync(default).ConfigureAwait(false), criteria, filters);
+            return TemplateListFilter.GetTemplateMatchInfo(await EnvironmentSettings.SettingsLoader.GetTemplatesAsync(cancellationToken).ConfigureAwait(false), criteria, filtersArray);
         }
 
         public async Task<ICreationResult> CreateAsync(ITemplateInfo info, string name, string outputPath, IReadOnlyDictionary<string, string> parameters, bool skipUpdateCheck, string baselineName)

--- a/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs
+++ b/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs
@@ -59,10 +59,27 @@ namespace Microsoft.TemplateEngine.IDE
             EnvironmentSettings.SettingsLoader.Components.RegisterMany(assembly.GetTypes());
         }
 
+        [Obsolete("Use GetTemplates instead")]
         public async Task<IReadOnlyCollection<IFilteredTemplateInfo>> ListTemplates(bool exactMatchesOnly, params Func<ITemplateInfo, MatchInfo?>[] filters)
         {
             EnsureInitialized();
             return TemplateListFilter.FilterTemplates(await EnvironmentSettings.SettingsLoader.GetTemplatesAsync(default).ConfigureAwait(false), exactMatchesOnly, filters);
+        }
+
+        /// <summary>
+        /// Gets list of available templates, if <paramref name="filters"/> are provided returns only matching templates.
+        /// </summary>
+        /// <param name="exactMatchesOnly">
+        /// true: templates should match all filters;
+        /// false:  templates should match any filter.
+        /// </param>
+        /// <param name="filters">List of filters to apply. See <see cref="WellKnownSearchFilters"/> for predefined filters.</param>
+        /// <returns>Filtered list of available templates with details on the applied filters matches.</returns>
+        public async Task<IReadOnlyCollection<ITemplateMatchInfo>> GetTemplates(bool exactMatchesOnly = true, params Func<ITemplateInfo, MatchInfo?>[] filters)
+        {
+            var criteria = exactMatchesOnly ? TemplateListFilter.ExactMatchFilter : TemplateListFilter.PartialMatchFilter;
+            EnsureInitialized();
+            return TemplateListFilter.GetTemplateMatchInfo(await EnvironmentSettings.SettingsLoader.GetTemplatesAsync(default).ConfigureAwait(false), criteria, filters);
         }
 
         public async Task<ICreationResult> CreateAsync(ITemplateInfo info, string name, string outputPath, IReadOnlyDictionary<string, string> parameters, bool skipUpdateCheck, string baselineName)

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
@@ -29,7 +29,8 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             await bootstrapper.InstallTestTemplateAsync("TemplateWithSourceName").ConfigureAwait(false);
 
             string output = TestUtils.CreateTemporaryFolder();
-            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter("TestAssets.TemplateWithSourceName")).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplatesAsync(
+                new[] { WellKnownSearchFilters.NameFilter("TestAssets.TemplateWithSourceName") }).ConfigureAwait(false);
             var result = await bootstrapper.GetCreationEffectsAsync(foundTemplates.First().Info, "test", output, new Dictionary<string, string>(), "").ConfigureAwait(false);
             Assert.Equal(2, result.CreationResult.PrimaryOutputs.Count);
             Assert.Equal(0, result.CreationResult.PostActions.Count);
@@ -56,7 +57,8 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             await bootstrapper.InstallTestTemplateAsync("TemplateWithSourceName").ConfigureAwait(false);
 
             string output = TestUtils.CreateTemporaryFolder();
-            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter("TestAssets.TemplateWithSourceName")).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplatesAsync(
+                new[] { WellKnownSearchFilters.NameFilter("TestAssets.TemplateWithSourceName") }).ConfigureAwait(false);
 
             var result = await bootstrapper.CreateAsync(foundTemplates.First().Info, "test", output, new Dictionary<string, string>(), false, "").ConfigureAwait(false);
 
@@ -75,7 +77,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 
             string output = TestUtils.CreateTemporaryFolder();
 
-            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter("console")).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter("console") }).ConfigureAwait(false);
             var result = await bootstrapper.GetCreationEffectsAsync(foundTemplates.First().Info, "test", output, new Dictionary<string, string>(), "").ConfigureAwait(false);
             Assert.Equal(2, result.CreationResult.PrimaryOutputs.Count);
             Assert.Equal(2, result.CreationResult.PostActions.Count);
@@ -101,7 +103,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             await bootstrapper.InstallTemplateAsync(packageLocation).ConfigureAwait(false);
 
             string output = TestUtils.CreateTemporaryFolder();
-            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter("console")).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter("console") }).ConfigureAwait(false);
             var result = await bootstrapper.CreateAsync(foundTemplates.First().Info, "test", output, new Dictionary<string, string>(), false, "").ConfigureAwait(false);
             Assert.Equal(2, result.PrimaryOutputs.Count);
             Assert.Equal(2, result.PostActions.Count);

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             await bootstrapper.InstallTestTemplateAsync("TemplateWithSourceName").ConfigureAwait(false);
 
             string output = TestUtils.CreateTemporaryFolder();
-            var foundTemplates = await bootstrapper.ListTemplates(true, WellKnownSearchFilters.NameFilter("TestAssets.TemplateWithSourceName")).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter("TestAssets.TemplateWithSourceName")).ConfigureAwait(false);
             var result = await bootstrapper.GetCreationEffectsAsync(foundTemplates.First().Info, "test", output, new Dictionary<string, string>(), "").ConfigureAwait(false);
             Assert.Equal(2, result.CreationResult.PrimaryOutputs.Count);
             Assert.Equal(0, result.CreationResult.PostActions.Count);
@@ -56,7 +56,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             await bootstrapper.InstallTestTemplateAsync("TemplateWithSourceName").ConfigureAwait(false);
 
             string output = TestUtils.CreateTemporaryFolder();
-            var foundTemplates = await bootstrapper.ListTemplates(true, WellKnownSearchFilters.NameFilter("TestAssets.TemplateWithSourceName")).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter("TestAssets.TemplateWithSourceName")).ConfigureAwait(false);
 
             var result = await bootstrapper.CreateAsync(foundTemplates.First().Info, "test", output, new Dictionary<string, string>(), false, "").ConfigureAwait(false);
 
@@ -75,7 +75,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 
             string output = TestUtils.CreateTemporaryFolder();
 
-            var foundTemplates = await bootstrapper.ListTemplates(true, WellKnownSearchFilters.NameFilter("console")).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter("console")).ConfigureAwait(false);
             var result = await bootstrapper.GetCreationEffectsAsync(foundTemplates.First().Info, "test", output, new Dictionary<string, string>(), "").ConfigureAwait(false);
             Assert.Equal(2, result.CreationResult.PrimaryOutputs.Count);
             Assert.Equal(2, result.CreationResult.PostActions.Count);
@@ -101,7 +101,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             await bootstrapper.InstallTemplateAsync(packageLocation).ConfigureAwait(false);
 
             string output = TestUtils.CreateTemporaryFolder();
-            var foundTemplates = await bootstrapper.ListTemplates(true, WellKnownSearchFilters.NameFilter("console")).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter("console")).ConfigureAwait(false);
             var result = await bootstrapper.CreateAsync(foundTemplates.First().Info, "test", output, new Dictionary<string, string>(), false, "").ConfigureAwait(false);
             Assert.Equal(2, result.PrimaryOutputs.Count);
             Assert.Equal(2, result.PostActions.Count);

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
@@ -208,7 +208,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
 
-            var foundTemplates = await bootstrapper.ListTemplates(true, WellKnownSearchFilters.NameFilter(templateName)).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter(templateName)).ConfigureAwait(false);
             ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName == $"TestAssets.{templateName}").Info;
             ICreationEffects result = await bootstrapper.GetCreationEffectsAsync(template, name, output, parametersDict, "").ConfigureAwait(false);
 
@@ -238,7 +238,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             string output = BasicParametersParser.GetOutputFromParameterString(parameters);
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
-            var foundTemplates = await bootstrapper.ListTemplates(true, WellKnownSearchFilters.NameFilter(templateName)).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter(templateName)).ConfigureAwait(false);
             ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName == $"TestAssets.{templateName}").Info;
             var result = await bootstrapper.CreateAsync(template, name, output, parametersDict, false, "").ConfigureAwait(false);
 
@@ -284,7 +284,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             string output = BasicParametersParser.GetOutputFromParameterString(parameters);
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
-            var foundTemplates = await bootstrapper.ListTemplates(true, WellKnownSearchFilters.NameFilter(templateName)).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter(templateName)).ConfigureAwait(false);
             ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName == $"TestAssets.{templateName}").Info;
             ICreationEffects result = await bootstrapper.GetCreationEffectsAsync(template, name, output, parametersDict, "").ConfigureAwait(false);
 
@@ -315,7 +315,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             string output = BasicParametersParser.GetOutputFromParameterString(parameters);
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
-            var foundTemplates = await bootstrapper.ListTemplates(true, WellKnownSearchFilters.NameFilter(templateName)).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter(templateName)).ConfigureAwait(false);
             ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName == $"TestAssets.{templateName}").Info;
             var result = await bootstrapper.CreateAsync(template, name, output, parametersDict, false, "").ConfigureAwait(false);
 

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
@@ -208,7 +208,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
 
-            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter(templateName)).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
             ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName == $"TestAssets.{templateName}").Info;
             ICreationEffects result = await bootstrapper.GetCreationEffectsAsync(template, name, output, parametersDict, "").ConfigureAwait(false);
 
@@ -238,7 +238,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             string output = BasicParametersParser.GetOutputFromParameterString(parameters);
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
-            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter(templateName)).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
             ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName == $"TestAssets.{templateName}").Info;
             var result = await bootstrapper.CreateAsync(template, name, output, parametersDict, false, "").ConfigureAwait(false);
 
@@ -284,7 +284,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             string output = BasicParametersParser.GetOutputFromParameterString(parameters);
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
-            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter(templateName)).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
             ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName == $"TestAssets.{templateName}").Info;
             ICreationEffects result = await bootstrapper.GetCreationEffectsAsync(template, name, output, parametersDict, "").ConfigureAwait(false);
 
@@ -315,7 +315,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             string output = BasicParametersParser.GetOutputFromParameterString(parameters);
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
-            var foundTemplates = await bootstrapper.GetTemplates(true, WellKnownSearchFilters.NameFilter(templateName)).ConfigureAwait(false);
+            var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
             ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName == $"TestAssets.{templateName}").Info;
             var result = await bootstrapper.CreateAsync(template, name, output, parametersDict, false, "").ConfigureAwait(false);
 


### PR DESCRIPTION
### Problem
Part of public API delivery.
made class IFilteredTemplateInfo obsolete - it is duplicate of ITemplateMatchInfo

### Solution
made class IFilteredTemplateInfo obsolete, removed usages

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)