### PR TITLE
Fix parsing cache from before discovery when host with same version is present

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Settings/SettingsLoader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/SettingsLoader.cs
@@ -151,6 +151,13 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
             EnsureLoaded();
             forceRebuild |= _userTemplateCache.Locale != CultureInfo.CurrentUICulture.Name;
+            if (_userTemplateCache.Version != TemplateInfo.CurrentVersion)
+            {
+                _environmentSettings.Host.LogDiagnosticMessage(
+                        $"Template cache file version is {_userTemplateCache.Version}, but template engine is {TemplateInfo.CurrentVersion}, rebuilding cache.",
+                        "Debug");
+                forceRebuild = true;
+            }
 
             var placesThatNeedScanning = new HashSet<string>();
             var allTemplatePackages = await _templatePackagesManager.GetTemplatePackagesAsync(forceRebuild).ConfigureAwait(false);

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
@@ -10,7 +10,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 {
     public class TemplateInfo : ITemplateInfo, IShortNameList
     {
-        public static readonly string CurrentVersion = "1.0.0.4";
+        public static readonly string CurrentVersion = "1.0.0.5";
 
         public TemplateInfo()
         {
@@ -29,6 +29,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             versionReaders.Add("1.0.0.2", TemplateInfoReaderVersion1_0_0_2.FromJObject);
             versionReaders.Add("1.0.0.3", TemplateInfoReaderVersion1_0_0_3.FromJObject);
             versionReaders.Add("1.0.0.4", TemplateInfoReaderVersion1_0_0_4.FromJObject);
+            versionReaders.Add("1.0.0.5", TemplateInfoReaderVersion1_0_0_4.FromJObject);
             _infoVersionReaders = versionReaders;
 
             _defaultReader = TemplateInfoReaderInitialVersion.FromJObject;


### PR DESCRIPTION
### Problem
We assumed that with introduction of discovery its safe to assume that cache format will be new since host version will be change which is not true on dotnet/sdk CI

### Solution
Solution is to bump format version and rebuild whole cache if cache version is different.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)