### PR TITLE
[PORT TO release/5.0.3xx] Fix #2992 of Creating new solution using "dotnet new sln" in .NET 5.0.201 SDK has wrong/invalid solution version number.

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
-VisualStudioVersion = 16.6.30114.105
+VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Fix #2992

Previous PR #3007 also has more context and detail. I have to close that PR, because it has more conflicts when I changed to main.
This PR target to `release/5.0.3xx` branch directly.

cc @DavidKarlas 