### PR TITLE
Fix randomly failing unit test on Linux

### DIFF
--- a/src/Microsoft.TemplateEngine.Utils/PhysicalFileSystem.cs
+++ b/src/Microsoft.TemplateEngine.Utils/PhysicalFileSystem.cs
@@ -106,6 +106,7 @@ namespace Microsoft.TemplateEngine.Utils
         {
             FileSystemWatcher watcher = new FileSystemWatcher(Path.GetDirectoryName(filepath), Path.GetFileName(filepath));
             watcher.Changed += fileChanged;
+            watcher.NotifyFilter = NotifyFilters.LastWrite;
             watcher.EnableRaisingEvents = true;
             return watcher;
         }


### PR DESCRIPTION
### Problem
Sometimes unit test is failing on Linux because packages list is empty, reason is that on Linux FileWatcher notifes about change before file is fully modified(maybe it notifies when opened), assumption is that we will get 2nd notification when file is fully written.

### Solution
Ignore empty packages list.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)