### PR TITLE
Fix 3039: dotnet new --install results in a null ref

### DIFF
--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -72,14 +72,11 @@ namespace dotnet_new3
             catch
             { }
 
+            // Keep this in sync with dotnet/sdk repo
             var builtIns = new AssemblyComponentCatalog(new[]
             {
                 // for assembly: Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 typeof(Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro).GetTypeInfo().Assembly,
-                // for assembly: Microsoft.TemplateEngine.Edge
-                typeof(Microsoft.TemplateEngine.Edge.Paths).GetTypeInfo().Assembly,
-                // for assembly: Microsoft.TemplateEngine.Cli
-                typeof(Microsoft.TemplateEngine.Cli.New3Command).GetTypeInfo().Assembly,
                 // for this assembly
                 typeof(Program).GetTypeInfo().Assembly
             });

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/ComponentManagerTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/ComponentManagerTests.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Installer;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.Mocks;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Edge.UnitTests
+{
+    public class ComponentManagerTests
+    {
+
+        [Fact]
+        public void TestAllEdgeComponentsAdded()
+        {
+            var componentManager = new ComponentManager(new MockSettingsLoader(new MockEngineEnvironmentSettings()
+            {
+                Host = new TestHelper.TestHost()
+            }), new SettingsStore());
+
+            var assemblyCatalog = new AssemblyComponentCatalog(new[] { typeof(ComponentManager).Assembly });
+            var expectedTypeNames = assemblyCatalog.Select(pair => pair.Value().FullName).OrderBy(name => name);
+
+            var actualTypeNames = componentManager._componentCache.Values.SelectMany(t => t.Values).Select(o => o.GetType().FullName).OrderBy(name => name);
+
+            Assert.Equal(expectedTypeNames, actualTypeNames);
+            Assert.Equal(2, componentManager.OfType<IInstallerFactory>().Count());
+        }
+    }
+}


### PR DESCRIPTION
### Problem

https://github.com/dotnet/templating/issues/3039

With recent refactoring we introduced 3 new components into Edge assembly:
-GlobalSettingsTemplatePackageProviderFactory
-NuGetInstallerFactory
-FolderInstallerFactory
For Edge assembly we register this components manually for perf reasons...

### Solution
I add this components now...
But there was no test until now to ensure we actually register everything, so I added test to ensure that for Edge
Another thing I did I removed Edge assembly from `dotnet new3` list of assemblies to align with `dotnet new` list of assembies to ensure our integrations tests are as close as possible to `dotnet new`

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)