### PR TITLE
Update export task scheduling

### DIFF
--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateLocalizer.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateLocalizer.cs
@@ -23,12 +23,12 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
             _logger = (ILogger?)loggerFactory?.CreateLogger<TemplateLocalizer>() ?? NullLogger.Instance;
         }
 
-        public async Task<ExportResult> ExportLocalizationFilesAsync(string templateJsonPath, ExportOptions options, CancellationToken cancellationToken = default)
+        public Task<ExportResult> ExportLocalizationFilesAsync(string templateJsonPath, ExportOptions options, CancellationToken cancellationToken = default)
         {
             ExportResult result = new ExportResult();
             result.TemplateJsonPath = templateJsonPath;
             result.ErrorMessage = "Operation failed.";
-            return result;
+            return Task.FromResult(result);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.cs.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.de.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.es.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.fr.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.it.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.ja.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.ko.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.pl.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.pt-BR.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.ru.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.tr.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.zh-Hans.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.zh-Hant.xlf
@@ -28,9 +28,14 @@
         <note>Do not localize: "template.json", "--recursive"</note>
       </trans-unit>
       <trans-unit id="command_export_log_cancelled">
-        <source>Export command for a template.json file was cancelled.</source>
-        <target state="new">Export command for a template.json file was cancelled.</target>
-        <note>Do not localize: "template.json", "export"</note>
+        <source>Export command for the following file was cancelled: "{0}".</source>
+        <target state="new">Export command for the following file was cancelled: "{0}".</target>
+        <note>Do not localize: "export"</note>
+      </trans-unit>
+      <trans-unit id="command_export_log_executionEnded">
+        <source>Execution of export command has completed. {0} files were processed.</source>
+        <target state="new">Execution of export command has completed. {0} files were processed.</target>
+        <note>{0} is the number of files. Do not localize "export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
         <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>


### PR DESCRIPTION
### Problem
Updates the scheduling part of changes introduced https://github.com/dotnet/templating/issues/2895
After investigating ConcurrentExclusiveSchedulerPair as an alternative solution, I have come to the conclusion that this kind of scheduling doesn't make much sense. Hence, I'm proposing this change to remove it.

### Solution
Removes the manual scheduling of tasks in batches.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)