### PR TITLE
Use `--debug:custom-hive` for `.templateengine` and not for `.templateengine/dotnetcli/v6.100.0.0`

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -386,7 +386,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             if (ephemeralHiveFlag)
             {
-                EnvironmentSettings.Host.VirtualizeDirectory(_paths.User.BaseDir);
+                EnvironmentSettings.Host.VirtualizeDirectory(EnvironmentSettings.Paths.TemplateEngineRootDir);
             }
 
             bool reinitFlag = _commandInput.HasDebuggingFlag("--debug:reinit");

--- a/src/Microsoft.TemplateEngine.Utils/EngineEnvironmentSettings.cs
+++ b/src/Microsoft.TemplateEngine.Utils/EngineEnvironmentSettings.cs
@@ -18,15 +18,10 @@ namespace Microsoft.TemplateEngine.Utils
         }
 
         public EngineEnvironmentSettings(ITemplateEngineHost host, Func<IEngineEnvironmentSettings, ISettingsLoader> settingsLoaderFactory, string hiveLocation)
-            :this(host, settingsLoaderFactory, hiveLocation, null)
-        {
-        }
-
-        public EngineEnvironmentSettings(ITemplateEngineHost host, Func<IEngineEnvironmentSettings, ISettingsLoader> settingsLoaderFactory, string hiveLocation, string engineRoot)
         {
             Host = host;
             Environment = new DefaultEnvironment();
-            Paths = new DefaultPathInfo(this, hiveLocation, engineRoot);
+            Paths = new DefaultPathInfo(this, hiveLocation);
             SettingsLoader = settingsLoaderFactory(this);
         }
 
@@ -40,15 +35,15 @@ namespace Microsoft.TemplateEngine.Utils
 
         private class DefaultPathInfo : IPathInfo
         {
-            public DefaultPathInfo(IEngineEnvironmentSettings parent, string hiveLocation, string engineRoot)
+            public DefaultPathInfo(IEngineEnvironmentSettings parent, string hiveLocation)
             {
                 bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
                 UserProfileDir = parent.Environment.GetEnvironmentVariable(isWindows
                     ? "USERPROFILE"
                     : "HOME");
-                TemplateEngineRootDir = engineRoot ?? Path.Combine(UserProfileDir, ".templateengine");
-                TemplateEngineHostDir = hiveLocation ?? Path.Combine(TemplateEngineRootDir, parent.Host.HostIdentifier);
-                TemplateEngineHostVersionDir = hiveLocation ?? Path.Combine(TemplateEngineRootDir, parent.Host.HostIdentifier, parent.Host.Version);
+                TemplateEngineRootDir = hiveLocation ?? Path.Combine(UserProfileDir, ".templateengine");
+                TemplateEngineHostDir = Path.Combine(TemplateEngineRootDir, parent.Host.HostIdentifier);
+                TemplateEngineHostVersionDir = Path.Combine(TemplateEngineRootDir, parent.Host.HostIdentifier, parent.Host.Version);
             }
 
             public string UserProfileDir { get; }

--- a/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateEngine.TestHelper
             else
             {
                 var tempateEngineRoot = Path.Combine(CreateTemporaryFolder(), ".templateengine");
-                engineEnvironmentSettings = new EngineEnvironmentSettings(host, (x) => new SettingsLoader(x), null, tempateEngineRoot);
+                engineEnvironmentSettings = new EngineEnvironmentSettings(host, (x) => new SettingsLoader(x), tempateEngineRoot);
             }
             engineEnvironmentToDispose.Add(engineEnvironmentSettings);
             return engineEnvironmentSettings;

--- a/test/Microsoft.TemplateEngine.TestHelper/TestUtils.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/TestUtils.cs
@@ -10,8 +10,6 @@ namespace Microsoft.TemplateEngine.TestHelper
 {
     public class TestUtils
     {
-        public static string HomeEnvironmentVariableName { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "USERPROFILE" : "HOME";
-
         public static string CreateTemporaryFolder(string name = "")
         {
             string workingDir = Path.Combine(Path.GetTempPath(), "TemplateEngine.Tests", Guid.NewGuid().ToString(), name);

--- a/test/dotnet-new3.UnitTests/AllProjectsWork.cs
+++ b/test/dotnet-new3.UnitTests/AllProjectsWork.cs
@@ -38,8 +38,8 @@ namespace dotnet_new3.UnitTests
             Directory.CreateDirectory(workingDir);
 
             new DotnetNewCommand(_log, args)
+                .WithCustomHive(_fixture.HomeDirectory)
                 .WithWorkingDirectory(workingDir)
-                .WithEnvironmentVariable(_fixture.HomeVariable, _fixture.HomeDirectory)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -73,8 +73,8 @@ namespace dotnet_new3.UnitTests
             BaseWorkingDirectory = TestUtils.CreateTemporaryFolder(nameof(AllProjectsWork));
             // create nuget.config file with nuget.org listed
             new DotnetNewCommand(Log, "nugetconfig")
+                .WithCustomHive(HomeDirectory)
                 .WithWorkingDirectory(BaseWorkingDirectory)
-                .WithEnvironmentVariable(HomeVariable, HomeDirectory)
                 .Execute()
                 .Should()
                 .ExitWith(0)

--- a/test/dotnet-new3.UnitTests/DotnetNewCommand.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewCommand.cs
@@ -12,6 +12,8 @@ namespace dotnet_new3.UnitTests
 {
     public class DotnetNewCommand : TestCommand
     {
+        bool _hiveSet = false;
+
         public DotnetNewCommand(ITestOutputHelper log, params string[] args) : base(log)
         {
             // Set dotnet-new3.dll as first Argument to be passed to "dotnet"
@@ -28,12 +30,28 @@ namespace dotnet_new3.UnitTests
                 Arguments = args.ToList(),
                 WorkingDirectory = WorkingDirectory
             };
-            if (!_environment.ContainsKey(TestUtils.HomeEnvironmentVariableName))
+
+            if (!_hiveSet)
             {
-                throw new Exception($"{nameof(TestUtils.HomeEnvironmentVariableName)} is not set, call {nameof(DotnetNewCommand)}{nameof(WithEnvironmentVariable)} to set it.");
+                throw new Exception($"\"--debug:custom-hive\" is not set, call {nameof(WithCustomHive)} to set it or {nameof(WithoutCustomHive)} if it is intentional.");
             }
+
             return sdkCommandSpec;
         }
-    }
 
+        public DotnetNewCommand WithCustomHive(string path = null)
+        {
+            path ??= TestUtils.CreateTemporaryFolder();
+            Arguments.Add("--debug:custom-hive");
+            Arguments.Add(path);
+            _hiveSet = true;
+            return this;
+        }
+
+        public DotnetNewCommand WithoutCustomHive()
+        {
+            _hiveSet = true;
+            return this;
+        }
+    }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -23,10 +23,9 @@ namespace dotnet_new3.UnitTests
         [Fact]
         public void CanInstallRemoteNuGetPackage()
         {
-            var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0", "--quiet")
+                .WithCustomHive()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -43,18 +42,18 @@ namespace dotnet_new3.UnitTests
         public void CanInstallRemoteNuGetPackage_LatestVariations()
         {
             var command1 = new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0", "--quiet")
+                .WithCustomHive()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, TestUtils.CreateTemporaryFolder())
                 .Execute();
 
             var command2 = new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::", "--quiet")
+                .WithCustomHive()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, TestUtils.CreateTemporaryFolder())
                 .Execute();
 
             var command3 = new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::*", "--quiet")
+                .WithCustomHive()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, TestUtils.CreateTemporaryFolder())
                 .Execute();
 
             foreach (var commandResult in new[] { command1, command2, command3 })
@@ -77,10 +76,9 @@ namespace dotnet_new3.UnitTests
         [Fact]
         public void CanInstallRemoteNuGetPackageWithVersion()
         {
-            var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0", "--quiet")
+                .WithCustomHive()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -97,10 +95,9 @@ namespace dotnet_new3.UnitTests
         [Fact]
         public void CanInstallRemoteNuGetPackageWithPrereleaseVersion()
         {
-            var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Take.Blip.Client.Templates::0.6.37-beta", "--quiet", "--nuget-source", "https://api.nuget.org/v3/index.json")
+                .WithCustomHive()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -116,8 +113,8 @@ namespace dotnet_new3.UnitTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Take.Blip.Client.Templates", "--quiet", "--nuget-source", "https://api.nuget.org/v3/index.json")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -128,8 +125,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("blip-console");
 
             new DotnetNewCommand(_log, "-i", "Take.Blip.Client.Templates", "--quiet", "--add-source", "https://api.nuget.org/v3/index.json")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -143,13 +140,12 @@ namespace dotnet_new3.UnitTests
         [Fact]
         public void CanInstallLocalNuGetPackage()
         {
-            var home = TestUtils.CreateTemporaryFolder("Home");
             using var packageManager = new PackageManager();
             string packageLocation = packageManager.PackTestTemplatesNuGetPackage();
 
             new DotnetNewCommand(_log, "-i", packageLocation)
+                .WithCustomHive()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should().ExitWith(0)
                 .And.NotHaveStdErr()
@@ -162,11 +158,10 @@ namespace dotnet_new3.UnitTests
         [Fact]
         public void CanInstallLocalFolder()
         {
-            var home = TestUtils.CreateTemporaryFolder("Home");
             string basicFSharp = TestUtils.GetTestTemplateLocation("TemplateResolution/DifferentLanguagesGroup/BasicFSharp");
             new DotnetNewCommand(_log, "-i", basicFSharp)
+                .WithCustomHive()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -183,8 +178,8 @@ namespace dotnet_new3.UnitTests
             var home = TestUtils.CreateTemporaryFolder("Home");
 
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0", "--quiet")
+               .WithCustomHive(home)
                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-               .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                .Execute()
                .Should()
                .ExitWith(0)
@@ -194,8 +189,8 @@ namespace dotnet_new3.UnitTests
                .And.HaveStdOutContaining("Console Application");
 
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -212,8 +207,8 @@ namespace dotnet_new3.UnitTests
             var home = TestUtils.CreateTemporaryFolder("Home");
 
             new DotnetNewCommand(_log, "-i", "BlaBlaBla", "--quiet")
+               .WithCustomHive(home)
                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-               .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                .Execute()
                .Should().Fail()
                .And.HaveStdErrContaining("BlaBlaBla could not be installed, the package does not exist");
@@ -225,8 +220,8 @@ namespace dotnet_new3.UnitTests
             var home = TestUtils.CreateTemporaryFolder("Home");
 
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0::16.0.0", "--quiet")
+               .WithCustomHive(home)
                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-               .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                .Execute()
                .Should().Fail()
                .And.HaveStdErrContaining("Microsoft.DotNet.Web.ProjectTemplates.5.0::16.0.0 could not be installed, the package does not exist");
@@ -240,8 +235,8 @@ namespace dotnet_new3.UnitTests
             string basicVB = TestUtils.GetTestTemplateLocation("TemplateResolution/DifferentLanguagesGroup/BasicVB");
 
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0", "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0", "-i", basicFSharp, "-i", basicVB, "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -261,8 +256,8 @@ namespace dotnet_new3.UnitTests
             var home = TestUtils.CreateTemporaryFolder("Home");
 
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -272,8 +267,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("classlib");
 
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
+                 .WithCustomHive(home)
                  .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                 .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                  .Execute()
                  .Should().Fail()
                  .And.HaveStdErrContaining("Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0 is already installed");
@@ -285,8 +280,8 @@ namespace dotnet_new3.UnitTests
             var home = TestUtils.CreateTemporaryFolder("Home");
             string basicFSharp = TestUtils.GetTestTemplateLocation("TemplateResolution/DifferentLanguagesGroup/BasicFSharp");
             new DotnetNewCommand(_log, "-i", basicFSharp)
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -295,8 +290,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("basic");
 
             new DotnetNewCommand(_log, "-i", basicFSharp)
+                 .WithCustomHive(home)
                  .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                 .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                  .Execute()
                  .Should().Fail()
                  .And.HaveStdErrContaining($"{basicFSharp} is already installed");
@@ -308,8 +303,8 @@ namespace dotnet_new3.UnitTests
             var home = TestUtils.CreateTemporaryFolder("Home");
 
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -319,8 +314,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("classlib");
 
             new DotnetNewCommand(_log, "-u")
+                 .WithCustomHive(home)
                  .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                 .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                  .Execute()
                  .Should().ExitWith(0)
                  .And.NotHaveStdErr()
@@ -328,11 +323,11 @@ namespace dotnet_new3.UnitTests
                  .And.HaveStdOutContaining("Version: 5.0.0")
                  .And.NotHaveStdOutContaining("Version: 5.0.1");
 
-            Assert.True(File.Exists(Path.Combine(home, ".templateengine", "packages", "Microsoft.DotNet.Common.ProjectTemplates.5.0.5.0.0.nupkg")));
+            Assert.True(File.Exists(Path.Combine(home, "packages", "Microsoft.DotNet.Common.ProjectTemplates.5.0.5.0.0.nupkg")));
 
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.1")
+                 .WithCustomHive(home)
                  .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                 .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                  .Execute()
                  .Should().ExitWith(0)
                  .And.NotHaveStdErr()
@@ -345,8 +340,8 @@ namespace dotnet_new3.UnitTests
                  .And.HaveStdOutContaining("classlib");
 
             new DotnetNewCommand(_log, "-u")
+                 .WithCustomHive(home)
                  .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                 .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                  .Execute()
                  .Should().ExitWith(0)
                  .And.NotHaveStdErr()
@@ -354,8 +349,8 @@ namespace dotnet_new3.UnitTests
                  .And.HaveStdOutContaining("Version: 5.0.1")
                  .And.NotHaveStdOutContaining("Version: 5.0.0");
 
-            Assert.False(File.Exists(Path.Combine(home, ".templateengine", "packages", "Microsoft.DotNet.Common.ProjectTemplates.5.0.5.0.0.nupkg")));
-            Assert.True(File.Exists(Path.Combine(home, ".templateengine", "packages", "Microsoft.DotNet.Common.ProjectTemplates.5.0.5.0.1.nupkg")));
+            Assert.False(File.Exists(Path.Combine(home, "packages", "Microsoft.DotNet.Common.ProjectTemplates.5.0.5.0.0.nupkg")));
+            Assert.True(File.Exists(Path.Combine(home, "packages", "Microsoft.DotNet.Common.ProjectTemplates.5.0.5.0.1.nupkg")));
         }
 
         [Fact]
@@ -367,8 +362,8 @@ namespace dotnet_new3.UnitTests
             string packageLocation = packageManager.PackProjectTemplatesNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
 
             new DotnetNewCommand(_log, "-i", packageLocation)
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should().ExitWith(0)
                 .And.NotHaveStdErr()
@@ -377,8 +372,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("classlib");
 
             new DotnetNewCommand(_log, "-u")
+                 .WithCustomHive(home)
                  .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                 .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                  .Execute()
                  .Should().ExitWith(0)
                  .And.NotHaveStdErr()
@@ -388,8 +383,8 @@ namespace dotnet_new3.UnitTests
                  .And.NotHaveStdOutContaining("Version: 5.0.0");
 
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should().ExitWith(0)
                 .And.NotHaveStdErr()
@@ -402,8 +397,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("classlib");
 
             new DotnetNewCommand(_log, "-u")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should().ExitWith(0)
                 .And.NotHaveStdErr()
@@ -428,8 +423,8 @@ namespace dotnet_new3.UnitTests
 
 
             new DotnetNewCommand(_log, "-i", pattern)
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should().ExitWith(0)
                 .And.NotHaveStdErr()
@@ -450,14 +445,11 @@ namespace dotnet_new3.UnitTests
             var home = TestUtils.CreateTemporaryFolder("Home");
             string codebase = typeof(Program).GetTypeInfo().Assembly.Location;
             new DotnetNewCommand(_log, "-i", codebase)
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining($"{codebase} is not supported");
         }
-
-
-
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
@@ -24,8 +24,8 @@ namespace dotnet_new3.UnitTests
             string workingDirectory = TestUtils.CreateTemporaryFolder();
 
             new DotnetNewCommand(_log, "console")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(workingDirectory)
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -39,8 +39,8 @@ namespace dotnet_new3.UnitTests
             var home = TestUtils.CreateTemporaryFolder("Home");
 
             new DotnetNewCommand(_log, "webapp", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .Fail()
@@ -58,8 +58,8 @@ namespace dotnet_new3.UnitTests
             Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicFSharp", _log, workingDirectory, home);
 
             new DotnetNewCommand(_log, "basic")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(workingDirectory)
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -76,8 +76,8 @@ namespace dotnet_new3.UnitTests
             Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicVB", _log, workingDirectory, home);
 
             new DotnetNewCommand(_log, "basic")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(workingDirectory)
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .Fail()
@@ -94,8 +94,8 @@ namespace dotnet_new3.UnitTests
             string workingDirectory = TestUtils.CreateTemporaryFolder();
 
             new DotnetNewCommand(_log, "conf", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(workingDirectory)
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .Fail()
@@ -105,8 +105,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdErrContaining("webconfig").And.HaveStdErrContaining("nugetconfig").And.NotHaveStdErrContaining("classlib");
 
             new DotnetNewCommand(_log, "file")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(workingDirectory)
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .Fail()
@@ -123,8 +123,8 @@ namespace dotnet_new3.UnitTests
             string workingDirectory = TestUtils.CreateTemporaryFolder();
 
             new DotnetNewCommand(_log, "console", "--fake", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(workingDirectory)
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .Fail()
@@ -134,8 +134,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdErrContaining("For more information, run 'dotnet new3 console --help'.");
 
             new DotnetNewCommand(_log, "console", "--framework", "fake")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(workingDirectory)
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .Fail()
@@ -147,8 +147,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdErrContaining("For more information, run 'dotnet new3 console --help'.");
 
             new DotnetNewCommand(_log, "console", "--framework", "netcoreapp")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(workingDirectory)
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .Fail()
@@ -160,8 +160,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdErrContaining("For more information, run 'dotnet new3 console --help'.");
 
             new DotnetNewCommand(_log, "console", "--framework", "netcoreapp", "--fake")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(workingDirectory)
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .Fail()
@@ -183,8 +183,8 @@ namespace dotnet_new3.UnitTests
             Helpers.InstallTestTemplate("TemplateResolution/SamePrecedenceGroup/BasicTemplate2", _log, workingDirectory, home);
 
             new DotnetNewCommand(_log, "basic")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(workingDirectory)
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .Fail()

--- a/test/dotnet-new3.UnitTests/DotnetNewList.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewList.cs
@@ -22,7 +22,7 @@ namespace dotnet_new3.UnitTests
         public void BasicTest()
         {
             new DotnetNewCommand(_log, "--list")
-                .WithEnvironmentVariable(_sharedHome.HomeVariable, _sharedHome.HomeDirectory)
+                .WithCustomHive(_sharedHome.HomeDirectory)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -37,7 +37,7 @@ namespace dotnet_new3.UnitTests
         public void CanShowAllColumns()
         {
             new DotnetNewCommand(_log, "--list", "--columns-all")
-                .WithEnvironmentVariable(_sharedHome.HomeVariable, _sharedHome.HomeDirectory)
+                .WithCustomHive(_sharedHome.HomeDirectory)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -50,7 +50,7 @@ namespace dotnet_new3.UnitTests
         public void CanFilterTags()
         {
             new DotnetNewCommand(_log, "--list", "--tag", "Common")
-                .WithEnvironmentVariable(_sharedHome.HomeVariable, _sharedHome.HomeDirectory)
+                .WithCustomHive(_sharedHome.HomeDirectory)
                 .Execute()
                 .Should()
                 .ExitWith(0)

--- a/test/dotnet-new3.UnitTests/DotnetNewLocaleTests.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewLocaleTests.cs
@@ -44,8 +44,8 @@ namespace dotnet_new3.UnitTests
                 "TemplateWithLocalization");
 
             var commandResult = new DotnetNewCommand(_log, "-i", testTemplatesFolder, "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", string.Empty)
                 .Execute();
 
@@ -78,8 +78,8 @@ namespace dotnet_new3.UnitTests
                 "TemplateWithLocalization");
 
             var commandResult = new DotnetNewCommand(_log, "-i", testTemplatesFolder, "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", dotnetCliEnvVar)
                 .Execute();
 

--- a/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
@@ -22,7 +22,7 @@ namespace dotnet_new3.UnitTests
         public void BasicTest()
         {
             new DotnetNewCommand(_log, "console", "--search")
-                .WithEnvironmentVariable(_sharedHome.HomeVariable, _sharedHome.HomeDirectory)
+                .WithCustomHive(_sharedHome.HomeDirectory)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -37,7 +37,7 @@ namespace dotnet_new3.UnitTests
         public void CanShowTags()
         {
             new DotnetNewCommand(_log, "console", "--search", "--columns", "tags")
-                .WithEnvironmentVariable(_sharedHome.HomeVariable, _sharedHome.HomeDirectory)
+                .WithCustomHive(_sharedHome.HomeDirectory)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -52,7 +52,7 @@ namespace dotnet_new3.UnitTests
         public void CanShowAllColumns()
         {
             new DotnetNewCommand(_log, "console", "--search", "--columns-all")
-                .WithEnvironmentVariable(_sharedHome.HomeVariable, _sharedHome.HomeDirectory)
+                .WithCustomHive(_sharedHome.HomeDirectory)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -67,7 +67,7 @@ namespace dotnet_new3.UnitTests
         public void CanFilterTags()
         {
             new DotnetNewCommand(_log, "console", "--search", "--columns", "tags", "--tag", "Common")
-                .WithEnvironmentVariable(_sharedHome.HomeVariable, _sharedHome.HomeDirectory)
+                .WithCustomHive(_sharedHome.HomeDirectory)
                 .Execute()
                 .Should()
                 .ExitWith(0)

--- a/test/dotnet-new3.UnitTests/DotnetNewUninstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUninstall.cs
@@ -29,8 +29,8 @@ namespace dotnet_new3.UnitTests
             Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicFSharp", _log, workingDirectory, home);
 
             new DotnetNewCommand(_log, "-u")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -45,8 +45,8 @@ namespace dotnet_new3.UnitTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -57,8 +57,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("blazorwasm");
 
             new DotnetNewCommand(_log, "-u")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -76,8 +76,8 @@ namespace dotnet_new3.UnitTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-u", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -94,8 +94,8 @@ namespace dotnet_new3.UnitTests
             string templateLocation = Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicFSharp", _log, workingDirectory, home);
 
             new DotnetNewCommand(_log, "-u")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -105,8 +105,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutMatching($"^\\s*dotnet new3 -u .*TemplateResolution{Regex.Escape(Path.DirectorySeparatorChar.ToString())}DifferentLanguagesGroup{Regex.Escape(Path.DirectorySeparatorChar.ToString())}BasicFSharp$", RegexOptions.Multiline);
 
             new DotnetNewCommand(_log, "-u", templateLocation)
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -115,8 +115,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOut($"Success: {templateLocation} was uninstalled.");
 
             new DotnetNewCommand(_log, "-u")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -132,8 +132,8 @@ namespace dotnet_new3.UnitTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -144,8 +144,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("blazorwasm");
 
             new DotnetNewCommand(_log, "-u")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -156,11 +156,11 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("Author: Microsoft")
                 .And.HaveStdOutContaining("dotnet new3 -u Microsoft.DotNet.Web.ProjectTemplates.5.0");
 
-            Assert.True(File.Exists(Path.Combine(home, ".templateengine", "packages", "Microsoft.DotNet.Web.ProjectTemplates.5.0.5.0.0.nupkg")));
+            Assert.True(File.Exists(Path.Combine(home, "packages", "Microsoft.DotNet.Web.ProjectTemplates.5.0.5.0.0.nupkg")));
 
             new DotnetNewCommand(_log, "-u", "Microsoft.DotNet.Web.ProjectTemplates.5.0")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -169,8 +169,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOut($"Success: Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0 was uninstalled.");
 
             new DotnetNewCommand(_log, "-u")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -178,7 +178,7 @@ namespace dotnet_new3.UnitTests
                 .NotHaveStdErr()
                 .And.HaveStdOut($"Currently installed items:{Environment.NewLine}(No Items)");
 
-            Assert.False(File.Exists(Path.Combine(home, ".templateengine", "packages", "Microsoft.DotNet.Web.ProjectTemplates.5.0.5.0.0.nupkg")));
+            Assert.False(File.Exists(Path.Combine(home, "packages", "Microsoft.DotNet.Web.ProjectTemplates.5.0.5.0.0.nupkg")));
         }
 
         [Fact]
@@ -190,8 +190,8 @@ namespace dotnet_new3.UnitTests
             string basicVB = Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicVB", _log, workingDirectory, home);
 
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0", "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -203,8 +203,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("classlib");
 
             new DotnetNewCommand(_log, "-u", "Microsoft.DotNet.Common.ProjectTemplates.5.0", "-u", basicFSharp)
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -214,8 +214,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining($"Success: {basicFSharp} was uninstalled.");
 
             new DotnetNewCommand(_log, "-u")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -232,8 +232,8 @@ namespace dotnet_new3.UnitTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -244,8 +244,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("blazorwasm");
 
             new DotnetNewCommand(_log, "-u", "Microsoft.DotNet.Common.ProjectTemplates.5.0")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining("The template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0' is not found")
@@ -258,8 +258,8 @@ namespace dotnet_new3.UnitTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -267,8 +267,8 @@ namespace dotnet_new3.UnitTests
                 .NotHaveStdErr();
 
             new DotnetNewCommand(_log, "-u", "console")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining("The template package 'console' is not found")
@@ -283,8 +283,8 @@ namespace dotnet_new3.UnitTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -292,8 +292,8 @@ namespace dotnet_new3.UnitTests
                 .NotHaveStdErr();
 
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.3.1::5.0.0", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -301,8 +301,8 @@ namespace dotnet_new3.UnitTests
                 .NotHaveStdErr();
 
             new DotnetNewCommand(_log, "-u", "console")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining("The template package 'console' is not found")

--- a/test/dotnet-new3.UnitTests/DotnetNewUpdateApply.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUpdateApply.cs
@@ -23,8 +23,8 @@ namespace dotnet_new3.UnitTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -35,8 +35,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("classlib");
 
             new DotnetNewCommand(_log, "--update-check")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -45,8 +45,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0' is available.");
 
             new DotnetNewCommand(_log, "--update-apply")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -67,8 +67,8 @@ namespace dotnet_new3.UnitTests
             string workingDirectory = TestUtils.CreateTemporaryFolder();
             string templateLocation = Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicFSharp", _log, workingDirectory, home);
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -79,8 +79,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("classlib");
 
             new DotnetNewCommand(_log, "--update-apply")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)

--- a/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
@@ -23,8 +23,8 @@ namespace dotnet_new3.UnitTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0", "--quiet")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -35,8 +35,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("classlib");
 
             new DotnetNewCommand(_log, "--update-check")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -52,8 +52,8 @@ namespace dotnet_new3.UnitTests
             string workingDirectory = TestUtils.CreateTemporaryFolder();
             string templateLocation = Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicFSharp", _log, workingDirectory, home);
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -64,8 +64,8 @@ namespace dotnet_new3.UnitTests
                 .And.HaveStdOutContaining("classlib");
 
             new DotnetNewCommand(_log, "--update-check")
+                .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)

--- a/test/dotnet-new3.UnitTests/FirstRunTest.cs
+++ b/test/dotnet-new3.UnitTests/FirstRunTest.cs
@@ -20,7 +20,7 @@ namespace dotnet_new3.UnitTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log)
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
+                .WithCustomHive(home)
                 .Execute()
                 .Should()
                 .ExitWith(0)
@@ -29,7 +29,7 @@ namespace dotnet_new3.UnitTests
                 .And.NotHaveStdOutContaining("Error");
 
             new DotnetNewCommand(_log, "--list")
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
+                .WithCustomHive(home)
                 .Execute()
                 .Should()
                 .ExitWith(0)

--- a/test/dotnet-new3.UnitTests/Helpers.cs
+++ b/test/dotnet-new3.UnitTests/Helpers.cs
@@ -14,8 +14,8 @@ namespace dotnet_new3.UnitTests
         internal static void InstallNuGetTemplate(string packageName, ITestOutputHelper log, string workingDirectory, string homeDirectory)
         {
             new DotnetNewCommand(log, "-i", packageName)
+                  .WithCustomHive()
                   .WithWorkingDirectory(workingDirectory)
-                  .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, homeDirectory)
                   .Execute()
                   .Should()
                   .ExitWith(0)
@@ -27,8 +27,8 @@ namespace dotnet_new3.UnitTests
         {
             string testTemplate = TestUtils.GetTestTemplateLocation(templateName);
             new DotnetNewCommand(log, "-i", testTemplate)
+                  .WithCustomHive(homeDirectory)
                   .WithWorkingDirectory(workingDirectory)
-                  .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, homeDirectory)
                   .Execute()
                   .Should()
                   .ExitWith(0)

--- a/test/dotnet-new3.UnitTests/PostActionTests.cs
+++ b/test/dotnet-new3.UnitTests/PostActionTests.cs
@@ -31,8 +31,8 @@ namespace dotnet_new3.UnitTests
             Helpers.InstallTestTemplate(templateLocation, _log, workingDirectory, home);
 
             new DotnetNewCommand(_log, templateName)
+                .WithCustomHive(home)
                 .WithWorkingDirectory(workingDirectory)
-                .WithEnvironmentVariable(TestUtils.HomeEnvironmentVariableName, home)
                 .Execute()
                 .Should()
                 .ExitWith(0)

--- a/test/dotnet-new3.UnitTests/Sdk/DotnetCommand.cs
+++ b/test/dotnet-new3.UnitTests/Sdk/DotnetCommand.cs
@@ -13,32 +13,6 @@ using Xunit.Abstractions;
 
 namespace Microsoft.NET.TestFramework.Commands
 {
-    public class DotnetNewCommand : TestCommand
-    {
-        public DotnetNewCommand(ITestOutputHelper log, params string[] args) : base(log)
-        {
-            // Set dotnet-new3.dll as first Argument to be passed to "dotnet"
-            // And use full path since we want to execute in any working directory
-            Arguments.Add(Path.GetFullPath("dotnet-new3.dll"));
-            Arguments.AddRange(args);
-        }
-
-        protected override SdkCommandSpec CreateCommand(IEnumerable<string> args)
-        {
-            var sdkCommandSpec = new SdkCommandSpec()
-            {
-                FileName = "dotnet",
-                Arguments = args.ToList(),
-                WorkingDirectory = WorkingDirectory
-            };
-            if (!_environment.ContainsKey(TestUtils.HomeEnvironmentVariableName))
-            {
-                throw new Exception($"{nameof(TestUtils.HomeEnvironmentVariableName)} is not set, call {nameof(DotnetNewCommand)}{nameof(WithEnvironmentVariable)} to set it.");
-            }
-            return sdkCommandSpec;
-        }
-    }
-
     public class DotnetCommand : TestCommand
     {
         private readonly string commandName;

--- a/test/dotnet-new3.UnitTests/SharedHomeDirectory.cs
+++ b/test/dotnet-new3.UnitTests/SharedHomeDirectory.cs
@@ -26,7 +26,6 @@ namespace dotnet_new3.UnitTests
         }
 
         public string HomeDirectory { get; } = TestUtils.CreateTemporaryFolder("Home");
-        public string HomeVariable { get; } = TestUtils.HomeEnvironmentVariableName;
 
         protected ITestOutputHelper Log { get; private set; }
 
@@ -48,7 +47,7 @@ namespace dotnet_new3.UnitTests
                 args.AddRange(new[] { "--nuget-source", nugetSource });
             }
             new DotnetNewCommand(Log, args.ToArray())
-                .WithEnvironmentVariable(HomeVariable, HomeDirectory)
+                .WithCustomHive(HomeDirectory)
                 .WithWorkingDirectory(workingDirectory)
                 .Execute()
                 .Should()
@@ -71,7 +70,7 @@ namespace dotnet_new3.UnitTests
             }
 
             new DotnetNewCommand(Log)
-                .WithEnvironmentVariable(HomeVariable, HomeDirectory)
+                .WithCustomHive(HomeDirectory)
                 .WithEnvironmentVariable("DN3", dn3Path)
                 .Execute()
                 .Should()


### PR DESCRIPTION
### Problem
Until now `--debug:custom-hive` represented only host+version specific folder, which meant that `packages.json` aka. user installed packages were outside this folder...

### Solution

With this change we custom-hive covers everything under `.templateengine` folder... We can stop using `HOME` environment variable for unit test and use `--debug:custom-hive` instead...

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)