### PR TITLE
Add "--debug:disable-sdk-templates"

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -197,6 +197,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                     Create.Option("--debug:emit-telemetry", string.Empty, Accept.NoArguments()),
                     Create.Option("--debug:custom-hive", string.Empty, Accept.ExactlyOneArgument()),
                     Create.Option("--debug:version", string.Empty, Accept.NoArguments()),
+                    Create.Option("--debug:disable-sdk-templates", string.Empty, Accept.NoArguments()),
 
                     Create.Option("--trace:authoring", string.Empty, Accept.NoArguments()),
                     Create.Option("--trace:install", string.Empty, Accept.NoArguments()),

--- a/src/dotnet-new3/BuiltInTemplatePackagesProvider.cs
+++ b/src/dotnet-new3/BuiltInTemplatePackagesProvider.cs
@@ -17,9 +17,11 @@ namespace dotnet_new3
     /// </summary>
     class BuiltInTemplatePackagesProviderFactory : ITemplatePackageProviderFactory
     {
+        public static readonly Guid FactoryId = new Guid("{3227D09D-C1EA-48F1-A33B-1F132BFD9F06}");
+
         public string DisplayName => "new3 BuiltIn";
 
-        public Guid Id { get; } = new Guid("{3227D09D-C1EA-48F1-A33B-1F132BFD9F06}");
+        public Guid Id => FactoryId;
 
         public ITemplatePackageProvider CreateProvider(IEngineEnvironmentSettings settings)
         {


### PR DESCRIPTION
### Problem
We don't have ability to uninstall SDK provided templates, this gives ability to at least disable whole provider.

### Solution
This is needed for aspnetcore repo, since we don't have ability to uninstall templates anymore, and they want to make sure that their local templates are installed.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)