### PR TITLE
Activator.CreateInstance can't create instance if constructor is not public

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/ChmodPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/ChmodPostActionProcessor.cs
@@ -12,10 +12,6 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 
         public Guid Id => ActionProcessorId;
 
-        internal ChmodPostActionProcessor()
-        {
-        }
-
         public bool Process(IEngineEnvironmentSettings environment, IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath)
         {
             bool allSucceeded = true;

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/DotnetRestorePostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/DotnetRestorePostActionProcessor.cs
@@ -13,10 +13,6 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 
         public Guid Id => ActionProcessorId;
 
-        internal DotnetRestorePostActionProcessor()
-        {
-        }
-
         public bool Process(IEngineEnvironmentSettings environment, IPostAction actionConfig, ICreationEffects2 creationEffects, ICreationResult templateCreationResult, string outputBasePath)
         {
             bool allSucceeded = true;

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/InstructionDisplayPostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/InstructionDisplayPostActionProcessor.cs
@@ -9,10 +9,6 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
 
         public Guid Id => ActionProcessorId;
 
-        internal InstructionDisplayPostActionProcessor()
-        {
-        }
-
         public bool Process(IEngineEnvironmentSettings settings, IPostAction actionConfig, ICreationResult templateCreationResult, string outputBasePath)
         {
             Console.WriteLine(string.Format(LocalizableStrings.PostActionDescription, actionConfig.Description));


### PR DESCRIPTION
### Problem
Will reported this:
```
dotnet new console
The template "Console Application" was created successfully.

 

Processing post-creation actions...
No parameterless constructor defined for type 'Microsoft.TemplateEngine.Cli.PostActionProcessors.DotnetRestorePostActionProcessor'.
```

### Solution
Problem was that constructor on that type is internal. I looked for other components as well.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)