### PR TITLE
Treat errors as warnings in VS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,7 @@
         <Product>Microsoft .NET Core</Product>
         <Copyright>$(CopyrightNetFoundation)</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <NoWarn>NU5105;NU5128;0419,0649</NoWarn>
     </PropertyGroup>
 


### PR DESCRIPTION
### Problem
Warnings are treated as errors in CI, but not in VS.

