### PR TITLE
Fixed random error in tests when downloading NuGet package

### DIFF
--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
         internal async Task GetCreationEffects_BasicTest_Package()
         {
             var bootstrapper = BootstrapperFactory.GetBootstrapper();
-            string packageLocation = _packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
+            string packageLocation = await _packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0").ConfigureAwait(false);
             await bootstrapper.InstallTemplateAsync(packageLocation).ConfigureAwait(false);
 
             string output = TestUtils.CreateTemporaryFolder();
@@ -99,7 +99,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
         internal async Task Create_BasicTest_Package()
         {
             var bootstrapper = BootstrapperFactory.GetBootstrapper();
-            string packageLocation = _packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
+            string packageLocation = await _packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0").ConfigureAwait(false);
             await bootstrapper.InstallTemplateAsync(packageLocation).ConfigureAwait(false);
 
             string output = TestUtils.CreateTemporaryFolder();

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/TemplatePackagesTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/TemplatePackagesTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
         internal async Task CanInstall_LocalNuGetPackage()
         {
             Bootstrapper bootstrapper = BootstrapperFactory.GetBootstrapper();
-            string packageLocation = _packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
+            string packageLocation = await _packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0").ConfigureAwait(false);
 
             InstallRequest installRequest = new InstallRequest(Path.GetFullPath(packageLocation));
 

--- a/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -15,6 +17,7 @@ using NuGet.Configuration;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.TestHelper
 {
@@ -36,7 +39,7 @@ namespace Microsoft.TemplateEngine.TestHelper
             return PackNuGetPackage(projectToPack);
         }
 
-        public string GetNuGetPackage(string templatePackName)
+        public string GetNuGetPackage(string templatePackName, ITestOutputHelper? log = null)
         {
             lock (string.Intern(templatePackName.ToLowerInvariant()))
             {
@@ -45,11 +48,24 @@ namespace Microsoft.TemplateEngine.TestHelper
                     return packagePath;
                 }
 
-                Task<string> downloadTask = DownloadPackageAsync(templatePackName);
-                downloadTask.Wait();
-                string downloadedPackage = downloadTask.Result;
-                _installedPackages[templatePackName] = downloadedPackage;
-                return downloadedPackage;
+                for (int retry = 0; retry < 5; retry++)
+                {
+                    try
+                    {
+                        Task<string> downloadTask = DownloadPackageAsync(templatePackName, log: log);
+                        downloadTask.Wait();
+                        string downloadedPackage = downloadTask.Result;
+                        _installedPackages[templatePackName] = downloadedPackage;
+                        return downloadedPackage;
+                    }
+                    catch (Exception ex)
+                    {
+                        log?.WriteLine($"[NuGet Package Manager] Download failed: package {templatePackName}, details: {ex}");
+                        //retry failed download
+                    }
+                    Task.Delay(1000);
+                }
+                throw new Exception($"Failed to download {templatePackName} after 5 retries");
             }
         }
 
@@ -94,7 +110,12 @@ namespace Microsoft.TemplateEngine.TestHelper
 
         public void Dispose() => Directory.Delete(_packageLocation, true);
 
-        private async Task<string> DownloadPackageAsync(string identifier, string version = null, IEnumerable<string> additionalSources = null, CancellationToken cancellationToken = default)
+        private async Task<string> DownloadPackageAsync(
+            string identifier,
+            string? version = null,
+            IEnumerable<string>? additionalSources = null,
+            ITestOutputHelper? log = null,
+            CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(identifier))
             {
@@ -109,12 +130,12 @@ namespace Microsoft.TemplateEngine.TestHelper
 
             if (string.IsNullOrWhiteSpace(version))
             {
-                (source, packageMetadata) = await GetLatestVersionInternalAsync(identifier, packagesSources, cancellationToken).ConfigureAwait(false);
+                (source, packageMetadata) = await GetLatestVersionInternalAsync(identifier, packagesSources, log, cancellationToken).ConfigureAwait(false);
             }
             else
             {
                 packageVersion = new NuGetVersion(version);
-                (source, packageMetadata) = await GetPackageMetadataAsync(identifier, packageVersion, packagesSources, cancellationToken).ConfigureAwait(false);
+                (source, packageMetadata) = await GetPackageMetadataAsync(identifier, packageVersion, packagesSources, log, cancellationToken).ConfigureAwait(false);
             }
 
             FindPackageByIdResource resource;
@@ -157,7 +178,11 @@ namespace Microsoft.TemplateEngine.TestHelper
             }
         }
 
-        private async Task<(PackageSource, IPackageSearchMetadata)> GetLatestVersionInternalAsync(string packageIdentifier, IEnumerable<PackageSource> packageSources, CancellationToken cancellationToken)
+        private async Task<(PackageSource, IPackageSearchMetadata)> GetLatestVersionInternalAsync(
+            string packageIdentifier,
+            IEnumerable<PackageSource> packageSources,
+            ITestOutputHelper? log = null,
+            CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(packageIdentifier))
             {
@@ -165,12 +190,12 @@ namespace Microsoft.TemplateEngine.TestHelper
             }
             _ = packageSources ?? throw new ArgumentNullException(nameof(packageSources));
 
-            (PackageSource source, IEnumerable<IPackageSearchMetadata> foundPackages)[] foundPackagesBySource =
+            (PackageSource source, IEnumerable<IPackageSearchMetadata>? foundPackages)[] foundPackagesBySource =
                 await Task.WhenAll(
-                    packageSources.Select(source => GetPackageMetadataAsync(source, packageIdentifier, includePrerelease: true, cancellationToken)))
+                    packageSources.Select(source => GetPackageMetadataAsync(source, packageIdentifier, includePrerelease: true, log, cancellationToken)))
                           .ConfigureAwait(false);
 
-            if (!foundPackagesBySource.Any())
+            if (!foundPackagesBySource.Where(result => result.foundPackages != null).Any())
             {
                 throw new Exception($"Failed to load NuGet sources {string.Join(";", packageSources.Select(source => source.Source))}");
             }
@@ -192,7 +217,12 @@ namespace Microsoft.TemplateEngine.TestHelper
             return latestVersion;
         }
 
-        private async Task<(PackageSource, IPackageSearchMetadata)> GetPackageMetadataAsync(string packageIdentifier, NuGetVersion packageVersion, IEnumerable<PackageSource> sources, CancellationToken cancellationToken)
+        private async Task<(PackageSource, IPackageSearchMetadata)> GetPackageMetadataAsync(
+            string packageIdentifier,
+            NuGetVersion packageVersion,
+            IEnumerable<PackageSource> sources,
+            ITestOutputHelper? log = null,
+            CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(packageIdentifier))
             {
@@ -204,7 +234,7 @@ namespace Microsoft.TemplateEngine.TestHelper
             bool atLeastOneSourceValid = false;
             using CancellationTokenSource linkedCts =
                       CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            var tasks = sources.Select(source => GetPackageMetadataAsync(source, packageIdentifier, includePrerelease: true, linkedCts.Token)).ToList();
+            var tasks = sources.Select(source => GetPackageMetadataAsync(source, packageIdentifier, includePrerelease: true, log, linkedCts.Token)).ToList();
             while (tasks.Any())
             {
                 var finishedTask = await Task.WhenAny(tasks).ConfigureAwait(false);
@@ -229,7 +259,12 @@ namespace Microsoft.TemplateEngine.TestHelper
             throw new Exception($"{packageIdentifier}, version: {packageVersion} is not found in {string.Join(";", sources.Select(source => source.Source))}");
         }
 
-        private async Task<(PackageSource source, IEnumerable<IPackageSearchMetadata> foundPackages)> GetPackageMetadataAsync(PackageSource source, string packageIdentifier, bool includePrerelease = false, CancellationToken cancellationToken = default)
+        private async Task<(PackageSource source, IEnumerable<IPackageSearchMetadata>? foundPackages)> GetPackageMetadataAsync(
+            PackageSource source,
+            string packageIdentifier,
+            bool includePrerelease = false,
+            ITestOutputHelper? log = null,
+            CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(packageIdentifier))
             {
@@ -237,16 +272,25 @@ namespace Microsoft.TemplateEngine.TestHelper
             }
             _ = source ?? throw new ArgumentNullException(nameof(source));
 
-            SourceRepository repository = Repository.Factory.GetCoreV3(source);
-            PackageMetadataResource resource = await repository.GetResourceAsync<PackageMetadataResource>(cancellationToken).ConfigureAwait(false);
-            IEnumerable<IPackageSearchMetadata> foundPackages = await resource.GetMetadataAsync(
-                packageIdentifier,
-                includePrerelease: includePrerelease,
-                includeUnlisted: false,
-                _cacheSettings,
-                _nugetLogger,
-                cancellationToken).ConfigureAwait(false);
-            return (source, foundPackages);
+            try
+            {
+                SourceRepository repository = Repository.Factory.GetCoreV3(source);
+                PackageMetadataResource resource = await repository.GetResourceAsync<PackageMetadataResource>(cancellationToken).ConfigureAwait(false);
+                IEnumerable<IPackageSearchMetadata> foundPackages = await resource.GetMetadataAsync(
+                    packageIdentifier,
+                    includePrerelease: includePrerelease,
+                    includeUnlisted: false,
+                    _cacheSettings,
+                    _nugetLogger,
+                    cancellationToken).ConfigureAwait(false);
+                return (source, foundPackages);
+            }
+            catch (Exception ex)
+            {
+                //ignore errors
+                log?.WriteLine($"Retrieving info from {source.Source} failed, details: {ex}");
+                return (source, null);
+            }
         }
 
         private IEnumerable<PackageSource> LoadNuGetSources(params string[] additionalSources)
@@ -265,7 +309,7 @@ namespace Microsoft.TemplateEngine.TestHelper
                 throw new Exception($"Failed to load NuGet sources configured for the folder {currentDirectory}", ex);
             }
 
-            if (!additionalSources?.Any() ?? true)
+            if (additionalSources == null || !additionalSources.Any())
             {
                 if (!defaultSources.Any())
                 {

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -6,6 +6,7 @@ using Microsoft.TemplateEngine.TestHelper;
 using System;
 using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -354,12 +355,12 @@ namespace dotnet_new3.IntegrationTests
         }
 
         [Fact]
-        public void InstallingSamePackageFromRemoteUpdatesLocal()
+        public async Task InstallingSamePackageFromRemoteUpdatesLocal()
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
 
             using var packageManager = new PackageManager();
-            string packageLocation = packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0", _log);
+            string packageLocation = await packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0", _log).ConfigureAwait(false);
 
             new DotnetNewCommand(_log, "-i", packageLocation)
                 .WithCustomHive(home)

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -359,7 +359,7 @@ namespace dotnet_new3.IntegrationTests
             var home = TestUtils.CreateTemporaryFolder("Home");
 
             using var packageManager = new PackageManager();
-            string packageLocation = packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0");
+            string packageLocation = packageManager.GetNuGetPackage("Microsoft.DotNet.Common.ProjectTemplates.5.0", _log);
 
             new DotnetNewCommand(_log, "-i", packageLocation)
                 .WithCustomHive(home)


### PR DESCRIPTION
### Problem
After recent changes the downloading of test package sometimes fails on windows

### Solution
added 5 retries on download
added logging on errors
in case failed to download info from NuGet source, it will be skipped 

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)