### PR TITLE
Include all `release/*` branches into AzureDevOps build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,18 +4,15 @@ trigger:
     include:
     - stabilize
     - main
-    - release/3*
-    - release/5*
-    - internal/release/3*
-    - internal/release/5*
+    - release/*
+    - internal/release/*
     - feature/*
 pr:
   branches:
     include:
     - stabilize
     - main
-    - release/3*
-    - release/5*
+    - release/*
     - feature/*
 
 variables:


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/pull/3064 is not building...

### Solution
We need this for .NET 6 branches, but eventually also 7...

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)