### PR TITLE
Fixes #2741: FirstRun can take long time because it needs to install/scan multiple packages, this could be done in parallel

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -21,7 +21,6 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         private readonly IEngineEnvironmentSettings _environmentSettings;
         private readonly Paths _paths;
         private IDictionary<string, ITemplate> _templateMemoryCache = new Dictionary<string, ITemplate>();
-        private Scanner _installScanner;
 
         public TemplateCache(IEngineEnvironmentSettings environmentSettings)
         {
@@ -49,24 +48,6 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
         [JsonProperty]
         public Dictionary<string, DateTime> MountPointsInfo { get; set; }
-
-        private Scanner InstallScanner
-        {
-            get
-            {
-                if (_installScanner == null)
-                {
-                    _installScanner = new Scanner(_environmentSettings);
-                }
-
-                return _installScanner;
-            }
-        }
-        public void Scan(string installDir)
-        {
-            ScanResult scanResult = InstallScanner.Scan(installDir);
-            AddTemplatesAndLangPacksFromScanResult(scanResult);
-        }
 
         public void DeleteAllLocaleCacheFiles()
         {
@@ -112,7 +93,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             WriteTemplateCache(mountPoints, mergedTemplateList, hasContentChanges);
         }
 
-        private void AddTemplatesAndLangPacksFromScanResult(ScanResult scanResult)
+        public void AddTemplatesAndLangPacksFromScanResult(ScanResult scanResult)
         {
             foreach (ILocalizationLocator locator in scanResult.Localizations)
             {


### PR DESCRIPTION
### Problem
#2741  First run of `dotnet new` is not as fast as it could be...

### Solution
This can save around 50% of time by doing it in parallel, primary because scanning is doing unzipping of .nupkg and parsing .json files

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)