### PR TITLE
Fixes #2717: Run template instantiation and check for updates in parallel

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1688,7 +1688,8 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to     install command: dotnet {0} -i {1}.
+        ///   Looks up a localized string similar to To update the package use: 
+        ///    dotnet {0} -i {1}.
         /// </summary>
         internal static string TemplatesPackageCoordinator_Update_Info_InstallCommand {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -494,7 +494,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
     <value>Could not find the template package containing template '{0}'</value>
   </data>
   <data name="TemplatesPackageCoordinator_Update_Info_InstallCommand" xml:space="preserve">
-    <value>    install command: dotnet {0} -i {1}</value>
+    <value>To update the package use: 
+    dotnet {0} -i {1}</value>
   </data>
   <data name="SearchOnlineNotification" xml:space="preserve">
     <value>Searching for the templates...</value>

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,23 +36,28 @@ namespace Microsoft.TemplateEngine.Cli
 
         internal async Task<CreationResultStatus> CoordinateInvocationOrAcquisitionAsync(ITemplateMatchInfo templateToInvoke, CancellationToken cancellationToken)
         {
-            // invoke and then check for updates
-            CreationResultStatus creationResult = await InvokeTemplateAsync(templateToInvoke).ConfigureAwait(false);
-            // check for updates on this template (pack)
-            await CheckForTemplateUpdateAsync(templateToInvoke, cancellationToken).ConfigureAwait(false);
-            return creationResult;
+            TemplatePackageCoordinator packageCoordinator = new TemplatePackageCoordinator(_telemetryLogger, _environment);
+
+            // start checking for updates
+            var checkForUpdateTask = packageCoordinator.CheckUpdateForTemplate(templateToInvoke.Info, _commandInput, cancellationToken);
+
+            // start creation of template
+            var templateCreationTask = InvokeTemplateAsync(templateToInvoke);
+
+            // await for both tasks to finish
+            await Task.WhenAll(checkForUpdateTask, templateCreationTask).ConfigureAwait(false);
+
+            // print if there is update for this template
+            packageCoordinator.DisplayUpdateCheckResults(checkForUpdateTask.Result, _commandInput, showUpdates: true);
+
+            // return creation result
+            return templateCreationTask.Result;
         }
 
         private Task<CreationResultStatus> InvokeTemplateAsync(ITemplateMatchInfo templateToInvoke)
         {
             TemplateInvoker invoker = new TemplateInvoker(_environment, _commandInput, _telemetryLogger, _commandName, _inputGetter, _callbacks);
             return invoker.InvokeTemplate(templateToInvoke);
-        }
-
-        private async Task CheckForTemplateUpdateAsync(ITemplateMatchInfo templateToInvoke, CancellationToken cancellationToken)
-        {
-            TemplatePackageCoordinator packageCoordinator = new TemplatePackageCoordinator(_telemetryLogger, _environment);
-            await packageCoordinator.CheckUpdateForTemplate(templateToInvoke.Info, _commandInput, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
@@ -47,8 +47,11 @@ namespace Microsoft.TemplateEngine.Cli
             // await for both tasks to finish
             await Task.WhenAll(checkForUpdateTask, templateCreationTask).ConfigureAwait(false);
 
-            // print if there is update for this template
-            packageCoordinator.DisplayUpdateCheckResults(checkForUpdateTask.Result, _commandInput, showUpdates: true);
+            if (checkForUpdateTask.Result != null)
+            {
+                // print if there is update for this template
+                packageCoordinator.DisplayUpdateCheckResult(checkForUpdateTask.Result, _commandInput);
+            }
 
             // return creation result
             return templateCreationTask.Result;

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -12,7 +14,6 @@ using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
 using Microsoft.TemplateEngine.Cli.HelpAndUsage;
 using Microsoft.TemplateEngine.Cli.NuGet;
-using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Edge.Template;
 using Microsoft.TemplateEngine.Utils;
@@ -32,7 +33,7 @@ namespace Microsoft.TemplateEngine.Cli
         internal TemplatePackageCoordinator(
             ITelemetryLogger telemetryLogger,
             IEngineEnvironmentSettings environmentSettings,
-            string defaultLanguage = null)
+            string? defaultLanguage = null)
         {
             _ = telemetryLogger ?? throw new ArgumentNullException(nameof(telemetryLogger));
             _ = environmentSettings ?? throw new ArgumentNullException(nameof(environmentSettings));
@@ -43,7 +44,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             _telemetryLogger = telemetryLogger;
             _engineEnvironmentSettings = environmentSettings;
-            _defaultLanguage = defaultLanguage;
+            _defaultLanguage = defaultLanguage!;
         }
 
         /// <summary>
@@ -99,13 +100,13 @@ namespace Microsoft.TemplateEngine.Cli
         }
 
         /// <summary>
-        /// Checks if there is an update for the package contiaing the <paramref name="template"/>.
+        /// Checks if there is an update for the package containing the <paramref name="template"/>.
         /// </summary>
         /// <param name="template">template to check the update for.</param>
         /// <param name="commandInput"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        internal async Task CheckUpdateForTemplate(ITemplateInfo template, INewCommandInput commandInput, CancellationToken cancellationToken = default)
+        internal async Task<IReadOnlyList<CheckUpdateResult>> CheckUpdateForTemplate(ITemplateInfo template, INewCommandInput commandInput, CancellationToken cancellationToken = default)
         {
             _ = template ?? throw new ArgumentNullException(nameof(template));
             _ = commandInput ?? throw new ArgumentNullException(nameof(commandInput));
@@ -119,19 +120,17 @@ namespace Microsoft.TemplateEngine.Cli
             catch (Exception)
             {
                 Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplatesPackageCoordinator_Error_PackageForTemplateNotFound, template.Identity));
-                return;
+                return Array.Empty<CheckUpdateResult>();
             }
 
-            IManagedTemplatePackage managedTemplatePackage = templatePackage as IManagedTemplatePackage;
-            if (managedTemplatePackage is null)
+            if (!(templatePackage is IManagedTemplatePackage managedTemplatePackage))
             {
                 //update is not supported - built-in or optional workload source
-                return;
+                return Array.Empty<CheckUpdateResult>();
             }
 
             InitializeNuGetCredentialService(commandInput);
-            IReadOnlyList<CheckUpdateResult> versionChecks = await managedTemplatePackage.ManagedProvider.GetLatestVersionsAsync(new[] { managedTemplatePackage }, cancellationToken).ConfigureAwait(false);
-            DisplayUpdateCheckResults(versionChecks, commandInput, showUpdates: true);
+            return await managedTemplatePackage.ManagedProvider.GetLatestVersionsAsync(new[] { managedTemplatePackage }, cancellationToken).ConfigureAwait(false);
         }
 
         private static void InitializeNuGetCredentialService(INewCommandInput commandInput)
@@ -180,7 +179,7 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 string[] splitByColons = installArg.Split(new[] { "::" }, StringSplitOptions.RemoveEmptyEntries);
                 string identifier = splitByColons[0];
-                string version = null;
+                string? version = null;
                 //'*' is placeholder for the latest version
                 if (splitByColons.Length > 1 && splitByColons[1] != "*")
                 {
@@ -286,7 +285,7 @@ namespace Microsoft.TemplateEngine.Cli
                         {
                             success = CreationResultStatus.CreateFailed;
                         }
-                        await DisplayInstallResultAsync(commandInput, updateResult.UpdateRequest.TemplatePackage?.DisplayName, updateResult, cancellationToken).ConfigureAwait(false);
+                        await DisplayInstallResultAsync(commandInput, updateResult.UpdateRequest.TemplatePackage.DisplayName, updateResult, cancellationToken).ConfigureAwait(false);
                     }
                 }
             }
@@ -462,7 +461,11 @@ namespace Microsoft.TemplateEngine.Cli
             });
         }
 
-        private void DisplayUpdateCheckResults(IEnumerable<CheckUpdateResult> versionCheckResults, INewCommandInput commandInput, bool showUpdates = true)
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "StyleCop.CSharp.OrderingRules",
+            "SA1202:Elements should be ordered by access",
+            Justification = "To make reviewing PR easier, will undo before merging.")]
+        internal void DisplayUpdateCheckResults(IEnumerable<CheckUpdateResult> versionCheckResults, INewCommandInput commandInput, bool showUpdates = true)
         {
             _ = versionCheckResults ?? throw new ArgumentNullException(nameof(versionCheckResults));
             _ = commandInput ?? throw new ArgumentNullException(nameof(commandInput));

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/test/dotnet-new3.UnitTests/DotnetNewCommand.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewCommand.cs
@@ -38,6 +38,18 @@ namespace Dotnet_new3.IntegrationTests
             return this;
         }
 
+        public DotnetNewCommand WithoutBuiltInTemplates()
+        {
+            Arguments.Add("--debug:disable-sdk-templates");
+            return this;
+        }
+
+        public DotnetNewCommand Quietly()
+        {
+            Arguments.Add("--quiet");
+            return this;
+        }
+
         protected override SdkCommandSpec CreateCommand(IEnumerable<string> args)
         {
             var sdkCommandSpec = new SdkCommandSpec()

--- a/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
@@ -73,5 +73,65 @@ namespace Dotnet_new3.IntegrationTests
                 .NotHaveStdErr()
                 .And.HaveStdOut("All template packages are up-to-date.");
         }
+
+        [Fact]
+        public void PrintInfoOnUpdateOnCreation()
+        {
+            var home = TestUtils.CreateTemporaryFolder("Home");
+            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
+                .WithCustomHive(home).WithoutBuiltInTemplates().Quietly()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And
+                .NotHaveStdErr()
+                .And.HaveStdOutContaining("Success:")
+                .And.HaveStdOutContaining("console")
+                .And.HaveStdOutContaining("classlib");
+
+            new DotnetNewCommand(_log, "console")
+                  .WithCustomHive(home).WithoutBuiltInTemplates()
+                  .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                  .Execute()
+                  .Should()
+                  .ExitWith(0)
+                  .And
+                  .NotHaveStdErr()
+                  .And.HaveStdOutContaining("The template \"Console Application\" was created successfully.")
+                  .And.HaveStdOutContaining("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0' is available")
+                  .And.HaveStdOutContaining("To update the package use:")
+                  .And.HaveStdOutMatching("    dotnet new3 -i Microsoft.DotNet.Common.ProjectTemplates.5.0::([\\d\\.a-z-])+");
+        }
+
+        [Fact]
+        public void DoesNotPrintUpdateInfoOnCreation_WhenLatestVersionIsInstalled()
+        {
+            var home = TestUtils.CreateTemporaryFolder("Home");
+            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0")
+                .WithCustomHive(home).WithoutBuiltInTemplates().Quietly()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And
+                .NotHaveStdErr()
+                .And.HaveStdOutContaining("Success:")
+                .And.HaveStdOutContaining("console")
+                .And.HaveStdOutContaining("classlib");
+
+            new DotnetNewCommand(_log, "console")
+                  .WithCustomHive(home).WithoutBuiltInTemplates()
+                  .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                  .Execute()
+                  .Should()
+                  .ExitWith(0)
+                  .And
+                  .NotHaveStdErr()
+                  .And.HaveStdOutContaining("The template \"Console Application\" was created successfully.")
+                  .And.NotHaveStdOutContaining("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0' is available")
+                  .And.NotHaveStdOutContaining("To update the package use:")
+                  .And.NotHaveStdOutMatching("    dotnet new3 -i Microsoft.DotNet.Common.ProjectTemplates.5.0::([\\d\\.a-z-])+");
+        }
     }
 }


### PR DESCRIPTION
### Problem
#2717 Before this PR we created template and only after that we started check if there is any update, this wastes 1 seconds... from whole `dotnet new someTemplate` execution...

### Solution
To prevent mixture on console output between update status and creation steps, I converted `TemplatePackageCoordinator.CheckUpdateForTemplate` to just return results and now `CoordinateInvocationOrAcquisitionAsync` calls `DisplayUpdateCheckResults` after...

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)