### PR TITLE
Fixes #3077: Relative --debug:custom-hive doesn't work anymore

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -171,6 +172,8 @@ namespace Microsoft.TemplateEngine.Cli
                     Reporter.Error.WriteLine("--debug:custom-hive requires 1 arg indicating the absolute or relative path to the custom hive".Bold().Red());
                     return 1;
                 }
+
+                hivePath = Path.GetFullPath(hivePath);
             }
 
             if (args.Length == 0)


### PR DESCRIPTION
### Problem
With recent changes with discovery and how we install and resolve things and how MountPointUri works, we can't handle relative path anymore for hive.

### Solution
As soon as we get `--debug:custom-hive` make sure its absolute.

### Checks:
- [ ] Added unit tests - will be added via https://github.com/dotnet/templating/issues/3053
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)