### PR TITLE
Install commands ux improvements

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInputExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInputExtensions.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.TemplateEngine.Cli.CommandParsing
+{
+    /// <summary>
+    /// Use these extensions to get examples of dotnet new commands.
+    /// </summary>
+    internal static class INewCommandInputExtensions
+    {
+        internal static string InstallCommandExample(this INewCommandInput command, bool withVersion = false,  string packageID = "", string version = "")
+        {
+            if (string.IsNullOrWhiteSpace(packageID))
+            {
+                return withVersion
+                    ? $"dotnet {command.CommandName} --install <PACKAGE_ID>::<VERSION>"
+                    : $"dotnet {command.CommandName} --install <PACKAGE_ID>";
+            }
+
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                return $"dotnet {command.CommandName} --install {packageID}";
+            }
+            else
+            {
+                return $"dotnet {command.CommandName} --install {packageID}::{version}";
+            }
+        }
+
+        internal static string UpdateApplyCommandExample(this INewCommandInput command)
+        {
+            return $"dotnet {command.CommandName} --update-apply";
+        }
+
+        internal static string ListCommandExample(this INewCommandInput command)
+        {
+            return $"dotnet {command.CommandName} --list";
+        }
+
+        internal static string UninstallCommandExample(this INewCommandInput command, string packageId = "", bool noArgs = false)
+        {
+            if (noArgs)
+            {
+                return $"dotnet {command.CommandName} --uninstall";
+            }
+
+            if (string.IsNullOrWhiteSpace(packageId))
+            {
+                return $"dotnet {command.CommandName} --uninstall <PACKAGE_ID>";
+            }
+            return $"dotnet {command.CommandName} --uninstall {packageId}";
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -518,6 +518,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Current.
+        /// </summary>
+        internal static string ColumnNameCurrentVersion {
+            get {
+                return ResourceManager.GetString("ColumnNameCurrentVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Identity.
         /// </summary>
         internal static string ColumnNameIdentity {
@@ -532,6 +541,15 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string ColumnNameLanguage {
             get {
                 return ResourceManager.GetString("ColumnNameLanguage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Latest.
+        /// </summary>
+        internal static string ColumnNameLatestVersion {
+            get {
+                return ResourceManager.GetString("ColumnNameLatestVersion", resourceCulture);
             }
         }
         
@@ -1382,6 +1400,312 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Could not find the template package containing template &apos;{0}&apos;.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Error_PackageForTemplateNotFound {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Error_PackageForTemplateNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} (contains {1} templates).
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Error_PackageNameContainsTemplates {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Error_PackageNameContainsTemplates", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The template package &apos;{0}&apos; is not found..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Error_PackageNotFound {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Error_PackageNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The template &apos;{0}&apos; is included to the packages:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Error_TemplateIncludedToPackages {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Error_TemplateIncludedToPackages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found no template packages to install..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The command is attempting to install the template package &apos;{0}&apos; twice, check the arguments and retry..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Install_Error_SameInstallRequests {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Install_Error_SameInstallRequests", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following template packages will be installed:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is already installed..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} could not be installed, download failed..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_lnstall_Error_DownloadFailed {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_lnstall_Error_DownloadFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} could not be installed..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_lnstall_Error_GenericError {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_lnstall_Error_GenericError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} could not be installed, no NuGet feeds are configured or they are invalid..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to install {0}, failed to uninstall previous version of the template package..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_lnstall_Error_InvalidPackage {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_lnstall_Error_InvalidPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} could not be installed, the package does not exist..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_lnstall_Error_PackageNotFound {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_lnstall_Error_PackageNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to install {0}, the template package is invalid..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_lnstall_Error_UninstallFailed {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_lnstall_Error_UninstallFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is not supported..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Success: {0} installed the following templates:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_lnstall_Info_Success {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_lnstall_Info_Success", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to uninstall {0}, reason: {1}..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Uninstall_Error_GenericError {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Uninstall_Error_GenericError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To list installed template packages use:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To uninstall the template package use:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Details:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Uninstall_Info_DetailsHeader {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Uninstall_Info_DetailsHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Currently installed items:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Uninstall_Info_InstalledItems {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Uninstall_Info_InstalledItems", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Success: {0} was uninstalled..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Uninstall_Info_Success {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Uninstall_Info_Success", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uninstall Command:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to check update for {0}: {1}..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Update_Error_GenericError {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Update_Error_GenericError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to check update for {0}: no NuGet feeds are configured or they are invalid..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to check update for {0}: the package is not available in configured NuGet feeds..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Update_Error_PackageNotFound {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Update_Error_PackageNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to check update for {0}: the package is not supported..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Update_Error_PackageNotSupported {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Update_Error_PackageNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All template packages are up-to-date..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following template packages will be updated:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To update all the packages use:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An update for template package &apos;{0}&apos; is available..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Update_Info_UpdateAvailable {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Update_Info_UpdateAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An update for template packages is available:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To update the package use:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to initialize NuGet credential service, details: {0}..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [Warning]: Failed to parse input for template {0}, it will be skipped from further processing..
         /// </summary>
         internal static string TemplateResolver_Warning_FailedToReparseTemplate {
@@ -1414,313 +1738,6 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string TemplatesNotValidGivenTheSpecifiedFilter {
             get {
                 return ResourceManager.GetString("TemplatesNotValidGivenTheSpecifiedFilter", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Could not find the template package containing template &apos;{0}&apos;.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Error_PackageForTemplateNotFound {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Error_PackageForTemplateNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to   {0} (contains {1} templates).
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Error_PackageNameContainsTemplates {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Error_PackageNameContainsTemplates", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The template package &apos;{0}&apos; is not found.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Error_PackageNotFound {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Error_PackageNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The template &apos;{0}&apos; is included to the packages:.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Error_TemplateIncludedToPackages {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Error_TemplateIncludedToPackages", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to   {0}.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Info_PackageName {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Info_PackageName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to   {0}, version: {1}.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Info_PackageNameVersion {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Info_PackageNameVersion", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Found no template packages to install.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The command is attempting to install the template package &apos;{0}&apos; twice, check the arguments and retry..
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Install_Error_SameInstallRequests {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Install_Error_SameInstallRequests", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The following template packages will be installed:.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} is already installed.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} could not be installed, download failed.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_lnstall_Error_DownloadFailed {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_DownloadFailed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} could not be installed.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_lnstall_Error_GenericError {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_GenericError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} could not be installed, no NuGet feeds are configured or they are invalid.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to install {0}, failed to uninstall previous version of the template package.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_lnstall_Error_InvalidPackage {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_InvalidPackage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} could not be installed, the package does not exist.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_lnstall_Error_PackageNotFound {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_PackageNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to install {0}, the template package is invalid.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_lnstall_Error_UninstallFailed {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_UninstallFailed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0} is not supported.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Success: {0} installed the following templates:.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_lnstall_Info_Success {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_lnstall_Info_Success", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to uninstall {0}, reason: {1}..
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Uninstall_Error_GenericError {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Error_GenericError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to To list installed template packages, use dotnet {0} -u.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to To uninstall the template package, use dotnet {0} -u {1}.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Details:.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Currently installed items:.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Uninstall_Info_InstalledItems {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Info_InstalledItems", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Success: {0} was uninstalled..
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Uninstall_Info_Success {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Info_Success", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Uninstall Command:.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to check update for {0}: {1}..
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Update_Error_GenericError {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Error_GenericError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to check update for {0}: no NuGet feeds are configured or they are invalid..
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to check update for {0}: the package is not available in configured NuGet feeds..
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Update_Error_PackageNotFound {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Error_PackageNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to check update for {0}: the package is not supported..
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Update_Error_PackageNotSupported {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Error_PackageNotSupported", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to All template packages are up-to-date..
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to To update the package use: 
-        ///    dotnet {0} -i {1}.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Update_Info_InstallCommand {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Info_InstallCommand", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The following template packages will be updated:.
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to An update for template package &apos;{0}&apos; is available..
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Update_Info_UpdateAvailable {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Update_Info_UpdateAvailable", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Failed to initialize NuGet credential service, details: {0}..
-        /// </summary>
-        internal static string TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError {
-            get {
-                return ResourceManager.GetString("TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1688,7 +1688,8 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to     install command: dotnet {0} -i {1}.
+        ///   Looks up a localized string similar to To update the package use: 
+        ///    dotnet {0} -i {1}.
         /// </summary>
         internal static string TemplatesPackageCoordinator_Update_Info_InstallCommand {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -256,7 +256,7 @@
   <data name="UnknownChangeKind" xml:space="preserve">
     <value>Unknown Change</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Update_Info_UpdateAvailable" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Update_Info_UpdateAvailable" xml:space="preserve">
     <value>An update for template package '{0}' is available.</value>
   </data>
   <data name="NoPrimaryOutputsToRestore" xml:space="preserve">
@@ -323,7 +323,7 @@
   <data name="UninstallHelp" xml:space="preserve">
     <value>Uninstalls a source or a template package.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Uninstall_Error_GenericError" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Uninstall_Error_GenericError" xml:space="preserve">
     <value>Failed to uninstall {0}, reason: {1}.</value>
   </data>
   <data name="InvalidParameterDefault" xml:space="preserve">
@@ -445,7 +445,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="Version" xml:space="preserve">
     <value>Version:</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Uninstall_Info_InstalledItems" xml:space="preserve">
     <value>Currently installed items:</value>
   </data>
   <data name="SettingsReadError" xml:space="preserve">
@@ -484,18 +484,14 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="CouldntDetermineFilesToRestore" xml:space="preserve">
     <value>Couldn't determine files to restore.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader" xml:space="preserve">
     <value>Details:</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint" xml:space="preserve">
     <value>Uninstall Command:</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Error_PackageForTemplateNotFound" xml:space="preserve">
     <value>Could not find the template package containing template '{0}'</value>
-  </data>
-  <data name="TemplatesPackageCoordinator_Update_Info_InstallCommand" xml:space="preserve">
-    <value>To update the package use: 
-    dotnet {0} -i {1}</value>
   </data>
   <data name="SearchOnlineNotification" xml:space="preserve">
     <value>Searching for the templates...</value>
@@ -614,20 +610,20 @@ Examples:
   <data name="AmbiguousLanguageHint" xml:space="preserve">
     <value>Re-run the command specifying the language to use with --language option.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed" xml:space="preserve">
-    <value>{0} could not be installed, download failed</value>
+  <data name="TemplatePackageCoordinator_lnstall_Error_DownloadFailed" xml:space="preserve">
+    <value>{0} could not be installed, download failed.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_lnstall_Error_GenericError" xml:space="preserve">
-    <value>{0} could not be installed</value>
+  <data name="TemplatePackageCoordinator_lnstall_Error_GenericError" xml:space="preserve">
+    <value>{0} could not be installed.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds" xml:space="preserve">
-    <value>{0} could not be installed, no NuGet feeds are configured or they are invalid</value>
+  <data name="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds" xml:space="preserve">
+    <value>{0} could not be installed, no NuGet feeds are configured or they are invalid.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound" xml:space="preserve">
-    <value>{0} could not be installed, the package does not exist</value>
+  <data name="TemplatePackageCoordinator_lnstall_Error_PackageNotFound" xml:space="preserve">
+    <value>{0} could not be installed, the package does not exist.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest" xml:space="preserve">
-    <value>{0} is not supported</value>
+  <data name="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest" xml:space="preserve">
+    <value>{0} is not supported.</value>
   </data>
   <data name="GenericError" xml:space="preserve">
     <value>Error: {0}</value>
@@ -638,70 +634,64 @@ Examples:
   <data name="OptionDescriptionTagFilter" xml:space="preserve">
     <value>Filters the templates based on the tag. Applies to --search and --list.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates" xml:space="preserve">
-    <value>  {0} (contains {1} templates)</value>
+  <data name="TemplatePackageCoordinator_Error_PackageNameContainsTemplates" xml:space="preserve">
+    <value>{0} (contains {1} templates)</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Error_PackageNotFound" xml:space="preserve">
-    <value>The template package '{0}' is not found</value>
+  <data name="TemplatePackageCoordinator_Error_PackageNotFound" xml:space="preserve">
+    <value>The template package '{0}' is not found.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Error_TemplateIncludedToPackages" xml:space="preserve">
     <value>The template '{0}' is included to the packages:</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Info_PackageName" xml:space="preserve">
-    <value>  {0}</value>
+  <data name="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall" xml:space="preserve">
+    <value>Found no template packages to install.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Info_PackageNameVersion" xml:space="preserve">
-    <value>  {0}, version: {1}</value>
-  </data>
-  <data name="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall" xml:space="preserve">
-    <value>Found no template packages to install</value>
-  </data>
-  <data name="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled" xml:space="preserve">
     <value>The following template packages will be installed:</value>
   </data>
-  <data name="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled" xml:space="preserve">
-    <value>{0} is already installed</value>
+  <data name="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled" xml:space="preserve">
+    <value>{0} is already installed.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage" xml:space="preserve">
-    <value>Failed to install {0}, failed to uninstall previous version of the template package</value>
+  <data name="TemplatePackageCoordinator_lnstall_Error_InvalidPackage" xml:space="preserve">
+    <value>Failed to install {0}, failed to uninstall previous version of the template package.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed" xml:space="preserve">
-    <value>Failed to install {0}, the template package is invalid</value>
+  <data name="TemplatePackageCoordinator_lnstall_Error_UninstallFailed" xml:space="preserve">
+    <value>Failed to install {0}, the template package is invalid.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_lnstall_Info_Success" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_lnstall_Info_Success" xml:space="preserve">
     <value>Success: {0} installed the following templates:</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint" xml:space="preserve">
-    <value>To list installed template packages, use dotnet {0} -u</value>
+  <data name="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader" xml:space="preserve">
+    <value>To list installed template packages use:</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint" xml:space="preserve">
-    <value>To uninstall the template package, use dotnet {0} -u {1}</value>
+  <data name="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader" xml:space="preserve">
+    <value>To uninstall the template package use:</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Uninstall_Info_Success" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Uninstall_Info_Success" xml:space="preserve">
     <value>Success: {0} was uninstalled.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Update_Error_GenericError" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Update_Error_GenericError" xml:space="preserve">
     <value>Failed to check update for {0}: {1}.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds" xml:space="preserve">
     <value>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Update_Error_PackageNotFound" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Update_Error_PackageNotFound" xml:space="preserve">
     <value>Failed to check update for {0}: the package is not available in configured NuGet feeds.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Update_Error_PackageNotSupported" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Update_Error_PackageNotSupported" xml:space="preserve">
     <value>Failed to check update for {0}: the package is not supported.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate" xml:space="preserve">
     <value>All template packages are up-to-date.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated" xml:space="preserve">
     <value>The following template packages will be updated:</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError" xml:space="preserve">
     <value>Failed to initialize NuGet credential service, details: {0}.</value>
   </data>
-  <data name="TemplatesPackageCoordinator_Install_Error_SameInstallRequests" xml:space="preserve">
+  <data name="TemplatePackageCoordinator_Install_Error_SameInstallRequests" xml:space="preserve">
     <value>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</value>
   </data>
   <data name="Generic_Details" xml:space="preserve">
@@ -709,5 +699,20 @@ Examples:
   </data>
   <data name="TemplateResolver_Warning_FailedToReparseTemplate" xml:space="preserve">
     <value>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</value>
+  </data>
+  <data name="ColumnNameCurrentVersion" xml:space="preserve">
+    <value>Current</value>
+  </data>
+  <data name="ColumnNameLatestVersion" xml:space="preserve">
+    <value>Latest</value>
+  </data>
+  <data name="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader" xml:space="preserve">
+    <value>To update all the packages use:</value>
+  </data>
+  <data name="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages" xml:space="preserve">
+    <value>An update for template packages is available:</value>
+  </data>
+  <data name="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader" xml:space="preserve">
+    <value>To update the package use:</value>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -494,7 +494,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
     <value>Could not find the template package containing template '{0}'</value>
   </data>
   <data name="TemplatesPackageCoordinator_Update_Info_InstallCommand" xml:space="preserve">
-    <value>    install command: dotnet {0} -i {1}</value>
+    <value>To update the package use: 
+    dotnet {0} -i {1}</value>
   </data>
   <data name="SearchOnlineNotification" xml:space="preserve">
     <value>Searching for the templates...</value>

--- a/src/Microsoft.TemplateEngine.Cli/ReporterExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/ReporterExtensions.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.TemplateEngine.Cli
+{
+    internal static class ReporterExtensions
+    {
+        private const int IndentSpaceCount = 3;
+
+        /// <summary>
+        /// Writes string formatted as command example. For now, just indentation is applied.
+        /// The extension forces the same format for all command examples.
+        /// </summary>
+        /// <param name="command"></param>
+        internal static void WriteCommand(this Reporter reporter, string command, int indentLevel = 0)
+        {
+            reporter.WriteLine(command.Indent(indentLevel + 1));
+        }
+
+        /// <summary>
+        /// Indents string, use this method to unify indents in the output.
+        /// </summary>
+        /// <param name="s">string to indent.</param>
+        /// <param name="level">indent level.</param>
+        /// <returns></returns>
+        internal static string Indent(this string s, int level = 1)
+        {
+            return new string(' ', IndentSpaceCount * level) + s;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,23 +36,28 @@ namespace Microsoft.TemplateEngine.Cli
 
         internal async Task<CreationResultStatus> CoordinateInvocationOrAcquisitionAsync(ITemplateMatchInfo templateToInvoke, CancellationToken cancellationToken)
         {
-            // invoke and then check for updates
-            CreationResultStatus creationResult = await InvokeTemplateAsync(templateToInvoke).ConfigureAwait(false);
-            // check for updates on this template (pack)
-            await CheckForTemplateUpdateAsync(templateToInvoke, cancellationToken).ConfigureAwait(false);
-            return creationResult;
+            TemplatePackageCoordinator packageCoordinator = new TemplatePackageCoordinator(_telemetryLogger, _environment);
+
+            // start checking for updates
+            var checkForUpdateTask = packageCoordinator.CheckUpdateForTemplate(templateToInvoke.Info, _commandInput, cancellationToken);
+
+            // start creation of template
+            var templateCreationTask = InvokeTemplateAsync(templateToInvoke);
+
+            // await for both tasks to finish
+            await Task.WhenAll(checkForUpdateTask, templateCreationTask).ConfigureAwait(false);
+
+            // print if there is update for this template
+            packageCoordinator.DisplayUpdateCheckResults(checkForUpdateTask.Result, _commandInput, showUpdates: true);
+
+            // return creation result
+            return templateCreationTask.Result;
         }
 
         private Task<CreationResultStatus> InvokeTemplateAsync(ITemplateMatchInfo templateToInvoke)
         {
             TemplateInvoker invoker = new TemplateInvoker(_environment, _commandInput, _telemetryLogger, _commandName, _inputGetter, _callbacks);
             return invoker.InvokeTemplate(templateToInvoke);
-        }
-
-        private async Task CheckForTemplateUpdateAsync(ITemplateMatchInfo templateToInvoke, CancellationToken cancellationToken)
-        {
-            TemplatePackageCoordinator packageCoordinator = new TemplatePackageCoordinator(_telemetryLogger, _environment);
-            await packageCoordinator.CheckUpdateForTemplate(templateToInvoke.Info, _commandInput, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
@@ -47,8 +47,11 @@ namespace Microsoft.TemplateEngine.Cli
             // await for both tasks to finish
             await Task.WhenAll(checkForUpdateTask, templateCreationTask).ConfigureAwait(false);
 
-            // print if there is update for this template
-            packageCoordinator.DisplayUpdateCheckResults(checkForUpdateTask.Result, _commandInput, showUpdates: true);
+            if (checkForUpdateTask.Result != null)
+            {
+                // print if there is update for this template
+                packageCoordinator.DisplayUpdateCheckResult(checkForUpdateTask.Result, _commandInput);
+            }
 
             // return creation result
             return templateCreationTask.Result;

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -266,6 +266,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
         <target state="new">Author</target>
         <note />
       </trans-unit>
+      <trans-unit id="ColumnNameCurrentVersion">
+        <source>Current</source>
+        <target state="new">Current</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ColumnNameIdentity">
         <source>Identity</source>
         <target state="new">Identity</target>
@@ -274,6 +279,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</target>
       <trans-unit id="ColumnNameLanguage">
         <source>Language</source>
         <target state="new">Language</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ColumnNameLatestVersion">
+        <source>Latest</source>
+        <target state="new">Latest</target>
         <note />
       </trans-unit>
       <trans-unit id="ColumnNamePackage">
@@ -759,6 +769,176 @@ Examples:
         <target state="new">The following option(s) or their value(s) are not valid in combination with other supplied options or their values:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
+        <source>Could not find the template package containing template '{0}'</source>
+        <target state="new">Could not find the template package containing template '{0}'</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNameContainsTemplates">
+        <source>{0} (contains {1} templates)</source>
+        <target state="new">{0} (contains {1} templates)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_PackageNotFound">
+        <source>The template package '{0}' is not found.</source>
+        <target state="new">The template package '{0}' is not found.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Error_TemplateIncludedToPackages">
+        <source>The template '{0}' is included to the packages:</source>
+        <target state="new">The template '{0}' is included to the packages:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_FoundNoPackagesToInstall">
+        <source>Found no template packages to install.</source>
+        <target state="new">Found no template packages to install.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Error_SameInstallRequests">
+        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
+        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
+        <source>The following template packages will be installed:</source>
+        <target state="new">The following template packages will be installed:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
+        <source>Failed to uninstall {0}, reason: {1}.</source>
+        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_ListPackagesHeader">
+        <source>To list installed template packages use:</source>
+        <target state="new">To list installed template packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_UninstallCommandHeader">
+        <source>To uninstall the template package use:</source>
+        <target state="new">To uninstall the template package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_DetailsHeader">
+        <source>Details:</source>
+        <target state="new">Details:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_InstalledItems">
+        <source>Currently installed items:</source>
+        <target state="new">Currently installed items:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_Success">
+        <source>Success: {0} was uninstalled.</source>
+        <target state="new">Success: {0} was uninstalled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint">
+        <source>Uninstall Command:</source>
+        <target state="new">Uninstall Command:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_GenericError">
+        <source>Failed to check update for {0}: {1}.</source>
+        <target state="new">Failed to check update for {0}: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_InvalidNuGetFeeds">
+        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotFound">
+        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
+        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Error_PackageNotSupported">
+        <source>Failed to check update for {0}: the package is not supported.</source>
+        <target state="new">Failed to check update for {0}: the package is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_AllPackagesAreUpToDate">
+        <source>All template packages are up-to-date.</source>
+        <target state="new">All template packages are up-to-date.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_PackagesToBeUpdated">
+        <source>The following template packages will be updated:</source>
+        <target state="new">The following template packages will be updated:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAllCommandHeader">
+        <source>To update all the packages use:</source>
+        <target state="new">To update all the packages use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailable">
+        <source>An update for template package '{0}' is available.</source>
+        <target state="new">An update for template package '{0}' is available.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateAvailablePackages">
+        <source>An update for template packages is available:</source>
+        <target state="new">An update for template packages is available:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader">
+        <source>To update the package use:</source>
+        <target state="new">To update the package use:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Verbose_NuGetCredentialServiceError">
+        <source>Failed to initialize NuGet credential service, details: {0}.</source>
+        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_AlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_DownloadFailed">
+        <source>{0} could not be installed, download failed.</source>
+        <target state="new">{0} could not be installed, download failed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_GenericError">
+        <source>{0} could not be installed.</source>
+        <target state="new">{0} could not be installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
+        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid.</source>
+        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_InvalidPackage">
+        <source>Failed to install {0}, failed to uninstall previous version of the template package.</source>
+        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_PackageNotFound">
+        <source>{0} could not be installed, the package does not exist.</source>
+        <target state="new">{0} could not be installed, the package does not exist.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UninstallFailed">
+        <source>Failed to install {0}, the template package is invalid.</source>
+        <target state="new">Failed to install {0}, the template package is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Error_UnsupportedRequest">
+        <source>{0} is not supported.</source>
+        <target state="new">{0} is not supported.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Info_Success">
+        <source>Success: {0} installed the following templates:</source>
+        <target state="new">Success: {0} installed the following templates:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>
@@ -777,178 +957,6 @@ Examples:
       <trans-unit id="TemplatesNotValidGivenTheSpecifiedFilter">
         <source>{0} template(s) partially matched, but failed on {1}.</source>
         <target state="new">{0} template(s) partially matched, but failed on {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageForTemplateNotFound">
-        <source>Could not find the template package containing template '{0}'</source>
-        <target state="new">Could not find the template package containing template '{0}'</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNameContainsTemplates">
-        <source>  {0} (contains {1} templates)</source>
-        <target state="new">  {0} (contains {1} templates)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_PackageNotFound">
-        <source>The template package '{0}' is not found</source>
-        <target state="new">The template package '{0}' is not found</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Error_TemplateIncludedToPackages">
-        <source>The template '{0}' is included to the packages:</source>
-        <target state="new">The template '{0}' is included to the packages:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageName">
-        <source>  {0}</source>
-        <target state="new">  {0}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Info_PackageNameVersion">
-        <source>  {0}, version: {1}</source>
-        <target state="new">  {0}, version: {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_FoundNoPackagesToInstall">
-        <source>Found no template packages to install</source>
-        <target state="new">Found no template packages to install</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Error_SameInstallRequests">
-        <source>The command is attempting to install the template package '{0}' twice, check the arguments and retry.</source>
-        <target state="new">The command is attempting to install the template package '{0}' twice, check the arguments and retry.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Install_Info_PackagesToBeInstalled">
-        <source>The following template packages will be installed:</source>
-        <target state="new">The following template packages will be installed:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_GenericError">
-        <source>Failed to uninstall {0}, reason: {1}.</source>
-        <target state="new">Failed to uninstall {0}, reason: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_ListPackagesHint">
-        <source>To list installed template packages, use dotnet {0} -u</source>
-        <target state="new">To list installed template packages, use dotnet {0} -u</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Error_UninstallCommandHint">
-        <source>To uninstall the template package, use dotnet {0} -u {1}</source>
-        <target state="new">To uninstall the template package, use dotnet {0} -u {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_DetailsHeader">
-        <source>Details:</source>
-        <target state="new">Details:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_InstalledItems">
-        <source>Currently installed items:</source>
-        <target state="new">Currently installed items:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_Success">
-        <source>Success: {0} was uninstalled.</source>
-        <target state="new">Success: {0} was uninstalled.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Uninstall_Info_UninstallCommandHint">
-        <source>Uninstall Command:</source>
-        <target state="new">Uninstall Command:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_GenericError">
-        <source>Failed to check update for {0}: {1}.</source>
-        <target state="new">Failed to check update for {0}: {1}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_InvalidNuGetFeeds">
-        <source>Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</source>
-        <target state="new">Failed to check update for {0}: no NuGet feeds are configured or they are invalid.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotFound">
-        <source>Failed to check update for {0}: the package is not available in configured NuGet feeds.</source>
-        <target state="new">Failed to check update for {0}: the package is not available in configured NuGet feeds.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Error_PackageNotSupported">
-        <source>Failed to check update for {0}: the package is not supported.</source>
-        <target state="new">Failed to check update for {0}: the package is not supported.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_AllPackagesAreUpToDate">
-        <source>All template packages are up-to-date.</source>
-        <target state="new">All template packages are up-to-date.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>To update the package use: 
-    dotnet {0} -i {1}</source>
-        <target state="new">To update the package use: 
-    dotnet {0} -i {1}</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">
-        <source>The following template packages will be updated:</source>
-        <target state="new">The following template packages will be updated:</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Update_Info_UpdateAvailable">
-        <source>An update for template package '{0}' is available.</source>
-        <target state="new">An update for template package '{0}' is available.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_Verbose_NuGetCredentialServiceError">
-        <source>Failed to initialize NuGet credential service, details: {0}.</source>
-        <target state="new">Failed to initialize NuGet credential service, details: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_AlreadyInstalled">
-        <source>{0} is already installed</source>
-        <target state="new">{0} is already installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_DownloadFailed">
-        <source>{0} could not be installed, download failed</source>
-        <target state="new">{0} could not be installed, download failed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_GenericError">
-        <source>{0} could not be installed</source>
-        <target state="new">{0} could not be installed</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidNuGetFeeds">
-        <source>{0} could not be installed, no NuGet feeds are configured or they are invalid</source>
-        <target state="new">{0} could not be installed, no NuGet feeds are configured or they are invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_InvalidPackage">
-        <source>Failed to install {0}, failed to uninstall previous version of the template package</source>
-        <target state="new">Failed to install {0}, failed to uninstall previous version of the template package</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_PackageNotFound">
-        <source>{0} could not be installed, the package does not exist</source>
-        <target state="new">{0} could not be installed, the package does not exist</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UninstallFailed">
-        <source>Failed to install {0}, the template package is invalid</source>
-        <target state="new">Failed to install {0}, the template package is invalid</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Error_UnsupportedRequest">
-        <source>{0} is not supported</source>
-        <target state="new">{0} is not supported</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="TemplatesPackageCoordinator_lnstall_Info_Success">
-        <source>Success: {0} installed the following templates:</source>
-        <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
       <trans-unit id="ThirdPartyNotices">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -885,8 +885,10 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_InstallCommand">
-        <source>    install command: dotnet {0} -i {1}</source>
-        <target state="new">    install command: dotnet {0} -i {1}</target>
+        <source>To update the package use: 
+    dotnet {0} -i {1}</source>
+        <target state="new">To update the package use: 
+    dotnet {0} -i {1}</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatesPackageCoordinator_Update_Info_PackagesToBeUpdated">

--- a/test/dotnet-new3.UnitTests/DotnetNewCommand.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewCommand.cs
@@ -38,6 +38,18 @@ namespace Dotnet_new3.IntegrationTests
             return this;
         }
 
+        public DotnetNewCommand WithoutBuiltInTemplates()
+        {
+            Arguments.Add("--debug:disable-sdk-templates");
+            return this;
+        }
+
+        public DotnetNewCommand Quietly()
+        {
+            Arguments.Add("--quiet");
+            return this;
+        }
+
         protected override SdkCommandSpec CreateCommand(IEnumerable<string> args)
         {
             var sdkCommandSpec = new SdkCommandSpec()

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -1,7 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
+#nullable enable
+
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -87,7 +88,7 @@ namespace Dotnet_new3.IntegrationTests
                 .NotHaveStdErr()
                 .And.NotHaveStdOutContaining("Determining projects to restore...")
                 .And.HaveStdOutContaining("The following template packages will be installed:")
-                .And.HaveStdOutContaining("Microsoft.DotNet.Web.ProjectTemplates.5.0, version: 5.0.0")
+                .And.HaveStdOutContaining("Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0")
                 .And.HaveStdOutContaining($"Success: Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0 installed the following templates:")
                 .And.HaveStdOutContaining("web")
                 .And.HaveStdOutContaining("blazorwasm");
@@ -333,7 +334,7 @@ namespace Dotnet_new3.IntegrationTests
                  .Should().ExitWith(0)
                  .And.NotHaveStdErr()
                  .And.HaveStdOutContaining("The following template packages will be installed:")
-                 .And.HaveStdOutContaining("Microsoft.DotNet.Common.ProjectTemplates.5.0, version: 5.0.1")
+                 .And.HaveStdOutContaining("Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.1")
                  .And.HaveStdOutContaining("Microsoft.DotNet.Common.ProjectTemplates.5.0 is already installed, version: 5.0.0, it will be replaced with version 5.0.1")
                  .And.HaveStdOutContaining("Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0 was successfully uninstalled")
                  .And.HaveStdOutContaining($"Success: Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.1 installed the following templates:")
@@ -390,7 +391,7 @@ namespace Dotnet_new3.IntegrationTests
                 .Should().ExitWith(0)
                 .And.NotHaveStdErr()
                 .And.HaveStdOutContaining("The following template packages will be installed:")
-                .And.HaveStdOutContaining("Microsoft.DotNet.Common.ProjectTemplates.5.0, version: 5.0.0")
+                .And.HaveStdOutContaining("Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
                 .And.HaveStdOutMatching("Microsoft\\.DotNet\\.Common\\.ProjectTemplates\\.5\\.0 is already installed, version: ([\\d\\.a-z-])+, it will be replaced with version 5\\.0\\.0")
                 .And.HaveStdOutMatching("Microsoft\\.DotNet\\.Common\\.ProjectTemplates\\.5\\.0::([\\d\\.a-z-])+ was successfully uninstalled")
                 .And.HaveStdOutContaining($"Success: Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0 installed the following templates:")
@@ -412,12 +413,8 @@ namespace Dotnet_new3.IntegrationTests
         public void CanExpandWhenInstall()
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
-            var outputFolder = TestUtils.CreateTemporaryFolder();
-
             string codebase = typeof(Program).GetTypeInfo().Assembly.Location;
-            Uri cb = new Uri(codebase);
-            string asmPath = cb.LocalPath;
-            string dir = Path.GetDirectoryName(asmPath);
+            string dir = Path.GetDirectoryName(codebase) ?? throw new System.Exception("Invalid assembly location");
             string testTemplateLocation = Path.Combine(dir, "..", "..", "..", "..", "..", "test", "Microsoft.TemplateEngine.TestTemplates", "test_templates");
             string testTemplateLocationAbsolute = Path.GetFullPath(testTemplateLocation);
             string pattern = testTemplateLocation + Path.DirectorySeparatorChar + "*";

--- a/test/dotnet-new3.UnitTests/DotnetNewUpdateApply.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUpdateApply.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using FluentAssertions;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.TemplateEngine.TestHelper;
@@ -22,8 +24,8 @@ namespace Dotnet_new3.IntegrationTests
         public void CanApplyUpdates()
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
-            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0", "--quiet")
-                .WithCustomHive(home)
+            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
+                .WithCustomHive(home).WithoutBuiltInTemplates().Quietly()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
                 .Should()
@@ -35,17 +37,22 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining("classlib");
 
             new DotnetNewCommand(_log, "--update-check")
-                .WithCustomHive(home)
+                .WithCustomHive(home).WithoutBuiltInTemplates()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
                 .Should()
                 .ExitWith(0)
                 .And
                 .NotHaveStdErr()
-                .And.HaveStdOutContaining("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0' is available.");
+                .And.HaveStdOutContaining("An update for template packages is available:")
+                .And.HaveStdOutMatching("Package\\s+Current\\s+Latest")
+                .And.HaveStdOutMatching("Microsoft.DotNet.Common.ProjectTemplates.5.0\\s+5.0.0\\s+([\\d\\.a-z-])+")
+                .And.HaveStdOutContaining("To update the package use:")
+                .And.HaveStdOutContaining("   dotnet new3 --install <PACKAGE_ID>::<VERSION>")
+                .And.HaveStdOutMatching("   dotnet new3 --install Microsoft\\.DotNet\\.Common\\.ProjectTemplates\\.5\\.0::([\\d\\.a-z-])+");
 
             new DotnetNewCommand(_log, "--update-apply")
-                .WithCustomHive(home)
+                .WithCustomHive(home).WithoutBuiltInTemplates()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
                 .Should()

--- a/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using FluentAssertions;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.TemplateEngine.TestHelper;
@@ -22,8 +24,8 @@ namespace Dotnet_new3.IntegrationTests
         public void CanCheckForUpdate()
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
-            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0", "--quiet")
-                .WithCustomHive(home)
+            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
+                .WithCustomHive(home).WithoutBuiltInTemplates().Quietly()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
                 .Should()
@@ -35,14 +37,19 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining("classlib");
 
             new DotnetNewCommand(_log, "--update-check")
-                .WithCustomHive(home)
+                .WithCustomHive(home).WithoutBuiltInTemplates()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
                 .Should()
                 .ExitWith(0)
                 .And
                 .NotHaveStdErr()
-                .And.HaveStdOutContaining("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0' is available.");
+                .And.HaveStdOutContaining("An update for template packages is available:")
+                .And.HaveStdOutMatching("Package\\s+Current\\s+Latest")
+                .And.HaveStdOutMatching("Microsoft.DotNet.Common.ProjectTemplates.5.0\\s+5.0.0\\s+([\\d\\.a-z-])+")
+                .And.HaveStdOutContaining("To update the package use:")
+                .And.HaveStdOutContaining("   dotnet new3 --install <PACKAGE_ID>::<VERSION>")
+                .And.HaveStdOutMatching("   dotnet new3 --install Microsoft\\.DotNet\\.Common\\.ProjectTemplates\\.5\\.0::([\\d\\.a-z-])+");
         }
 
         [Fact]
@@ -50,7 +57,7 @@ namespace Dotnet_new3.IntegrationTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             string workingDirectory = TestUtils.CreateTemporaryFolder();
-            string templateLocation = Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicFSharp", _log, workingDirectory, home);
+            Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicFSharp", _log, workingDirectory, home);
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0")
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
@@ -101,7 +108,7 @@ namespace Dotnet_new3.IntegrationTests
                   .And.HaveStdOutContaining("The template \"Console Application\" was created successfully.")
                   .And.HaveStdOutContaining("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0' is available")
                   .And.HaveStdOutContaining("To update the package use:")
-                  .And.HaveStdOutMatching("    dotnet new3 -i Microsoft.DotNet.Common.ProjectTemplates.5.0::([\\d\\.a-z-])+");
+                  .And.HaveStdOutMatching("   dotnet new3 --install Microsoft.DotNet.Common.ProjectTemplates.5.0::([\\d\\.a-z-])+");
         }
 
         [Fact]
@@ -131,7 +138,7 @@ namespace Dotnet_new3.IntegrationTests
                   .And.HaveStdOutContaining("The template \"Console Application\" was created successfully.")
                   .And.NotHaveStdOutContaining("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0' is available")
                   .And.NotHaveStdOutContaining("To update the package use:")
-                  .And.NotHaveStdOutMatching("    dotnet new3 -i Microsoft.DotNet.Common.ProjectTemplates.5.0::([\\d\\.a-z-])+");
+                  .And.NotHaveStdOutMatching("    dotnet new3 --install Microsoft.DotNet.Common.ProjectTemplates.5.0::([\\d\\.a-z-])+");
         }
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
@@ -73,5 +73,65 @@ namespace Dotnet_new3.IntegrationTests
                 .NotHaveStdErr()
                 .And.HaveStdOut("All template packages are up-to-date.");
         }
+
+        [Fact]
+        public void PrintInfoOnUpdateOnCreation()
+        {
+            var home = TestUtils.CreateTemporaryFolder("Home");
+            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
+                .WithCustomHive(home).WithoutBuiltInTemplates().Quietly()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And
+                .NotHaveStdErr()
+                .And.HaveStdOutContaining("Success:")
+                .And.HaveStdOutContaining("console")
+                .And.HaveStdOutContaining("classlib");
+
+            new DotnetNewCommand(_log, "console")
+                  .WithCustomHive(home).WithoutBuiltInTemplates()
+                  .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                  .Execute()
+                  .Should()
+                  .ExitWith(0)
+                  .And
+                  .NotHaveStdErr()
+                  .And.HaveStdOutContaining("The template \"Console Application\" was created successfully.")
+                  .And.HaveStdOutContaining("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0' is available")
+                  .And.HaveStdOutContaining("To update the package use:")
+                  .And.HaveStdOutMatching("    dotnet new3 -i Microsoft.DotNet.Common.ProjectTemplates.5.0::([\\d\\.a-z-])+");
+        }
+
+        [Fact]
+        public void DoesNotPrintUpdateInfoOnCreation_WhenLatestVersionIsInstalled()
+        {
+            var home = TestUtils.CreateTemporaryFolder("Home");
+            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0")
+                .WithCustomHive(home).WithoutBuiltInTemplates().Quietly()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And
+                .NotHaveStdErr()
+                .And.HaveStdOutContaining("Success:")
+                .And.HaveStdOutContaining("console")
+                .And.HaveStdOutContaining("classlib");
+
+            new DotnetNewCommand(_log, "console")
+                  .WithCustomHive(home).WithoutBuiltInTemplates()
+                  .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                  .Execute()
+                  .Should()
+                  .ExitWith(0)
+                  .And
+                  .NotHaveStdErr()
+                  .And.HaveStdOutContaining("The template \"Console Application\" was created successfully.")
+                  .And.NotHaveStdOutContaining("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0' is available")
+                  .And.NotHaveStdOutContaining("To update the package use:")
+                  .And.NotHaveStdOutMatching("    dotnet new3 -i Microsoft.DotNet.Common.ProjectTemplates.5.0::([\\d\\.a-z-])+");
+        }
     }
 }


### PR DESCRIPTION
### Problem
UX improvements for uninstall/update check

### Solution
- changed output of --update-check to tabular format
- fixed template count in dotnet new -u <short name> error message to count template groups
- created bunch of extensions to get command examples rather then managing them via LocalizableStrings
- created indentation extensions to make it consistent

PR is based on: https://github.com/dotnet/templating/pull/3074

### Checks:
- [x] Added unit tests - already available, added some more
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)