### PR TITLE
Fix unit test Helpers.InstallNuGetTemplate that doesn't use homeDirectory

### DIFF
--- a/test/dotnet-new3.UnitTests/Helpers.cs
+++ b/test/dotnet-new3.UnitTests/Helpers.cs
@@ -14,7 +14,7 @@ namespace Dotnet_new3.IntegrationTests
         internal static void InstallNuGetTemplate(string packageName, ITestOutputHelper log, string workingDirectory, string homeDirectory)
         {
             new DotnetNewCommand(log, "-i", packageName)
-                  .WithCustomHive()
+                  .WithCustomHive(homeDirectory)
                   .WithWorkingDirectory(workingDirectory)
                   .Execute()
                   .Should()


### PR DESCRIPTION
### Problem
Helpers.InstallNuGetTemplate doesn't work as expected, reason this was not caught... Is that is not used yet...

### Solution
Use homeDirectory parameter

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)