### PR TITLE
fixes dotnet/templating#2898 added unit tests for search option

### DIFF
--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearcherTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearcherTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
### Problem
fixes dotnet/templating#2898 

### Solution
Search is pretty well covered with unit tests already in `TemplateSearchCacheTests` and `TemplateSearcherTests`. I've added tests for --tag option.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)