### PR TITLE
PostAction and ManualInstruction localizations shouldn't use indices

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/ILocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ILocalizationModel.cs
@@ -34,8 +34,8 @@ namespace Microsoft.TemplateEngine.Abstractions
 
         /// <summary>
         /// Gets the localization models for the post actions defined in this template.
-        /// The keys represend the indices of the post actions as they appear in the template config file.
+        /// The keys represent the id of the post actions.
         /// </summary>
-        IReadOnlyDictionary<int, IPostActionLocalizationModel> PostActions { get; }
+        IReadOnlyDictionary<string, IPostActionLocalizationModel> PostActions { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/IPostActionLocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IPostActionLocalizationModel.cs
@@ -19,9 +19,8 @@ namespace Microsoft.TemplateEngine.Abstractions
 
         /// <summary>
         /// Gets the localized manual instructions that the user should perform.
-        /// The key represents the index of the instruction as it appears in the
-        /// same post action in the template config file.
+        /// The key represents the instruction id.
         /// </summary>
-        IReadOnlyDictionary<int, string> Instructions { get; }
+        IReadOnlyDictionary<string, string> Instructions { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Shipped.txt
@@ -64,7 +64,6 @@ Microsoft.TemplateEngine.Abstractions.ILocalizationModel.Author.get -> string?
 Microsoft.TemplateEngine.Abstractions.ILocalizationModel.Description.get -> string?
 Microsoft.TemplateEngine.Abstractions.ILocalizationModel.Name.get -> string?
 Microsoft.TemplateEngine.Abstractions.ILocalizationModel.ParameterSymbols.get -> System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Abstractions.IParameterSymbolLocalizationModel!>!
-Microsoft.TemplateEngine.Abstractions.ILocalizationModel.PostActions.get -> System.Collections.Generic.IReadOnlyDictionary<int, Microsoft.TemplateEngine.Abstractions.IPostActionLocalizationModel!>!
 Microsoft.TemplateEngine.Abstractions.Installer.CheckUpdateResult
 Microsoft.TemplateEngine.Abstractions.Installer.CheckUpdateResult.IsLatestVersion.get -> bool
 Microsoft.TemplateEngine.Abstractions.Installer.IInstaller
@@ -116,9 +115,6 @@ Microsoft.TemplateEngine.Abstractions.IPostAction.Description.get -> string?
 Microsoft.TemplateEngine.Abstractions.IPostAction.ManualInstructions.get -> string?
 Microsoft.TemplateEngine.Abstractions.IPostActionLocalizationModel
 Microsoft.TemplateEngine.Abstractions.IPostActionLocalizationModel.Description.get -> string?
-Microsoft.TemplateEngine.Abstractions.IPostActionLocalizationModel.Instructions.get -> System.Collections.Generic.IReadOnlyDictionary<int, string!>!
-Microsoft.TemplateEngine.Abstractions.IPrioritizedComponent
-Microsoft.TemplateEngine.Abstractions.IPrioritizedComponent.Priority.get -> int
 Microsoft.TemplateEngine.Abstractions.ISearchPackFilter
 Microsoft.TemplateEngine.Abstractions.ISettingsLoader
 Microsoft.TemplateEngine.Abstractions.ISettingsLoader.Save() -> void

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Shipped.txt
@@ -108,6 +108,8 @@ Microsoft.TemplateEngine.Abstractions.IPostAction.Args.get -> System.Collections
 Microsoft.TemplateEngine.Abstractions.IPostAction.ContinueOnError.get -> bool
 Microsoft.TemplateEngine.Abstractions.IPostAction.Description.get -> string?
 Microsoft.TemplateEngine.Abstractions.IPostAction.ManualInstructions.get -> string?
+Microsoft.TemplateEngine.Abstractions.IPrioritizedComponent
+Microsoft.TemplateEngine.Abstractions.IPrioritizedComponent.Priority.get -> int
 Microsoft.TemplateEngine.Abstractions.ISearchPackFilter
 Microsoft.TemplateEngine.Abstractions.ISettingsLoader
 Microsoft.TemplateEngine.Abstractions.ISettingsLoader.Save() -> void

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Shipped.txt
@@ -59,11 +59,6 @@ Microsoft.TemplateEngine.Abstractions.IGenerator
 Microsoft.TemplateEngine.Abstractions.IIdentifiedComponent
 Microsoft.TemplateEngine.Abstractions.IIdentifiedComponent.Id.get -> System.Guid
 Microsoft.TemplateEngine.Abstractions.ILocalizationLocator
-Microsoft.TemplateEngine.Abstractions.ILocalizationModel
-Microsoft.TemplateEngine.Abstractions.ILocalizationModel.Author.get -> string?
-Microsoft.TemplateEngine.Abstractions.ILocalizationModel.Description.get -> string?
-Microsoft.TemplateEngine.Abstractions.ILocalizationModel.Name.get -> string?
-Microsoft.TemplateEngine.Abstractions.ILocalizationModel.ParameterSymbols.get -> System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Abstractions.IParameterSymbolLocalizationModel!>!
 Microsoft.TemplateEngine.Abstractions.Installer.CheckUpdateResult
 Microsoft.TemplateEngine.Abstractions.Installer.CheckUpdateResult.IsLatestVersion.get -> bool
 Microsoft.TemplateEngine.Abstractions.Installer.IInstaller
@@ -113,8 +108,6 @@ Microsoft.TemplateEngine.Abstractions.IPostAction.Args.get -> System.Collections
 Microsoft.TemplateEngine.Abstractions.IPostAction.ContinueOnError.get -> bool
 Microsoft.TemplateEngine.Abstractions.IPostAction.Description.get -> string?
 Microsoft.TemplateEngine.Abstractions.IPostAction.ManualInstructions.get -> string?
-Microsoft.TemplateEngine.Abstractions.IPostActionLocalizationModel
-Microsoft.TemplateEngine.Abstractions.IPostActionLocalizationModel.Description.get -> string?
 Microsoft.TemplateEngine.Abstractions.ISearchPackFilter
 Microsoft.TemplateEngine.Abstractions.ISettingsLoader
 Microsoft.TemplateEngine.Abstractions.ISettingsLoader.Save() -> void

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
@@ -1,4 +1,2 @@
-﻿Microsoft.TemplateEngine.Abstractions.ILocalizationModel.PostActions.get -> System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Abstractions.IPostActionLocalizationModel!>!
-Microsoft.TemplateEngine.Abstractions.IPostActionLocalizationModel.Instructions.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
-Microsoft.TemplateEngine.Abstractions.IPrioritizedComponent
+﻿Microsoft.TemplateEngine.Abstractions.IPrioritizedComponent
 Microsoft.TemplateEngine.Abstractions.IPrioritizedComponent.Priority.get -> int

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
-﻿
+﻿Microsoft.TemplateEngine.Abstractions.ILocalizationModel.PostActions.get -> System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Abstractions.IPostActionLocalizationModel!>!
+Microsoft.TemplateEngine.Abstractions.IPostActionLocalizationModel.Instructions.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+Microsoft.TemplateEngine.Abstractions.IPrioritizedComponent
+Microsoft.TemplateEngine.Abstractions.IPrioritizedComponent.Priority.get -> int

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
-﻿Microsoft.TemplateEngine.Abstractions.IPrioritizedComponent
-Microsoft.TemplateEngine.Abstractions.IPrioritizedComponent.Priority.get -> int
+﻿

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ILocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ILocalizationModel.cs
@@ -4,13 +4,14 @@
 #nullable enable
 
 using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
 
-namespace Microsoft.TemplateEngine.Abstractions
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
     /// <summary>
     /// Represents the data model that contains the localized strings for a template.
     /// </summary>
-    public interface ILocalizationModel
+    internal interface ILocalizationModel
     {
         /// <summary>
         /// Gets the localized author name.

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IPostActionLocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IPostActionLocalizationModel.cs
@@ -5,12 +5,12 @@
 
 using System.Collections.Generic;
 
-namespace Microsoft.TemplateEngine.Abstractions
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
     /// <summary>
     /// Defines <see cref="IPostAction"/> localization model.
     /// </summary>
-    public interface IPostActionLocalizationModel
+    internal interface IPostActionLocalizationModel
     {
         /// <summary>
         /// Gets the localized description of this post action.

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IPostActionModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IPostActionModel.cs
@@ -12,6 +12,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
     internal interface IPostActionModel : IConditionedConfigurationElement
     {
         /// <summary>
+        /// Gets a string that uniquely identifies this post action within a template.
+        /// </summary>
+        string? Id { get; }
+
+        /// <summary>
         /// Gets the description of the post action.
         /// </summary>
         string? Description { get; }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file..
+        ///   Looks up a localized string similar to In templatestrings.json file under the post action with &quot;id&quot; &quot;{1}&quot;, there are localized strings for manual instruction(s) with ids &quot;{0}&quot;. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file..
         /// </summary>
         internal static string Authoring_InvalidManualInstructionLocalizationIndex {
             get {
@@ -79,7 +79,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file..
+        ///   Looks up a localized string similar to Post action(s) with id(s) &quot;{0}&quot; specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file..
         /// </summary>
         internal static string Authoring_InvalidPostActionLocalizationIndex {
             get {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class LocalizableStrings {
@@ -106,6 +106,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Id of the manual instruction &quot;{0}&quot; at index {1} under post action &quot;{2}&quot; is not unique. Only the first manual instruction that uses this Id will be localized..
+        /// </summary>
+        internal static string Authoring_ManualInstructionIdIsNotUnique {
+            get {
+                return ResourceManager.GetString("Authoring_ManualInstructionIdIsNotUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Missing &apos;{0}&apos; in &apos;{1}&apos;.
         /// </summary>
         internal static string Authoring_MissingValue {
@@ -120,6 +129,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         internal static string Authoring_NonBoolDataTypeForRegexMatch {
             get {
                 return ResourceManager.GetString("Authoring_NonBoolDataTypeForRegexMatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Id of the post action &quot;{0}&quot; at index {1} is not unique. Only the first post action that uses this Id will be localized..
+        /// </summary>
+        internal static string Authoring_PostActionIdIsNotUnique {
+            get {
+                return ResourceManager.GetString("Authoring_PostActionIdIsNotUnique", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
@@ -121,13 +121,13 @@
     <value>"templatestrings.json" file should only contain elements with type "string". Remove elements that are not strings.</value>
   </data>
   <data name="Authoring_InvalidManualInstructionLocalizationIndex" xml:space="preserve">
-    <value>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</value>
-    <comment>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</comment>
+    <value>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</value>
+    <comment>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</comment>
   </data>
   <data name="Authoring_InvalidPostActionLocalizationIndex" xml:space="preserve">
-    <value>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</value>
-    <comment>{0} is a list of indices separated by comma. Such as "3, 7, 22".</comment>
+    <value>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</value>
+    <comment>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</comment>
   </data>
   <data name="Authoring_InvalidRegex" xml:space="preserve">
     <value>'{0}' could not be parsed as a regular expression</value>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
@@ -135,11 +135,22 @@
   <data name="Authoring_MalformedPostActionManualInstructions" xml:space="preserve">
     <value>One or more postActions have a malformed or missing manualInstructions value in '{0}'</value>
   </data>
+  <data name="Authoring_ManualInstructionIdIsNotUnique" xml:space="preserve">
+    <value>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</value>
+    <comment>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</comment>
+  </data>
   <data name="Authoring_MissingValue" xml:space="preserve">
     <value>Missing '{0}' in '{1}'</value>
   </data>
   <data name="Authoring_NonBoolDataTypeForRegexMatch" xml:space="preserve">
     <value>A non-bool DataType was specified for a regexMatch type symbol</value>
+  </data>
+  <data name="Authoring_PostActionIdIsNotUnique" xml:space="preserve">
+    <value>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</value>
+    <comment>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</comment>
   </data>
   <data name="Authoring_SourceDoesNotExist" xml:space="preserve">
     <value>    Source '{0}' in template does not exist.</value>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/LocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/LocalizationModel.cs
@@ -16,7 +16,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Localization
             string? description,
             string? author,
             IReadOnlyDictionary<string, IParameterSymbolLocalizationModel> parameterSymbols,
-            IReadOnlyDictionary<int, IPostActionLocalizationModel> postActions)
+            IReadOnlyDictionary<string, IPostActionLocalizationModel> postActions)
         {
             Name = name;
             Description = description;
@@ -38,6 +38,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Localization
         public IReadOnlyDictionary<string, IParameterSymbolLocalizationModel> ParameterSymbols { get; }
 
         /// <inheritdoc/>
-        public IReadOnlyDictionary<int, IPostActionLocalizationModel> PostActions { get; }
+        public IReadOnlyDictionary<string, IPostActionLocalizationModel> PostActions { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/PostActionLocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/PostActionLocalizationModel.cs
@@ -4,7 +4,6 @@
 #nullable enable
 
 using System.Collections.Generic;
-using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Localization
 {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/PostActionLocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/PostActionLocalizationModel.cs
@@ -16,14 +16,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Localization
         public string? Description { get; set; }
 
         /// <summary>
-        /// Contains the localized manual instructions of the post action.
-        /// Order of the items here matches the order of the manual instructions defined
-        /// in the culture-neutral template config file.
+        /// Gets or sets the localized manual instructions of the post action.
+        /// The keys represent the manual instruction ids.
         /// </summary>
-        /// <returns>
-        /// The list of localized instructions. A null value means that a localization
-        /// was not provided for that instruction and the culture-neutral text should be used.
-        /// </returns>
-        public IReadOnlyDictionary<int, string> Instructions { get; set; } = new Dictionary<int, string>();
+        public IReadOnlyDictionary<string, string> Instructions { get; set; } = new Dictionary<string, string>();
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ManualInstructionModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ManualInstructionModel.cs
@@ -26,6 +26,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         /// <summary>
         /// Gets the string identifying this instruction within the post action.
+        /// This property can be null if the author has not provided one. In that case this manual instruction
+        /// cannot be referenced in a context where an id is required, such as in templatestrings.json files.
         /// </summary>
         public string? Id { get; }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ManualInstructionModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ManualInstructionModel.cs
@@ -11,16 +11,23 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
     /// </summary>
     internal sealed class ManualInstructionModel : ConditionedConfigurationElementBase
     {
-        public ManualInstructionModel(string text)
+        public ManualInstructionModel(string? id, string text)
         {
+            Id = id;
             Text = text;
         }
 
-        public ManualInstructionModel(string text, string? condition)
+        public ManualInstructionModel(string? id, string text, string? condition)
         {
+            Id = id;
             Text = text;
             Condition = condition;
         }
+
+        /// <summary>
+        /// Gets the string identifying this instruction within the post action.
+        /// </summary>
+        public string? Id { get; }
 
         /// <summary>
         /// Gets the text explaining the steps the user should take.

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostAction.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostAction.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
@@ -11,25 +13,32 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
     internal class PostAction : IPostAction
     {
-        Guid IPostAction.ActionId => ActionId;
+        public PostAction(string? id, string? description, string? manualInstructions, Guid actionId, bool continueOnError, IReadOnlyDictionary<string, string> args)
+        {
+            Id = id;
+            Description = description;
+            ManualInstructions = manualInstructions;
+            ActionId = actionId;
+            ContinueOnError = continueOnError;
+            Args = args;
+        }
 
-        bool IPostAction.ContinueOnError => ContinueOnError;
+        /// <summary>
+        /// Gets the string that uniquely identifies this post action within the same template.
+        /// This property can be null if the author has not provided one. In that case this post
+        /// action cannot be referenced in a context where an id is required, such as in templatestrings.json files.
+        /// </summary>
+        public string? Id { get; }
 
-        IReadOnlyDictionary<string, string> IPostAction.Args => Args;
+        public string? Description { get; }
 
-        string IPostAction.ManualInstructions => ManualInstructions;
+        public string? ManualInstructions { get; }
 
-        string IPostAction.Description => Description;
+        public Guid ActionId { get; }
 
-        internal string Description { get; private set; }
+        public bool ContinueOnError { get; private set; }
 
-        internal Guid ActionId { get; private set; }
-
-        internal bool ContinueOnError { get; private set; }
-
-        internal IReadOnlyDictionary<string, string> Args { get; private set; }
-
-        internal string ManualInstructions { get; private set; }
+        public IReadOnlyDictionary<string, string> Args { get; } = new Dictionary<string, string>();
 
         internal static List<IPostAction> ListFromModel(IEngineEnvironmentSettings environmentSettings, IReadOnlyList<IPostActionModel> modelList, IVariableCollection rootVariableCollection)
         {
@@ -74,14 +83,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     }
                 }
 
-                IPostAction postAction = new PostAction()
-                {
-                    Description = model.Description,
-                    ActionId = model.ActionId,
-                    ContinueOnError = model.ContinueOnError,
-                    Args = model.Args,
-                    ManualInstructions = chosenInstruction,
-                };
+                IPostAction postAction = new PostAction(
+                    model.Id,
+                    model.Description,
+                    chosenInstruction,
+                    model.ActionId,
+                    model.ContinueOnError,
+                    model.Args);
 
                 actionList.Add(postAction);
             }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostAction.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostAction.cs
@@ -13,22 +13,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
     internal class PostAction : IPostAction
     {
-        public PostAction(string? id, string? description, string? manualInstructions, Guid actionId, bool continueOnError, IReadOnlyDictionary<string, string> args)
+        public PostAction(string? description, string? manualInstructions, Guid actionId, bool continueOnError, IReadOnlyDictionary<string, string> args)
         {
-            Id = id;
             Description = description;
             ManualInstructions = manualInstructions;
             ActionId = actionId;
             ContinueOnError = continueOnError;
             Args = args;
         }
-
-        /// <summary>
-        /// Gets the string that uniquely identifies this post action within the same template.
-        /// This property can be null if the author has not provided one. In that case this post
-        /// action cannot be referenced in a context where an id is required, such as in templatestrings.json files.
-        /// </summary>
-        public string? Id { get; }
 
         public string? Description { get; }
 
@@ -84,7 +76,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 }
 
                 IPostAction postAction = new PostAction(
-                    model.Id,
                     model.Description,
                     chosenInstruction,
                     model.ActionId,

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostActionModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostActionModel.cs
@@ -128,7 +128,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             {
                 // Localizations provide more translations than the number of post actions we have.
                 string excessPostActionLocalizationIds = string.Join(", ", localizations.Keys.Where(k => !localizedPostActions.Any(p => p.Id == k)).Select(k => k.ToString()));
-                host.Logger.LogWarning(string.Format(LocalizableStrings.Authoring_InvalidPostActionLocalizationId, excessPostActionLocalizationId));
+                host.Logger.LogWarning(string.Format(LocalizableStrings.Authoring_InvalidPostActionLocalizationIndex, excessPostActionLocalizationIds));
             }
             return localizedPostActions;
         }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
@@ -602,7 +602,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 }
             }
 
-            config.PostActionModel = RunnableProjects.PostActionModel.ListFromJArray(source.Get<JArray>("PostActions"), localizationModel?.PostActions, environmentSettings.Host);
+            config.PostActionModel = RunnableProjects.PostActionModel.ListFromJArray(source.Get<JArray>("PostActions"), localizationModel?.PostActions, environmentSettings.Host.Logger);
             config.PrimaryOutputs = CreationPathModel.ListFromJArray(source.Get<JArray>(nameof(PrimaryOutputs)));
 
             // Custom operations at the global level

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
@@ -28,6 +28,13 @@
         <target state="new">One or more postActions have a malformed or missing manualInstructions value in '{0}'</target>
         <note />
       </trans-unit>
+      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
+        <source>Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</source>
+        <target state="new">Id of the manual instruction "{0}" at index {1} under post action "{2}" is not unique. Only the first manual instruction that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".
+{2} is any identifier string that user provided in the file or a whole number. Such as: myPostAction, firstPostAction, postAction1, 5, 0 etc.</note>
+      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}' in '{1}'</source>
         <target state="new">Missing '{0}' in '{1}'</target>
@@ -37,6 +44,12 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="new">A non-bool DataType was specified for a regexMatch type symbol</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Authoring_PostActionIdIsNotUnique">
+        <source>Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</source>
+        <target state="new">Id of the post action "{0}" at index {1} is not unique. Only the first post action that uses this Id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>    Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
@@ -8,15 +8,15 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_InvalidManualInstructionLocalizationIndex">
-        <source>In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
-        <target state="new">In templatestrings.json file under the post action with index {1}, there are localized strings for manual instruction(s) {0}. These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".
-{1} is a whole number. Such as "5".</note>
+        <source>In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</source>
+        <target state="new">In templatestrings.json file under the post action with "id" "{1}", there are localized strings for manual instruction(s) with ids "{0}". These manual instructions do not exist in the template.json file and should be removed from templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
+{1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
-        <source>Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
-        <target state="new">Post action(s) with index(es) {0} specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
-        <note>{0} is a list of indices separated by comma. Such as "3, 7, 22".</note>
+        <source>Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</source>
+        <target state="new">Post action(s) with id(s) "{0}" specified in the localization file do not exist in the template.json file. Remove the localized strings from the templatestrings.json file.</target>
+        <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidRegex">
         <source>'{0}' could not be parsed as a regular expression</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/ExportResult.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/ExportResult.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
         /// <summary>
         /// Creates an instance of <see cref="ExportResult"/>.
         /// </summary>
-        public ExportResult(string? templateJsonPath, string? errorMessage) : this(templateJsonPath, templateJsonPath, null) { }
+        public ExportResult(string? templateJsonPath, string? errorMessage) : this(templateJsonPath, errorMessage, null) { }
 
         /// <summary>
         /// Creates an instance of <see cref="ExportResult"/>.

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/KeyCreators/IJsonKeyCreator.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/KeyCreators/IJsonKeyCreator.cs
@@ -18,7 +18,8 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core.KeyCreators
         /// <param name="elementName">Name of the element that the key is being created for.</param>
         /// <param name="parentElementName">Name of the parent element.</param>
         /// <param name="indexInParent">Index of this element with respect to its siblings under the same parent.</param>
+        /// <param name="parentChildCount">The number of children that the parent element has.</param>
         /// <returns>The key string.</returns>
-        string CreateKey(JsonElement element, string? elementName, string? parentElementName, int indexInParent);
+        string CreateKey(JsonElement element, string? elementName, string? parentElementName, int indexInParent, int parentChildCount);
     }
 }

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/KeyCreators/IndexBasedKeyCreator.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/KeyCreators/IndexBasedKeyCreator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core.KeyCreators
     internal sealed class IndexBasedKeyCreator : IJsonKeyCreator
     {
         /// <inheritdoc/>
-        public string CreateKey(JsonElement element, string? elementName, string? parentElementName, int indexInParent)
+        public string CreateKey(JsonElement element, string? elementName, string? parentElementName, int indexInParent, int parentChildCount)
         {
             return string.Concat(parentElementName, "[", indexInParent.ToString(), "]");
         }

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/KeyCreators/NameKeyCreator.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/KeyCreators/NameKeyCreator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core.KeyCreators
     internal sealed class NameKeyCreator : IJsonKeyCreator
     {
         /// <inheritdoc/>
-        public string CreateKey(JsonElement element, string? elementName, string? parentElementName, int indexInParent)
+        public string CreateKey(JsonElement element, string? elementName, string? parentElementName, int indexInParent, int parentChildCount)
         {
             return elementName ?? string.Empty;
         }

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateLocalizer.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateLocalizer.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.TemplateEngine.TemplateLocalizer.Core.Exceptions;
 
 namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
 {
@@ -58,6 +59,11 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
                     cancellationToken).ConfigureAwait(false);
 
                 return new ExportResult(templateJsonPath);
+            }
+            catch (JsonMemberMissingException jsonMemberMissingException)
+            {
+                // Output a more friendly text without stack trace for known errors.
+                return new ExportResult(templateJsonPath, jsonMemberMissingException.Message);
             }
             catch (Exception exception)
             {

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateStringExtractor.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateStringExtractor.cs
@@ -63,7 +63,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
                         // Include "description" of the post action.
                         new StringFilteredTraversalRule("description"),
                         // Include "manualInstructions" of the post action, if they also comply with child rules.
-                        new RegexFilteredTraversalRule("manualInstructions", new ChildValueKeyCreator("id", "default")).WithChild(
+                        new RegexFilteredTraversalRule("manualInstructions", new ChildValueKeyCreator("id", onlyChildDefaultValue: "default")).WithChild(
                             // Include all the manual instructions in the array. Skip none.
                             new AllInclusiveTraversalRule().WithChild(
                                 // Include "text" of the post action.

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateStringExtractor.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateStringExtractor.cs
@@ -57,13 +57,13 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
                                 // Include "description" of each choice.
                                 new StringFilteredTraversalRule("description"))))),
                 // Include "postActions" under the root, if they also comply with child rules.
-                new StringFilteredTraversalRule("postActions").WithChild(
+                new StringFilteredTraversalRule("postActions", new ChildValueKeyCreator("id")).WithChild(
                     // Any post action in "postActions" array should be included. Skip none.
                     new AllInclusiveTraversalRule().WithChildren(
                         // Include "description" of the post action.
                         new StringFilteredTraversalRule("description"),
                         // Include "manualInstructions" of the post action, if they also comply with child rules.
-                        new RegexFilteredTraversalRule("manualInstructions").WithChild(
+                        new RegexFilteredTraversalRule("manualInstructions", new ChildValueKeyCreator("id", "default")).WithChild(
                             // Include all the manual instructions in the array. Skip none.
                             new AllInclusiveTraversalRule().WithChild(
                                 // Include "text" of the post action.
@@ -184,13 +184,14 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
 
         private void ProcessArrayElement(JsonElement element, string elementName, TraversalArgs args)
         {
+            int childrenCount = element.GetArrayLength();
             foreach (TraversalRule rule in args.Rules)
             {
                 int childIndex = 0;
                 foreach (var child in element.EnumerateArray())
                 {
                     string childElementName = childIndex.ToString();
-                    string? childKey = (rule.KeyCreator ?? _defaultArrayKeyExtractor).CreateKey(child, childElementName, elementName, childIndex);
+                    string? childKey = (rule.KeyCreator ?? _defaultArrayKeyExtractor).CreateKey(child, childElementName, elementName, childIndex, childrenCount);
 
                     TraversalArgs nextArgs = args;
                     nextArgs.Rules = rule.ChildRules;
@@ -204,13 +205,14 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
 
         private void ProcessObjectElement(JsonElement element, string elementName, TraversalArgs args)
         {
+            int childrenCount = element.EnumerateObject().Count();
             foreach (TraversalRule rule in args.Rules)
             {
                 int childIndex = 0;
                 foreach (JsonProperty child in element.EnumerateObject())
                 {
                     string childElementName = child.Name;
-                    string childKey = (rule.KeyCreator ?? _defaultObjectKeyExtractor).CreateKey(child.Value, childElementName, elementName, childIndex);
+                    string childKey = (rule.KeyCreator ?? _defaultObjectKeyExtractor).CreateKey(child.Value, childElementName, elementName, childIndex, childrenCount);
 
                     TraversalArgs nextArgs = args;
                     nextArgs.Rules = rule.ChildRules;

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/Commands/Export/ExportCommand.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/Commands/Export/ExportCommand.cs
@@ -120,7 +120,9 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Commands.Export
                 else
                 {
                     // Tasks is known to have already completed. We can get the result without await.
-                    exportResults.Add(pathTaskPair.Task.Result);
+                    ExportResult result = pathTaskPair.Task.Result;
+                    exportResults.Add(result);
+                    failed |= !result.Succeeded;
                 }
             }
 
@@ -209,7 +211,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Commands.Export
                     }
                     else
                     {
-                        Logger.LogError(LocalizableStrings.command_export_log_templateExportFailedWithError, result.TemplateJsonPath, result.ErrorMessage);
+                        Logger.LogError(LocalizableStrings.command_export_log_templateExportFailedWithError, result.ErrorMessage, result.TemplateJsonPath);
                     }
                 }
             }

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/LocalizableStrings.Designer.cs
@@ -124,7 +124,9 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Generating localization files for the following template.json file has failed: &quot;{0}&quot;. Error message: &quot;{1}&quot;..
+        ///   Looks up a localized string similar to Generating localization files for a template.json has failed.
+        ///Reason: {0}.
+        ///File Path: {1}..
         /// </summary>
         internal static string command_export_log_templateExportFailedWithError {
             get {

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/LocalizableStrings.resx
@@ -144,7 +144,12 @@
     <comment>{0} is the number of files. Do not localize "--export"</comment>
   </data>
   <data name="command_export_log_templateExportFailedWithError" xml:space="preserve">
-    <value>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</value>
+    <value>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</value>
+    <comment>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</comment>
   </data>
   <data name="command_export_log_templateExportFailedWithException" xml:space="preserve">
     <value>Generating localization files for the following template.json file has failed: "{0}".</value>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.cs.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.de.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.es.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.fr.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.it.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.ja.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.ko.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.pl.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.pt-BR.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.ru.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.tr.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.zh-Hans.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/xlf/LocalizableStrings.zh-Hant.xlf
@@ -38,9 +38,15 @@
         <note>{0} is the number of files. Do not localize "--export"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithError">
-        <source>Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</source>
-        <target state="new">Generating localization files for the following template.json file has failed: "{0}". Error message: "{1}".</target>
-        <note />
+        <source>Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</source>
+        <target state="new">Generating localization files for a template.json has failed.
+Reason: {0}.
+File Path: {1}.</target>
+        <note>{0} is a sentence such as "Json property should contain a field 'ID'"
+{1} is a file path such as: C:\temp\template.json
+Do not localize: "template.json"</note>
       </trans-unit>
       <trans-unit id="command_export_log_templateExportFailedWithException">
         <source>Generating localization files for the following template.json file has failed: "{0}".</source>

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/LocalizationTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/LocalizationTests.cs
@@ -109,12 +109,12 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         }
 
         [Theory]
-        [InlineData(0, null, "pa0_desc", "pa0_manualInstructions")]
-        [InlineData(0, "de-DE", "pa0_desc_de-DE:äÄßöÖüÜ", "pa0_manualInstructions_de-DE:äÄßöÖüÜ")]
-        [InlineData(0, "tr-TR", "pa0_desc_tr-TR:çÇğĞıIİöÖşŞüÜ", "pa0_manualInstructions_tr-TR:çÇğĞıIİöÖşŞüÜ")]
-        [InlineData(1, null, "pa1_desc", "pa1_manualInstructions0")]
-        [InlineData(1, "de-DE", "pa1_desc_de-DE:äÄßöÖüÜ", "pa1_manualInstructions0")]
-        [InlineData(1, "tr-TR", "pa1_desc_tr-TR:çÇğĞıIİöÖşŞüÜ", "pa1_manualInstructions0_tr-TR:çÇğĞıIİöÖşŞüÜ")]
+        [InlineData(1, null, "pa0_desc", "pa0_manualInstructions")]
+        [InlineData(1, "de-DE", "pa0_desc_de-DE:äÄßöÖüÜ", "pa0_manualInstructions_de-DE:äÄßöÖüÜ")]
+        [InlineData(1, "tr-TR", "pa0_desc_tr-TR:çÇğĞıIİöÖşŞüÜ", "pa0_manualInstructions_tr-TR:çÇğĞıIİöÖşŞüÜ")]
+        [InlineData(2, null, "pa1_desc", "pa1_manualInstructions0")]
+        [InlineData(2, "de-DE", "pa1_desc_de-DE:äÄßöÖüÜ", "pa1_manualInstructions0")]
+        [InlineData(2, "tr-TR", "pa1_desc_tr-TR:çÇğĞıIİöÖşŞüÜ", "pa1_manualInstructions0_tr-TR:çÇğĞıIİöÖşŞüÜ")]
         public async Task TestLocalizedPostActionFields(
             int postActionIndex,
             string locale,

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/LocalizationTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/LocalizationTests.cs
@@ -109,12 +109,12 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         }
 
         [Theory]
-        [InlineData(1, null, "pa0_desc", "pa0_manualInstructions")]
-        [InlineData(1, "de-DE", "pa0_desc_de-DE:äÄßöÖüÜ", "pa0_manualInstructions_de-DE:äÄßöÖüÜ")]
-        [InlineData(1, "tr-TR", "pa0_desc_tr-TR:çÇğĞıIİöÖşŞüÜ", "pa0_manualInstructions_tr-TR:çÇğĞıIİöÖşŞüÜ")]
-        [InlineData(2, null, "pa1_desc", "pa1_manualInstructions0")]
-        [InlineData(2, "de-DE", "pa1_desc_de-DE:äÄßöÖüÜ", "pa1_manualInstructions0")]
-        [InlineData(2, "tr-TR", "pa1_desc_tr-TR:çÇğĞıIİöÖşŞüÜ", "pa1_manualInstructions0_tr-TR:çÇğĞıIİöÖşŞüÜ")]
+        [InlineData(0, null, "pa0_desc", "pa0_manualInstructions")]
+        [InlineData(0, "de-DE", "pa0_desc_de-DE:äÄßöÖüÜ", "pa0_manualInstructions_de-DE:äÄßöÖüÜ")]
+        [InlineData(0, "tr-TR", "pa0_desc_tr-TR:çÇğĞıIİöÖşŞüÜ", "pa0_manualInstructions_tr-TR:çÇğĞıIİöÖşŞüÜ")]
+        [InlineData(1, null, "pa1_desc", "pa1_manualInstructions0")]
+        [InlineData(1, "de-DE", "pa1_desc_de-DE:äÄßöÖüÜ", "pa1_manualInstructions0")]
+        [InlineData(1, "tr-TR", "pa1_desc_tr-TR:çÇğĞıIİöÖşŞüÜ", "pa1_manualInstructions0_tr-TR:çÇğĞıIİöÖşŞüÜ")]
         public async Task TestLocalizedPostActionFields(
             int postActionIndex,
             string locale,

--- a/test/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/StringExtractorTests.cs
+++ b/test/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/StringExtractorTests.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
@@ -91,7 +94,8 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests
 
         private static string GetTestTemplateJsonContent()
         {
-            string thisDir = Path.GetDirectoryName(typeof(StringExtractorTests).Assembly.Location);
+            string thisDir = Path.GetDirectoryName(typeof(StringExtractorTests).Assembly.Location)
+                ?? throw new Exception("Failed to get assembly location, which is required to access test templates.");
             string templateJsonPath = Path.GetFullPath(Path.Combine(
                 thisDir,
                 "..",

--- a/test/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/StringExtractorTests.cs
+++ b/test/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/StringExtractorTests.cs
@@ -64,8 +64,8 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests
         {
             var strings = ExtractStrings(GetTestTemplateJsonContent(), out _);
 
-            Assert.Contains(strings, s => s.Identifier == "//postactions/0/description" && s.LocalizationKey == "postActions[0]/description" && s.Value == "pa0_desc");
-            Assert.Contains(strings, s => s.Identifier == "//postactions/1/description" && s.LocalizationKey == "postActions[1]/description" && s.Value == "pa1_desc");
+            Assert.Contains(strings, s => s.Identifier == "//postactions/0/description" && s.LocalizationKey == "postActions/pa0/description" && s.Value == "pa0_desc");
+            Assert.Contains(strings, s => s.Identifier == "//postactions/1/description" && s.LocalizationKey == "postActions/pa1/description" && s.Value == "pa1_desc");
         }
 
         [Fact]
@@ -73,7 +73,8 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests
         {
             var strings = ExtractStrings(GetTestTemplateJsonContent(), out _);
 
-            Assert.Contains(strings, s => s.Identifier == "//postactions/0/manualinstructions/0/text" && s.LocalizationKey == "postActions[0]/manualInstructions[0]/text" && s.Value == "pa0_manualInstructions");
+            Assert.Contains(strings, s => s.Identifier == "//postactions/0/manualinstructions/0/text" && s.LocalizationKey == "postActions/pa0/manualInstructions/first_instruction/text" && s.Value == "pa0_manualInstructions");
+            Assert.Contains(strings, s => s.Identifier == "//postactions/2/manualinstructions/0/text" && s.LocalizationKey == "postActions/pa2/manualInstructions/default/text" && s.Value == "pa2_manualInstructions");
         }
 
         private static IReadOnlyList<TemplateString> ExtractStrings(string json, out string language)

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/localize/templatestrings.de-DE.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/localize/templatestrings.de-DE.json
@@ -6,8 +6,8 @@
     "symbols/someChoice/description": "sym1_desc_de-DE:äÄßöÖüÜ",
     "symbols/someChoice/choices/choice0/description": "sym1_choice0_de-DE:äÄßöÖüÜ",
     "symbols/someChoice/choices/choice1/description": "sym1_choice1_de-DE:äÄßöÖüÜ",
-    "postActions[0]/description": "pa0_desc_de-DE:äÄßöÖüÜ",
-    "postActions[0]/manualInstructions[0]/text": "pa0_manualInstructions_de-DE:äÄßöÖüÜ",
-    "postActions[1]/description": "pa1_desc_de-DE:äÄßöÖüÜ",
-    "postActions[1]/manualInstructions[1]/text": "pa1_manualInstructions1_de-DE:äÄßöÖüÜ"
+    "postActions/pa0/description": "pa0_desc_de-DE:äÄßöÖüÜ",
+    "postActions/pa0/manualInstructions/default/text": "pa0_manualInstructions_de-DE:äÄßöÖüÜ",
+    "postActions/pa1/description": "pa1_desc_de-DE:äÄßöÖüÜ",
+    "postActions/pa1/manualInstructions/third_instruction/text": "pa1_manualInstructions1_de-DE:äÄßöÖüÜ"
 }

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/localize/templatestrings.tr.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/localize/templatestrings.tr.json
@@ -7,8 +7,8 @@
     "symbols/someChoice/displayName": "sym1_displayName_tr-TR:çÇğĞıIİöÖşŞüÜ",
     "symbols/someChoice/choices/choice0/description": "sym1_choice0_tr-TR:çÇğĞıIİöÖşŞüÜ",
     "symbols/someChoice/choices/choice2/description": "sym1_choice2_tr-TR:çÇğĞıIİöÖşŞüÜ",
-    "postActions[0]/description": "pa0_desc_tr-TR:çÇğĞıIİöÖşŞüÜ",
-    "postActions[0]/manualInstructions[0]/text": "pa0_manualInstructions_tr-TR:çÇğĞıIİöÖşŞüÜ",
-    "postActions[1]/description": "pa1_desc_tr-TR:çÇğĞıIİöÖşŞüÜ",
-    "postActions[1]/manualInstructions[0]/text": "pa1_manualInstructions0_tr-TR:çÇğĞıIİöÖşŞüÜ",
+    "postActions/pa0/description": "pa0_desc_tr-TR:çÇğĞıIİöÖşŞüÜ",
+    "postActions/pa0/manualInstructions/first_instruction/text": "pa0_manualInstructions_tr-TR:çÇğĞıIİöÖşŞüÜ",
+    "postActions/pa1/description": "pa1_desc_tr-TR:çÇğĞıIİöÖşŞüÜ",
+    "postActions/pa1/manualInstructions/first_instruction/text": "pa1_manualInstructions0_tr-TR:çÇğĞıIİöÖşŞüÜ"
 }

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/template.json
@@ -51,7 +51,7 @@
     },
     "postActions": [
         {
-            "description": "pa0_desc",
+            "description": "post action with no id: unlocalizable",
             "manualInstructions": [
                 {
                     "text": "pa0_manualInstructions"
@@ -60,13 +60,30 @@
             "actionId": "58E1433C-303B-4713-8A47-26E7B03BD8A5"
         },
         {
+            "id": "pa0",
+            "description": "pa0_desc",
+            "manualInstructions": [
+                {
+                    "id": "first_instruction",
+                    "text": "pa0_manualInstructions"
+                }
+            ],
+            "actionId": "58E1433C-303B-4713-8A47-26E7B03BD8A5"
+        },
+        {
+            "id": "pa1",
             "description": "pa1_desc",
             "manualInstructions": [
                 {
+                    "id": "first_instruction",
                     "text": "pa1_manualInstructions0"
                 },
                 {
                     "text": "pa1_manualInstructions1"
+                },
+                {
+                    "id": "third_instruction",
+                    "text": "pa1_manualInstructions2"
                 }
             ],
             "actionId": "2B5CDBB7-1FAC-41EC-ADCC-08A73021BC40"

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithLocalization/.template.config/template.json
@@ -51,15 +51,6 @@
     },
     "postActions": [
         {
-            "description": "post action with no id: unlocalizable",
-            "manualInstructions": [
-                {
-                    "text": "pa0_manualInstructions"
-                }
-            ],
-            "actionId": "58E1433C-303B-4713-8A47-26E7B03BD8A5"
-        },
-        {
             "id": "pa0",
             "description": "pa0_desc",
             "manualInstructions": [
@@ -79,6 +70,7 @@
                     "text": "pa1_manualInstructions0"
                 },
                 {
+                    "id": "second_instruction",
                     "text": "pa1_manualInstructions1"
                 },
                 {
@@ -87,6 +79,15 @@
                 }
             ],
             "actionId": "2B5CDBB7-1FAC-41EC-ADCC-08A73021BC40"
+        },
+        {
+            "id": "pa2",
+            "manualInstructions": [
+                {
+                    "text": "pa2_manualInstructions"
+                }
+            ],
+            "actionId": "58E1433C-303B-4713-8A47-26E7B03BD8A5"
         }
     ]
 }


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/3133

### Solution
See the issue for planned/delivered changes.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)