### PR TITLE
Fixes #3135: Wpf doesn't have TFM net6.0 but net5.0 in .NET 6 SDK

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Settings/ScanResult.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/ScanResult.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
+using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 
@@ -8,28 +11,16 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 {
     public class ScanResult
     {
-        private List<ILocalizationLocator> _localizations;
+        public static readonly ScanResult Empty = new(Array.Empty<ITemplate>(), Array.Empty<ILocalizationLocator>());
 
-        private List<ITemplate> _templates;
-
-        public ScanResult()
+        public ScanResult(IReadOnlyList<ITemplate> templates, IReadOnlyList<ILocalizationLocator> localizations)
         {
-            _localizations = new List<ILocalizationLocator>();
-            _templates = new List<ITemplate>();
+            Templates = templates;
+            Localizations = localizations;
         }
 
-        public IReadOnlyList<ILocalizationLocator> Localizations => _localizations;
+        public IReadOnlyList<ILocalizationLocator> Localizations { get; }
 
-        public IReadOnlyList<ITemplate> Templates => _templates;
-
-        public void AddLocalization(ILocalizationLocator locater)
-        {
-            _localizations.Add(locater);
-        }
-
-        public void AddTemplate(ITemplate template)
-        {
-            _templates.Add(template);
-        }
+        public IReadOnlyList<ITemplate> Templates { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
@@ -56,11 +56,11 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                                                 && !sourceLocation.StartsWith(_paths.ScratchDir);
 
                     return new MountPointScanSource(
-                        sourceLocation,
-                        mountPoint,
-                        isLocalFlatFileSource,
-                        false,
-                        false
+                        location: sourceLocation,
+                        mountPoint: mountPoint,
+                        shouldStayInOriginalLocation: isLocalFlatFileSource,
+                        foundComponents: false,
+                        foundTemplates: false
                     );
                 }
             }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json;
@@ -19,6 +18,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         public TemplateCache(IEnumerable<ScanResult> scanResults, Dictionary<string, DateTime> mountPoints)
         {
             var localizationsByTemplateId = new Dictionary<string, ILocalizationLocator>();
+            var templateMemoryCache = new Dictionary<string, ITemplate>();
 
             string uiLocale = CultureInfo.CurrentUICulture.Name;
             string uiLocaleWithoutCountry = GetLocaleNameWithoutCountry(uiLocale);
@@ -45,10 +45,15 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     // This localization is either the perfect match, or a suitable substitude and there are no other candidates for the job yet.
                     localizationsByTemplateId[locator.Identity] = locator;
                 }
+
+                foreach (ITemplate template in scanResult.Templates)
+                {
+                    templateMemoryCache[template.Identity] = template;
+                }
             }
 
             var templates = new List<TemplateInfo>();
-            foreach (ITemplate newTemplate in scanResults.SelectMany(s => s.Templates))
+            foreach (ITemplate newTemplate in templateMemoryCache.Values)
             {
                 localizationsByTemplateId.TryGetValue(newTemplate.Identity, out ILocalizationLocator locatorForTemplate);
                 TemplateInfo localizedTemplate = LocalizeTemplate(newTemplate, locatorForTemplate);

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
@@ -53,10 +53,11 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
 
             var sources = new List<ITemplatePackage>();
-            foreach (var task in cachedSources.Values)
+            foreach (var task in cachedSources.OrderBy((p) => (p.Key.Factory as IPrioritizedComponent)?.Priority ?? 0))
             {
-                sources.AddRange(await task.ConfigureAwait(false));
+                sources.AddRange(await task.Value.ConfigureAwait(false));
             }
+
             return sources;
         }
 

--- a/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
@@ -50,8 +50,8 @@ namespace Microsoft.TemplateEngine.TestHelper
             }
             else
             {
-                var tempateEngineRoot = Path.Combine(CreateTemporaryFolder(), ".templateengine");
-                engineEnvironmentSettings = new EngineEnvironmentSettings(host, settingsLocation: tempateEngineRoot);
+                var templateEngineRoot = Path.Combine(CreateTemporaryFolder(), ".templateengine");
+                engineEnvironmentSettings = new EngineEnvironmentSettings(host, settingsLocation: templateEngineRoot);
             }
             _engineEnvironmentToDispose.Add(engineEnvironmentSettings);
             return engineEnvironmentSettings;


### PR DESCRIPTION
## Problem
Different version of WPF templates all have same Identity so on machine where .NET 3.1, 5.0 and 6.0 are installed... We process 3 different .nupkg files all containing templates with same Identity...
Since we allow only 1 template identity at time, last one in order wins... Since begining SDK templates provider always ensured to returned ordered list of packages which was installed sequentially and latest always won... With recent changes this was not true anymore...

## Solution
Do ordering of providers before putting their results into list, and remove need for sorting list later... And maintain that order all the way... Also added 2 unit tests to ensure this...

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)