### PR TITLE
Fixes #3085: dotnet new crashes if template contains #ifdef

### DIFF
--- a/src/Microsoft.TemplateEngine.Core/Expressions/Cpp/CppStyleEvaluatorDefinition.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/Cpp/CppStyleEvaluatorDefinition.cs
@@ -114,7 +114,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions.Cpp
             }
 
             int braceDepth = 0;
-            if (tokens[0].Family == TokenFamily.OpenBrace)
+            if (tokens.Count > 0 && tokens[0].Family == TokenFamily.OpenBrace)
             {
                 ++braceDepth;
             }


### PR DESCRIPTION
### Problem
Problem was that in `if` statement above took path where `tokens` doesn't add any token, reason for that is that there was no `whitespace` or `brace` token after it, instead just "Literal" which is not fully parsed yet and can't be added to `tokens`, at least that's my understanding...
What is weird about current logic is... that `#ifBAR` is same as `#if BAR`... Easy fix would be to do add space after `if`, but might cause other issues...

### Solution
I think lets not invest too much enery into this and lets just fix crash if user types `#iffoo bar` so it doesn't crash...

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)