### PR TITLE
[public API] Abstractions: made IFileLastWriteTimeSource obsolete

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/PhysicalFileSystem/IFileLastWriteTimeSource.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/PhysicalFileSystem/IFileLastWriteTimeSource.cs
@@ -5,6 +5,7 @@ using System;
 
 namespace Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem
 {
+    [Obsolete("Use IPhysicalFileSystem properties instead.")]
     public interface IFileLastWriteTimeSource
     {
         DateTime GetLastWriteTimeUtc(string file);

--- a/src/Microsoft.TemplateEngine.Abstractions/PhysicalFileSystem/IPhysicalFileSystem.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/PhysicalFileSystem/IPhysicalFileSystem.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -108,5 +110,21 @@ namespace Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem
         /// To stop watching dispose returned object.
         /// </remarks>
         IDisposable WatchFileChanges(string filepath, FileSystemEventHandler fileChanged);
+
+        /// <summary>
+        /// Gets the last write time for the <paramref name="file"/> in UTC.
+        /// Same behavior as <see cref="File.GetLastWriteTimeUtc(string)"/>.
+        /// </summary>
+        /// <param name="file">The file to get last write time for.</param>
+        /// <returns></returns>
+        DateTime GetLastWriteTimeUtc(string file);
+
+        /// <summary>
+        /// Sets the last write time for the <paramref name="file"/> in UTC.
+        /// Same behavior as <see cref="File.SetLastWriteTimeUtc(string, DateTime)"/>.
+        /// </summary>
+        /// <param name="file">The file to set last write time for.</param>
+        /// <param name="lastWriteTimeUtc">the time to set.</param>
+        void SetLastWriteTimeUtc(string file, DateTime lastWriteTimeUtc);
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
@@ -167,6 +167,26 @@ Microsoft.TemplateEngine.Abstractions.ParameterChoiceLocalizationModel.DisplayNa
 Microsoft.TemplateEngine.Abstractions.ParameterChoiceLocalizationModel.ParameterChoiceLocalizationModel(string? displayName, string? description) -> void
 Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IFileLastWriteTimeSource
 Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.CreateDirectory(string! path) -> void
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.CreateFile(string! path) -> System.IO.Stream!
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.DirectoryDelete(string! path, bool recursive) -> void
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.DirectoryExists(string! directory) -> bool
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.EnumerateDirectories(string! path, string! pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.EnumerateFiles(string! path, string! pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.EnumerateFileSystemEntries(string! directoryName, string! pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.FileCopy(string! sourcePath, string! targetPath, bool overwrite) -> void
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.FileDelete(string! path) -> void
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.FileExists(string! file) -> bool
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.GetCurrentDirectory() -> string!
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.GetFileAttributes(string! file) -> System.IO.FileAttributes
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.GetLastWriteTimeUtc(string! file) -> System.DateTime
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.OpenRead(string! path) -> System.IO.Stream!
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.ReadAllBytes(string! path) -> byte[]!
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.ReadAllText(string! path) -> string!
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.SetFileAttributes(string! file, System.IO.FileAttributes attributes) -> void
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.SetLastWriteTimeUtc(string! file, System.DateTime lastWriteTimeUtc) -> void
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.WatchFileChanges(string! filepath, System.IO.FileSystemEventHandler! fileChanged) -> System.IDisposable!
+Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.WriteAllText(string! path, string! value) -> void
 Microsoft.TemplateEngine.Abstractions.TemplateFiltering.ITemplateMatchInfo
 Microsoft.TemplateEngine.Abstractions.TemplateFiltering.ITemplateMatchInfo.AddMatchDisposition(Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo! newDisposition) -> void
 Microsoft.TemplateEngine.Abstractions.TemplateFiltering.ITemplateMatchInfo.Info.get -> Microsoft.TemplateEngine.Abstractions.ITemplateInfo!
@@ -328,24 +348,6 @@ Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.VirtualizeDirectory(st
 ~Microsoft.TemplateEngine.Abstractions.Mount.IMountPointManager.TryDemandMountPoint(string mountPointUri, out Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint mountPoint) -> bool
 ~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IFileLastWriteTimeSource.GetLastWriteTimeUtc(string file) -> System.DateTime
 ~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IFileLastWriteTimeSource.SetLastWriteTimeUtc(string file, System.DateTime lastWriteTimeUtc) -> void
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.CreateDirectory(string path) -> void
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.CreateFile(string path) -> System.IO.Stream
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.DirectoryDelete(string path, bool recursive) -> void
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.DirectoryExists(string directory) -> bool
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.EnumerateDirectories(string path, string pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string>
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.EnumerateFiles(string path, string pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string>
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.EnumerateFileSystemEntries(string directoryName, string pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string>
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.FileCopy(string sourcePath, string targetPath, bool overwrite) -> void
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.FileDelete(string path) -> void
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.FileExists(string file) -> bool
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.GetCurrentDirectory() -> string
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.GetFileAttributes(string file) -> System.IO.FileAttributes
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.OpenRead(string path) -> System.IO.Stream
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.ReadAllBytes(string path) -> byte[]
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.ReadAllText(string path) -> string
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.SetFileAttributes(string file, System.IO.FileAttributes attributes) -> void
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.WatchFileChanges(string filepath, System.IO.FileSystemEventHandler fileChanged) -> System.IDisposable
-~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem.WriteAllText(string path, string value) -> void
 ~Microsoft.TemplateEngine.Abstractions.TemplatePackage.IManagedTemplatePackage.DisplayName.get -> string
 ~Microsoft.TemplateEngine.Abstractions.TemplatePackage.IManagedTemplatePackage.GetDetails() -> System.Collections.Generic.IReadOnlyDictionary<string, string>
 ~Microsoft.TemplateEngine.Abstractions.TemplatePackage.IManagedTemplatePackage.Identifier.get -> string

--- a/src/Microsoft.TemplateEngine.Cli/CliTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CliTemplateEngineHost.cs
@@ -71,7 +71,7 @@ namespace Microsoft.TemplateEngine.Cli
                     {
                         workingPath = Path.GetDirectoryName(workingPath.TrimEnd('/', '\\'));
 
-                        if (!FileSystem.DirectoryExists(workingPath))
+                        if (string.IsNullOrWhiteSpace(workingPath) || !FileSystem.DirectoryExists(workingPath))
                         {
                             workingPath = null;
                         }

--- a/src/Microsoft.TemplateEngine.Edge/Installers/Folder/FolderManagedTemplatePackage.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/Folder/FolderManagedTemplatePackage.cs
@@ -1,13 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Installer;
-using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 
 namespace Microsoft.TemplateEngine.Edge.Installers.Folder
@@ -43,7 +44,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.Folder
             {
                 try
                 {
-                    return (_settings.Host.FileSystem as IFileLastWriteTimeSource)?.GetLastWriteTimeUtc(MountPointUri) ?? File.GetLastWriteTime(MountPointUri);
+                    return _settings.Host.FileSystem.GetLastWriteTimeUtc(MountPointUri);
                 }
                 catch (Exception e)
                 {
@@ -59,7 +60,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.Folder
 
         public IManagedTemplatePackageProvider ManagedProvider { get; }
 
-        public string Version => null;
+        public string? Version => null;
 
         public IReadOnlyDictionary<string, string> GetDetails() => _emptyDictionary;
     }

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetManagedTemplatePackage.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetManagedTemplatePackage.cs
@@ -1,14 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Installer;
-using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 
 namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
@@ -78,9 +78,10 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             {
                 throw new ArgumentException($"{nameof(details)} should contain key {PackageIdKey}", nameof(details));
             }
+            _logger = settings.Host.LoggerFactory.CreateLogger<NuGetInstaller>();
         }
 
-        public string Author
+        public string? Author
         {
             get
             {
@@ -91,7 +92,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             {
                 if (!string.IsNullOrWhiteSpace(value))
                 {
-                    Details[AuthorKey] = value;
+                    Details[AuthorKey] = value!;
                 }
                 else
                 {
@@ -102,7 +103,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 
         public string DisplayName => string.IsNullOrWhiteSpace(Version) ? Identifier : $"{Identifier}::{Version}";
 
-        public string Identifier => Details.TryGetValue(PackageIdKey, out string identifier) ? identifier : null;
+        public string Identifier => Details[PackageIdKey];
 
         public IInstaller Installer { get; }
 
@@ -112,7 +113,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             {
                 try
                 {
-                    return (_settings.Host.FileSystem as IFileLastWriteTimeSource)?.GetLastWriteTimeUtc(MountPointUri) ?? File.GetLastWriteTime(MountPointUri);
+                    return _settings.Host.FileSystem.GetLastWriteTimeUtc(MountPointUri);
                 }
                 catch (Exception e)
                 {
@@ -148,7 +149,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 
         public string MountPointUri { get; }
 
-        public string NuGetSource
+        public string? NuGetSource
         {
             get
             {
@@ -159,7 +160,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             {
                 if (!string.IsNullOrWhiteSpace(value))
                 {
-                    Details[NuGetSourceKey] = value;
+                    Details[NuGetSourceKey] = value!;
                 }
                 else
                 {
@@ -172,7 +173,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 
         public IManagedTemplatePackageProvider ManagedProvider { get; }
 
-        public string Version
+        public string? Version
         {
             get
             {
@@ -183,7 +184,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             {
                 if (!string.IsNullOrWhiteSpace(value))
                 {
-                    Details[PackageVersionKey] = value;
+                    Details[PackageVersionKey] = value!;
                 }
                 else
                 {
@@ -209,11 +210,11 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             Dictionary<string, string> details = new Dictionary<string, string>();
             if (!string.IsNullOrWhiteSpace(Author))
             {
-                details[AuthorKey] = Author;
+                details[AuthorKey] = Author!;
             }
             if (!string.IsNullOrWhiteSpace(NuGetSource))
             {
-                details[NuGetSourceKey] = NuGetSource;
+                details[NuGetSourceKey] = NuGetSource!;
             }
             return details;
         }

--- a/src/Microsoft.TemplateEngine.Utils/DefaultTemplatePackageProvider.cs
+++ b/src/Microsoft.TemplateEngine.Utils/DefaultTemplatePackageProvider.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 
 #nullable enable
@@ -56,23 +54,13 @@ namespace Microsoft.TemplateEngine.Utils
             var list = new List<ITemplatePackage>();
             foreach (var nupkg in expandedNupkgs)
             {
-                list.Add(new TemplatePackage(this, nupkg, GetLastWriteTimeUtc(nupkg)));
+                list.Add(new TemplatePackage(this, nupkg, _environmentSettings.Host.FileSystem.GetLastWriteTimeUtc(nupkg)));
             }
             foreach (var folder in expandedFolders)
             {
-                list.Add(new TemplatePackage(this, folder, GetLastWriteTimeUtc(folder)));
+                list.Add(new TemplatePackage(this, folder, _environmentSettings.Host.FileSystem.GetLastWriteTimeUtc(folder)));
             }
             return Task.FromResult<IReadOnlyList<ITemplatePackage>>(list);
-        }
-
-        private DateTime GetLastWriteTimeUtc(string path)
-        {
-            if (_environmentSettings.Host.FileSystem is IFileLastWriteTimeSource fileSystem)
-            {
-                return fileSystem.GetLastWriteTimeUtc(path);
-            }
-
-            return File.GetLastWriteTimeUtc(path);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Utils/PhysicalFileSystem.cs
+++ b/src/Microsoft.TemplateEngine.Utils/PhysicalFileSystem.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -12,7 +14,7 @@ namespace Microsoft.TemplateEngine.Utils
     /// Local file system implementation of <see cref="IPhysicalFileSystem"/>.
     /// </summary>
     /// <seealso cref="Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost"/>
-    public class PhysicalFileSystem : IPhysicalFileSystem, IFileLastWriteTimeSource
+    public class PhysicalFileSystem : IPhysicalFileSystem
     {
         public bool DirectoryExists(string directory)
         {

--- a/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
@@ -43,6 +43,27 @@ Microsoft.TemplateEngine.Utils.FileFindHelpers
 Microsoft.TemplateEngine.Utils.FileSystemInfoExtensions
 Microsoft.TemplateEngine.Utils.Glob
 Microsoft.TemplateEngine.Utils.InMemoryFileSystem
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.CreateDirectory(string! path) -> void
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.CreateFile(string! path) -> System.IO.Stream!
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.DirectoryDelete(string! path, bool recursive) -> void
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.DirectoryExists(string! directory) -> bool
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.EnumerateDirectories(string! path, string! pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.EnumerateFiles(string! path, string! pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.EnumerateFileSystemEntries(string! directoryName, string! pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.FileCopy(string! sourcePath, string! targetPath, bool overwrite) -> void
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.FileDelete(string! path) -> void
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.FileExists(string! file) -> bool
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.GetCurrentDirectory() -> string!
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.GetFileAttributes(string! file) -> System.IO.FileAttributes
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.GetLastWriteTimeUtc(string! file) -> System.DateTime
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.InMemoryFileSystem(string! root, Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem! basis) -> void
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.OpenRead(string! path) -> System.IO.Stream!
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.ReadAllBytes(string! path) -> byte[]!
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.ReadAllText(string! path) -> string!
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.SetFileAttributes(string! file, System.IO.FileAttributes attributes) -> void
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.SetLastWriteTimeUtc(string! file, System.DateTime lastWriteTimeUtc) -> void
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.WatchFileChanges(string! filepath, System.IO.FileSystemEventHandler! fileChanged) -> System.IDisposable!
+Microsoft.TemplateEngine.Utils.InMemoryFileSystem.WriteAllText(string! path, string! value) -> void
 Microsoft.TemplateEngine.Utils.InstallRequestPathResolution
 Microsoft.TemplateEngine.Utils.ListExtensions
 Microsoft.TemplateEngine.Utils.LocalizationLocator
@@ -56,7 +77,27 @@ Microsoft.TemplateEngine.Utils.LocalizationLocator.Name.get -> string!
 Microsoft.TemplateEngine.Utils.LocalizationLocator.ParameterSymbols.get -> System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Abstractions.IParameterSymbolLocalizationModel!>!
 Microsoft.TemplateEngine.Utils.ParserExtensions
 Microsoft.TemplateEngine.Utils.PhysicalFileSystem
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.CreateDirectory(string! path) -> void
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.CreateFile(string! path) -> System.IO.Stream!
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.DirectoryDelete(string! path, bool recursive) -> void
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.DirectoryExists(string! directory) -> bool
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.EnumerateDirectories(string! path, string! pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.EnumerateFiles(string! path, string! pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.EnumerateFileSystemEntries(string! directoryName, string! pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string!>!
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.FileCopy(string! source, string! target, bool overwrite) -> void
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.FileDelete(string! path) -> void
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.FileExists(string! file) -> bool
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.GetCurrentDirectory() -> string!
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.GetFileAttributes(string! file) -> System.IO.FileAttributes
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.GetLastWriteTimeUtc(string! file) -> System.DateTime
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.OpenRead(string! path) -> System.IO.Stream!
 Microsoft.TemplateEngine.Utils.PhysicalFileSystem.PhysicalFileSystem() -> void
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.ReadAllBytes(string! path) -> byte[]!
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.ReadAllText(string! path) -> string!
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.SetFileAttributes(string! file, System.IO.FileAttributes attributes) -> void
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.SetLastWriteTimeUtc(string! file, System.DateTime lastWriteTimeUtc) -> void
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.WatchFileChanges(string! filepath, System.IO.FileSystemEventHandler! fileChanged) -> System.IDisposable!
+Microsoft.TemplateEngine.Utils.PhysicalFileSystem.WriteAllText(string! path, string! value) -> void
 Microsoft.TemplateEngine.Utils.RangeVersionSpecification
 Microsoft.TemplateEngine.Utils.RangeVersionSpecification.IsEndInclusive.get -> bool
 Microsoft.TemplateEngine.Utils.RangeVersionSpecification.IsStartInclusive.get -> bool
@@ -139,47 +180,6 @@ static Microsoft.TemplateEngine.Utils.WellKnownSearchFilters.TypeFilter(string? 
 ~Microsoft.TemplateEngine.Utils.ExactVersionSpecification.ExactVersionSpecification(string version) -> void
 ~Microsoft.TemplateEngine.Utils.ExactVersionSpecification.RequiredVersion.get -> string
 ~Microsoft.TemplateEngine.Utils.Glob.IsMatch(string test) -> bool
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.CreateDirectory(string path) -> void
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.CreateFile(string path) -> System.IO.Stream
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.DirectoryDelete(string path, bool recursive) -> void
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.DirectoryExists(string directory) -> bool
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.EnumerateDirectories(string path, string pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string>
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.EnumerateFiles(string path, string pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string>
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.EnumerateFileSystemEntries(string directoryName, string pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string>
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.FileCopy(string sourcePath, string targetPath, bool overwrite) -> void
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.FileDelete(string path) -> void
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.FileExists(string file) -> bool
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.GetCurrentDirectory() -> string
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.GetFileAttributes(string file) -> System.IO.FileAttributes
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.GetLastWriteTimeUtc(string file) -> System.DateTime
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.InMemoryFileSystem(string root, Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem basis) -> void
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.OpenRead(string path) -> System.IO.Stream
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.ReadAllBytes(string path) -> byte[]
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.ReadAllText(string path) -> string
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.SetFileAttributes(string file, System.IO.FileAttributes attributes) -> void
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.SetLastWriteTimeUtc(string file, System.DateTime lastWriteTimeUtc) -> void
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.WatchFileChanges(string filepath, System.IO.FileSystemEventHandler fileChanged) -> System.IDisposable
-~Microsoft.TemplateEngine.Utils.InMemoryFileSystem.WriteAllText(string path, string value) -> void
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.CreateDirectory(string path) -> void
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.CreateFile(string path) -> System.IO.Stream
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.DirectoryDelete(string path, bool recursive) -> void
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.DirectoryExists(string directory) -> bool
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.EnumerateDirectories(string path, string pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string>
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.EnumerateFiles(string path, string pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string>
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.EnumerateFileSystemEntries(string directoryName, string pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<string>
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.FileCopy(string source, string target, bool overwrite) -> void
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.FileDelete(string path) -> void
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.FileExists(string file) -> bool
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.GetCurrentDirectory() -> string
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.GetFileAttributes(string file) -> System.IO.FileAttributes
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.GetLastWriteTimeUtc(string file) -> System.DateTime
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.OpenRead(string path) -> System.IO.Stream
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.ReadAllBytes(string path) -> byte[]
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.ReadAllText(string path) -> string
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.SetFileAttributes(string file, System.IO.FileAttributes attributes) -> void
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.SetLastWriteTimeUtc(string file, System.DateTime lastWriteTimeUtc) -> void
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.WatchFileChanges(string filepath, System.IO.FileSystemEventHandler fileChanged) -> System.IDisposable
-~Microsoft.TemplateEngine.Utils.PhysicalFileSystem.WriteAllText(string path, string value) -> void
 ~Microsoft.TemplateEngine.Utils.RangeVersionSpecification.CheckIfVersionIsValid(string versionToCheck) -> bool
 ~Microsoft.TemplateEngine.Utils.RangeVersionSpecification.MaxVersion.get -> string
 ~Microsoft.TemplateEngine.Utils.RangeVersionSpecification.MinVersion.get -> string

--- a/test/Microsoft.TemplateEngine.Mocks/MockFileSystem.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockFileSystem.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -11,7 +13,7 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Mocks
 {
-    public class MockFileSystem : IPhysicalFileSystem, IFileLastWriteTimeSource
+    public class MockFileSystem : IPhysicalFileSystem
     {
         private HashSet<string> _directories = new HashSet<string>(StringComparer.Ordinal);
 
@@ -19,11 +21,11 @@ namespace Microsoft.TemplateEngine.Mocks
 
         private List<DirectoryScanParameters> _directoriesScanned = new List<DirectoryScanParameters>();
 
-        public string CurrentDirectory { get; set; }
+        public string? CurrentDirectory { get; set; }
 
         public IReadOnlyList<DirectoryScanParameters> DirectoriesScanned => _directoriesScanned;
 
-        public MockFileSystem Add(string filePath, string contents, Encoding encoding = null, DateTime? lastWriteTime = null)
+        public MockFileSystem Add(string filePath, string contents, Encoding? encoding = null, DateTime? lastWriteTime = null)
         {
             _files[filePath] = new FileSystemFile()
             {
@@ -90,7 +92,7 @@ namespace Microsoft.TemplateEngine.Mocks
 
         public string GetCurrentDirectory()
         {
-            return CurrentDirectory;
+            return CurrentDirectory ?? string.Empty;
         }
 
         public IEnumerable<string> EnumerateFiles(string path, string pattern, SearchOption searchOption)
@@ -120,7 +122,7 @@ namespace Microsoft.TemplateEngine.Mocks
 
         public byte[] ReadAllBytes(string path)
         {
-            return _files[path].Data;
+            return _files[path].Data ?? Array.Empty<byte>();
         }
 
         public void DirectoryDelete(string path, bool recursive)
@@ -234,9 +236,9 @@ namespace Microsoft.TemplateEngine.Mocks
 
         public class DirectoryScanParameters
         {
-            public string DirectoryName { get; set; }
+            public string? DirectoryName { get; set; }
 
-            public string Pattern { get; set; }
+            public string? Pattern { get; set; }
 
             public SearchOption SearchOption { get; set; }
         }
@@ -254,7 +256,7 @@ namespace Microsoft.TemplateEngine.Mocks
                 LastWriteTimeUtc = file.LastWriteTimeUtc;
             }
 
-            public byte[] Data { get; set; }
+            public byte[]? Data { get; set; }
 
             public FileAttributes Attributes { get; set; }
 

--- a/test/Microsoft.TemplateEngine.TestHelper/MonitoredFileSystem.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/MonitoredFileSystem.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -8,7 +10,7 @@ using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
 
 namespace Microsoft.TemplateEngine.TestHelper
 {
-    public class MonitoredFileSystem : IPhysicalFileSystem, IFileLastWriteTimeSource
+    public class MonitoredFileSystem : IPhysicalFileSystem
     {
         private readonly IPhysicalFileSystem _baseFileSystem;
         private List<DirectoryScanParameters> _directoriesScanned = new List<DirectoryScanParameters>();
@@ -73,9 +75,9 @@ namespace Microsoft.TemplateEngine.TestHelper
 
         public IDisposable WatchFileChanges(string filepath, FileSystemEventHandler fileChanged) => _baseFileSystem.WatchFileChanges(filepath, fileChanged);
 
-        public DateTime GetLastWriteTimeUtc(string file) => (_baseFileSystem as IFileLastWriteTimeSource)?.GetLastWriteTimeUtc(file) ?? throw new NotImplementedException();
+        public DateTime GetLastWriteTimeUtc(string file) => _baseFileSystem.GetLastWriteTimeUtc(file);
 
-        public void SetLastWriteTimeUtc(string file, DateTime lastWriteTimeUtc) => (_baseFileSystem as IFileLastWriteTimeSource)?.SetLastWriteTimeUtc(file, lastWriteTimeUtc);
+        public void SetLastWriteTimeUtc(string file, DateTime lastWriteTimeUtc) => _baseFileSystem.SetLastWriteTimeUtc(file, lastWriteTimeUtc);
 
         private void RecordDirectoryScan(string directoryName, string pattern, SearchOption searchOption)
         {
@@ -89,9 +91,9 @@ namespace Microsoft.TemplateEngine.TestHelper
 
         public class DirectoryScanParameters
         {
-            public string DirectoryName { get; set; }
+            public string? DirectoryName { get; set; }
 
-            public string Pattern { get; set; }
+            public string? Pattern { get; set; }
 
             public SearchOption SearchOption { get; set; }
         }


### PR DESCRIPTION
### Problem
part of https://github.com/dotnet/templating/issues/2732

### Solution
Deprecating: `IFileLastWriteTimeSource`

### Checks:
- [ ] Added unit tests - NA
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)