### PR TITLE
fixes dotnet/templating#3118  deprecate ITemplateInfo.ShortNameList in favor of single ShortName

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/ITemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ITemplateInfo.cs
@@ -28,7 +28,9 @@ namespace Microsoft.TemplateEngine.Abstractions
 
         string Name { get; }
 
-        [Obsolete("Templates support multiple short names, use ShortNameList instead")]
+        /// <summary>
+        /// Gets short name of the template.
+        /// </summary>
         string ShortName { get; }
 
         IReadOnlyDictionary<string, ICacheTag> Tags { get; }
@@ -55,6 +57,7 @@ namespace Microsoft.TemplateEngine.Abstractions
         /// <summary>
         /// Gets the list of short names defined for the template.
         /// </summary>
+        [Obsolete("Templates should have only single short name, use ShortName instead.")]
         IReadOnlyList<string> ShortNameList { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/TemplateFiltering/MatchInfo.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/TemplateFiltering/MatchInfo.cs
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateEngine.Abstractions.TemplateFiltering
             public const string Name = "Name";
 
             /// <summary>
-            /// Template short names <see cref="ITemplateInfo.ShortNameList"/>.
+            /// Template short name <see cref="ITemplateInfo.ShortName"/>.
             /// </summary>
             public const string ShortName = "ShortName";
 

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -208,9 +208,9 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
         /// <returns>the help command or null in case template does not have short name defined.</returns>
         internal static string? GetTemplateHelpCommand(string commandName, ITemplateInfo template)
         {
-            if (template.ShortNameList.Any())
+            if (!string.IsNullOrWhiteSpace(template.ShortName))
             {
-                return GetTemplateHelpCommand(commandName, template.ShortNameList[0]);
+                return GetTemplateHelpCommand(commandName, template.ShortName);
             }
             return null;
         }
@@ -383,7 +383,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 {
                     TemplateIdentity = template.Info.Identity,
                     TemplateName = template.Info.Name,
-                    TemplateShortNames = template.Info.ShortNameList,
+                    TemplateShortName = template.Info.ShortName,
                     TemplateLanguage = template.Info.GetLanguage(),
                     TemplatePrecedence = template.Info.Precedence,
                     TemplateAuthor = template.Info.Author ?? string.Empty,
@@ -402,7 +402,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                         blankLineBetweenRows: false)
                     .DefineColumn(t => t.TemplateIdentity, LocalizableStrings.ColumnNameIdentity, showAlways: true)
                     .DefineColumn(t => t.TemplateName, LocalizableStrings.ColumnNameTemplateName, shrinkIfNeeded: true, minWidth: 15, showAlways: true)
-                    .DefineColumn(t => string.Join(",", t.TemplateShortNames), LocalizableStrings.ColumnNameShortName, showAlways: true)
+                    .DefineColumn(t => string.Join(",", t.TemplateShortName), LocalizableStrings.ColumnNameShortName, showAlways: true)
                     .DefineColumn(t => t.TemplateLanguage, LocalizableStrings.ColumnNameLanguage, showAlways: true)
                     .DefineColumn(t => t.TemplatePrecedence.ToString(), out object prcedenceColumn, LocalizableStrings.ColumnNamePrecedence, showAlways: true)
                     .DefineColumn(t => t.TemplateAuthor, LocalizableStrings.ColumnNameAuthor, showAlways: true, shrinkIfNeeded: true, minWidth: 10)
@@ -557,7 +557,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
         {
             internal string TemplateIdentity;
             internal string TemplateName;
-            internal IReadOnlyList<string> TemplateShortNames;
+            internal string TemplateShortName;
             internal string TemplateLanguage;
             internal int TemplatePrecedence;
             internal string TemplateAuthor;

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
@@ -36,7 +36,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 
             foreach (string preferredName in preferredNameList)
             {
-                ITemplateInfo? template = templateList.FirstOrDefault(x => x.ShortNameList.Contains(preferredName, StringComparer.OrdinalIgnoreCase));
+                ITemplateInfo? template = templateList.FirstOrDefault(x => x.ShortName.Equals(preferredName, StringComparison.OrdinalIgnoreCase));
 
                 if (template != null)
                 {
@@ -171,11 +171,11 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                     return false;
                 }
 
-                Reporter.Output.WriteLine($"    dotnet {commandName} {templateInfo.ShortNameList[0]} {hostTemplateData.UsageExamples[0]}");
+                Reporter.Output.WriteLine($"    dotnet {commandName} {templateInfo.ShortName} {hostTemplateData.UsageExamples[0]}");
                 return true;
             }
 
-            Reporter.Output.Write($"    dotnet {commandName} {templateInfo.ShortNameList[0]}");
+            Reporter.Output.Write($"    dotnet {commandName} {templateInfo.ShortName}");
             IReadOnlyList<ITemplateParameter> allParameterDefinitions = templateInfo.Parameters;
             IEnumerable<ITemplateParameter> filteredParams = TemplateParameterHelpBase.FilterParamsForHelp(allParameterDefinitions, hostTemplateData.HiddenParameterNames, parametersToAlwaysShow: hostTemplateData.ParametersToAlwaysShow);
 

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -435,7 +435,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             foreach (ITemplateMatchInfo templateMatchInfo in allTemplates)
             {
-                allShortNames.UnionWith(templateMatchInfo.Info.ShortNameList);
+                allShortNames.Add(templateMatchInfo.Info.ShortName);
             }
 
             return allShortNames;

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -14,7 +14,6 @@ using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
 using Microsoft.TemplateEngine.Cli.HelpAndUsage;
 using Microsoft.TemplateEngine.Cli.NuGet;
-using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Edge.Template;
 using Microsoft.TemplateEngine.Utils;
 using NuGet.Credentials;
@@ -442,9 +441,7 @@ namespace Microsoft.TemplateEngine.Cli
 
             IReadOnlyList<ITemplateInfo> templates = await _engineEnvironmentSettings.SettingsLoader.GetTemplatesAsync(cancellationToken).ConfigureAwait(false);
             var templatesWithMatchedShortName = templates.Where(template =>
-            {
-                return template.ShortNameList.Contains(sourceIdentifier, StringComparer.OrdinalIgnoreCase);
-            });
+                template.ShortName.Equals(sourceIdentifier, StringComparison.OrdinalIgnoreCase));
 
             var templatePackages = await Task.WhenAll(
                 templatesWithMatchedShortName.Select(
@@ -465,7 +462,7 @@ namespace Microsoft.TemplateEngine.Cli
             IReadOnlyList<ITemplateInfo> templates = await _engineEnvironmentSettings.SettingsLoader.GetTemplatesAsync(cancellationToken).ConfigureAwait(false);
             return templates.Any(template =>
             {
-                return template.ShortNameList.Contains(sourceIdentifier, StringComparer.OrdinalIgnoreCase);
+                return template.ShortName.Equals(sourceIdentifier, StringComparison.OrdinalIgnoreCase);
             });
         }
 
@@ -557,17 +554,16 @@ namespace Microsoft.TemplateEngine.Cli
                 if (templates.Any())
                 {
                     Reporter.Output.WriteLine($"{LocalizableStrings.Templates}:".Indent(level: 2));
-                    foreach (TemplateInfo info in templates)
+                    foreach (ITemplateInfo info in templates)
                     {
                         string templateLanguage = info.GetLanguage();
-                        string shortNames = string.Join(",", info.ShortNameList);
                         if (!string.IsNullOrWhiteSpace(templateLanguage))
                         {
-                            Reporter.Output.WriteLine($"{info.Name} ({shortNames}) {templateLanguage}".Indent(level: 3));
+                            Reporter.Output.WriteLine($"{info.Name} ({info.ShortName}) {templateLanguage}".Indent(level: 3));
                         }
                         else
                         {
-                            Reporter.Output.WriteLine($"{info.Name} ({shortNames})".Indent(level: 3));
+                            Reporter.Output.WriteLine($"{info.Name} ({info.ShortName})".Indent(level: 3));
                         }
                     }
                 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateGroup.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateGroup.cs
@@ -64,12 +64,12 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             {
                 if (HasSingleTemplate)
                 {
-                    return Templates.First().Info.ShortNameList;
+                    return new[] { Templates.First().Info.ShortName };
                 }
                 HashSet<string> shortNames = new HashSet<string>();
                 foreach (ITemplateMatchInfo template in Templates)
                 {
-                    shortNames.UnionWith(template.Info.ShortNameList);
+                    shortNames.Add(template.Info.ShortName);
                 }
                 return shortNames.ToList();
             }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
@@ -354,7 +354,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                 }
                 catch (CommandParserException ex)
                 {
-                    string shortname = template.Info.ShortNameList.Any() ? template.Info.ShortNameList[0] : $"'{template.Info.Name}'";
+                    string shortname = !string.IsNullOrWhiteSpace(template.Info.ShortName) ? template.Info.ShortName : $"'{template.Info.Name}'";
                     // if we do actually throw, add a non-match
                     Reporter.Error.WriteLine(
                         string.Format(
@@ -390,7 +390,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                     shortNames = new HashSet<string>();
                     shortNamesByGroup[effectiveGroupIdentity] = shortNames;
                 }
-                shortNames.UnionWith(template.ShortNameList);
+                shortNames.Add(template.ShortName);
             }
 
             // create the TemplateInfoWithGroupShortNames with the group short names
@@ -500,9 +500,9 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 
             public string Name => _parent.Name;
 
-            [Obsolete]
             public string ShortName => _parent.ShortName;
 
+            [Obsolete]
             public IReadOnlyList<string> ShortNameList => _parent.ShortNameList;
 
             public IReadOnlyList<string> GroupShortNameList { get; } = new List<string>();

--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
@@ -69,7 +69,6 @@ Microsoft.TemplateEngine.Edge.Settings.TemplateInfo.GeneratorId.get -> System.Gu
 Microsoft.TemplateEngine.Edge.Settings.TemplateInfo.GeneratorId.set -> void
 Microsoft.TemplateEngine.Edge.Settings.TemplateInfo.Precedence.get -> int
 Microsoft.TemplateEngine.Edge.Settings.TemplateInfo.Precedence.set -> void
-Microsoft.TemplateEngine.Edge.Settings.TemplateInfo.ShouldSerializeShortName() -> bool
 Microsoft.TemplateEngine.Edge.Settings.TemplateInfo.TemplateInfo() -> void
 Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders.TemplateInfoReaderInitialVersion
 Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders.TemplateInfoReaderVersion1_0_0_0

--- a/src/Microsoft.TemplateEngine.Edge/Settings/SettingsLoader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/SettingsLoader.cs
@@ -132,7 +132,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             return UpdateTemplateCacheAsync(true);
         }
 
-        public ITemplate? LoadTemplate(ITemplateInfo info, string baselineName)
+        public ITemplate? LoadTemplate(ITemplateInfo info, string? baselineName)
         {
             if (_disposed)
             {

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -143,9 +143,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 Name = localizationInfo?.Name ?? template.Name,
                 Tags = LocalizeCacheTags(template, localizationInfo),
                 CacheParameters = LocalizeCacheParameters(template, localizationInfo),
-#pragma warning disable CS0618 // Type or member is obsolete
                 ShortName = template.ShortName,
-#pragma warning restore CS0618 // Type or member is obsolete
                 Classifications = template.Classifications,
                 Author = localizationInfo?.Author ?? template.Author,
                 Description = localizationInfo?.Description ?? template.Description,
@@ -157,7 +155,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 HostConfigPlace = template.HostConfigPlace,
                 ThirdPartyNotices = template.ThirdPartyNotices,
                 BaselineInfo = template.BaselineInfo,
+#pragma warning disable CS0618 // Type or member is obsolete
                 ShortNameList = template.ShortNameList
+#pragma warning restore CS0618 // Type or member is obsolete
             };
 
             return localizedTemplate;

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
@@ -36,7 +36,6 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
         public TemplateInfo()
         {
-            ShortNameList = new List<string>();
         }
 
         [JsonIgnore]
@@ -131,30 +130,11 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         public string Name { get; set; }
 
         [JsonProperty]
-        public string ShortName
-        {
-            get
-            {
-                if (ShortNameList.Count > 0)
-                {
-                    return ShortNameList[0];
-                }
+        public string ShortName { get; set; }
 
-                return string.Empty;
-            }
-
-            set
-            {
-                if (ShortNameList.Count > 0)
-                {
-                    throw new Exception("Can't set the short name when the ShortNameList already has entries.");
-                }
-
-                ShortNameList = new List<string>() { value };
-            }
-        }
-
-        public IReadOnlyList<string> ShortNameList { get; set; }
+        [Obsolete("The templates are limited only to use single short name, Use ShortName instead.")]
+        [JsonProperty]
+        public IReadOnlyList<string> ShortNameList { get; set; } = new List<string>();
 
         [JsonProperty]
         public IReadOnlyDictionary<string, ICacheTag> Tags
@@ -214,14 +194,6 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
 
             return infoReader(entry);
-        }
-
-        // ShortName should get deserialized when it exists, for backwards compat.
-        // But moving forward, ShortNameList should be the definitive source.
-        // It can still be ShortName in the template.json, but in the caches it'll be ShortNameList
-        public bool ShouldSerializeShortName()
-        {
-            return false;
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_2.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReaders/TemplateInfoReaderVersion1_0_0_2.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Utils;
@@ -18,16 +19,22 @@ namespace Microsoft.TemplateEngine.Edge.Settings.TemplateInfoReaders
             return reader.Read(jObject);
         }
 
+        [Obsolete("Only single short name is allowed.")]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         protected override void ReadShortNameInfo(JObject jObject, TemplateInfo info)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
         {
             JToken shortNameToken = jObject.Get<JToken>(nameof(TemplateInfo.ShortNameList));
             info.ShortNameList = JTokenStringOrArrayToCollection(shortNameToken, System.Array.Empty<string>());
-
             if (info.ShortNameList.Count == 0)
             {
                 // template.json stores the short name(s) in ShortName
                 // but the cache will store it in ShortNameList
                 base.ReadShortNameInfo(jObject, info);
+            }
+            else
+            {
+                info.ShortName = info.ShortNameList[0];
             }
         }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IRunnableProjectConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IRunnableProjectConfig.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
@@ -24,7 +25,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         string Name { get; }
 
+        [Obsolete]
         IReadOnlyList<string> ShortNameList { get; }
+
+        string ShortName { get; }
 
         string Author { get; }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -611,7 +611,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 errorMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "name", templateFile.FullPath));
             }
 
-            if ((templateModel.ShortNameList?.Count ?? 0) == 0)
+            if (string.IsNullOrWhiteSpace(templateModel.ShortName))
             {
                 errorMessages.Add(string.Format(LocalizableStrings.Authoring_MissingValue, "shortName", templateFile.FullPath));
             }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
@@ -29,9 +29,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             DefaultName = config.DefaultName;
             Name = config.Name;
             Identity = config.Identity ?? config.Name;
-
+            ShortName = config.ShortName;
+#pragma warning disable CS0612 // Type or member is obsolete
             ShortNameList = config.ShortNameList ?? new List<string>();
-
+#pragma warning restore CS0612 // Type or member is obsolete
             Author = config.Author;
             Tags = config.Tags ?? new Dictionary<string, ICacheTag>(StringComparer.OrdinalIgnoreCase);
             CacheParameters = config.CacheParameters ?? new Dictionary<string, ICacheParameter>(StringComparer.OrdinalIgnoreCase);
@@ -75,29 +76,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         public string Name { get; }
 
-        public string ShortName
-        {
-            get
-            {
-                if (ShortNameList.Count > 0)
-                {
-                    return ShortNameList[0];
-                }
+        public string ShortName { get; }
 
-                return string.Empty;
-            }
-
-            set
-            {
-                if (ShortNameList.Count > 0)
-                {
-                    throw new Exception("Can't set the short name when the ShortNameList already has entries.");
-                }
-
-                ShortNameList = new List<string>() { value };
-            }
-        }
-
+        [Obsolete]
         public IReadOnlyList<string> ShortNameList { get; private set; }
 
         public IReadOnlyDictionary<string, ICacheTag> Tags

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
@@ -702,8 +702,7 @@
     },
     "shortName": {
       "description": "A shorthand name or a list of names for selecting the template (applies to environments where the template name is specified by the user - not selected via a GUI). The first entry is the preferred short name.",
-      "type": [ "string", "array" ],
-      "minLength": 1
+      "type": [ "string" ]
     },
     "sourceName": {
       "description": "The name in the source tree to replace with the name the user specifies",

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
@@ -78,7 +78,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         public string Name { get; set; }
 
+        [Obsolete]
         public IReadOnlyList<string> ShortNameList { get; set; }
+
+        public string ShortName { get; set; }
 
         public IReadOnlyList<IPostActionModel> PostActionModel { get; set; }
 
@@ -576,7 +579,10 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             };
 
             JToken shortNameToken = source.Get<JToken>("ShortName");
+#pragma warning disable CS0612 // Type or member is obsolete
             config.ShortNameList = JTokenStringOrArrayToCollection(shortNameToken, Array.Empty<string>());
+            config.ShortName = config.ShortNameList.Any() ? config.ShortNameList[0] : string.Empty;
+#pragma warning restore CS0612 // Type or member is obsolete
 
             config.Forms = SetupValueFormMapForTemplate(source);
 

--- a/src/Microsoft.TemplateEngine.Utils/WellKnownSearchFilters.cs
+++ b/src/Microsoft.TemplateEngine.Utils/WellKnownSearchFilters.cs
@@ -34,9 +34,9 @@ namespace Microsoft.TemplateEngine.Utils
         /// Matches <paramref name="name"/> on the following criteria: <br/>
         /// - if <paramref name="name"/> is null or empty, adds match disposition <see cref="MatchInfo.BuiltIn.Name"/> with <see cref="MatchKind.Partial"/>;<br/>
         /// - if <paramref name="name"/> is equal to <see cref="ITemplateInfo.Name"/> (case insensitive), adds match disposition <see cref="MatchInfo.BuiltIn.Name"/> with <see cref="MatchKind.Exact"/>;<br/>
-        /// - if <paramref name="name"/> is equal to one of the short names in <see cref="ITemplateInfo.ShortNameList"/> (case insensitive), adds match disposition <see cref="MatchInfo.BuiltIn.ShortName"/> with <see cref="MatchKind.Exact"/>;<br/>
+        /// - if <paramref name="name"/> is equal to <see cref="ITemplateInfo.ShortName"/> (case insensitive), adds match disposition <see cref="MatchInfo.BuiltIn.ShortName"/> with <see cref="MatchKind.Exact"/>;<br/>
         /// - if <see cref="ITemplateInfo.Name"/> contains <paramref name="name"/> (case insensitive), adds match disposition <see cref="MatchInfo.BuiltIn.Name"/> with <see cref="MatchKind.Partial"/>;<br/>
-        /// - if one of the short names in <see cref="ITemplateInfo.ShortNameList"/> contains <paramref name="name"/> (case insensitive), adds match disposition <see cref="MatchInfo.BuiltIn.ShortName"/> with <see cref="MatchKind.Partial"/>;<br/>
+        /// - if <see cref="ITemplateInfo.ShortName"/> contains <paramref name="name"/> (case insensitive), adds match disposition <see cref="MatchInfo.BuiltIn.ShortName"/> with <see cref="MatchKind.Partial"/>;<br/>
         /// - adds match disposition <see cref="MatchInfo.BuiltIn.Name"/> with <see cref="MatchKind.Mismatch"/> otherwise.<br/>
         /// </summary>
         /// <returns> the predicate to be used with <see cref="ISettingsLoader.GetTemplatesAsync(Func{ITemplateMatchInfo, bool}, System.Collections.Generic.IEnumerable{Func{ITemplateInfo, MatchInfo?}}[], System.Threading.CancellationToken)"/> as the filter.</returns>
@@ -57,18 +57,14 @@ namespace Microsoft.TemplateEngine.Utils
                 }
 
                 bool hasShortNamePartialMatch = false;
+                int shortNameIndex = template.ShortName.IndexOf(name, StringComparison.OrdinalIgnoreCase);
 
-                foreach (string shortName in template.ShortNameList)
+                if (shortNameIndex == 0 && template.ShortName.Length == name.Length)
                 {
-                    int shortNameIndex = shortName.IndexOf(name, StringComparison.OrdinalIgnoreCase);
-
-                    if (shortNameIndex == 0 && shortName.Length == name.Length)
-                    {
-                        return new MatchInfo(MatchInfo.BuiltIn.ShortName, name, MatchKind.Exact);
-                    }
-
-                    hasShortNamePartialMatch |= shortNameIndex > -1;
+                    return new MatchInfo(MatchInfo.BuiltIn.ShortName, name, MatchKind.Exact);
                 }
+
+                hasShortNamePartialMatch = shortNameIndex > -1;
 
                 if (nameIndex > -1)
                 {

--- a/src/Microsoft.TemplateSearch.Common/FileMetadataTemplateSearchCache.cs
+++ b/src/Microsoft.TemplateSearch.Common/FileMetadataTemplateSearchCache.cs
@@ -39,8 +39,7 @@ namespace Microsoft.TemplateSearch.Common
 
             return TemplateDiscoveryMetadata.TemplateCache.Where(
                 template => template.Name.IndexOf(searchName, StringComparison.OrdinalIgnoreCase) >= 0
-                || template.ShortNameList.Any(shortName => shortName.IndexOf(searchName, StringComparison.OrdinalIgnoreCase) >= 0))
-                .ToList();
+                || template.ShortName.IndexOf(searchName, StringComparison.OrdinalIgnoreCase) >= 0).ToList();
         }
 
         public IReadOnlyDictionary<string, PackInfo> GetTemplateToPackMapForTemplateIdentities(IReadOnlyList<string> identities)

--- a/src/Microsoft.TemplateSearch.Common/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateSearch.Common/PublicAPI.Unshipped.txt
@@ -10,6 +10,7 @@ Microsoft.TemplateSearch.Common.BlobStorageTemplateInfo.GroupIdentity.get -> str
 Microsoft.TemplateSearch.Common.BlobStorageTemplateInfo.Identity.get -> string!
 Microsoft.TemplateSearch.Common.BlobStorageTemplateInfo.Name.get -> string!
 Microsoft.TemplateSearch.Common.BlobStorageTemplateInfo.Precedence.get -> int
+Microsoft.TemplateSearch.Common.BlobStorageTemplateInfo.ShortName.get -> string!
 Microsoft.TemplateSearch.Common.BlobStorageTemplateInfo.ShortNameList.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateSearch.Common.BlobStorageTemplateInfo.Tags.get -> System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Abstractions.ICacheTag!>!
 Microsoft.TemplateSearch.Common.BlobStorageTemplateInfo.ThirdPartyNotices.get -> string?

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
@@ -75,8 +75,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
                             Verbose.WriteLine("Found templates:");
                             foreach (ITemplateInfo template in packCheckResult.FoundTemplates)
                             {
-                                string shortNames = string.Join(",", template.ShortNameList);
-                                Verbose.WriteLine($"  - {template.Identity} ({shortNames}) by {template.Author}, group: {(string.IsNullOrWhiteSpace(template.GroupIdentity) ? "<not set>" : template.GroupIdentity)}, precedence: {template.Precedence}");
+                                Verbose.WriteLine($"  - {template.Identity} ({template.ShortName}) by {template.Author}, group: {(string.IsNullOrWhiteSpace(template.GroupIdentity) ? "<not set>" : template.GroupIdentity)}, precedence: {template.Precedence}");
                             }
                         }
                         else

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockTemplateSearchSource.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockTemplateSearchSource.cs
@@ -91,7 +91,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 
             foreach (ITemplateNameSearchResult candidate in possibleSearchResults)
             {
-                if (candidate.Template.Name.Contains(templateName) || candidate.Template.ShortNameList.Any(shortName => shortName.Contains(templateName)))
+                if (candidate.Template.Name.Contains(templateName) || candidate.Template.ShortName.Contains(templateName))
                 {
                     if (!_packFilter.ShouldPackBeFiltered(candidate.Template.Name, candidate.PackInfo.Version))
                     {

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/HelpTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/HelpTemplateListResolverTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
-            Assert.Equal("console2", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
+            Assert.Equal("console2", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
             Assert.Equal("Console.App2", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
             Assert.Equal(1, matchResult.UnambiguousTemplateGroup.Count);
         }
@@ -44,7 +44,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
-            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
+            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
             Assert.Equal("Console.App", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
             Assert.Equal(1, matchResult.UnambiguousTemplateGroup.Count);
         }
@@ -99,7 +99,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
             Assert.True(matchResult.HasUnambiguousTemplateGroupForDefaultLanguage);
-            Assert.Equal("console", matchResult.UnambiguousTemplatesForDefaultLanguage.Single().Info.ShortNameList.Single());
+            Assert.Equal("console", matchResult.UnambiguousTemplatesForDefaultLanguage.Single().Info.ShortName);
             Assert.Equal("Console.App.L1", matchResult.UnambiguousTemplatesForDefaultLanguage.Single().Info.Identity);
             Assert.Equal("L1", matchResult.UnambiguousTemplatesForDefaultLanguage.Single().Info.Tags["language"].Choices.Keys.FirstOrDefault());
             Assert.Equal(2, matchResult.UnambiguousTemplateGroup.Count);
@@ -118,7 +118,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "L1");
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
-            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
+            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
             Assert.Equal("Console.App.L2", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
             Assert.Equal("L2", matchResult.UnambiguousTemplateGroup.Single().Info.Tags["language"].Choices.Keys.FirstOrDefault());
             Assert.Equal(1, matchResult.UnambiguousTemplateGroup.Count);

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
-            Assert.Equal("console2", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
+            Assert.Equal("console2", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
             Assert.Equal("Console.App2", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
             Assert.Equal(1, matchResult.UnambiguousTemplateGroup.Count);
         }
@@ -117,7 +117,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "L1");
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
-            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
+            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
             Assert.Equal("Console.App.L2", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
             Assert.Equal("L2", matchResult.UnambiguousTemplateGroup.Single().Info.Tags["language"].Choices.Keys.FirstOrDefault());
             Assert.Equal(1, matchResult.UnambiguousTemplateGroup.Count);
@@ -299,7 +299,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             Assert.False(matchResult.HasLanguageMismatch);
             Assert.False(matchResult.HasTypeMismatch);
             Assert.False(matchResult.HasBaselineMismatch);
-            Assert.Equal("console1", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
+            Assert.Equal("console1", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
             Assert.Equal("Console.App.T1", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
         }
 
@@ -329,7 +329,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             Assert.False(matchResult.HasLanguageMismatch);
             Assert.False(matchResult.HasTypeMismatch);
             Assert.False(matchResult.HasBaselineMismatch);
-            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
+            Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortName);
             Assert.Equal("Console.App.T1", matchResult.UnambiguousTemplateGroup.Single().Info.Identity);
         }
 

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/SettingsLoaderTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/SettingsLoaderTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
                 .ConfigureAwait(false);
 
             Assert.Equal(1, templates.Count);
-            Assert.Equal("sample99", templates.Single().ShortNameList[0]);
+            Assert.Equal("sample99", templates.Single().ShortName);
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
                 .ConfigureAwait(false);
 
             Assert.Equal(1, templates.Count);
-            Assert.Equal("sample49", templates.Single().ShortNameList[0]);
+            Assert.Equal("sample49", templates.Single().ShortName);
         }
 
         [Fact]

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/FileRenameTests.cs
@@ -208,7 +208,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
             var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
-            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortNameList.Contains($"TestAssets.{templateName}")).Info;
+            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName.Equals($"TestAssets.{templateName}")).Info;
             ICreationEffects result = await bootstrapper.GetCreationEffectsAsync(template, name, output, parametersDict, "").ConfigureAwait(false);
 
             Assert.Equal(expectedResult.CreationResult.PrimaryOutputs.Count, result.CreationResult.PrimaryOutputs.Count);
@@ -237,7 +237,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
             var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
-            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortNameList.Contains($"TestAssets.{templateName}")).Info;
+            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName.Equals($"TestAssets.{templateName}")).Info;
             var result = await bootstrapper.CreateAsync(template, name, output, parametersDict, false, "").ConfigureAwait(false);
 
             Assert.Equal(expectedResult.CreationResult.PrimaryOutputs.Count, result.PrimaryOutputs.Count);
@@ -283,7 +283,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
             var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
-            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortNameList.Contains($"TestAssets.{templateName}")).Info;
+            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName.Equals($"TestAssets.{templateName}")).Info;
             ICreationEffects result = await bootstrapper.GetCreationEffectsAsync(template, name, output, parametersDict, "").ConfigureAwait(false);
 
             Assert.Equal(expectedResult.CreationResult.PrimaryOutputs.Count, result.CreationResult.PrimaryOutputs.Count);
@@ -313,7 +313,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Dictionary<string, string> parametersDict = BasicParametersParser.ParseParameterString(parameters);
 
             var foundTemplates = await bootstrapper.GetTemplatesAsync(new[] { WellKnownSearchFilters.NameFilter(templateName) }).ConfigureAwait(false);
-            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortNameList.Contains($"TestAssets.{templateName}")).Info;
+            ITemplateInfo template = foundTemplates.Single(template => template.Info.ShortName.Equals($"TestAssets.{templateName}")).Info;
             var result = await bootstrapper.CreateAsync(template, name, output, parametersDict, false, "").ConfigureAwait(false);
 
             Assert.Equal(expectedResult.CreationResult.PrimaryOutputs.Count, result.PrimaryOutputs.Count);

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
@@ -202,5 +202,32 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdErrContaining($"{Path.DirectorySeparatorChar}test_templates{Path.DirectorySeparatorChar}TemplateResolution{Path.DirectorySeparatorChar}SamePrecedenceGroup{Path.DirectorySeparatorChar}BasicTemplate2")
                 .And.HaveStdErrContaining($"{Path.DirectorySeparatorChar}test_templates{Path.DirectorySeparatorChar}TemplateResolution{Path.DirectorySeparatorChar}SamePrecedenceGroup{Path.DirectorySeparatorChar}BasicTemplate1");
         }
+
+        [Fact]
+        public void CannotInstantiateTemplateWithSecondShortName()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+            Helpers.InstallNuGetTemplate("Microsoft.DotNet.Web.ProjectTemplates.5.0", _log, workingDirectory, home);
+
+            new DotnetNewCommand(_log, "webapp")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining("The template \"ASP.NET Core Web App\" was created successfully.");
+
+            new DotnetNewCommand(_log, "razor", "-o", "template2")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining("The template \"Razor Class Library\" was created successfully.")
+                .And.NotHaveStdOutContaining("The template \"ASP.NET Core Web App\" was created successfully.");
+        }
     }
 }


### PR DESCRIPTION
### Problem
fixes dotnet/templating#3118 

### Solution
after discussion we decided to deprecate possibility of having several short names in the template.
only 2 templates are using this feature: razor from aspnet and the template based on it.
Reason: the short name supposed to be unique throughout all the templates and the pool of the names is not endless, so better to force author to select single short name. In case user would like to change the name, they might use --alias option. In case the template author would like to change name in new version of template, this still will be supported as the template group shares the short names of all the templates inside the group.

### Checks:
- [x] Added unit tests - modified existing tests for new logic
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - added to files with major modifications