### PR TITLE
dotnet/templating#3146 made OnPotentiallyDestructiveChangesDetected and OnParameterError deprecated

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs
@@ -67,20 +67,6 @@ namespace Microsoft.TemplateEngine.Abstractions
         /// <param name="path"></param>
         void VirtualizeDirectory(string path);
 
-        /// <summary>
-        /// Action to be done when potentially destructive changes on template instantiation are detected.
-        /// The host can implement it as needed: prompt user, show error, etc.
-        /// In case template instantiation should proceed, the method should return true.
-        /// In case template instantiation should be aborted, the method should return false.
-        /// </summary>
-        /// <param name="changes">the list of file changes to be done on template instantiation.</param>
-        /// <param name="destructiveChanges">the list of destructive file changes (modify/remove) to be performed on template instantiation.</param>
-        /// <returns>
-        /// true - in case template engine should proceed with template instantiation and perform destructive changes;
-        /// false - if the template instantiation should be aborted.
-        /// </returns>
-        bool OnPotentiallyDestructiveChangesDetected(IReadOnlyList<IFileChange> changes, IReadOnlyList<IFileChange> destructiveChanges);
-
         #region Obsolete
 
         [Obsolete("Use " + nameof(Logger) + " instead.")]
@@ -95,6 +81,7 @@ namespace Microsoft.TemplateEngine.Abstractions
         [Obsolete("Use " + nameof(Logger) + " instead.")]
         bool OnNonCriticalError(string code, string message, string currentFile, long currentPosition);
 
+        [Obsolete("The method is deprecated.")]
         bool OnParameterError(ITemplateParameter parameter, string receivedValue, string message, out string newValue);
 
         [Obsolete("The method is deprecated.")]
@@ -105,6 +92,21 @@ namespace Microsoft.TemplateEngine.Abstractions
 
         [Obsolete("The method is deprecated.")]
         bool OnConfirmPartialMatch(string name);
+
+        /// <summary>
+        /// Action to be done when potentially destructive changes on template instantiation are detected.
+        /// The host can implement it as needed: prompt user, show error, etc.
+        /// In case template instantiation should proceed, the method should return true.
+        /// In case template instantiation should be aborted, the method should return false.
+        /// </summary>
+        /// <param name="changes">the list of file changes to be done on template instantiation.</param>
+        /// <param name="destructiveChanges">the list of destructive file changes (modify/remove) to be performed on template instantiation.</param>
+        /// <returns>
+        /// true - in case template engine should proceed with template instantiation and perform destructive changes;
+        /// false - if the template instantiation should be aborted.
+        /// </returns>
+        [Obsolete("The method is deprecated. If potentially destructive changes are detected without passing force, TemplateCreator will return DestructiveChangesDetected CreationResultStatus that can be processed by host.")]
+        bool OnPotentiallyDestructiveChangesDetected(IReadOnlyList<IFileChange> changes, IReadOnlyList<IFileChange> destructiveChanges);
 
         #endregion
     }

--- a/src/Microsoft.TemplateEngine.Cli/CliTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CliTemplateEngineHost.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Microsoft.TemplateEngine.Abstractions;
@@ -100,23 +99,6 @@ namespace Microsoft.TemplateEngine.Cli
             _baseHost.VirtualizeDirectory(path);
         }
 
-        public bool OnPotentiallyDestructiveChangesDetected(IReadOnlyList<IFileChange> changes, IReadOnlyList<IFileChange> destructiveChanges)
-        {
-            Reporter.Error.WriteLine(LocalizableStrings.DestructiveChangesNotification.Bold().Red());
-            int longestChangeTextLength = destructiveChanges.Max(x => GetChangeString(x.ChangeKind).Length);
-            int padLen = 5 + longestChangeTextLength;
-
-            foreach (IFileChange change in destructiveChanges)
-            {
-                string changeKind = GetChangeString(change.ChangeKind);
-                Reporter.Error.WriteLine(($"  {changeKind}".PadRight(padLen) + change.TargetRelativePath).Bold().Red());
-            }
-
-            Reporter.Error.WriteLine();
-            Reporter.Error.WriteLine(LocalizableStrings.RerunCommandAndPassForceToCreateAnyway.Bold().Red());
-            return false;
-        }
-
         #region Obsolete
         [Obsolete]
         void ITemplateEngineHost.LogMessage(string message)
@@ -168,29 +150,13 @@ namespace Microsoft.TemplateEngine.Cli
         {
             //do nothing
         }
-        #endregion
 
-        private static string GetChangeString(ChangeKind kind)
+        [Obsolete]
+        bool ITemplateEngineHost.OnPotentiallyDestructiveChangesDetected(IReadOnlyList<IFileChange> changes, IReadOnlyList<IFileChange> destructiveChanges)
         {
-            string changeType;
-
-            switch (kind)
-            {
-                case ChangeKind.Change:
-                    changeType = LocalizableStrings.Change;
-                    break;
-                case ChangeKind.Delete:
-                    changeType = LocalizableStrings.Delete;
-                    break;
-                case ChangeKind.Overwrite:
-                    changeType = LocalizableStrings.Overwrite;
-                    break;
-                default:
-                    changeType = LocalizableStrings.UnknownChangeKind;
-                    break;
-            }
-
-            return changeType;
+            //do nothing - CreationStatusResult is handled instead in TemplateInvoker
+            return false;
         }
+        #endregion
     }
 }

--- a/src/Microsoft.TemplateEngine.Core/VariableCollection.cs
+++ b/src/Microsoft.TemplateEngine.Core/VariableCollection.cs
@@ -184,10 +184,6 @@ namespace Microsoft.TemplateEngine.Core
                 {
                     if (param.Priority != TemplateParameterPriority.Optional && param.Priority != TemplateParameterPriority.Suggested)
                     {
-                        while (environmentSettings.Host.OnParameterError(param, null, "ParameterValueNotSpecified", out string val))
-                        {
-                        }
-
                         parameters.ResolvedValues[param] = value;
                     }
                 }
@@ -195,10 +191,6 @@ namespace Microsoft.TemplateEngine.Core
                 {
                     if (param.Priority != TemplateParameterPriority.Optional && param.Priority != TemplateParameterPriority.Suggested)
                     {
-                        while (environmentSettings.Host.OnParameterError(param, null, "ParameterValueNull", out string val))
-                        {
-                        }
-
                         parameters.ResolvedValues[param] = value;
                     }
                 }

--- a/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs
@@ -80,11 +80,6 @@ namespace Microsoft.TemplateEngine.Edge
             FileSystem = new InMemoryFileSystem(path, FileSystem);
         }
 
-        public bool OnPotentiallyDestructiveChangesDetected(IReadOnlyList<IFileChange> changes, IReadOnlyList<IFileChange> destructiveChanges)
-        {
-            return true;
-        }
-
         #region Obsolete
 
 #pragma warning disable SA1201 // Elements should appear in the correct order
@@ -93,18 +88,18 @@ namespace Microsoft.TemplateEngine.Edge
 #pragma warning restore SA1201 // Elements should appear in the correct order
 
         [Obsolete("The method is deprecated.")]
-        public bool OnConfirmPartialMatch(string name)
+        bool ITemplateEngineHost.OnConfirmPartialMatch(string name)
         {
             return true;
         }
 
         [Obsolete("The method is deprecated.")]
-        public virtual void OnSymbolUsed(string symbol, object value)
+        void ITemplateEngineHost.OnSymbolUsed(string symbol, object value)
         {
         }
 
         [Obsolete("The method is deprecated.")]
-        public virtual bool OnParameterError(ITemplateParameter parameter, string receivedValue, string message, out string newValue)
+        bool ITemplateEngineHost.OnParameterError(ITemplateParameter parameter, string receivedValue, string message, out string newValue)
         {
             newValue = "";
             return false;
@@ -117,7 +112,7 @@ namespace Microsoft.TemplateEngine.Edge
         }
 
         [Obsolete("Use " + nameof(Logger) + " instead")]
-        public void LogDiagnosticMessage(string message, string category, params string[] details)
+        void ITemplateEngineHost.LogDiagnosticMessage(string message, string category, params string[] details)
         {
             if (_diagnosticLoggers.TryGetValue(category, out Action<string, string[]> messageHandler))
             {
@@ -126,27 +121,33 @@ namespace Microsoft.TemplateEngine.Edge
         }
 
         [Obsolete("Use " + nameof(Logger) + " instead")]
-        public void LogTiming(string label, TimeSpan duration, int depth)
+        void ITemplateEngineHost.LogTiming(string label, TimeSpan duration, int depth)
         {
             OnLogTiming?.Invoke(label, duration, depth);
         }
 
         [Obsolete("Use " + nameof(Logger) + " instead")]
-        public virtual void LogMessage(string message)
+        void ITemplateEngineHost.LogMessage(string message)
         {
             Console.WriteLine(message);
         }
 
         [Obsolete("Use " + nameof(Logger) + " instead")]
-        public virtual void OnCriticalError(string code, string message, string currentFile, long currentPosition)
+        void ITemplateEngineHost.OnCriticalError(string code, string message, string currentFile, long currentPosition)
         {
         }
 
         [Obsolete("Use " + nameof(Logger) + " instead")]
-        public virtual bool OnNonCriticalError(string code, string message, string currentFile, long currentPosition)
+        bool ITemplateEngineHost.OnNonCriticalError(string code, string message, string currentFile, long currentPosition)
         {
-            LogMessage(string.Format($"Error: {message}"));
+            ((ITemplateEngineHost)this).LogMessage(string.Format($"Error: {message}"));
             return false;
+        }
+
+        [Obsolete]
+        bool ITemplateEngineHost.OnPotentiallyDestructiveChangesDetected(IReadOnlyList<IFileChange> changes, IReadOnlyList<IFileChange> destructiveChanges)
+        {
+            return true;
         }
         #endregion
     }

--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
@@ -5,14 +5,10 @@ Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.DefaultTemplateEngineHos
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.FallbackHostTemplateConfigNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.FileSystem.get -> Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem!
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.HostIdentifier.get -> string!
-Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.LogDiagnosticMessage(string! message, string! category, params string![]! details) -> void
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.Logger.get -> Microsoft.Extensions.Logging.ILogger!
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.LoggerFactory.get -> Microsoft.Extensions.Logging.ILoggerFactory!
-Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.LogTiming(string! label, System.TimeSpan duration, int depth) -> void
-Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.OnConfirmPartialMatch(string! name) -> bool
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.OnLogTiming.get -> System.Action<string!, System.TimeSpan, int>?
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.OnLogTiming.set -> void
-Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.OnPotentiallyDestructiveChangesDetected(System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.IFileChange!>! changes, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.IFileChange!>! destructiveChanges) -> bool
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.RegisterDiagnosticLogger(string! category, System.Action<string!, string![]!>! messageHandler) -> void
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.Version.get -> string!
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.VirtualizeDirectory(string! path) -> void
@@ -49,6 +45,7 @@ Microsoft.TemplateEngine.Edge.Settings.ScanResult.Templates.get -> System.Collec
 Microsoft.TemplateEngine.Edge.Template.CreationResultStatus
 Microsoft.TemplateEngine.Edge.Template.CreationResultStatus.Cancelled = -2147467260 -> Microsoft.TemplateEngine.Edge.Template.CreationResultStatus
 Microsoft.TemplateEngine.Edge.Template.CreationResultStatus.CreateFailed = -2147352567 -> Microsoft.TemplateEngine.Edge.Template.CreationResultStatus
+Microsoft.TemplateEngine.Edge.Template.CreationResultStatus.DestructiveChangesDetected = -2147467259 -> Microsoft.TemplateEngine.Edge.Template.CreationResultStatus
 Microsoft.TemplateEngine.Edge.Template.CreationResultStatus.InvalidParamValues = -2147352571 -> Microsoft.TemplateEngine.Edge.Template.CreationResultStatus
 Microsoft.TemplateEngine.Edge.Template.CreationResultStatus.MissingMandatoryParam = -2147352561 -> Microsoft.TemplateEngine.Edge.Template.CreationResultStatus
 Microsoft.TemplateEngine.Edge.Template.CreationResultStatus.NotFound = 2097158 -> Microsoft.TemplateEngine.Edge.Template.CreationResultStatus
@@ -119,11 +116,6 @@ static Microsoft.TemplateEngine.Edge.TemplateListFilter.GetTemplateMatchInfo(Sys
 static Microsoft.TemplateEngine.Edge.TemplateListFilter.PartialMatchFilter.get -> System.Func<Microsoft.TemplateEngine.Edge.Template.ITemplateMatchInfo!, bool>!
 static readonly Microsoft.TemplateEngine.Edge.Settings.ScanResult.Empty -> Microsoft.TemplateEngine.Edge.Settings.ScanResult!
 virtual Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.BuiltInComponents.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<System.Guid, System.Func<System.Type!>!>>!
-virtual Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.LogMessage(string! message) -> void
-virtual Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.OnCriticalError(string! code, string! message, string! currentFile, long currentPosition) -> void
-virtual Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.OnNonCriticalError(string! code, string! message, string! currentFile, long currentPosition) -> bool
-virtual Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.OnParameterError(Microsoft.TemplateEngine.Abstractions.ITemplateParameter! parameter, string! receivedValue, string! message, out string! newValue) -> bool
-virtual Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.OnSymbolUsed(string! symbol, object! value) -> void
 virtual Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.TryGetHostParamDefault(string! paramName, out string? value) -> bool
 ~Microsoft.TemplateEngine.Edge.AssemblyComponentCatalog.AssemblyComponentCatalog(System.Collections.Generic.IReadOnlyList<System.Reflection.Assembly> assemblies) -> void
 ~Microsoft.TemplateEngine.Edge.AssemblyComponentCatalog.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<System.Guid, System.Func<System.Type>>>

--- a/src/Microsoft.TemplateEngine.Edge/Template/CreationResultStatus.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/CreationResultStatus.cs
@@ -11,6 +11,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
         InvalidParamValues = unchecked((int)0x80020005),
         OperationNotSpecified = unchecked((int)0x8002000E),
         NotFound = unchecked((int)0x800200006),
-        Cancelled = unchecked((int)0x80004004)
+        Cancelled = unchecked((int)0x80004004),
+        DestructiveChangesDetected = unchecked((int)0x80004005)
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
@@ -79,9 +79,12 @@ namespace Microsoft.TemplateEngine.Edge.Template
 
                     if (!forceCreation && destructiveChanges.Count > 0)
                     {
+                        //if-case should be removed after obsolete member is removed.
+#pragma warning disable CS0618 // Type or member is obsolete
                         if (!_environmentSettings.Host.OnPotentiallyDestructiveChangesDetected(changes, destructiveChanges))
+#pragma warning restore CS0618 // Type or member is obsolete
                         {
-                            return new TemplateCreationResult("Cancelled", CreationResultStatus.Cancelled, template.Name);
+                            return new TemplateCreationResult("Destructive changes detected", CreationResultStatus.DestructiveChangesDetected, template.Name, null, null, creationEffects);
                         }
                     }
 
@@ -254,7 +257,9 @@ namespace Microsoft.TemplateEngine.Edge.Template
                 if (parameter.Priority == TemplateParameterPriority.Required && !templateParams.ResolvedValues.ContainsKey(parameter))
                 {
                     string newParamValue;
+#pragma warning disable CS0618 // Type or member is obsolete - for backward compatibility
                     while (host.OnParameterError(parameter, null, "Missing required parameter", out newParamValue)
+#pragma warning restore CS0618 // Type or member is obsolete
                         && string.IsNullOrEmpty(newParamValue))
                     {
                     }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -244,7 +244,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     // which takes care of making null bool -> true as appropriate.
                     // This else can also happen if there is a value but it can't be converted.
                     string val;
+#pragma warning disable CS0618 // Type or member is obsolete - for backward compatibility
                     while (environmentSettings.Host.OnParameterError(param, null, "ParameterValueNotSpecified", out val) && !bool.TryParse(val, out boolVal))
+#pragma warning restore CS0618 // Type or member is obsolete
                     {
                     }
 
@@ -265,7 +267,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 }
 
                 string val;
+#pragma warning disable CS0618 // Type or member is obsolete - for backward compatibility
                 while (environmentSettings.Host.OnParameterError(param, null, "ValueNotValid:" + string.Join(",", param.Choices.Keys), out val)
+#pragma warning restore CS0618 // Type or member is obsolete
                         && !TryResolveChoiceValue(literal, param, out val))
                 {
                 }
@@ -282,7 +286,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 else
                 {
                     string val;
+#pragma warning disable CS0618 // Type or member is obsolete - for backward compatibility
                     while (environmentSettings.Host.OnParameterError(param, null, "ValueNotValidMustBeFloat", out val) && (val == null || !ParserExtensions.DoubleTryParseСurrentOrInvariant(val, out convertedFloat)))
+#pragma warning restore CS0618 // Type or member is obsolete
                     {
                     }
 
@@ -300,7 +306,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 else
                 {
                     string val;
+#pragma warning disable CS0618 // Type or member is obsolete - for backward compatibility
                     while (environmentSettings.Host.OnParameterError(param, null, "ValueNotValidMustBeInteger", out val) && (val == null || !long.TryParse(val, out convertedInt)))
+#pragma warning restore CS0618 // Type or member is obsolete
                     {
                     }
 
@@ -317,7 +325,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 else
                 {
                     string val;
+#pragma warning disable CS0618 // Type or member is obsolete - for backward compatibility
                     while (environmentSettings.Host.OnParameterError(param, null, "ValueNotValidMustBeHex", out val) && (val == null || val.Length < 3 || !long.TryParse(val.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out convertedHex)))
+#pragma warning restore CS0618 // Type or member is obsolete
                     {
                     }
 


### PR DESCRIPTION
### Problem
fixes dotnet/templating#3146 

### Solution
Deprecating OnPotentiallyDestructiveChangesDetected and OnParameterError methods of ITemplateEngineHost. 
Both should be handled as the error of template creation instead.

Some of usages were removed as the result of calling was never used.

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)