### PR TITLE
fixes dotnet/templating#2613 Provide the implementation for registering default assemblies in Bootstrapper

### DIFF
--- a/src/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj
+++ b/src/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Edge\Microsoft.TemplateEngine.Edge.csproj" />
+    <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Orchestrator.RunnableProjects\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj" />
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
   </ItemGroup>
 

--- a/src/Microsoft.TemplateEngine.IDE/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.IDE/PublicAPI.Unshipped.txt
@@ -1,6 +1,6 @@
 ﻿Microsoft.TemplateEngine.IDE.Bootstrapper
 Microsoft.TemplateEngine.IDE.Bootstrapper.AddComponent(System.Type! interfaceType, Microsoft.TemplateEngine.Abstractions.IIdentifiedComponent! component) -> void
-Microsoft.TemplateEngine.IDE.Bootstrapper.Bootstrapper(Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost! host, System.Action<Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings!>! onFirstRun, bool virtualizeConfiguration) -> void
+Microsoft.TemplateEngine.IDE.Bootstrapper.Bootstrapper(Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost! host, System.Action<Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings!>! onFirstRun, bool virtualizeConfiguration, bool loadDefaultComponents = true) -> void
 Microsoft.TemplateEngine.IDE.Bootstrapper.CreateAsync(Microsoft.TemplateEngine.Abstractions.ITemplateInfo! info, string! name, string! outputPath, System.Collections.Generic.IReadOnlyDictionary<string!, string?>! parameters, bool skipUpdateCheck, string! baselineName) -> System.Threading.Tasks.Task<Microsoft.TemplateEngine.Abstractions.ICreationResult?>!
 Microsoft.TemplateEngine.IDE.Bootstrapper.CreateAsync(Microsoft.TemplateEngine.Abstractions.ITemplateInfo! info, string? name, string! outputPath, System.Collections.Generic.IReadOnlyDictionary<string!, string?>! parameters, string? baselineName = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.TemplateEngine.Edge.Template.ITemplateCreationResult!>!
 Microsoft.TemplateEngine.IDE.Bootstrapper.Dispose() -> void
@@ -15,6 +15,7 @@ Microsoft.TemplateEngine.IDE.Bootstrapper.Install(string! path) -> void
 Microsoft.TemplateEngine.IDE.Bootstrapper.Install(System.Collections.Generic.IEnumerable<string!>! paths) -> void
 Microsoft.TemplateEngine.IDE.Bootstrapper.InstallTemplatePackagesAsync(System.Collections.Generic.IEnumerable<Microsoft.TemplateEngine.Abstractions.Installer.InstallRequest!>! installRequests, Microsoft.TemplateEngine.Abstractions.TemplatePackage.InstallationScope scope = Microsoft.TemplateEngine.Abstractions.TemplatePackage.InstallationScope.Global, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.Installer.InstallResult!>!>!
 Microsoft.TemplateEngine.IDE.Bootstrapper.ListTemplates(bool exactMatchesOnly, params System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Edge.Template.MatchInfo?>![]! filters) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyCollection<Microsoft.TemplateEngine.Edge.Template.IFilteredTemplateInfo!>!>!
+Microsoft.TemplateEngine.IDE.Bootstrapper.LoadDefaultComponents() -> void
 Microsoft.TemplateEngine.IDE.Bootstrapper.Register(System.Reflection.Assembly! assembly) -> void
 Microsoft.TemplateEngine.IDE.Bootstrapper.Register(System.Type! type) -> void
 Microsoft.TemplateEngine.IDE.Bootstrapper.Uninstall(params string![]! paths) -> System.Collections.Generic.IEnumerable<string!>!

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Utils/BootstrapperFactory.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Utils/BootstrapperFactory.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 using Microsoft.TemplateEngine.Edge;
@@ -25,7 +24,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests.Utils
                     host.VirtualizeDirectory(virtualLocation);
                 }
             }
-            return new Bootstrapper(host, null, true);
+            return new Bootstrapper(host, onFirstRun: null, virtualizeConfiguration: true, loadDefaultComponents: true);
         }
 
         private static ITemplateEngineHost CreateHost(bool loadBuiltInTemplates = false)
@@ -36,9 +35,6 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests.Utils
             };
 
             var builtIns = new List<(Type, IIdentifiedComponent)>();
-            builtIns.AddRange(Edge.Components.AllComponents);
-            builtIns.AddRange(Orchestrator.RunnableProjects.Components.AllComponents);
-
             if (loadBuiltInTemplates)
             {
                 builtIns.Add((typeof(ITemplatePackageProviderFactory), new BuiltInTemplatePackagesProviderFactory()));


### PR DESCRIPTION
### Problem
fixes dotnet/templating#2613

### Solution
Adds new method and option in Bootstrapper constructor which allows loading default components.