### PR TITLE
fixes dotnet/templating#3038 show all available short names for template group

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -475,7 +475,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                         headerSeparator: '-',
                         blankLineBetweenRows: false)
                     .DefineColumn(t => t.Name, out object nameColumn, LocalizableStrings.ColumnNameTemplateName, shrinkIfNeeded: true, minWidth: 15, showAlways: true)
-                    .DefineColumn(t => t.ShortName, LocalizableStrings.ColumnNameShortName, showAlways: true)
+                    .DefineColumn(t => t.ShortNames, LocalizableStrings.ColumnNameShortName, showAlways: true)
                     .DefineColumn(t => t.Languages, out object languageColumn, LocalizableStrings.ColumnNameLanguage, NewCommandInputCli.LanguageColumnFilter, defaultColumn: true)
                     .DefineColumn(t => t.Type, LocalizableStrings.ColumnNameType, NewCommandInputCli.TypeColumnFilter, defaultColumn: false)
                     .DefineColumn(t => t.Author, LocalizableStrings.ColumnNameAuthor, NewCommandInputCli.AuthorColumnFilter, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)

--- a/src/Microsoft.TemplateEngine.Cli/TableOutput/TemplateGroupTableRow.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TableOutput/TemplateGroupTableRow.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace Microsoft.TemplateEngine.Cli.TableOutput
 {
     /// <summary>
@@ -16,7 +18,7 @@ namespace Microsoft.TemplateEngine.Cli.TableOutput
 
         internal string Name { get; set; }
 
-        internal string ShortName { get; set; }
+        internal string ShortNames { get; set; }
 
         internal string Type { get; set; }
     }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateGroup.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateGroup.cs
@@ -63,14 +63,17 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         {
             get
             {
-                if (HasSingleTemplate)
-                {
-                    return Templates.First().Info.ShortNameList;
-                }
-                HashSet<string> shortNames = new HashSet<string>();
+                HashSet<string> shortNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 foreach (ITemplateMatchInfo template in Templates)
                 {
-                    shortNames.UnionWith(template.Info.ShortNameList);
+                    if (template.Info is TemplateInfoWithGroupShortNames groupAwareTemplate)
+                    {
+                        shortNames.UnionWith(groupAwareTemplate.GroupShortNameList);
+                    }
+                    else
+                    {
+                        shortNames.UnionWith(template.Info.ShortNameList);
+                    }
                 }
                 return shortNames.ToList();
             }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateInfoWithGroupShortNames.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateInfoWithGroupShortNames.cs
@@ -1,0 +1,77 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Cli.TemplateResolution
+{
+    /// <summary>
+    /// In addition to <see cref="ITemplateInfo"/> the class contains <see cref="GroupShortNameList"/> property which contains the short names of other templates in the template group.
+    /// The class is used for template filtering using specific TemplateResolver.CliNameFilter which takes into account the short names of template group when matching names.
+    /// </summary>
+    internal class TemplateInfoWithGroupShortNames : ITemplateInfo
+    {
+        private ITemplateInfo _parent;
+
+        internal TemplateInfoWithGroupShortNames(ITemplateInfo source, IEnumerable<string> groupShortNameList)
+        {
+            _parent = source;
+            GroupShortNameList = groupShortNameList.ToList();
+        }
+
+        public string? Author => _parent.Author;
+
+        public string? Description => _parent.Description;
+
+        public IReadOnlyList<string> Classifications => _parent.Classifications;
+
+        public string? DefaultName => _parent.DefaultName;
+
+        public string Identity => _parent.Identity;
+
+        public Guid GeneratorId => _parent.GeneratorId;
+
+        public string? GroupIdentity => _parent.GroupIdentity;
+
+        public int Precedence => _parent.Precedence;
+
+        public string Name => _parent.Name;
+
+        [Obsolete]
+        public string ShortName => _parent.ShortName;
+
+        public IReadOnlyList<string> ShortNameList => _parent.ShortNameList;
+
+        public IReadOnlyList<string> GroupShortNameList { get; } = new List<string>();
+
+        [Obsolete]
+        public IReadOnlyDictionary<string, ICacheTag> Tags => _parent.Tags;
+
+        [Obsolete]
+        public IReadOnlyDictionary<string, ICacheParameter> CacheParameters => _parent.CacheParameters;
+
+        public IReadOnlyList<ITemplateParameter> Parameters => _parent.Parameters;
+
+        public string MountPointUri => _parent.MountPointUri;
+
+        public string ConfigPlace => _parent.ConfigPlace;
+
+        public string? LocaleConfigPlace => _parent.LocaleConfigPlace;
+
+        public string? HostConfigPlace => _parent.HostConfigPlace;
+
+        public string? ThirdPartyNotices => _parent.ThirdPartyNotices;
+
+        public IReadOnlyDictionary<string, IBaselineInfo> BaselineInfo => _parent.BaselineInfo;
+
+        public IReadOnlyDictionary<string, string> TagsCollection => _parent.TagsCollection;
+
+        bool ITemplateInfo.HasScriptRunningPostActions { get; set; }
+
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
@@ -391,7 +391,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 
                 if (!shortNamesByGroup.TryGetValue(effectiveGroupIdentity, out HashSet<string>? shortNames))
                 {
-                    shortNames = new HashSet<string>();
+                    shortNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                     shortNamesByGroup[effectiveGroupIdentity] = shortNames;
                 }
                 shortNames.UnionWith(template.ShortNameList);
@@ -470,70 +470,6 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         {
             HostSpecificTemplateData hostData = hostDataLoader.ReadHostSpecificTemplateData(templateInfo);
             return hostData.IsHidden;
-        }
-
-        /// <summary>
-        /// In addition to <see cref="ITemplateInfo"/> the class contains <see cref="TemplateInfoWithGroupShortNames.GroupShortNameList"/> property which contains the short names of other templates in the template group.
-        /// The class is used for template filtering using specific <see cref="CliNameFilter(string)"/> filter which takes into account the short names of template group when matching names.
-        /// </summary>
-        private class TemplateInfoWithGroupShortNames : ITemplateInfo
-        {
-            private ITemplateInfo _parent;
-
-            internal TemplateInfoWithGroupShortNames(ITemplateInfo source, IEnumerable<string> groupShortNameList)
-            {
-                _parent = source;
-                GroupShortNameList = groupShortNameList.ToList();
-            }
-
-            public string? Author => _parent.Author;
-
-            public string? Description => _parent.Description;
-
-            public IReadOnlyList<string> Classifications => _parent.Classifications;
-
-            public string? DefaultName => _parent.DefaultName;
-
-            public string Identity => _parent.Identity;
-
-            public Guid GeneratorId => _parent.GeneratorId;
-
-            public string? GroupIdentity => _parent.GroupIdentity;
-
-            public int Precedence => _parent.Precedence;
-
-            public string Name => _parent.Name;
-
-            [Obsolete]
-            public string ShortName => _parent.ShortName;
-
-            public IReadOnlyList<string> ShortNameList => _parent.ShortNameList;
-
-            public IReadOnlyList<string> GroupShortNameList { get; } = new List<string>();
-
-            [Obsolete]
-            public IReadOnlyDictionary<string, ICacheTag> Tags => _parent.Tags;
-
-            [Obsolete]
-            public IReadOnlyDictionary<string, ICacheParameter> CacheParameters => _parent.CacheParameters;
-
-            public IReadOnlyList<ITemplateParameter> Parameters => _parent.Parameters;
-
-            public string MountPointUri => _parent.MountPointUri;
-
-            public string ConfigPlace => _parent.ConfigPlace;
-
-            public string? LocaleConfigPlace => _parent.LocaleConfigPlace;
-
-            public string? HostConfigPlace => _parent.HostConfigPlace;
-
-            public string? ThirdPartyNotices => _parent.ThirdPartyNotices;
-
-            public IReadOnlyDictionary<string, IBaselineInfo> BaselineInfo => _parent.BaselineInfo;
-
-            public IReadOnlyDictionary<string, string> TagsCollection => _parent.TagsCollection;
-
-            bool ITemplateInfo.HasScriptRunningPostActions { get; set; }
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -102,7 +102,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                         headerSeparator: '-',
                         blankLineBetweenRows: false)
                     .DefineColumn(r => r.TemplateGroupInfo.Name, out object nameColumn, LocalizableStrings.ColumnNameTemplateName, showAlways: true, shrinkIfNeeded: true, minWidth: 15)
-                    .DefineColumn(r => r.TemplateGroupInfo.ShortName, LocalizableStrings.ColumnNameShortName, showAlways: true)
+                    .DefineColumn(r => r.TemplateGroupInfo.ShortNames, LocalizableStrings.ColumnNameShortName, showAlways: true)
                     .DefineColumn(r => r.TemplateGroupInfo.Author, LocalizableStrings.ColumnNameAuthor, NewCommandInputCli.AuthorColumnFilter, defaultColumn: true, shrinkIfNeeded: true, minWidth: 10)
                     .DefineColumn(r => r.TemplateGroupInfo.Languages, LocalizableStrings.ColumnNameLanguage, NewCommandInputCli.LanguageColumnFilter, defaultColumn: true)
                     .DefineColumn(r => r.TemplateGroupInfo.Type, LocalizableStrings.ColumnNameType, NewCommandInputCli.TypeColumnFilter, defaultColumn: false)

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
@@ -300,6 +300,32 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining("The template \"Console Application\" was created successfully.");
 
             Assert.Equal(commandResult.StdOut, forceCommandResult.StdOut);
-        }    
+        }
+
+        [Fact]
+        public void CanInstantiateTemplateWithSecondShortName()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+            Helpers.InstallNuGetTemplate("Microsoft.DotNet.Web.ProjectTemplates.5.0", _log, workingDirectory, home);
+
+            new DotnetNewCommand(_log, "webapp", "-o", "webapp")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining("The template \"ASP.NET Core Web App\" was created successfully.");
+
+            new DotnetNewCommand(_log, "razor", "-o", "razor")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining("The template \"ASP.NET Core Web App\" was created successfully.");
+        }
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewList.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewList.cs
@@ -73,7 +73,7 @@ namespace Dotnet_new3.IntegrationTests
 ASP.NET Core Empty                            web            [C#],F#     Web/Empty             
 ASP.NET Core gRPC Service                     grpc           [C#]        Web/gRPC              
 ASP.NET Core Web API                          webapi         [C#],F#     Web/WebAPI            
-ASP.NET Core Web App                          webapp         [C#]        Web/MVC/Razor Pages   
+ASP.NET Core Web App                          webapp,razor   [C#]        Web/MVC/Razor Pages   
 ASP.NET Core Web App (Model-View-Controller)  mvc            [C#],F#     Web/MVC               
 Blazor Server App                             blazorserver   [C#]        Web/Blazor            
 Blazor WebAssembly App                        blazorwasm     [C#]        Web/Blazor/WebAssembly
@@ -98,7 +98,53 @@ Worker Service                                worker         [C#],F#     Common/
                 .ExitWith(0)
                 .And.HaveStdOut(expectedOutput)
                 .And.NotHaveStdErr();
+        }
 
+		[Fact]
+        public void CanShowMultipleShortNames()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0")
+                  .WithCustomHive(home)
+                  .WithWorkingDirectory(workingDirectory)
+                  .Execute()
+                  .Should()
+                  .ExitWith(0)
+                  .And
+                  .NotHaveStdErr()
+                  .And.HaveStdOutMatching("ASP\\.NET Core Web App\\s+webapp,razor\\s+\\[C#\\]\\s+Web/MVC/Razor Pages");
+
+            new DotnetNewCommand(_log, "--list")
+                .WithCustomHive(home)
+                .WithoutBuiltInTemplates()
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutMatching("ASP\\.NET Core Web App\\s+webapp,razor\\s+\\[C#\\]\\s+Web/MVC/Razor Pages");
+
+            new DotnetNewCommand(_log, "webapp", "--list")
+                .WithCustomHive(home)
+                .WithoutBuiltInTemplates()
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutMatching("ASP\\.NET Core Web App\\s+webapp,razor\\s+\\[C#\\]\\s+Web/MVC/Razor Pages");
+
+            new DotnetNewCommand(_log, "razor", "--list")
+                .WithCustomHive(home)
+                .WithoutBuiltInTemplates()
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutMatching("ASP\\.NET Core Web App\\s+webapp,razor\\s+\\[C#\\]\\s+Web/MVC/Razor Pages");
         }
     }
 }


### PR DESCRIPTION
### Problem
fixes dotnet/templating#3038
fixes https://github.com/dotnet/templating/issues/2704

### Solution
Templates can be matched by:
- any of short name they have
- any of short name the group have

However, in the table outputs (--list, --search) we only show first short name, and users are not aware about other names (se #3039).
This PR changes it - all short names now will be shown.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)