### PR TITLE
 dotnet/templating#2994: adds missing localization for error messages in TemplateEngine.Edge

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsTemplatePackageProvider.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsTemplatePackageProvider.cs
@@ -142,11 +142,17 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
                 }
                 if (installersThatCanInstall.Count == 0)
                 {
-                    return InstallResult.CreateFailure(installRequest, InstallerErrorCode.UnsupportedRequest, $"{installRequest.PackageIdentifier} cannot be installed.");
+                    return InstallResult.CreateFailure(
+                        installRequest,
+                        InstallerErrorCode.UnsupportedRequest,
+                        string.Format(LocalizableStrings.GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled, installRequest.PackageIdentifier));
                 }
                 if (installersThatCanInstall.Count > 1)
                 {
-                    return InstallResult.CreateFailure(installRequest, InstallerErrorCode.UnsupportedRequest, $"{installRequest.PackageIdentifier} can be installed by several installers, specify the installer name to use.");
+                    return InstallResult.CreateFailure(
+                        installRequest,
+                        InstallerErrorCode.UnsupportedRequest,
+                               string.Format(LocalizableStrings.GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed, installRequest.PackageIdentifier));
                 }
 
                 IInstaller installer = installersThatCanInstall[0];
@@ -231,7 +237,7 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
                 //if same version is already installed - return
                 if (packageToBeUpdated.Version == version)
                 {
-                    return (InstallerErrorCode.AlreadyInstalled, $"{packageToBeUpdated.DisplayName} is already installed.");
+                    return (InstallerErrorCode.AlreadyInstalled, string.Format(LocalizableStrings.GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled, packageToBeUpdated.DisplayName));
                 }
                 if (!update)
                 {

--- a/src/Microsoft.TemplateEngine.Edge/Installers/Folder/FolderInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/Folder/FolderInstaller.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -61,7 +63,10 @@ namespace Microsoft.TemplateEngine.Edge.Installers.Folder
             }
             else
             {
-                return Task.FromResult(InstallResult.CreateFailure(installRequest, InstallerErrorCode.PackageNotFound, $"The folder {installRequest.PackageIdentifier} doesn't exist"));
+                return Task.FromResult(InstallResult.CreateFailure(
+                    installRequest,
+                    InstallerErrorCode.PackageNotFound,
+                    string.Format(LocalizableStrings.FolderInstaller_InstallResult_Error_FolderDoesNotExist, installRequest.PackageIdentifier)));
             }
         }
 

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The folder {0} doesn&apos;t exist..
+        /// </summary>
+        internal static string FolderInstaller_InstallResult_Error_FolderDoesNotExist {
+            get {
+                return ResourceManager.GetString("FolderInstaller_InstallResult_Error_FolderDoesNotExist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to latest version.
         /// </summary>
         internal static string Generic_LatestVersion {
@@ -79,7 +88,37 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is already installed, version: {1}, it will be replaced with {2}.
+        ///   Looks up a localized string similar to {0} can be installed by several installers. Specify the installer name to be used..
+        /// </summary>
+        internal static string GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed {
+            get {
+                return ResourceManager.GetString("GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBe" +
+                        "Used", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is already installed..
+        /// </summary>
+        internal static string GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled {
+            get {
+                return ResourceManager.GetString("GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled" +
+                        "", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} cannot be installed..
+        /// </summary>
+        internal static string GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled {
+            get {
+                return ResourceManager.GetString("GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalle" +
+                        "d", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is already installed, version: {1}, it will be replaced with {2}..
         /// </summary>
         internal static string GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled {
             get {
@@ -88,7 +127,7 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} was successfully uninstalled.
+        ///   Looks up a localized string similar to {0} was successfully uninstalled..
         /// </summary>
         internal static string GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled {
             get {
@@ -97,7 +136,7 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to load the NuGet source {0}.
+        ///   Looks up a localized string similar to Failed to load the NuGet source {0}..
         /// </summary>
         internal static string NuGetApiPackageManager_Error_FailedToLoadSource {
             get {
@@ -106,7 +145,7 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to load NuGet sources configured for the folder {currentDirectory}.
+        ///   Looks up a localized string similar to Failed to load NuGet sources configured for the folder {0}..
         /// </summary>
         internal static string NuGetApiPackageManager_Error_FailedToLoadSources {
             get {
@@ -115,7 +154,7 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to read package information from NuGet source {0}.
+        ///   Looks up a localized string similar to Failed to read package information from NuGet source {0}..
         /// </summary>
         internal static string NuGetApiPackageManager_Error_FailedToReadPackage {
             get {
@@ -124,7 +163,7 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File {0} already exists.
+        ///   Looks up a localized string similar to File {0} already exists..
         /// </summary>
         internal static string NuGetApiPackageManager_Error_FileAlreadyExists {
             get {
@@ -133,7 +172,7 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No NuGet sources are defined or enabled.
+        ///   Looks up a localized string similar to No NuGet sources are defined or enabled..
         /// </summary>
         internal static string NuGetApiPackageManager_Error_NoSources {
             get {
@@ -151,7 +190,7 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to download {0} from NuGet feed {1}.
+        ///   Looks up a localized string similar to Failed to download {0} from NuGet feed {1}..
         /// </summary>
         internal static string NuGetApiPackageManager_Warning_FailedToDownload {
             get {
@@ -169,7 +208,7 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is not found in NuGet feeds {1}.
+        ///   Looks up a localized string similar to {0} is not found in NuGet feeds {1}..
         /// </summary>
         internal static string NuGetApiPackageManager_Warning_PackageNotFound {
             get {
@@ -178,7 +217,7 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to copy package {0} to {1}.
+        ///   Looks up a localized string similar to Failed to copy package {0} to {1}..
         /// </summary>
         internal static string NuGetInstaller_Error_CopyFailed {
             get {
@@ -187,7 +226,7 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to read content of package {0}.
+        ///   Looks up a localized string similar to Failed to read content of package {0}..
         /// </summary>
         internal static string NuGetInstaller_Error_FailedToReadPackage {
             get {
@@ -196,7 +235,7 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to File {0} already exists.
+        ///   Looks up a localized string similar to File {0} already exists..
         /// </summary>
         internal static string NuGetInstaller_Error_FileAlreadyExists {
             get {
@@ -205,11 +244,142 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to scan &quot;{0}&quot;: {1}.
+        ///   Looks up a localized string similar to Failed to download {0} from {1}..
         /// </summary>
-        internal static string SettingsLoader_Error_FailedToScan {
+        internal static string NuGetInstaller_InstallResut_Error_DownloadFailed {
             get {
-                return ResourceManager.GetString("SettingsLoader_Error_FailedToScan", resourceCulture);
+                return ResourceManager.GetString("NuGetInstaller_InstallResut_Error_DownloadFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to install the package {0}.
+        ///Details: {1}..
+        /// </summary>
+        internal static string NuGetInstaller_InstallResut_Error_InstallGeneric {
+            get {
+                return ResourceManager.GetString("NuGetInstaller_InstallResut_Error_InstallGeneric", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The install request {0} cannot be processed by installer {1}..
+        /// </summary>
+        internal static string NuGetInstaller_InstallResut_Error_InstallRequestNotSupported {
+            get {
+                return ResourceManager.GetString("NuGetInstaller_InstallResut_Error_InstallRequestNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The NuGet package {0} is invalid..
+        /// </summary>
+        internal static string NuGetInstaller_InstallResut_Error_InvalidPackage {
+            get {
+                return ResourceManager.GetString("NuGetInstaller_InstallResut_Error_InvalidPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The configured NuGet sources are invalid: {0}..
+        /// </summary>
+        internal static string NuGetInstaller_InstallResut_Error_InvalidSources {
+            get {
+                return ResourceManager.GetString("NuGetInstaller_InstallResut_Error_InvalidSources", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No NuGet sources are configured..
+        /// </summary>
+        internal static string NuGetInstaller_InstallResut_Error_InvalidSources_None {
+            get {
+                return ResourceManager.GetString("NuGetInstaller_InstallResut_Error_InvalidSources_None", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The operation was cancelled..
+        /// </summary>
+        internal static string NuGetInstaller_InstallResut_Error_OperationCancelled {
+            get {
+                return ResourceManager.GetString("NuGetInstaller_InstallResut_Error_OperationCancelled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} was not found in NuGet feeds {1}..
+        /// </summary>
+        internal static string NuGetInstaller_InstallResut_Error_PackageNotFound {
+            get {
+                return ResourceManager.GetString("NuGetInstaller_InstallResut_Error_PackageNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The package {0} is not supported by installer {1}..
+        /// </summary>
+        internal static string NuGetInstaller_InstallResut_Error_PackageNotSupported {
+            get {
+                return ResourceManager.GetString("NuGetInstaller_InstallResut_Error_PackageNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to uninstall the package {0}.
+        ///Details: {1}..
+        /// </summary>
+        internal static string NuGetInstaller_InstallResut_Error_UninstallGeneric {
+            get {
+                return ResourceManager.GetString("NuGetInstaller_InstallResut_Error_UninstallGeneric", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to check the update for the package {0}.
+        ///Details: {1}..
+        /// </summary>
+        internal static string NuGetInstaller_InstallResut_Error_UpdateCheckGeneric {
+            get {
+                return ResourceManager.GetString("NuGetInstaller_InstallResut_Error_UpdateCheckGeneric", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not load template..
+        /// </summary>
+        internal static string TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate {
+            get {
+                return ResourceManager.GetString("TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to create template.
+        ///Details: {0}..
+        /// </summary>
+        internal static string TemplateCreator_TemplateCreationResult_Error_CreationFailed {
+            get {
+                return ResourceManager.GetString("TemplateCreator_TemplateCreationResult_Error_CreationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Destructive changes detected..
+        /// </summary>
+        internal static string TemplateCreator_TemplateCreationResult_Error_DestructiveChanges {
+            get {
+                return ResourceManager.GetString("TemplateCreator_TemplateCreationResult_Error_DestructiveChanges", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to scan {0}.
+        ///Details: {1}..
+        /// </summary>
+        internal static string TemplatePackageManager_Error_FailedToScan {
+            get {
+                return ResourceManager.GetString("TemplatePackageManager_Error_FailedToScan", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="FolderInstaller_InstallResult_Error_FolderDoesNotExist" xml:space="preserve">
+    <value>The folder {0} doesn't exist.</value>
+  </data>
   <data name="Generic_LatestVersion" xml:space="preserve">
     <value>latest version</value>
     <comment>small letters, string is used in the sentence</comment>
@@ -125,49 +128,105 @@
     <value>version {0}</value>
     <comment>small letters, string is used in the sentence</comment>
   </data>
+  <data name="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed" xml:space="preserve">
+    <value>{0} can be installed by several installers. Specify the installer name to be used.</value>
+  </data>
+  <data name="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled" xml:space="preserve">
+    <value>{0} is already installed.</value>
+  </data>
+  <data name="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled" xml:space="preserve">
+    <value>{0} cannot be installed.</value>
+  </data>
   <data name="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled" xml:space="preserve">
-    <value>{0} is already installed, version: {1}, it will be replaced with {2}</value>
+    <value>{0} is already installed, version: {1}, it will be replaced with {2}.</value>
   </data>
   <data name="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled" xml:space="preserve">
-    <value>{0} was successfully uninstalled</value>
+    <value>{0} was successfully uninstalled.</value>
   </data>
   <data name="NuGetApiPackageManager_Error_FailedToLoadSource" xml:space="preserve">
-    <value>Failed to load the NuGet source {0}</value>
+    <value>Failed to load the NuGet source {0}.</value>
   </data>
   <data name="NuGetApiPackageManager_Error_FailedToLoadSources" xml:space="preserve">
-    <value>Failed to load NuGet sources configured for the folder {currentDirectory}</value>
+    <value>Failed to load NuGet sources configured for the folder {0}.</value>
   </data>
   <data name="NuGetApiPackageManager_Error_FailedToReadPackage" xml:space="preserve">
-    <value>Failed to read package information from NuGet source {0}</value>
+    <value>Failed to read package information from NuGet source {0}.</value>
   </data>
   <data name="NuGetApiPackageManager_Error_FileAlreadyExists" xml:space="preserve">
-    <value>File {0} already exists</value>
+    <value>File {0} already exists.</value>
   </data>
   <data name="NuGetApiPackageManager_Error_NoSources" xml:space="preserve">
-    <value>No NuGet sources are defined or enabled</value>
+    <value>No NuGet sources are defined or enabled.</value>
   </data>
   <data name="NuGetApiPackageManager_Warning_FailedToDelete" xml:space="preserve">
     <value>Failed to remove {0} after failed download. Remove the file manually if it exists.</value>
   </data>
   <data name="NuGetApiPackageManager_Warning_FailedToDownload" xml:space="preserve">
-    <value>Failed to download {0} from NuGet feed {1}</value>
+    <value>Failed to download {0} from NuGet feed {1}.</value>
   </data>
   <data name="NuGetApiPackageManager_Warning_FailedToLoadSource" xml:space="preserve">
     <value>Failed to load NuGet source {0}: the source is not valid. It will be skipped in further processing.</value>
   </data>
   <data name="NuGetApiPackageManager_Warning_PackageNotFound" xml:space="preserve">
-    <value>{0} is not found in NuGet feeds {1}</value>
+    <value>{0} is not found in NuGet feeds {1}.</value>
   </data>
   <data name="NuGetInstaller_Error_CopyFailed" xml:space="preserve">
-    <value>Failed to copy package {0} to {1}</value>
+    <value>Failed to copy package {0} to {1}.</value>
   </data>
   <data name="NuGetInstaller_Error_FailedToReadPackage" xml:space="preserve">
-    <value>Failed to read content of package {0}</value>
+    <value>Failed to read content of package {0}.</value>
   </data>
   <data name="NuGetInstaller_Error_FileAlreadyExists" xml:space="preserve">
-    <value>File {0} already exists</value>
+    <value>File {0} already exists.</value>
   </data>
-  <data name="SettingsLoader_Error_FailedToScan" xml:space="preserve">
-    <value>Failed to scan "{0}": {1}</value>
+  <data name="NuGetInstaller_InstallResut_Error_DownloadFailed" xml:space="preserve">
+    <value>Failed to download {0} from {1}.</value>
+  </data>
+  <data name="NuGetInstaller_InstallResut_Error_InstallGeneric" xml:space="preserve">
+    <value>Failed to install the package {0}.
+Details: {1}.</value>
+  </data>
+  <data name="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported" xml:space="preserve">
+    <value>The install request {0} cannot be processed by installer {1}.</value>
+  </data>
+  <data name="NuGetInstaller_InstallResut_Error_InvalidPackage" xml:space="preserve">
+    <value>The NuGet package {0} is invalid.</value>
+  </data>
+  <data name="NuGetInstaller_InstallResut_Error_InvalidSources" xml:space="preserve">
+    <value>The configured NuGet sources are invalid: {0}.</value>
+  </data>
+  <data name="NuGetInstaller_InstallResut_Error_InvalidSources_None" xml:space="preserve">
+    <value>No NuGet sources are configured.</value>
+  </data>
+  <data name="NuGetInstaller_InstallResut_Error_OperationCancelled" xml:space="preserve">
+    <value>The operation was cancelled.</value>
+  </data>
+  <data name="NuGetInstaller_InstallResut_Error_PackageNotFound" xml:space="preserve">
+    <value>{0} was not found in NuGet feeds {1}.</value>
+  </data>
+  <data name="NuGetInstaller_InstallResut_Error_PackageNotSupported" xml:space="preserve">
+    <value>The package {0} is not supported by installer {1}.</value>
+  </data>
+  <data name="NuGetInstaller_InstallResut_Error_UninstallGeneric" xml:space="preserve">
+    <value>Failed to uninstall the package {0}.
+Details: {1}.</value>
+  </data>
+  <data name="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric" xml:space="preserve">
+    <value>Failed to check the update for the package {0}.
+Details: {1}.</value>
+  </data>
+  <data name="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate" xml:space="preserve">
+    <value>Could not load template.</value>
+  </data>
+  <data name="TemplateCreator_TemplateCreationResult_Error_CreationFailed" xml:space="preserve">
+    <value>Failed to create template.
+Details: {0}.</value>
+  </data>
+  <data name="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges" xml:space="preserve">
+    <value>Destructive changes detected.</value>
+  </data>
+  <data name="TemplatePackageManager_Error_FailedToScan" xml:space="preserve">
+    <value>Failed to scan {0}.
+Details: {1}.</value>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
@@ -301,7 +301,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 catch (Exception ex)
                 {
                     scanResults[index] = ScanResult.Empty;
-                    _logger.LogWarning($"Failed to scan \"{allTemplatePackages[index].MountPointUri}\":{Environment.NewLine}{ex}");
+                    _logger.LogWarning(LocalizableStrings.TemplatePackageManager_Error_FailedToScan, allTemplatePackages[index].MountPointUri, ex);
                 }
             });
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
@@ -60,7 +60,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
             ITemplate? template = LoadTemplate(templateInfo, baselineName);
             if (template == null)
             {
-                return new TemplateCreationResult(CreationResultStatus.NotFound, templateInfo.Name, "Could not load template");
+                return new TemplateCreationResult(CreationResultStatus.NotFound, templateInfo.Name, LocalizableStrings.TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate);
             }
 
             string? realName = name ?? fallbackName ?? template.DefaultName;
@@ -103,7 +103,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                         return new TemplateCreationResult(
                             CreationResultStatus.DestructiveChangesDetected,
                             template.Name,
-                            "Destructive changes detected",
+                            LocalizableStrings.TemplateCreator_TemplateCreationResult_Error_DestructiveChanges,
                             null,
                             null,
                             creationEffects);
@@ -136,7 +136,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                 return new TemplateCreationResult(
                     status: CreationResultStatus.CreateFailed,
                     templateName: template.Name,
-                    localizedErrorMessage: message,
+                    localizedErrorMessage: string.Format(LocalizableStrings.TemplateCreator_TemplateCreationResult_Error_CreationFailed, message),
                     outputBaseDir: targetDir);
             }
             catch (Exception ex)
@@ -144,7 +144,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                 return new TemplateCreationResult(
                     status: CreationResultStatus.CreateFailed,
                     templateName: template.Name,
-                    localizedErrorMessage: ex.Message,
+                    localizedErrorMessage: string.Format(LocalizableStrings.TemplateCreator_TemplateCreationResult_Error_CreationFailed, ex.Message),
                     outputBaseDir: targetDir);
             }
             finally

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="FolderInstaller_InstallResult_Error_FolderDoesNotExist">
+        <source>The folder {0} doesn't exist.</source>
+        <target state="new">The folder {0} doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="new">latest version</target>
@@ -12,39 +17,54 @@
         <target state="new">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
+        <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
+        <target state="new">{0} can be installed by several installers. Specify the installer name to be used.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageAlreadyInstalled">
+        <source>{0} is already installed.</source>
+        <target state="new">{0} is already installed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_PackageCannotBeInstalled">
+        <source>{0} cannot be installed.</source>
+        <target state="new">{0} cannot be installed.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageAlreadyInstalled">
-        <source>{0} is already installed, version: {1}, it will be replaced with {2}</source>
-        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}</target>
+        <source>{0} is already installed, version: {1}, it will be replaced with {2}.</source>
+        <target state="new">{0} is already installed, version: {1}, it will be replaced with {2}.</target>
         <note />
       </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled">
-        <source>{0} was successfully uninstalled</source>
-        <target state="new">{0} was successfully uninstalled</target>
+        <source>{0} was successfully uninstalled.</source>
+        <target state="new">{0} was successfully uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
-        <source>Failed to load the NuGet source {0}</source>
-        <target state="new">Failed to load the NuGet source {0}</target>
+        <source>Failed to load the NuGet source {0}.</source>
+        <target state="new">Failed to load the NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSources">
-        <source>Failed to load NuGet sources configured for the folder {currentDirectory}</source>
-        <target state="new">Failed to load NuGet sources configured for the folder {currentDirectory}</target>
+        <source>Failed to load NuGet sources configured for the folder {0}.</source>
+        <target state="new">Failed to load NuGet sources configured for the folder {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToReadPackage">
-        <source>Failed to read package information from NuGet source {0}</source>
-        <target state="new">Failed to read package information from NuGet source {0}</target>
+        <source>Failed to read package information from NuGet source {0}.</source>
+        <target state="new">Failed to read package information from NuGet source {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_NoSources">
-        <source>No NuGet sources are defined or enabled</source>
-        <target state="new">No NuGet sources are defined or enabled</target>
+        <source>No NuGet sources are defined or enabled.</source>
+        <target state="new">No NuGet sources are defined or enabled.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDelete">
@@ -53,8 +73,8 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToDownload">
-        <source>Failed to download {0} from NuGet feed {1}</source>
-        <target state="new">Failed to download {0} from NuGet feed {1}</target>
+        <source>Failed to download {0} from NuGet feed {1}.</source>
+        <target state="new">Failed to download {0} from NuGet feed {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_FailedToLoadSource">
@@ -63,28 +83,108 @@
         <note />
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
-        <source>{0} is not found in NuGet feeds {1}</source>
-        <target state="new">{0} is not found in NuGet feeds {1}</target>
+        <source>{0} is not found in NuGet feeds {1}.</source>
+        <target state="new">{0} is not found in NuGet feeds {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_CopyFailed">
-        <source>Failed to copy package {0} to {1}</source>
-        <target state="new">Failed to copy package {0} to {1}</target>
+        <source>Failed to copy package {0} to {1}.</source>
+        <target state="new">Failed to copy package {0} to {1}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FailedToReadPackage">
-        <source>Failed to read content of package {0}</source>
-        <target state="new">Failed to read content of package {0}</target>
+        <source>Failed to read content of package {0}.</source>
+        <target state="new">Failed to read content of package {0}.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetInstaller_Error_FileAlreadyExists">
-        <source>File {0} already exists</source>
-        <target state="new">File {0} already exists</target>
+        <source>File {0} already exists.</source>
+        <target state="new">File {0} already exists.</target>
         <note />
       </trans-unit>
-      <trans-unit id="SettingsLoader_Error_FailedToScan">
-        <source>Failed to scan "{0}": {1}</source>
-        <target state="new">Failed to scan "{0}": {1}</target>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_DownloadFailed">
+        <source>Failed to download {0} from {1}.</source>
+        <target state="new">Failed to download {0} from {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallGeneric">
+        <source>Failed to install the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to install the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InstallRequestNotSupported">
+        <source>The install request {0} cannot be processed by installer {1}.</source>
+        <target state="new">The install request {0} cannot be processed by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidPackage">
+        <source>The NuGet package {0} is invalid.</source>
+        <target state="new">The NuGet package {0} is invalid.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources">
+        <source>The configured NuGet sources are invalid: {0}.</source>
+        <target state="new">The configured NuGet sources are invalid: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_InvalidSources_None">
+        <source>No NuGet sources are configured.</source>
+        <target state="new">No NuGet sources are configured.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_OperationCancelled">
+        <source>The operation was cancelled.</source>
+        <target state="new">The operation was cancelled.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotFound">
+        <source>{0} was not found in NuGet feeds {1}.</source>
+        <target state="new">{0} was not found in NuGet feeds {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_PackageNotSupported">
+        <source>The package {0} is not supported by installer {1}.</source>
+        <target state="new">The package {0} is not supported by installer {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UninstallGeneric">
+        <source>Failed to uninstall the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to uninstall the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_UpdateCheckGeneric">
+        <source>Failed to check the update for the package {0}.
+Details: {1}.</source>
+        <target state="new">Failed to check the update for the package {0}.
+Details: {1}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
+        <source>Could not load template.</source>
+        <target state="new">Could not load template.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
+        <source>Failed to create template.
+Details: {0}.</source>
+        <target state="new">Failed to create template.
+Details: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges">
+        <source>Destructive changes detected.</source>
+        <target state="new">Destructive changes detected.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToScan">
+        <source>Failed to scan {0}.
+Details: {1}.</source>
+        <target state="new">Failed to scan {0}.
+Details: {1}.</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
### Problem
fixes dotnet/templating#2994 

### Solution
Failure messages returned by Edge were not localized, the PR adds localization for them.
Note: some of the messages are not localizable at the moment: https://github.com/dotnet/templating/issues/3194

### Checks:
- [x] Added unit tests - already available
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)