### PR TITLE
fixes dotnet/templating#3147 log template loading errors as errors instead of debug

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1562,6 +1562,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No templates were found in the package {0}..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to uninstall {0}, reason: {1}..
         /// </summary>
         internal static string TemplatePackageCoordinator_Uninstall_Error_GenericError {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -721,4 +721,7 @@ Examples:
   <data name="PostAction_ProcessStartProcessor_Error_ConfigMissingExecutable" xml:space="preserve">
     <value>Failed to run the command: argument 'executable' is missing in post action configuration.</value>
   </data>
+  <data name="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package" xml:space="preserve">
+    <value>No templates were found in the package {0}.</value>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -592,12 +592,21 @@ namespace Microsoft.TemplateEngine.Cli
 
             if (result.Success)
             {
-                Reporter.Output.WriteLine(
-                    string.Format(
-                        LocalizableStrings.TemplatePackageCoordinator_lnstall_Info_Success,
-                        result.TemplatePackage.DisplayName));
                 IEnumerable<ITemplateInfo> templates = await _templatePackageManager.GetTemplatesAsync(result.TemplatePackage, cancellationToken).ConfigureAwait(false);
-                HelpForTemplateResolution.DisplayTemplateList(templates, _engineEnvironmentSettings, commandInput, _defaultLanguage);
+                if (templates.Any())
+                {
+                    Reporter.Output.WriteLine(
+                        string.Format(
+                            LocalizableStrings.TemplatePackageCoordinator_lnstall_Info_Success,
+                            result.TemplatePackage.DisplayName));
+                    HelpForTemplateResolution.DisplayTemplateList(templates, _engineEnvironmentSettings, commandInput, _defaultLanguage);
+                }
+                else
+                {
+                    Reporter.Output.WriteLine(string.Format(
+                            LocalizableStrings.TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package,
+                            result.TemplatePackage.DisplayName));
+                }
             }
             else
             {

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -949,6 +949,11 @@ Examples:
         <target state="new">Success: {0} installed the following templates:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_lnstall_Warning_No_Templates_In_Package">
+        <source>No templates were found in the package {0}.</source>
+        <target state="new">No templates were found in the package {0}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateResolver_Warning_FailedToReparseTemplate">
         <source>[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</source>
         <target state="new">[Warning]: Failed to parse input for template {0}, it will be skipped from further processing.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class LocalizableStrings {
@@ -196,7 +196,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; was not loaded.
+        ///   Looks up a localized string similar to Failed to load template from {0}:.
         /// </summary>
         internal static string Authoring_TemplateNotInstalled {
             get {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
@@ -171,7 +171,8 @@
     <value>Template: '{0}'</value>
   </data>
   <data name="Authoring_TemplateNotInstalled" xml:space="preserve">
-    <value>'{0}' was not loaded</value>
+    <value>Failed to load template from {0}:</value>
+    <comment>{0} is uri of template location.</comment>
   </data>
   <data name="Authoring_TemplateRootOutsideInstallSource" xml:space="preserve">
     <value>Template: '{0}' - Template root is outside the specified install source location.</value>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
@@ -82,9 +82,9 @@
         <note />
       </trans-unit>
       <trans-unit id="Authoring_TemplateNotInstalled">
-        <source>'{0}' was not loaded</source>
-        <target state="new">'{0}' was not loaded</target>
-        <note />
+        <source>Failed to load template from {0}:</source>
+        <target state="new">Failed to load template from {0}:</target>
+        <note>{0} is uri of template location.</note>
       </trans-unit>
       <trans-unit id="Authoring_TemplateRootOutsideInstallSource">
         <source>Template: '{0}' - Template root is outside the specified install source location.</source>

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TemplateRootTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TemplateRootTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             SimpleConfigModel templateModel = SimpleConfigModel.FromJObject(templateFile.MountPoint.EnvironmentSettings, srcObject);
             RunnableProjectTemplate runnableProjectTemplate = new RunnableProjectTemplate(srcObject, generator, templateFile, templateModel, null, null);
 
-            bool allPathsAreValid = generator.AreAllTemplatePathsValid(_engineEnvironmentSettings, templateModel, runnableProjectTemplate);
+            bool allPathsAreValid = generator.ValidateTemplateSourcePaths(_engineEnvironmentSettings.Host.Logger, templateModel, runnableProjectTemplate);
             Assert.Equal(shouldAllPathsBeValid, allPathsAreValid);
         }
 
@@ -114,7 +114,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             SimpleConfigModel templateModel = SimpleConfigModel.FromJObject(templateFile.MountPoint.EnvironmentSettings, srcObject);
             RunnableProjectTemplate runnableProjectTemplate = new RunnableProjectTemplate(srcObject, generator, templateFile, templateModel, null, null);
 
-            bool allPathsAreValid = generator.AreAllTemplatePathsValid(_engineEnvironmentSettings, templateModel, runnableProjectTemplate);
+            bool allPathsAreValid = generator.ValidateTemplateSourcePaths(_engineEnvironmentSettings.Host.Logger, templateModel, runnableProjectTemplate);
             Assert.Equal(shouldAllPathsBeValid, allPathsAreValid);
         }
 
@@ -158,7 +158,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             SimpleConfigModel templateModel = SimpleConfigModel.FromJObject(templateFile.MountPoint.EnvironmentSettings, srcObject);
             RunnableProjectTemplate runnableProjectTemplate = new RunnableProjectTemplate(srcObject, generator, templateFile, templateModel, null, null);
 
-            bool allPathsAreValid = generator.AreAllTemplatePathsValid(_engineEnvironmentSettings, templateModel, runnableProjectTemplate);
+            bool allPathsAreValid = generator.ValidateTemplateSourcePaths(_engineEnvironmentSettings.Host.Logger, templateModel, runnableProjectTemplate);
             Assert.Equal(shouldAllPathsBeValid, allPathsAreValid);
         }
     }

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/MissingMandatoryConfig/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/MissingMandatoryConfig/template.json
@@ -1,0 +1,8 @@
+{
+    "author": "Test Asset",
+    "classifications": [ "Test Asset" ],
+    "generatorVersions": "[1.0.0.0-*)",
+    "groupIdentity": "group",
+    "precedence": "100",
+    "sourceName": "Basic"
+}

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -500,5 +500,24 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining("TestAssets.TemplateWithTags")
                 .And.HaveStdOutContaining("TestAssets.ConfigurationKitchenSink");
         }
+
+        [Fact]
+        public void CannotInstallTemplateWithoutMandatoryConfig()
+        {
+            var home = TestUtils.CreateTemporaryFolder("Home");
+            string invalidTemplatePath = TestUtils.GetTestTemplateLocation("Invalid/MissingMandatoryConfig");
+            new DotnetNewCommand(_log, "-i", invalidTemplatePath)
+                .WithCustomHive(home)
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining($"Error: Failed to load template from {invalidTemplatePath}:")
+                .And.HaveStdOutContaining($"Error:     Missing 'identity' in '/template.json'")
+                .And.HaveStdOutContaining($"Error:     Missing 'name' in '/template.json'")
+                .And.HaveStdOutContaining($"Error:     Missing 'shortName' in '/template.json'")
+                .And.HaveStdOutContaining($"No templates were found in the package {invalidTemplatePath}.");
+        }
     }
 }


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/3147

### Solution
`RunnableProjectGenerator` contains validation logic, however it is logged to debug level.
Changed the logging to report errors to error level instead.
Warnings are kept in debug level, as they are not used for end user, only for template author.

### Checks:
- [ ] Added unit tests -  some tests exist, added one integration test.
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)