### PR TITLE
fixes dotnet/templating#2739 disable checking for template updates on instantiation

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/CommandParserSupport.cs
@@ -60,6 +60,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                     Create.Option("--columns", LocalizableStrings.OptionDescriptionColumns, Accept.ExactlyOneArgument().With(LocalizableStrings.OptionDescriptionColumns, "COLUMNS_LIST")),
                     Create.Option("--columns-all", LocalizableStrings.OptionDescriptionColumnsAll, Accept.NoArguments()),
                     Create.Option("--tag", LocalizableStrings.OptionDescriptionTagFilter, Accept.ExactlyOneArgument().With(LocalizableStrings.OptionDescriptionTagFilter, "TAG")),
+                    Create.Option("--no-update-check", LocalizableStrings.OptionDescriptionNoUpdateCheck, Accept.NoArguments()),
                 };
             }
         }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
@@ -60,6 +60,11 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         string Name { get; }
 
+        /// <summary>
+        /// True when the user specified --no-update-check option.
+        /// </summary>
+        bool NoUpdateCheck { get; }
+
         string OutputPath { get; }
 
         string PackageFilter { get; }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/NewCommandInputCli.cs
@@ -164,6 +164,8 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         public string Language => _parseResult.GetArgumentValueAtPath(new[] { _commandName, "language" });
 
+        public bool NoUpdateCheck => _parseResult.HasAppliedOption(new[] { _commandName, "no-update-check" });
+
         public string Name => _parseResult.GetArgumentValueAtPath(new[] { _commandName, "name" });
 
         public string OutputPath => _parseResult.GetArgumentValueAtPath(new[] { _commandName, "output" });

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1071,6 +1071,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Disables checking for the template package updates when instantiating a template..
+        /// </summary>
+        internal static string OptionDescriptionNoUpdateCheck {
+            get {
+                return ResourceManager.GetString("OptionDescriptionNoUpdateCheck", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Filters the templates based on NuGet package ID. Applies to --search..
         /// </summary>
         internal static string OptionDescriptionPackageFilter {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -712,6 +712,9 @@ Examples:
   <data name="TemplatePackageCoordinator_Update_Info_UpdateSingleCommandHeader" xml:space="preserve">
     <value>To update the package use:</value>
   </data>
+  <data name="OptionDescriptionNoUpdateCheck" xml:space="preserve">
+    <value>Disables checking for the template package updates when instantiating a template.</value>
+  </data>
   <data name="PostActionDispatcher_Error_NotSupported" xml:space="preserve">
     <value>The post action {0} is not supported.</value>
   </data>

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -112,6 +112,12 @@ namespace Microsoft.TemplateEngine.Cli
             _ = commandInput ?? throw new ArgumentNullException(nameof(commandInput));
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (commandInput.NoUpdateCheck)
+            {
+                Reporter.Verbose.WriteLine("The check for update is skipped by user.");
+                return null;
+            }
+
             ITemplatePackage templatePackage;
             try
             {

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -574,6 +574,11 @@ The supported columns are: language, tags, author, type.</target>
         <target state="new">Display all columns in --list and --search output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="OptionDescriptionNoUpdateCheck">
+        <source>Disables checking for the template package updates when instantiating a template.</source>
+        <target state="new">Disables checking for the template package updates when instantiating a template.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OptionDescriptionPackageFilter">
         <source>Filters the templates based on NuGet package ID. Applies to --search.</source>
         <target state="new">Filters the templates based on NuGet package ID. Applies to --search.</target>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
-using Microsoft.TemplateEngine.Edge.Template;
 using Newtonsoft.Json;
 using Xunit.Abstractions;
 
@@ -139,6 +138,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
         public IList<string> ToUninstallList { get; }
 
         public string TypeFilter => _commandOptions.ContainsKey("--type") ? _commandOptions["--type"] : string.Empty;
+
+        public bool NoUpdateCheck => throw new NotImplementedException();
 
         public MockNewCommandInput WithTemplateOption(string optionName, string optionValue = null)
         {

--- a/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
@@ -38,7 +38,8 @@ Options:
   --columns <COLUMNS_LIST>       Comma separated list of columns to display in --list and --search output.
                                  The supported columns are: language, tags, author, type.
   --columns-all                  Display all columns in --list and --search output.
-  --tag <TAG>                    Filters the templates based on the tag. Applies to --search and --list.";
+  --tag <TAG>                    Filters the templates based on the tag. Applies to --search and --list.
+  --no-update-check              Disables checking for the template package updates when instantiating a template.";
 
         private const string ConsoleHelp =
 @"Console Application (C#)

--- a/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
@@ -112,6 +112,49 @@ namespace Dotnet_new3.IntegrationTests
         }
 
         [Fact]
+        public void DoesNotPrintUpdateInfoOnCreation_WhenNoUpdateCheckOption()
+        {
+            var home = TestUtils.CreateTemporaryFolder("Home");
+            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
+                .WithCustomHive(home).WithoutBuiltInTemplates().Quietly()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And
+                .NotHaveStdErr()
+                .And.HaveStdOutContaining("Success:")
+                .And.HaveStdOutContaining("console")
+                .And.HaveStdOutContaining("classlib");
+
+            new DotnetNewCommand(_log, "console", "--no-update-check", "-o", "no-update-check")
+                  .WithCustomHive(home).WithoutBuiltInTemplates()
+                  .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                  .Execute()
+                  .Should()
+                  .ExitWith(0)
+                  .And
+                  .NotHaveStdErr()
+                  .And.HaveStdOutContaining("The template \"Console Application\" was created successfully.")
+                  .And.NotHaveStdOutContaining("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0' is available")
+                  .And.NotHaveStdOutContaining("To update the package use:")
+                  .And.NotHaveStdOutContaining("   dotnet new3 --install Microsoft.DotNet.Common.ProjectTemplates.5.0::([\\d\\.a-z-])+");
+
+            new DotnetNewCommand(_log, "console", "-o", "update-check")
+                  .WithCustomHive(home).WithoutBuiltInTemplates()
+                  .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                  .Execute()
+                  .Should()
+                  .ExitWith(0)
+                  .And
+                  .NotHaveStdErr()
+                  .And.HaveStdOutContaining("The template \"Console Application\" was created successfully.")
+                  .And.HaveStdOutContaining("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0' is available")
+                  .And.HaveStdOutContaining("To update the package use:")
+                  .And.HaveStdOutMatching("   dotnet new3 --install Microsoft.DotNet.Common.ProjectTemplates.5.0::([\\d\\.a-z-])+");
+        }
+
+        [Fact]
         public void DoesNotPrintUpdateInfoOnCreation_WhenLatestVersionIsInstalled()
         {
             var home = TestUtils.CreateTemporaryFolder("Home");


### PR DESCRIPTION
### Problem
fixes dotnet/templating#2739

### Solution
Now `dotnet new` check for template package update each time the template is run without ability to disable that behavior.
PR adds `--no-update-check` option which allows to disable update-check.

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - didn't add it to parser files as they will be changed soon