### PR TITLE
#2980: removed Debug|x64, Debug|x86, Release|x64, Release|x86 configurations from sln template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
@@ -6,11 +6,7 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Problem
fixes dotnet/templating#2980

### Solution
removed Debug|x64, Debug|x86, Release|x64, Release|x86 configurations from sln template to be consistent with default solution created in Visual Studio.
