### PR TITLE
Tests for errors during validation of template localization

### DIFF
--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/Exceptions/JsonMemberMissingException.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/Exceptions/JsonMemberMissingException.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core.Exceptions
         /// a member with the given name.</param>
         /// <param name="memberName">Name of the missing member.</param>
         public JsonMemberMissingException(string owningElementName, string memberName)
-            : base($"Json element \"{owningElementName}\" must have a member \"{memberName}\"")
+            : base(string.Format(LocalizableStrings.stringExtractor_log_jsonMemberIsMissing, owningElementName, memberName))
         {
             OwningElementName = owningElementName;
             MemberName = memberName;

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/Exceptions/LocalizationKeyIsNotUniqueException.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/Exceptions/LocalizationKeyIsNotUniqueException.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.TemplateEngine.TemplateLocalizer.Core.Exceptions
+{
+    /// <summary>
+    /// Exception that is thrown when the template.json file contains elements
+    /// whose identifiers are not unique.
+    /// </summary>
+    internal class LocalizationKeyIsNotUniqueException : TemplateLocalizerException
+    {
+        /// <summary>
+        /// Creates an instance of <see cref="LocalizationKeyIsNotUniqueException"/>.
+        /// </summary>
+        /// <param name="reusedKey">The localization key that should have been unique, but was used more than once.</param>
+        /// <param name="owningElementIdentifier">Identifier of the JSON element containing the reused key.</param>
+        public LocalizationKeyIsNotUniqueException(string reusedKey, string owningElementIdentifier)
+            : base(string.Format(LocalizableStrings.stringExtractor_log_jsonKeyIsNotUnique, owningElementIdentifier, reusedKey))
+        {
+            ReusedKey = reusedKey;
+            OwningElementIdentifier = owningElementIdentifier;
+        }
+
+        /// <summary>
+        /// The localization key that should have been unique, but was used more than once.
+        /// </summary>
+        /// <example>"myManualInstruction".</example>
+        /// <example>"firstSymbol".</example>
+        public string ReusedKey { get; }
+
+        /// <summary>
+        /// Identifier of the JSON element containing the reused key.
+        /// </summary>
+        /// <example>"postActions/pa0/manualInstructions".</example>
+        /// <example>"symbols".</example>
+        public string OwningElementIdentifier { get; }
+    }
+}

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/LocalizableStrings.Designer.cs
@@ -88,6 +88,15 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Json element &quot;{0}&quot; must have a member &quot;{1}&quot;..
+        /// </summary>
+        internal static string stringExtractor_log_jsonMemberIsMissing {
+            get {
+                return ResourceManager.GetString("stringExtractor_log_jsonMemberIsMissing", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}.
         /// </summary>
         internal static string stringExtractor_log_skippingAlreadyAddedElement {

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/LocalizableStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class LocalizableStrings {
@@ -61,56 +61,65 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}.
+        ///   Looks up a localized string similar to Adding into localizable strings: {0}.
         /// </summary>
-        internal static string stringExtractor_log_commandDebugElementExcluded {
+        internal static string stringExtractor_log_jsonElementAdded {
             get {
-                return ResourceManager.GetString("stringExtractor_log_commandDebugElementExcluded", resourceCulture);
+                return ResourceManager.GetString("stringExtractor_log_jsonElementAdded", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Adding into localizable strings: {0}.
+        ///   Looks up a localized string similar to The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}.
         /// </summary>
-        internal static string stringExtractor_log_commandElementAdded {
+        internal static string stringExtractor_log_jsonElementExcluded {
             get {
-                return ResourceManager.GetString("stringExtractor_log_commandElementAdded", resourceCulture);
+                return ResourceManager.GetString("stringExtractor_log_jsonElementExcluded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Each child of &quot;{0}&quot; should have a unique id. Currently, the id &quot;{1}&quot; is shared by multiple children..
+        /// </summary>
+        internal static string stringExtractor_log_jsonKeyIsNotUnique {
+            get {
+                return ResourceManager.GetString("stringExtractor_log_jsonKeyIsNotUnique", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}.
         /// </summary>
-        internal static string stringExtractor_log_commandElementAlreadyAdded {
+        internal static string stringExtractor_log_skippingAlreadyAddedElement {
             get {
-                return ResourceManager.GetString("stringExtractor_log_commandElementAlreadyAdded", resourceCulture);
+                return ResourceManager.GetString("stringExtractor_log_skippingAlreadyAddedElement", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to &quot;Failed to read the existing strings from &quot;{0}&quot;.
         /// </summary>
-        internal static string stringUpdater_log_commandFailedToReadLocFile {
+        internal static string stringUpdater_log_failedToReadLocFile {
             get {
-                return ResourceManager.GetString("stringUpdater_log_commandFailedToReadLocFile", resourceCulture);
+                return ResourceManager.GetString("stringUpdater_log_failedToReadLocFile", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Loading existing localizations from file &quot;{0}&quot;.
         /// </summary>
-        internal static string stringUpdater_log_commandLoadingLocFile {
+        internal static string stringUpdater_log_loadingLocFile {
             get {
-                return ResourceManager.GetString("stringUpdater_log_commandLoadingLocFile", resourceCulture);
+                return ResourceManager.GetString("stringUpdater_log_loadingLocFile", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to &quot;Opening the following templatestrings.json file for writing: &quot;{0}&quot;.
         /// </summary>
-        internal static string stringUpdater_log_commandOpeningTemplatesJson {
+        internal static string stringUpdater_log_openingTemplatesJson {
             get {
-                return ResourceManager.GetString("stringUpdater_log_commandOpeningTemplatesJson", resourceCulture);
+                return ResourceManager.GetString("stringUpdater_log_openingTemplatesJson", resourceCulture);
             }
         }
     }

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/LocalizableStrings.resx
@@ -130,6 +130,10 @@
     <comment>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</comment>
   </data>
+  <data name="stringExtractor_log_jsonMemberIsMissing" xml:space="preserve">
+    <value>Json element "{0}" must have a member "{1}".</value>
+    <comment>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</comment>
+  </data>
   <data name="stringExtractor_log_skippingAlreadyAddedElement" xml:space="preserve">
     <value>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</value>
     <comment>{0} is a string similar to "postActions/0/manualInstructions/2/text"</comment>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/LocalizableStrings.resx
@@ -117,28 +117,33 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="stringExtractor_log_commandDebugElementExcluded" xml:space="preserve">
-    <value>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</value>
-    <comment>{0} will be replaced by the element name string</comment>
-  </data>
-  <data name="stringExtractor_log_commandElementAdded" xml:space="preserve">
+  <data name="stringExtractor_log_jsonElementAdded" xml:space="preserve">
     <value>Adding into localizable strings: {0}</value>
-    <comment>{0} will be replaced by the element identifier</comment>
+    <comment>{0} is a string similar to "postActions/0/manualInstructions/2/text"</comment>
   </data>
-  <data name="stringExtractor_log_commandElementAlreadyAdded" xml:space="preserve">
+  <data name="stringExtractor_log_jsonElementExcluded" xml:space="preserve">
+    <value>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</value>
+    <comment>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</comment>
+  </data>
+  <data name="stringExtractor_log_jsonKeyIsNotUnique" xml:space="preserve">
+    <value>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</value>
+    <comment>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</comment>
+  </data>
+  <data name="stringExtractor_log_skippingAlreadyAddedElement" xml:space="preserve">
     <value>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</value>
-    <comment>{0} will be replaced by the element identifier</comment>
+    <comment>{0} is a string similar to "postActions/0/manualInstructions/2/text"</comment>
   </data>
-  <data name="stringUpdater_log_commandFailedToReadLocFile" xml:space="preserve">
+  <data name="stringUpdater_log_failedToReadLocFile" xml:space="preserve">
     <value>"Failed to read the existing strings from "{0}"</value>
-    <comment>{0} will be replaced by the localization file path.</comment>
+    <comment>{0} is a file path.</comment>
   </data>
-  <data name="stringUpdater_log_commandLoadingLocFile" xml:space="preserve">
+  <data name="stringUpdater_log_loadingLocFile" xml:space="preserve">
     <value>Loading existing localizations from file "{0}"</value>
-    <comment>{0} will be replaced by the localization file path.</comment>
+    <comment>{0} is a file path.</comment>
   </data>
-  <data name="stringUpdater_log_commandOpeningTemplatesJson" xml:space="preserve">
+  <data name="stringUpdater_log_openingTemplatesJson" xml:space="preserve">
     <value>"Opening the following templatestrings.json file for writing: "{0}"</value>
-    <comment>{0} will be replaced by the templates string JSon file path.</comment>
+    <comment>{0} is a file path.</comment>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateLocalizer.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateLocalizer.cs
@@ -60,10 +60,11 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
 
                 return new ExportResult(templateJsonPath);
             }
-            catch (JsonMemberMissingException jsonMemberMissingException)
+            catch (Exception exception)
+                when (exception is JsonMemberMissingException || exception is LocalizationKeyIsNotUniqueException)
             {
                 // Output a more friendly text without stack trace for known errors.
-                return new ExportResult(templateJsonPath, jsonMemberMissingException.Message);
+                return new ExportResult(templateJsonPath, exception.Message);
             }
             catch (Exception exception)
             {

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateStringUpdater.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateStringUpdater.cs
@@ -62,7 +62,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
         {
             try
             {
-                logger.LogDebug(LocalizableStrings.stringUpdater_log_commandLoadingLocFile, locFilePath);
+                logger.LogDebug(LocalizableStrings.stringUpdater_log_loadingLocFile, locFilePath);
                 using FileStream openStream = File.OpenRead(locFilePath);
 
                 JsonSerializerOptions serializerOptions = new()
@@ -82,7 +82,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
             }
             catch (Exception)
             {
-                logger.LogError(LocalizableStrings.stringUpdater_log_commandFailedToReadLocFile, locFilePath);
+                logger.LogError(LocalizableStrings.stringUpdater_log_failedToReadLocFile, locFilePath);
                 throw;
             }
         }
@@ -102,7 +102,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
                 Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
                 Indented = true,
             };
-            logger.LogDebug(LocalizableStrings.stringUpdater_log_commandOpeningTemplatesJson, filePath);
+            logger.LogDebug(LocalizableStrings.stringUpdater_log_openingTemplatesJson, filePath);
             using FileStream fileStream = new FileStream(filePath, FileMode.Create, FileAccess.Write);
             using Utf8JsonWriter jsonWriter = new Utf8JsonWriter(fileStream, writerOptions);
 

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.cs.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.cs.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.de.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.de.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.es.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.es.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.fr.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.fr.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.it.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.it.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.ja.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.ja.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.ko.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.ko.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.pl.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.pl.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.pt-BR.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.ru.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.ru.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.tr.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.tr.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.zh-Hans.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.zh-Hant.xlf
@@ -18,6 +18,11 @@
         <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
 {1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
       </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonMemberIsMissing">
+        <source>Json element "{0}" must have a member "{1}".</source>
+        <target state="new">Json element "{0}" must have a member "{1}".</target>
+        <note>{0} and {1} are strings such as "postActions", "manualInstructions", "id" etc.</note>
+      </trans-unit>
       <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,35 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="stringExtractor_log_commandDebugElementExcluded">
-        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
-        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
-        <note>{0} will be replaced by the element name string</note>
-      </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAdded">
+      <trans-unit id="stringExtractor_log_jsonElementAdded">
         <source>Adding into localizable strings: {0}</source>
         <target state="new">Adding into localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringExtractor_log_commandElementAlreadyAdded">
+      <trans-unit id="stringExtractor_log_jsonElementExcluded">
+        <source>The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</source>
+        <target state="new">The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: {0}</target>
+        <note>{0} is any string from a json file. Such as "postActions", "myParameter", "author" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_jsonKeyIsNotUnique">
+        <source>Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</source>
+        <target state="new">Each child of "{0}" should have a unique id. Currently, the id "{1}" is shared by multiple children.</target>
+        <note>{0} is an identifier string similar to "postActions/0/manualInstructions/2/text"
+{1} is a user-defined string such as "myPostAction", "pa0", "postActionFirst" etc.</note>
+      </trans-unit>
+      <trans-unit id="stringExtractor_log_skippingAlreadyAddedElement">
         <source>The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</source>
         <target state="new">The following element in the template.json will be skipped since it was already added to the list of localizable strings: {0}</target>
-        <note>{0} will be replaced by the element identifier</note>
+        <note>{0} is a string similar to "postActions/0/manualInstructions/2/text"</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandFailedToReadLocFile">
+      <trans-unit id="stringUpdater_log_failedToReadLocFile">
         <source>"Failed to read the existing strings from "{0}"</source>
         <target state="new">"Failed to read the existing strings from "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandLoadingLocFile">
+      <trans-unit id="stringUpdater_log_loadingLocFile">
         <source>Loading existing localizations from file "{0}"</source>
         <target state="new">Loading existing localizations from file "{0}"</target>
-        <note>{0} will be replaced by the localization file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
-      <trans-unit id="stringUpdater_log_commandOpeningTemplatesJson">
+      <trans-unit id="stringUpdater_log_openingTemplatesJson">
         <source>"Opening the following templatestrings.json file for writing: "{0}"</source>
         <target state="new">"Opening the following templatestrings.json file for writing: "{0}"</target>
-        <note>{0} will be replaced by the templates string JSon file path.</note>
+        <note>{0} is a file path.</note>
       </trans-unit>
     </body>
   </file>

--- a/test/Microsoft.TemplateEngine.Cli.TestHelper/BasicCommand.cs
+++ b/test/Microsoft.TemplateEngine.Cli.TestHelper/BasicCommand.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.NET.TestFramework.Commands;
+using Xunit.Abstractions;
+
+namespace Microsoft.TemplateEngine.TestHelper
+{
+    public class BasicCommand : TestCommand
+    {
+        private readonly string _processName;
+
+        public BasicCommand(ITestOutputHelper log, string processName, params string[] args) : base(log)
+        {
+            _processName = processName;
+            Arguments.AddRange(args);
+        }
+
+        protected override SdkCommandSpec CreateCommand(IEnumerable<string> args)
+        {
+            var sdkCommandSpec = new SdkCommandSpec()
+            {
+                FileName = _processName,
+                Arguments = args.ToList(),
+                WorkingDirectory = WorkingDirectory
+            };
+            return sdkCommandSpec;
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Cli.TestHelper/BasicCommand.cs
+++ b/test/Microsoft.TemplateEngine.Cli.TestHelper/BasicCommand.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.NET.TestFramework.Commands;
@@ -15,7 +17,7 @@ namespace Microsoft.TemplateEngine.TestHelper
         public BasicCommand(ITestOutputHelper log, string processName, params string[] args) : base(log)
         {
             _processName = processName;
-            Arguments.AddRange(args);
+            Arguments.AddRange(args.Where(a => !string.IsNullOrWhiteSpace(a)));
         }
 
         protected override SdkCommandSpec CreateCommand(IEnumerable<string> args)

--- a/test/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests/ExportCommandFailureTests.cs
+++ b/test/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests/ExportCommandFailureTests.cs
@@ -151,7 +151,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests
         {
             string filePath = Path.Combine(_workingDirectory, Path.GetRandomFileName() + ".json");
             await File.WriteAllTextAsync(filePath, templateJsonContent);
-            return new BasicCommand(_log, "Microsoft.TemplateEngine.TemplateLocalizer.exe", "export", filePath);
+            return new BasicCommand(_log, "dotnet", Path.GetFullPath("Microsoft.TemplateEngine.TemplateLocalizer.dll"), "export", filePath);
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests/ExportCommandFailureTests.cs
+++ b/test/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests/ExportCommandFailureTests.cs
@@ -1,0 +1,157 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.TemplateEngine.TestHelper;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests
+{
+    public class ExportCommandFailureTests : IDisposable
+    {
+        private string _workingDirectory;
+
+        private readonly ITestOutputHelper _log;
+
+        public ExportCommandFailureTests(ITestOutputHelper log)
+        {
+            _log = log;
+
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
+            _workingDirectory = Path.Combine(Path.GetTempPath(), "Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests", Path.GetRandomFileName());
+            Directory.CreateDirectory(_workingDirectory);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete(_workingDirectory, true);
+        }
+
+        [Fact]
+        public async Task PostActionsShouldHaveIds()
+        {
+            string json = @"{
+    ""postActions"": [
+        {
+        },
+    ]
+}";
+            (await CreateTemplateAndExport(json))
+                .Execute()
+                .Should()
+                .ExitWith(1)
+                .And.HaveStdOutContaining("Generating localization files for a template.json has failed.")
+                .And.HaveStdOutContaining("Json element \"postActions/0\" must have a member \"id\".");
+        }
+
+        [Fact]
+        public async Task PostActionIdsAreUnique()
+        {
+            string json = @"{
+    ""postActions"": [
+        {
+            ""id"": ""postAction1""
+        },
+        {
+            ""id"": ""postAction1""
+        }
+    ]
+}";
+            (await CreateTemplateAndExport(json))
+                .Execute()
+                .Should()
+                .ExitWith(1)
+                .And.HaveStdOutContaining("Generating localization files for a template.json has failed.")
+                .And.HaveStdOutContaining(@"Each child of ""//postActions"" should have a unique id. Currently, the id ""postActions/postAction1"" is shared by multiple children.");
+        }
+
+        [Fact]
+        public async Task SingleManualInstructionDoesntNeedId()
+        {
+            string json = @"{
+    ""postActions"": [
+        {
+            ""id"": ""postActionId"",
+            ""manualInstructions"": [
+                {
+                    ""text"": ""some text""
+                }
+            ]
+        }
+    ]
+}";
+            (await CreateTemplateAndExport(json))
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.HaveStdOutContaining("Localization files were successfully generated");
+        }
+
+        [Fact]
+        public async Task MultipleManualInstructionShouldHaveIds()
+        {
+            string json = @"{
+    ""postActions"": [
+        {
+            ""id"": ""postActionId"",
+            ""manualInstructions"": [
+                {
+                    ""text"": ""some text""
+                },
+                {
+                    ""text"": ""some other text""
+                }
+            ]
+        }
+    ]
+}";
+            (await CreateTemplateAndExport(json))
+                .Execute()
+                .Should()
+                .ExitWith(1)
+                .And.HaveStdOutContaining("Generating localization files for a template.json has failed.")
+                .And.HaveStdOutContaining(@"Json element ""manualInstructions/0"" must have a member ""id"".");
+        }
+
+        [Fact]
+        public async Task ManualInstructionIdsAreUnique()
+        {
+            string json = @"{
+    ""postActions"": [
+        {
+            ""id"": ""postActionId"",
+            ""manualInstructions"": [
+                {
+                    ""id"": ""mi""
+                },
+                {
+                    ""id"": ""mi""
+                },
+            ]
+        }
+    ]
+}";
+            (await CreateTemplateAndExport(json))
+                .Execute()
+                .Should()
+                .ExitWith(1)
+                .And.HaveStdOutContaining("Generating localization files for a template.json has failed.")
+                .And.HaveStdOutContaining("Each child of \"//postActions/0/manualInstructions\" should have a unique id. Currently, the id \"manualInstructions/mi\" is shared by multiple children.");
+        }
+
+        private async Task<BasicCommand> CreateTemplateAndExport(string templateJsonContent)
+        {
+            string filePath = Path.Combine(_workingDirectory, Path.GetRandomFileName() + ".json");
+            await File.WriteAllTextAsync(filePath, templateJsonContent);
+            return new BasicCommand(_log, "Microsoft.TemplateEngine.TemplateLocalizer.exe", "export", filePath);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests/ExportCommandFailureTests.cs
+++ b/test/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests/ExportCommandFailureTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Globalization;
 using System.IO;

--- a/test/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests.csproj
+++ b/test/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.TemplateLocalizer\Microsoft.TemplateEngine.TemplateLocalizer.csproj" />
     <ProjectReference Include="$(TestDir)Microsoft.TemplateEngine.TestTemplates\Microsoft.TemplateEngine.TestTemplates.csproj" />
+    <ProjectReference Include="..\Microsoft.TemplateEngine.Cli.TestHelper\Microsoft.TemplateEngine.Cli.TestHelper.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Problem
Partly delivers #3132.
Deserialization tests will come in a separate PR.

### Solution
Added tests.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)