### PR TITLE
Handle Missing GeneratorId in template.json

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReader.cs
@@ -40,7 +40,15 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
                 info.DefaultName = entry.ToString(nameof(DefaultName));
                 info.Description = entry.ToString(nameof(Description));
-                info.GeneratorId = Guid.Parse(entry.ToString(nameof(GeneratorId)));
+
+                if (entry.ToString(nameof(GeneratorId)) is { Length: > 0 } value)
+                {
+                    if (Guid.TryParse(value, out var generatorId))
+                    {
+                        info.GeneratorId = generatorId;
+                    }
+                }
+
                 info.GroupIdentity = entry.ToString(nameof(GroupIdentity));
                 info.Precedence = entry.ToInt32(nameof(Precedence));
 


### PR DESCRIPTION
### Problem
<!-- Add the issue number if exists. Describe the problem otherwise. -->

The `GeneratorId` is not guaranteed to be set, looking at .NET 6 preview 4 templates, which lack the `generatorId` value.

### Solution

Unable to parse the template info if `generatorId` is missing, since we get a `value is cannot be null` exception when calling `Guid.Parse`. If the `GeneratorId` is not present, it's likely on purpose and not necessary. Clients should determine if the `generatorId` is necessary and throw an exception.
