### PR TITLE
#3035 Sort table output (--list, --search) in alphabetic order by first column

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -430,13 +430,14 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                         columnPadding: 2,
                         headerSeparator: '-',
                         blankLineBetweenRows: false)
-                    .DefineColumn(t => t.TemplateIdentity, LocalizableStrings.ColumnNameIdentity, showAlways: true)
+                    .DefineColumn(t => t.TemplateIdentity, out object identityColumn, LocalizableStrings.ColumnNameIdentity, showAlways: true)
                     .DefineColumn(t => t.TemplateName, LocalizableStrings.ColumnNameTemplateName, shrinkIfNeeded: true, minWidth: 15, showAlways: true)
                     .DefineColumn(t => string.Join(",", t.TemplateShortNames), LocalizableStrings.ColumnNameShortName, showAlways: true)
                     .DefineColumn(t => t.TemplateLanguage, LocalizableStrings.ColumnNameLanguage, showAlways: true)
                     .DefineColumn(t => t.TemplatePrecedence.ToString(), out object prcedenceColumn, LocalizableStrings.ColumnNamePrecedence, showAlways: true)
                     .DefineColumn(t => t.TemplateAuthor, LocalizableStrings.ColumnNameAuthor, showAlways: true, shrinkIfNeeded: true, minWidth: 10)
                     .DefineColumn(t => t.TemplatePackage != null ? t.TemplatePackage.Identifier : string.Empty, LocalizableStrings.ColumnNamePackage, showAlways: true)
+                    .OrderBy(identityColumn, StringComparer.OrdinalIgnoreCase)
                     .OrderByDescending(prcedenceColumn, new NullOrEmptyIsLastStringComparer());
             Reporter.Error.WriteLine(formatter.Layout().Bold().Red());
 
@@ -469,15 +470,13 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                         columnPadding: 2,
                         headerSeparator: '-',
                         blankLineBetweenRows: false)
-                    .DefineColumn(t => t.Name, LocalizableStrings.ColumnNameTemplateName, shrinkIfNeeded: true, minWidth: 15, showAlways: true)
+                    .DefineColumn(t => t.Name, out object nameColumn, LocalizableStrings.ColumnNameTemplateName, shrinkIfNeeded: true, minWidth: 15, showAlways: true)
                     .DefineColumn(t => t.ShortName, LocalizableStrings.ColumnNameShortName, showAlways: true)
                     .DefineColumn(t => t.Languages, out object languageColumn, LocalizableStrings.ColumnNameLanguage, NewCommandInputCli.LanguageColumnFilter, defaultColumn: true)
                     .DefineColumn(t => t.Type, LocalizableStrings.ColumnNameType, NewCommandInputCli.TypeColumnFilter, defaultColumn: false)
                     .DefineColumn(t => t.Author, LocalizableStrings.ColumnNameAuthor, NewCommandInputCli.AuthorColumnFilter, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)
                     .DefineColumn(t => t.Classifications, out object tagsColumn, LocalizableStrings.ColumnNameTags, NewCommandInputCli.TagsColumnFilter, defaultColumn: true)
-
-                    .OrderByDescending(languageColumn, new NullOrEmptyIsLastStringComparer())
-                    .OrderBy(tagsColumn);
+                    .OrderBy(nameColumn);
 
             Reporter reporter = useErrorOutput ? Reporter.Error : Reporter.Output;
             reporter.WriteLine(formatter.Layout());

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,7 +27,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
         /// <c>New3CommandStatus.Cancelled</c> when the command validation fails;
         /// <c>New3CommandStatus.NotFound</c> when no templates found based on the filter criteria.
         /// </returns>
-        internal static async Task<New3CommandStatus> SearchForTemplateMatchesAsync(IEngineEnvironmentSettings environmentSettings, TemplatePackageManager templatePackageManager, INewCommandInput commandInput, string defaultLanguage)
+        internal static async Task<New3CommandStatus> SearchForTemplateMatchesAsync(IEngineEnvironmentSettings environmentSettings, TemplatePackageManager templatePackageManager, INewCommandInput commandInput, string? defaultLanguage)
         {
             if (!ValidateCommandInput(commandInput))
             {
@@ -45,7 +47,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
 
             if (searchResults.MatchesBySource.Count > 0)
             {
-                string packageIdToShow = null;
+                string? packageIdToShow = null;
                 foreach (TemplateSourceSearchResult sourceResult in searchResults.MatchesBySource)
                 {
                     DisplayResultsForPack(sourceResult, environmentSettings, commandInput, defaultLanguage);
@@ -79,7 +81,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
             }
         }
 
-        private static void DisplayResultsForPack(TemplateSourceSearchResult sourceResult, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, string defaultLanguage)
+        private static void DisplayResultsForPack(TemplateSourceSearchResult sourceResult, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, string? defaultLanguage)
         {
             string sourceHeader = string.Format(LocalizableStrings.SearchResultSourceIndicator, sourceResult.SourceDisplayName);
 
@@ -97,7 +99,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                         columnPadding: 2,
                         headerSeparator: '-',
                         blankLineBetweenRows: false)
-                    .DefineColumn(r => r.TemplateGroupInfo.Name, LocalizableStrings.ColumnNameTemplateName, showAlways: true, shrinkIfNeeded: true, minWidth: 15)
+                    .DefineColumn(r => r.TemplateGroupInfo.Name, out object nameColumn, LocalizableStrings.ColumnNameTemplateName, showAlways: true, shrinkIfNeeded: true, minWidth: 15)
                     .DefineColumn(r => r.TemplateGroupInfo.ShortName, LocalizableStrings.ColumnNameShortName, showAlways: true)
                     .DefineColumn(r => r.TemplateGroupInfo.Author, LocalizableStrings.ColumnNameAuthor, NewCommandInputCli.AuthorColumnFilter, defaultColumn: true, shrinkIfNeeded: true, minWidth: 10)
                     .DefineColumn(r => r.TemplateGroupInfo.Languages, LocalizableStrings.ColumnNameLanguage, NewCommandInputCli.LanguageColumnFilter, defaultColumn: true)
@@ -105,12 +107,12 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                     .DefineColumn(r => r.TemplateGroupInfo.Classifications, LocalizableStrings.ColumnNameTags, NewCommandInputCli.TagsColumnFilter, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)
                     .DefineColumn(r => r.PackageName, out object packageColumn, LocalizableStrings.ColumnNamePackage, showAlways: true)
                     .DefineColumn(r => r.PrintableTotalDownloads, LocalizableStrings.ColumnNameTotalDownloads, showAlways: true, rightAlign: true)
-                    .OrderBy(packageColumn);
+                    .OrderBy(nameColumn);
 
             Reporter.Output.WriteLine(formatter.Layout());
         }
 
-        private static IReadOnlyCollection<SearchResultTableRow> GetSearchResultsForDisplay(TemplateSourceSearchResult sourceResult, string language, string defaultLanguage)
+        private static IReadOnlyCollection<SearchResultTableRow> GetSearchResultsForDisplay(TemplateSourceSearchResult sourceResult, string language, string? defaultLanguage)
         {
             List<SearchResultTableRow> templateGroupsForDisplay = new List<SearchResultTableRow>();
 

--- a/test/dotnet-new3.UnitTests/DotnetNewList.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewList.cs
@@ -1,7 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.TemplateEngine.TestHelper;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -59,6 +62,43 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutMatching("Console Application\\s+console\\s+\\[C#\\],F#,VB\\s+Common/Console")
                 .And.NotHaveStdOutMatching("dotnet gitignore file\\s+gitignore\\s+Config")
                 .And.HaveStdOutMatching("Class Library\\s+classlib\\s+\\[C#\\],F#,VB\\s+Common/Library");
+        }
+
+        [Fact]
+        public void CanSortByName()
+        {
+            const string expectedOutput =
+@"Template Name                                 Short Name     Language    Tags                  
+--------------------------------------------  -------------  ----------  ----------------------
+ASP.NET Core Empty                            web            [C#],F#     Web/Empty             
+ASP.NET Core Web API                          webapi         [C#],F#     Web/WebAPI            
+ASP.NET Core Web App                          webapp         [C#]        Web/MVC/Razor Pages   
+ASP.NET Core Web App (Model-View-Controller)  mvc            [C#],F#     Web/MVC               
+ASP.NET Core gRPC Service                     grpc           [C#]        Web/gRPC              
+Blazor Server App                             blazorserver   [C#]        Web/Blazor            
+Blazor WebAssembly App                        blazorwasm     [C#]        Web/Blazor/WebAssembly
+Class Library                                 classlib       [C#],F#,VB  Common/Library        
+Console Application                           console        [C#],F#,VB  Common/Console        
+Dotnet local tool manifest file               tool-manifest              Config                
+NuGet Config                                  nugetconfig                Config                
+Razor Class Library                           razorclasslib  [C#]        Web/Razor/Library     
+Solution File                                 sln                        Solution              
+Web Config                                    webconfig                  Config                
+Worker Service                                worker         [C#],F#     Common/Worker/Web     
+dotnet gitignore file                         gitignore                  Config                
+global.json file                              globaljson                 Config                ";
+
+            string home = TestUtils.CreateTemporaryFolder();
+            Helpers.InstallNuGetTemplate("Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0", _log, null, home);
+
+            new DotnetNewCommand(_log, "--list")
+                .WithCustomHive(home)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.HaveStdOut(expectedOutput)
+                .And.NotHaveStdErr();
+
         }
     }
 }


### PR DESCRIPTION
### Problem
fixes dotnet/templating#3035 

### Solution
Sorted output for search and list in alphabetic order (ordinal) by first column

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)