### PR TITLE
fixes dotnet/templating#3113 disable partial matching on name for instantiation and --help

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Alias/AliasSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Alias/AliasSupport.cs
@@ -23,7 +23,10 @@ namespace Microsoft.TemplateEngine.Cli.Alias
         // TODO: make this test more robust.
         private static readonly Regex ValidFirstTokenRegex = new Regex("^[a-z0-9]", RegexOptions.IgnoreCase);
 
-        internal static New3CommandStatus CoordinateAliasExpansion(INewCommandInput commandInput, AliasRegistry aliasRegistry, ITelemetryLogger telemetryLogger)
+        internal static New3CommandStatus CoordinateAliasExpansion(
+            INewCommandInput commandInput,
+            AliasRegistry aliasRegistry,
+            TemplateInformationCoordinator templateInformationCoordinator)
         {
             AliasExpansionStatus aliasExpansionStatus = AliasSupport.TryExpandAliases(commandInput, aliasRegistry);
             if (aliasExpansionStatus == AliasExpansionStatus.ExpansionError)
@@ -38,7 +41,7 @@ namespace Microsoft.TemplateEngine.Cli.Alias
                 if (commandInput.HasParseError)
                 {
                     Reporter.Output.WriteLine(LocalizableStrings.AliasExpandedCommandParseError);
-                    return HelpForTemplateResolution.HandleParseError(commandInput, telemetryLogger);
+                    return templateInformationCoordinator.HandleParseError(commandInput);
                 }
             }
 

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInputExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInputExtensions.cs
@@ -41,6 +41,16 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             return $"dotnet {command.CommandName} --list";
         }
 
+        internal static string SearchCommandExample(this INewCommandInput command, string templateName)
+        {
+            if (templateName.Any(char.IsWhiteSpace))
+            {
+                templateName = $"'{templateName}'";
+            }
+
+            return $"dotnet {command.CommandName} {templateName} --search";
+        }
+
         internal static string UninstallCommandExample(this INewCommandInput command, string packageId = "", bool noArgs = false)
         {
             if (noArgs)

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInputExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInputExtensions.cs
@@ -3,6 +3,8 @@
 
 #nullable enable
 
+using System.Linq;
+
 namespace Microsoft.TemplateEngine.Cli.CommandParsing
 {
     /// <summary>

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/InvalidParameterInfo.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/InvalidParameterInfo.cs
@@ -173,7 +173,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 
             text.Append(' ').AppendLine(LocalizableStrings.PossibleValuesHeader);
             int longestChoiceLength = possibleValues.Keys.Max(x => x.Length);
-            foreach (KeyValuePair<string, ParameterChoice> choiceInfo in possibleValues)
+            foreach (KeyValuePair<string, ParameterChoice> choiceInfo in possibleValues.OrderBy(x => x.Key, StringComparer.Ordinal))
             {
                 text.Append(' ', padWidth * 2).Append(choiceInfo.Key.PadRight(longestChoiceLength + padWidth));
 

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
@@ -65,8 +65,8 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 case TemplateResolutionResult.Status.NoMatch:
                     Reporter.Error.WriteLine(
                         string.Format(LocalizableStrings.NoTemplatesMatchingInputParameters, GetInputParametersString(commandInput)).Bold().Red());
-                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.ListTemplatesCommand, commandInput.CommandName).Bold().Red());
-                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.SearchTemplatesCommand, commandInput.CommandName, commandInput.TemplateName).Bold().Red());
+                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.ListTemplatesCommand, commandInput.ListCommandExample()).Bold().Red());
+                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.SearchTemplatesCommand, commandInput.SearchCommandExample(commandInput.TemplateName)).Bold().Red());
                     return Task.FromResult(New3CommandStatus.NotFound);
                 case TemplateResolutionResult.Status.AmbiguousLanguageChoice:
                     Reporter.Error.WriteLine(LocalizableStrings.AmbiguousTemplateGroupListHeader.Bold().Red());
@@ -495,11 +495,11 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             if (!commandInput.IsListFlagSpecified)
             {
                 // To list installed templates, run 'dotnet {0} --list'.
-                Reporter.Error.WriteLine(string.Format(LocalizableStrings.ListTemplatesCommand, commandInput.CommandName).Bold().Red());
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.ListTemplatesCommand, commandInput.ListCommandExample()).Bold().Red());
             }
 
             // To search for the templates on NuGet.org, run 'dotnet {0} <template name> --search'.
-            Reporter.Error.WriteLine(string.Format(LocalizableStrings.SearchTemplatesCommand, commandInput.CommandName, commandInput.TemplateName).Bold().Red());
+            Reporter.Error.WriteLine(string.Format(LocalizableStrings.SearchTemplatesCommand, commandInput.SearchCommandExample(commandInput.TemplateName)).Bold().Red());
             Reporter.Error.WriteLine();
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
@@ -20,63 +20,43 @@ using TemplateCreator = Microsoft.TemplateEngine.Edge.Template.TemplateCreator;
 
 namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 {
-    internal static class HelpForTemplateResolution
+    internal class TemplateInformationCoordinator
     {
-        internal static Task<New3CommandStatus> CoordinateHelpAndUsageDisplayAsync(
-            TemplateListResolutionResult templateResolutionResult,
-            IEngineEnvironmentSettings environmentSettings,
-            INewCommandInput commandInput,
-            IHostSpecificDataLoader hostDataLoader,
-            ITelemetryLogger telemetryLogger,
+        private readonly IEngineEnvironmentSettings _engineEnvironmentSettings;
+        private readonly TemplatePackageManager _templatePackageManager;
+        private readonly TemplateCreator _templateCreator;
+        private readonly IHostSpecificDataLoader _hostSpecificDataLoader;
+        private readonly ITelemetryLogger _telemetryLogger;
+        private readonly string? _defaultLanguage;
+
+        internal TemplateInformationCoordinator(
+            IEngineEnvironmentSettings engineEnvironmentSettings,
+            TemplatePackageManager templatePackageManager,
             TemplateCreator templateCreator,
-            string? defaultLanguage,
-            CancellationToken cancellationToken)
+            IHostSpecificDataLoader hostSpecificDataLoader,
+            ITelemetryLogger telemetryLogger,
+            string? defaultLanguage)
+
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            //in case only --help option is specified we don't need to show templates list
-            if (commandInput.IsHelpFlagSpecified && string.IsNullOrEmpty(commandInput.TemplateName))
-            {
-                ShowUsageHelp(commandInput, telemetryLogger);
-                return Task.FromResult(New3CommandStatus.Success);
-            }
-
-            // in case list is specified we always need to list templates
-            if (commandInput.IsListFlagSpecified)
-            {
-                return DisplayListOrHelpForAmbiguousTemplateGroupAsync(templateResolutionResult, environmentSettings, commandInput, hostDataLoader, defaultLanguage, cancellationToken);
-            }
-            else // help flag specified or no flag specified
-            {
-                if (!string.IsNullOrEmpty(commandInput.TemplateName)
-                    && templateResolutionResult.HasUnambiguousTemplateGroup)
-                {
-                    // This will show detailed help on the template group, which only makes sense if there is a single template group adn all templates are the same language.
-                    return DisplayHelpForUnambiguousTemplateGroupAsync(templateResolutionResult, environmentSettings, commandInput, hostDataLoader, templateCreator, defaultLanguage, cancellationToken);
-                }
-                else
-                {
-                    return DisplayListOrHelpForAmbiguousTemplateGroupAsync(templateResolutionResult, environmentSettings, commandInput, hostDataLoader, defaultLanguage, cancellationToken);
-                }
-            }
+            _engineEnvironmentSettings = engineEnvironmentSettings ?? throw new ArgumentNullException(nameof(engineEnvironmentSettings));
+            _templatePackageManager = templatePackageManager ?? throw new ArgumentNullException(nameof(templatePackageManager));
+            _templateCreator = templateCreator ?? throw new ArgumentNullException(nameof(templateCreator));
+            _hostSpecificDataLoader = hostSpecificDataLoader ?? throw new ArgumentNullException(nameof(hostSpecificDataLoader));
+            _telemetryLogger = telemetryLogger ?? throw new ArgumentNullException(nameof(telemetryLogger));
+            _defaultLanguage = defaultLanguage;
         }
 
         /// <summary>
-        /// Displays the help in case it is not possible to resolve template to use based on user input on template instantiation.
+        /// Displays the help in case it is not possible to resolve template to use based on user input.
+        /// Used for template instantiation and template help.
         /// </summary>
         /// <param name="resolutionResult">template resolution result.</param>
-        /// <param name="environmentSettings"></param>
-        /// <param name="templatePackageManager"></param>
         /// <param name="commandInput">command input used in CLI.</param>
-        /// <param name="defaultLanguage">default language for the host.</param>
-        /// <param name="cancellationToken"></param>
+        /// <param name="cancellationToken">cancellation token.</param>
         /// <returns></returns>
-        internal static Task<New3CommandStatus> CoordinateAmbiguousTemplateResolutionDisplayAsync(
+        internal Task<New3CommandStatus> CoordinateAmbiguousTemplateResolutionDisplayAsync(
             TemplateResolutionResult resolutionResult,
-            IEngineEnvironmentSettings environmentSettings,
-            TemplatePackageManager templatePackageManager,
             INewCommandInput commandInput,
-            string? defaultLanguage,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -90,48 +70,83 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                     return Task.FromResult(New3CommandStatus.NotFound);
                 case TemplateResolutionResult.Status.AmbiguousLanguageChoice:
                     Reporter.Error.WriteLine(LocalizableStrings.AmbiguousTemplateGroupListHeader.Bold().Red());
-                    DisplayTemplateList(resolutionResult.TemplateGroups, environmentSettings, commandInput, defaultLanguage, useErrorOutput: true);
+                    DisplayTemplateList(resolutionResult.TemplateGroups, commandInput, useErrorOutput: true);
                     Reporter.Error.WriteLine(LocalizableStrings.AmbiguousLanguageHint.Bold().Red());
                     return Task.FromResult(New3CommandStatus.NotFound);
                 case TemplateResolutionResult.Status.AmbiguousTemplateGroupChoice:
                     Reporter.Error.WriteLine(LocalizableStrings.AmbiguousTemplateGroupListHeader.Bold().Red());
-                    DisplayTemplateList(resolutionResult.TemplateGroups, environmentSettings, commandInput, defaultLanguage, useErrorOutput: true);
+                    DisplayTemplateList(resolutionResult.TemplateGroups, commandInput, useErrorOutput: true);
                     Reporter.Error.WriteLine(LocalizableStrings.AmbiguousTemplateGroupListHint.Bold().Red());
                     return Task.FromResult(New3CommandStatus.NotFound);
                 case TemplateResolutionResult.Status.AmbiguousParameterValueChoice:
+                    if (resolutionResult.UnambiguousTemplateGroup == null)
+                    {
+                        throw new ArgumentException($"{nameof(resolutionResult.UnambiguousTemplateGroup)} should not be null if {nameof(resolutionResult.ResolutionStatus)} is {nameof(TemplateResolutionResult.Status.AmbiguousParameterValueChoice)}");
+                    }
                     Reporter.Verbose.WriteLine(LocalizableStrings.Authoring_AmbiguousChoiceParameterValue);
                     return Task.FromResult(DisplayInvalidParameterError(resolutionResult.UnambiguousTemplateGroup, commandInput));
                 case TemplateResolutionResult.Status.AmbiguousTemplateChoice:
+                    if (resolutionResult.UnambiguousTemplateGroup == null)
+                    {
+                        throw new ArgumentException($"{nameof(resolutionResult.UnambiguousTemplateGroup)} should not be null if {nameof(resolutionResult.ResolutionStatus)} is {nameof(TemplateResolutionResult.Status.AmbiguousParameterValueChoice)}");
+                    }
                     Reporter.Verbose.WriteLine(LocalizableStrings.Authoring_AmbiguousBestPrecedence);
-                    return DisplayAmbiguousPrecedenceErrorAsync(resolutionResult.UnambiguousTemplateGroup, environmentSettings, templatePackageManager, commandInput, cancellationToken);
+                    return DisplayAmbiguousPrecedenceErrorAsync(resolutionResult.UnambiguousTemplateGroup, commandInput, cancellationToken);
                 case TemplateResolutionResult.Status.InvalidParameter:
+                    if (resolutionResult.UnambiguousTemplateGroup == null)
+                    {
+                        throw new ArgumentException($"{nameof(resolutionResult.UnambiguousTemplateGroup)} should not be null if {nameof(resolutionResult.ResolutionStatus)} is {nameof(TemplateResolutionResult.Status.AmbiguousParameterValueChoice)}");
+                    }
                     return Task.FromResult(DisplayInvalidParameterError(resolutionResult.UnambiguousTemplateGroup, commandInput));
             }
             return Task.FromResult(New3CommandStatus.CreateFailed);
         }
 
-        // Displays the list of templates in a table, one row per template group.
-        //
-        // The columns displayed are as follows:
-        // Except where noted, the values are taken from the highest-precedence template in the group. The info could vary among the templates in the group, but shouldn't.
-        // (There is no check that the info doesn't vary.)
-        // - Template Name
-        // - Short Name: displays the first short name from the highest precedence template in the group.
-        // - Language: All languages supported by any template in the group are displayed, with the default language in brackets, e.g.: [C#]
-        // - Tags
-        internal static void DisplayTemplateList(IReadOnlyCollection<TemplateGroup> templateGroups, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, string? defaultLanguage, bool useErrorOutput = false)
+        /// <summary>
+        /// Displays the list of templates in a table, one row per template group.
+        ///
+        /// The columns displayed are as follows:
+        /// Except where noted, the values are taken from the highest-precedence template in the group. The info could vary among the templates in the group, but shouldn't.
+        /// (There is no check that the info doesn't vary.)
+        /// - Template Name
+        /// - Short Name: displays the all available short names for the group.
+        /// - Language: All languages supported by any template in the group are displayed, with the default language in brackets, e.g.: [C#]
+        /// - Tags
+        /// The columns can be configured in <see cref="INewCommandInput.Columns"/> and <see cref="INewCommandInput.ShowAllColumns"/>.
+        /// </summary>
+        internal void DisplayTemplateList(
+            IReadOnlyCollection<TemplateGroup> templateGroups,
+            INewCommandInput commandInput,
+            bool useErrorOutput = false)
         {
-            IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay = TemplateGroupDisplay.GetTemplateGroupsForListDisplay(templateGroups, commandInput.Language, defaultLanguage);
-            DisplayTemplateList(groupsForDisplay, environmentSettings, commandInput, useErrorOutput);
+            IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay = TemplateGroupDisplay.GetTemplateGroupsForListDisplay(templateGroups, commandInput.Language, _defaultLanguage);
+            DisplayTemplateList(groupsForDisplay, commandInput, useErrorOutput);
         }
 
-        internal static void DisplayTemplateList(IEnumerable<ITemplateInfo> templates, IEngineEnvironmentSettings environmentSettings, INewCommandInput commandInput, string defaultLanguage, bool useErrorOutput = false)
+        /// <summary>
+        /// Displays the list of templates in a table, one row per template group.
+        ///
+        /// The columns displayed are as follows:
+        /// Except where noted, the values are taken from the highest-precedence template in the group. The info could vary among the templates in the group, but shouldn't.
+        /// (There is no check that the info doesn't vary.)
+        /// - Template Name
+        /// - Short Name: displays the all available short names for the group.
+        /// - Language: All languages supported by any template in the group are displayed, with the default language in brackets, e.g.: [C#]
+        /// - Tags
+        /// The columns can be configured in <see cref="INewCommandInput.Columns"/> and <see cref="INewCommandInput.ShowAllColumns"/>.
+        /// </summary>
+        internal void DisplayTemplateList(
+            IEnumerable<ITemplateInfo> templates,
+            INewCommandInput commandInput,
+            bool useErrorOutput = false)
         {
-            IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay = TemplateGroupDisplay.GetTemplateGroupsForListDisplay(templates, commandInput.Language, defaultLanguage);
-            DisplayTemplateList(groupsForDisplay, environmentSettings, commandInput, useErrorOutput);
+            IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay = TemplateGroupDisplay.GetTemplateGroupsForListDisplay(templates, commandInput.Language, _defaultLanguage);
+            DisplayTemplateList(groupsForDisplay, commandInput, useErrorOutput);
         }
 
+#pragma warning disable SA1204 // Static elements should appear before instance elements
         internal static void DisplayInvalidParameters(IEnumerable<string> invalidParams)
+#pragma warning restore SA1204 // Static elements should appear before instance elements
         {
             _ = invalidParams ?? throw new ArgumentNullException(nameof(invalidParams));
 
@@ -145,7 +160,9 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             }
         }
 
-        // Returns a list of the parameter names that are invalid for every template in the input group.
+        /// <summary>
+        /// Returns a list of the parameter names that are invalid for every template in the input group.
+        /// </summary>
         internal static void GetParametersInvalidForTemplatesInList(IReadOnlyCollection<ITemplateMatchInfo> templateList, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates)
         {
             IDictionary<string, int> invalidCounts = new Dictionary<string, int>();
@@ -175,18 +192,18 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 ?? new List<string>();
         }
 
-        internal static void ShowUsageHelp(INewCommandInput commandInput, ITelemetryLogger telemetryLogger)
+        internal void ShowUsageHelp(INewCommandInput commandInput)
         {
             if (commandInput.IsHelpFlagSpecified)
             {
-                telemetryLogger.TrackEvent(commandInput.CommandName + "-Help");
+                _telemetryLogger.TrackEvent(commandInput.CommandName + "-Help");
             }
 
             Reporter.Output.WriteLine(commandInput.HelpText);
             Reporter.Output.WriteLine();
         }
 
-        internal static New3CommandStatus HandleParseError(INewCommandInput commandInput, ITelemetryLogger telemetryLogger)
+        internal New3CommandStatus HandleParseError(INewCommandInput commandInput)
         {
             TemplateResolver.ValidateRemainingParameters(commandInput, out IReadOnlyList<string> invalidParams);
             DisplayInvalidParameters(invalidParams);
@@ -195,7 +212,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             if (commandInput.IsHelpFlagSpecified)
             {
                 // this code path doesn't go through the full help & usage stack, so needs it's own call to ShowUsageHelp().
-                ShowUsageHelp(commandInput, telemetryLogger);
+                ShowUsageHelp(commandInput);
             }
             else if (invalidParams.Count > 0)
             {
@@ -215,7 +232,9 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
         /// <param name="commandName"></param>
         /// <param name="template"></param>
         /// <returns>the help command or null in case template does not have short name defined.</returns>
+#pragma warning disable SA1204 // Static elements should appear before instance elements
         internal static string? GetTemplateHelpCommand(string commandName, ITemplateInfo template)
+#pragma warning restore SA1204 // Static elements should appear before instance elements
         {
             if (template.ShortNameList.Any())
             {
@@ -224,104 +243,61 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             return null;
         }
 
-        private static Task<New3CommandStatus> DisplayHelpForUnambiguousTemplateGroupAsync(
-            TemplateListResolutionResult templateResolutionResult,
-            IEngineEnvironmentSettings environmentSettings,
+        /// <summary>
+        /// Handles help display for the template (dotnet new3 template-name --help).
+        /// </summary>
+        /// <param name="commandInput">user command input.</param>
+        /// <param name="cancellationToken">cancellation token.</param>
+        /// <returns><see cref="New3CommandStatus"/> for operation.</returns>
+        internal async Task<New3CommandStatus> DisplayDetailedHelpAsync(
             INewCommandInput commandInput,
-            IHostSpecificDataLoader hostDataLoader,
-            TemplateCreator templateCreator,
-            string? defaultLanguage,
-            CancellationToken cancellationToken)
-        {
-            // sanity check: should never happen; as condition for unambiguous template group is checked above
-            if (!templateResolutionResult.UnambiguousTemplateGroup.Any())
-            {
-                return DisplayListOrHelpForAmbiguousTemplateGroupAsync(templateResolutionResult, environmentSettings, commandInput, hostDataLoader, defaultLanguage, cancellationToken);
-            }
-
-            //if language is specified and all templates in unambigiuos group match the language show the help for that template
-            if (templateResolutionResult.AllTemplatesInUnambiguousTemplateGroupAreSameLanguage)
-            {
-                IReadOnlyCollection<ITemplateMatchInfo> unambiguousTemplateGroupForDetailDisplay = templateResolutionResult.UnambiguousTemplateGroup;
-                return TemplateDetailedHelpForSingularTemplateGroupAsync(unambiguousTemplateGroupForDetailDisplay, environmentSettings, commandInput, hostDataLoader, templateCreator, cancellationToken);
-            }
-            //if language is not specified and group has template that matches the language show the help for that the template that matches the language
-            if (string.IsNullOrEmpty(commandInput.Language) && !string.IsNullOrEmpty(defaultLanguage) && templateResolutionResult.HasUnambiguousTemplateGroupForDefaultLanguage)
-            {
-                IReadOnlyCollection<ITemplateMatchInfo> unambiguousTemplateGroupForDetailDisplay = templateResolutionResult.UnambiguousTemplatesForDefaultLanguage;
-                return TemplateDetailedHelpForSingularTemplateGroupAsync(unambiguousTemplateGroupForDetailDisplay, environmentSettings, commandInput, hostDataLoader, templateCreator, cancellationToken);
-            }
-            else
-            {
-                return DisplayListOrHelpForAmbiguousTemplateGroupAsync(templateResolutionResult, environmentSettings, commandInput, hostDataLoader, defaultLanguage, cancellationToken);
-            }
-        }
-
-        private static async Task<New3CommandStatus> TemplateDetailedHelpForSingularTemplateGroupAsync(
-            IReadOnlyCollection<ITemplateMatchInfo> unambiguousTemplateGroup,
-            IEngineEnvironmentSettings environmentSettings,
-            INewCommandInput commandInput,
-            IHostSpecificDataLoader hostDataLoader,
-            TemplateCreator templateCreator,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            // sanity check: should never happen; as condition for unambiguous template group is checked above
-            if (!unambiguousTemplateGroup.Any())
-            {
-                return New3CommandStatus.NotFound;
-            }
 
-            GetParametersInvalidForTemplatesInList(unambiguousTemplateGroup, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
-
-            if (invalidForAllTemplates.Count > 0 || invalidForSomeTemplates.Count > 0)
+            TemplateResolutionResult helpResolutionResult = TemplateResolver.GetTemplateResolutionResultForHelp(await _templatePackageManager.GetTemplatesAsync(default).ConfigureAwait(false), _hostSpecificDataLoader, commandInput, _defaultLanguage);
+            if (helpResolutionResult.GroupResolutionStatus == TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch && helpResolutionResult.TemplatesForDetailedHelp.Any())
             {
-                DisplayInvalidParameters(invalidForAllTemplates);
-                DisplayParametersInvalidForSomeTemplates(invalidForSomeTemplates, LocalizableStrings.SingleTemplateGroupPartialMatchSwitchesNotValidForAllMatches);
-            }
-
-            if (invalidForAllTemplates.Count == 0)
-            {
+                IReadOnlyCollection<ITemplateMatchInfo> unambiguousTemplateGroup = helpResolutionResult.TemplatesForDetailedHelp.ToList();
                 bool showImplicitlyHiddenParams = unambiguousTemplateGroup.Count > 1;
-                await TemplateDetailsDisplay.ShowTemplateGroupHelpAsync(unambiguousTemplateGroup, environmentSettings, commandInput, hostDataLoader, templateCreator, showImplicitlyHiddenParams, cancellationToken).ConfigureAwait(false);
+                return await TemplateDetailsDisplay.ShowTemplateGroupHelpAsync(unambiguousTemplateGroup, _engineEnvironmentSettings, commandInput, _hostSpecificDataLoader, _templateCreator, showImplicitlyHiddenParams, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                string? templateHelpCommand = GetTemplateHelpCommand(commandInput.CommandName, unambiguousTemplateGroup.First().Info);
-                if (!string.IsNullOrWhiteSpace(templateHelpCommand))
-                {
-                    Reporter.Error.WriteLine(
-                        string.Format(LocalizableStrings.InvalidParameterTemplateHint, templateHelpCommand).Bold().Red());
-                }
+                return await CoordinateAmbiguousTemplateResolutionDisplayAsync(helpResolutionResult, commandInput, cancellationToken).ConfigureAwait(false);
             }
-
-            return invalidForAllTemplates.Count > 0 || invalidForSomeTemplates.Count > 0
-                ? New3CommandStatus.InvalidParamValues
-                : New3CommandStatus.Success;
         }
 
-        private static Task<New3CommandStatus> DisplayListOrHelpForAmbiguousTemplateGroupAsync(
-            TemplateListResolutionResult templateResolutionResult,
-            IEngineEnvironmentSettings environmentSettings,
+        /// <summary>
+        /// Handles template list display (dotnet new3 --list).
+        /// </summary>
+        /// <param name="commandInput">user command input.</param>
+        /// <param name="cancellationToken">cancellation token.</param>
+        /// <returns></returns>
+        internal async Task<New3CommandStatus> DisplayTemplateGroupListAsync(
             INewCommandInput commandInput,
-            IHostSpecificDataLoader hostDataLoader,
-            string? defaultLanguage,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            TemplateListResolutionResult listingTemplateResolutionResult = TemplateResolver.GetTemplateResolutionResultForList(
+               await _templatePackageManager.GetTemplatesAsync(default).ConfigureAwait(false),
+               _hostSpecificDataLoader,
+               commandInput,
+               _defaultLanguage);
+
             // The following occurs when:
-            //      --alias <value> is specifed
+            //      --alias <value> is specified
             //      --help is specified
             //      template (group) can't be resolved
             if (!string.IsNullOrWhiteSpace(commandInput.Alias))
             {
                 Reporter.Error.WriteLine(LocalizableStrings.InvalidInputSwitch.Bold().Red());
                 Reporter.Error.WriteLine("  " + commandInput.TemplateParamInputFormat("--alias").Bold().Red());
-                return Task.FromResult(New3CommandStatus.NotFound);
+                return New3CommandStatus.NotFound;
             }
 
             bool hasInvalidParameters = false;
-            IReadOnlyCollection<ITemplateMatchInfo> templatesForDisplay = templateResolutionResult.ExactMatchedTemplates;
+            IReadOnlyCollection<ITemplateMatchInfo> templatesForDisplay = listingTemplateResolutionResult.ExactMatchedTemplates;
             GetParametersInvalidForTemplatesInList(templatesForDisplay, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
             if (invalidForAllTemplates.Any() || invalidForSomeTemplates.Any())
             {
@@ -330,32 +306,28 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 DisplayParametersInvalidForSomeTemplates(invalidForSomeTemplates, LocalizableStrings.PartialTemplateMatchSwitchesNotValidForAllMatches);
             }
 
-            if (templateResolutionResult.HasExactMatches)
+            if (listingTemplateResolutionResult.HasExactMatches)
             {
                 ShowTemplatesFoundMessage(commandInput);
-                DisplayTemplateList(templateResolutionResult.ExactMatchedTemplateGroups, environmentSettings, commandInput, defaultLanguage);
+                DisplayTemplateList(listingTemplateResolutionResult.ExactMatchedTemplateGroups, commandInput);
             }
             else
             {
-                ShowContextAndTemplateNameMismatchHelp(templateResolutionResult, commandInput);
+                ShowContextAndTemplateNameMismatchHelp(listingTemplateResolutionResult, commandInput);
             }
 
             if (!commandInput.IsListFlagSpecified)
             {
-                TemplateUsageHelp.ShowInvocationExamples(templateResolutionResult, hostDataLoader, commandInput.CommandName);
+                TemplateUsageHelp.ShowInvocationExamples(listingTemplateResolutionResult, _hostSpecificDataLoader, commandInput.CommandName);
             }
 
             if (hasInvalidParameters)
             {
-                return Task.FromResult(New3CommandStatus.NotFound);
-            }
-            else if (commandInput.IsListFlagSpecified || commandInput.IsHelpFlagSpecified)
-            {
-                return Task.FromResult(templateResolutionResult.HasExactMatches ? New3CommandStatus.Success : New3CommandStatus.NotFound);
+                return New3CommandStatus.NotFound;
             }
             else
             {
-                return Task.FromResult(New3CommandStatus.NotFound);
+                return listingTemplateResolutionResult.HasExactMatches ? New3CommandStatus.Success : New3CommandStatus.NotFound;
             }
         }
 
@@ -392,17 +364,13 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
         /// Displays the help when <paramref name="unambiguousTemplateGroup"/> contains the invokable templates with ambiguous precedence.
         /// </summary>
         /// <param name="unambiguousTemplateGroup">resolved unambiguous template group to use based on the command input.</param>
-        /// <param name="environmentSettings"></param>
-        /// <param name="templatePackageManager"></param>
         /// <param name="commandInput">the command input.</param>
         /// <param name="cancellationToken">a cancellation token.</param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException">when <paramref name="unambiguousTemplateGroup"/> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException">when <paramref name="commandInput"/> is <see langword="null" />.</exception>
-        private static async Task<New3CommandStatus> DisplayAmbiguousPrecedenceErrorAsync(
+        private async Task<New3CommandStatus> DisplayAmbiguousPrecedenceErrorAsync(
             TemplateGroup unambiguousTemplateGroup,
-            IEngineEnvironmentSettings environmentSettings,
-            TemplatePackageManager templatePackageManager,
             INewCommandInput commandInput,
             CancellationToken cancellationToken)
         {
@@ -421,14 +389,14 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                     TemplateLanguage = template.Info.GetLanguage() ?? string.Empty,
                     TemplatePrecedence = template.Info.Precedence,
                     TemplateAuthor = template.Info.Author ?? string.Empty,
-                    TemplatePackage = await templatePackageManager.GetTemplatePackageAsync(template.Info, cancellationToken).ConfigureAwait(false) as IManagedTemplatePackage
+                    TemplatePackage = await _templatePackageManager.GetTemplatePackageAsync(template.Info, cancellationToken).ConfigureAwait(false) as IManagedTemplatePackage
                 });
             }
 
             HelpFormatter<AmbiguousTemplateDetails> formatter =
                 HelpFormatter
                     .For(
-                        environmentSettings,
+                        _engineEnvironmentSettings,
                         commandInput,
                         ambiguousTemplateDetails,
                         columnPadding: 2,
@@ -448,7 +416,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             string hintMessage = LocalizableStrings.AmbiguousTemplatesMultiplePackagesHint;
             if (unambiguousTemplateGroup.Templates.AllAreTheSame(t => t.Info.MountPointUri))
             {
-                IManagedTemplatePackage? templatePackage = await templatePackageManager.GetTemplatePackageAsync(
+                IManagedTemplatePackage? templatePackage = await _templatePackageManager.GetTemplatePackageAsync(
                     unambiguousTemplateGroup.Templates.First().Info, cancellationToken).ConfigureAwait(false) as IManagedTemplatePackage;
                 if (templatePackage != null)
                 {
@@ -459,16 +427,15 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             return New3CommandStatus.NotFound;
         }
 
-        private static void DisplayTemplateList(
+        private void DisplayTemplateList(
             IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay,
-            IEngineEnvironmentSettings environmentSettings,
             INewCommandInput commandInput,
             bool useErrorOutput = false)
         {
             HelpFormatter<TemplateGroupTableRow> formatter =
                 HelpFormatter
                     .For(
-                        environmentSettings,
+                        _engineEnvironmentSettings,
                         commandInput,
                         groupsForDisplay,
                         columnPadding: 2,
@@ -486,7 +453,9 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             reporter.WriteLine(formatter.Layout());
         }
 
+#pragma warning disable SA1204 // Static elements should appear before instance elements
         private static void DisplayParametersInvalidForSomeTemplates(IReadOnlyList<string> invalidParams, string messageHeader)
+#pragma warning restore SA1204 // Static elements should appear before instance elements
         {
             if (invalidParams.Count > 0)
             {

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateUsageHelp.cs
@@ -71,7 +71,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             Reporter.Output.WriteLine($"    dotnet {commandName} --help");
 
             // show a help example for template
-            string? templateHelpCommand = HelpForTemplateResolution.GetTemplateHelpCommand(commandName, bestMatchedTemplates.First().Info);
+            string? templateHelpCommand = TemplateInformationCoordinator.GetTemplateHelpCommand(commandName, bestMatchedTemplates.First().Info);
             if (!string.IsNullOrWhiteSpace(templateHelpCommand))
             {
                 Reporter.Output.WriteLine($"    {templateHelpCommand}");

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -953,7 +953,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To list installed templates, run &apos;dotnet {0} --list&apos;..
+        ///   Looks up a localized string similar to To list installed templates, run &apos;{0}&apos;..
         /// </summary>
         internal static string ListTemplatesCommand {
             get {
@@ -1391,7 +1391,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To search for the templates on NuGet.org, run &apos;dotnet {0} {1} --search&apos;..
+        ///   Looks up a localized string similar to To search for the templates on NuGet.org, run &apos;{0}&apos;..
         /// </summary>
         internal static string SearchTemplatesCommand {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -401,7 +401,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to resolve the template to instantiate, these templates matched your input:.
+        ///   Looks up a localized string similar to Unable to resolve the template, these templates matched your input:.
         /// </summary>
         internal static string AmbiguousTemplateGroupListHeader {
             get {
@@ -419,7 +419,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to resolve the template to instantiate, the following installed templates are conflicting:.
+        ///   Looks up a localized string similar to Unable to resolve the template, the following installed templates are conflicting:.
         /// </summary>
         internal static string AmbiguousTemplatesHeader {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -578,13 +578,13 @@ Examples:
     <value>The value '{1}' is ambiguous for option {0}.</value>
   </data>
   <data name="AmbiguousTemplateGroupListHeader" xml:space="preserve">
-    <value>Unable to resolve the template to instantiate, these templates matched your input:</value>
+    <value>Unable to resolve the template, these templates matched your input:</value>
   </data>
   <data name="AmbiguousTemplateGroupListHint" xml:space="preserve">
     <value>Re-run the command using the template's exact short name.</value>
   </data>
   <data name="AmbiguousTemplatesHeader" xml:space="preserve">
-    <value>Unable to resolve the template to instantiate, the following installed templates are conflicting:</value>
+    <value>Unable to resolve the template, the following installed templates are conflicting:</value>
   </data>
   <data name="AmbiguousTemplatesMultiplePackagesHint" xml:space="preserve">
     <value>Uninstall the templates or the packages to keep only one template from the list.</value>

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -518,7 +518,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
     <value>For more information, run '{0}'.</value>
   </data>
   <data name="ListTemplatesCommand" xml:space="preserve">
-    <value>To list installed templates, run 'dotnet {0} --list'.</value>
+    <value>To list installed templates, run '{0}'.</value>
   </data>
   <data name="ColumnNameAuthor" xml:space="preserve">
     <value>Author</value>
@@ -572,7 +572,7 @@ Examples:
     <value>Downloads</value>
   </data>
   <data name="SearchTemplatesCommand" xml:space="preserve">
-    <value>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</value>
+    <value>To search for the templates on NuGet.org, run '{0}'.</value>
   </data>
   <data name="AmbiguousParameterDetail" xml:space="preserve">
     <value>The value '{1}' is ambiguous for option {0}.</value>

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -32,6 +32,7 @@ namespace Microsoft.TemplateEngine.Cli
         private readonly ITelemetryLogger _telemetryLogger;
         private readonly TemplateCreator _templateCreator;
         private readonly TemplatePackageManager _templatePackageManager;
+        private readonly TemplateInformationCoordinator _templateInformationCoordinator;
         private readonly AliasRegistry _aliasRegistry;
 
         /// <summary>
@@ -61,16 +62,13 @@ namespace Microsoft.TemplateEngine.Cli
             CommandName = commandName;
             _hostDataLoader = new HostSpecificDataLoader(EnvironmentSettings);
             _commandInput = commandInput;
-            _callbacks = callbacks;
-            if (callbacks == null)
-            {
-                callbacks = new New3Callbacks();
-            }
+            _callbacks = callbacks ?? new New3Callbacks();
 
             if (!EnvironmentSettings.Host.TryGetHostParamDefault("prefs:language", out _defaultLanguage))
             {
                 _defaultLanguage = null;
             }
+            _templateInformationCoordinator = new TemplateInformationCoordinator(EnvironmentSettings, _templatePackageManager, _templateCreator, _hostDataLoader, _telemetryLogger, _defaultLanguage);
         }
 
         internal string TemplateName => _commandInput.TemplateName;
@@ -247,11 +245,11 @@ namespace Microsoft.TemplateEngine.Cli
         {
             if (!TemplateResolver.ValidateRemainingParameters(_commandInput, out IReadOnlyList<string> invalidParams))
             {
-                HelpForTemplateResolution.DisplayInvalidParameters(invalidParams);
+                TemplateInformationCoordinator.DisplayInvalidParameters(invalidParams);
                 if (_commandInput.IsHelpFlagSpecified)
                 {
                     // this code path doesn't go through the full help & usage stack, so needs it's own call to ShowUsageHelp().
-                    HelpForTemplateResolution.ShowUsageHelp(_commandInput, _telemetryLogger);
+                    _templateInformationCoordinator.ShowUsageHelp(_commandInput);
                 }
                 else
                 {
@@ -261,55 +259,39 @@ namespace Microsoft.TemplateEngine.Cli
                 return New3CommandStatus.InvalidParamValues;
             }
 
-            // No other cases specified, we've fallen through to "Optional usage help + List"
-            TemplateListResolutionResult templateResolutionResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(
-                await _templatePackageManager.GetTemplatesAsync(default).ConfigureAwait(false),
-                _hostDataLoader,
-                _commandInput,
-                _defaultLanguage);
-            await HelpForTemplateResolution.CoordinateHelpAndUsageDisplayAsync(
-                templateResolutionResult,
-                EnvironmentSettings,
-                _commandInput,
-                _hostDataLoader,
-                _telemetryLogger,
-                _templateCreator,
-                _defaultLanguage,
-                default).ConfigureAwait(false);
+            // dotnet new -h case
+            if (_commandInput.IsHelpFlagSpecified)
+            {
+                _templateInformationCoordinator.ShowUsageHelp(_commandInput);
+                return New3CommandStatus.Success;
+            }
 
-            return New3CommandStatus.Success;
+            // No other cases specified, we've fallen through to "Optional usage help + List"
+            return await _templateInformationCoordinator.DisplayTemplateGroupListAsync(_commandInput, default).ConfigureAwait(false);
         }
 
         private async Task<New3CommandStatus> EnterTemplateManipulationFlowAsync()
         {
-            if (_commandInput.IsListFlagSpecified || _commandInput.IsHelpFlagSpecified)
+            if (_commandInput.IsHelpFlagSpecified)
             {
-                TemplateListResolutionResult listingTemplateResolutionResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(
-                    await _templatePackageManager.GetTemplatesAsync(default).ConfigureAwait(false),
-                    _hostDataLoader,
-                    _commandInput,
-                    _defaultLanguage);
-                return await HelpForTemplateResolution.CoordinateHelpAndUsageDisplayAsync(
-                    listingTemplateResolutionResult,
-                    EnvironmentSettings,
-                    _commandInput,
-                    _hostDataLoader,
-                    _telemetryLogger,
-                    _templateCreator,
-                    _defaultLanguage,
-                    default).ConfigureAwait(false);
+                return await _templateInformationCoordinator.DisplayDetailedHelpAsync(_commandInput, default).ConfigureAwait(false);
+            }
+            if (_commandInput.IsListFlagSpecified)
+            {
+                return await _templateInformationCoordinator.DisplayTemplateGroupListAsync(_commandInput, default).ConfigureAwait(false);
             }
 
-            TemplateResolutionResult templateResolutionResult = TemplateResolver.GetTemplateResolutionResult(await _templatePackageManager.GetTemplatesAsync(default).ConfigureAwait(false), _hostDataLoader, _commandInput, _defaultLanguage);
-            if (templateResolutionResult.ResolutionStatus == TemplateResolutionResult.Status.SingleMatch)
-            {
-                TemplateInvocationCoordinator invocationCoordinator = new TemplateInvocationCoordinator(EnvironmentSettings, _templatePackageManager, _commandInput, _telemetryLogger, CommandName, _inputGetter, _callbacks);
-                return await invocationCoordinator.CoordinateInvocationOrAcquisitionAsync(templateResolutionResult.TemplateToInvoke, CancellationToken.None).ConfigureAwait(false);
-            }
-            else
-            {
-                return await HelpForTemplateResolution.CoordinateAmbiguousTemplateResolutionDisplayAsync(templateResolutionResult, EnvironmentSettings, _templatePackageManager, _commandInput, _defaultLanguage, default).ConfigureAwait(false);
-            }
+            TemplateInvocationCoordinator invocationCoordinator = new TemplateInvocationCoordinator(
+                EnvironmentSettings,
+                _templatePackageManager,
+                _templateInformationCoordinator,
+                _hostDataLoader,
+                _telemetryLogger,
+                _defaultLanguage,
+                _inputGetter,
+                _callbacks);
+
+            return await invocationCoordinator.CoordinateInvocationOrAcquisitionAsync(_commandInput, default).ConfigureAwait(false);
         }
 
         private async Task<New3CommandStatus> ExecuteAsync()
@@ -317,7 +299,7 @@ namespace Microsoft.TemplateEngine.Cli
             // this is checking the initial parse, which is template agnostic.
             if (_commandInput.HasParseError)
             {
-                return HelpForTemplateResolution.HandleParseError(_commandInput, _telemetryLogger);
+                return _templateInformationCoordinator.HandleParseError(_commandInput);
             }
 
             if (_commandInput.IsHelpFlagSpecified)
@@ -341,7 +323,7 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 // The --alias param is for creating / updating / deleting aliases.
                 // If it's not present, try expanding aliases now.
-                New3CommandStatus aliasExpansionResult = AliasSupport.CoordinateAliasExpansion(_commandInput, _aliasRegistry, _telemetryLogger);
+                New3CommandStatus aliasExpansionResult = AliasSupport.CoordinateAliasExpansion(_commandInput, _aliasRegistry, _templateInformationCoordinator);
 
                 if (aliasExpansionResult != New3CommandStatus.Success)
                 {
@@ -378,7 +360,7 @@ namespace Microsoft.TemplateEngine.Cli
 
                 if (TemplatePackageCoordinator.IsTemplatePackageManipulationFlow(_commandInput))
                 {
-                    TemplatePackageCoordinator packageCoordinator = new TemplatePackageCoordinator(_telemetryLogger, EnvironmentSettings, _templatePackageManager, _defaultLanguage);
+                    TemplatePackageCoordinator packageCoordinator = new TemplatePackageCoordinator(_telemetryLogger, EnvironmentSettings, _templatePackageManager, _templateInformationCoordinator, _defaultLanguage);
                     return await packageCoordinator.ProcessAsync(_commandInput).ConfigureAwait(false);
                 }
 

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -291,7 +291,7 @@ namespace Microsoft.TemplateEngine.Cli
                 _inputGetter,
                 _callbacks);
 
-            return await invocationCoordinator.CoordinateInvocationOrAcquisitionAsync(_commandInput, default).ConfigureAwait(false);
+            return await invocationCoordinator.CoordinateInvocationAsync(_commandInput, default).ConfigureAwait(false);
         }
 
         private async Task<New3CommandStatus> ExecuteAsync()

--- a/src/Microsoft.TemplateEngine.Cli/New3CommandStatus.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3CommandStatus.cs
@@ -58,6 +58,11 @@ namespace Microsoft.TemplateEngine.Cli
         /// <summary>
         /// Post action failed.
         /// </summary>
-        PostActionFailed = unchecked((int)0x80010003)
+        PostActionFailed = unchecked((int)0x80010003),
+
+        /// <summary>
+        /// Generic error when displaying help.
+        /// </summary>
+        DisplayHelpFailed = unchecked((int)0x80010004)
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
@@ -7,7 +7,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Abstractions.TemplateFiltering;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
 using Microsoft.TemplateEngine.Cli.HelpAndUsage;
 using Microsoft.TemplateEngine.Cli.TemplateResolution;
@@ -48,7 +47,7 @@ namespace Microsoft.TemplateEngine.Cli
             _invoker = new TemplateInvoker(_environment, _telemetryLogger, _inputGetter, _callbacks);
         }
 
-        internal async Task<New3CommandStatus> CoordinateInvocationOrAcquisitionAsync(INewCommandInput commandInput, CancellationToken cancellationToken)
+        internal async Task<New3CommandStatus> CoordinateInvocationAsync(INewCommandInput commandInput, CancellationToken cancellationToken)
         {
             TemplateResolutionResult templateResolutionResult = TemplateResolver.GetTemplateResolutionResult(
                 await _templatePackageManager.GetTemplatesAsync(default).ConfigureAwait(false),

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
@@ -9,6 +9,8 @@ using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.TemplateFiltering;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Cli.HelpAndUsage;
+using Microsoft.TemplateEngine.Cli.TemplateResolution;
 using Microsoft.TemplateEngine.Edge.Settings;
 
 namespace Microsoft.TemplateEngine.Cli
@@ -16,51 +18,69 @@ namespace Microsoft.TemplateEngine.Cli
     internal class TemplateInvocationCoordinator
     {
         private readonly IEngineEnvironmentSettings _environment;
-        private readonly INewCommandInput _commandInput;
         private readonly ITelemetryLogger _telemetryLogger;
-        private readonly string _commandName;
+        private readonly string? _defaultLanguage;
         private readonly Func<string> _inputGetter;
         private readonly New3Callbacks _callbacks;
         private readonly TemplatePackageManager _templatePackageManager;
+        private readonly TemplateInformationCoordinator _templateInformationCoordinator;
+        private readonly IHostSpecificDataLoader _hostSpecificDataLoader;
+        private readonly TemplateInvoker _invoker;
 
-        internal TemplateInvocationCoordinator(IEngineEnvironmentSettings environment, TemplatePackageManager templatePackageManager, INewCommandInput commandInput, ITelemetryLogger telemetryLogger, string commandName, Func<string> inputGetter, New3Callbacks callbacks)
+        internal TemplateInvocationCoordinator(
+            IEngineEnvironmentSettings environment,
+            TemplatePackageManager templatePackageManager,
+            TemplateInformationCoordinator templateInformationCoordinator,
+            IHostSpecificDataLoader hostSpecificDataLoader,
+            ITelemetryLogger telemetryLogger,
+            string? defaultLanguage,
+            Func<string> inputGetter,
+            New3Callbacks callbacks)
         {
-            _environment = environment;
-            _commandInput = commandInput;
-            _telemetryLogger = telemetryLogger;
-            _commandName = commandName;
-            _inputGetter = inputGetter;
-            _callbacks = callbacks;
-            _templatePackageManager = templatePackageManager;
+            _environment = environment ?? throw new ArgumentNullException(nameof(environment));
+            _telemetryLogger = telemetryLogger ?? throw new ArgumentNullException(nameof(telemetryLogger));
+            _defaultLanguage = defaultLanguage;
+            _inputGetter = inputGetter ?? throw new ArgumentNullException(nameof(inputGetter));
+            _callbacks = callbacks ?? throw new ArgumentNullException(nameof(callbacks));
+            _templatePackageManager = templatePackageManager ?? throw new ArgumentNullException(nameof(templatePackageManager));
+            _templateInformationCoordinator = templateInformationCoordinator ?? throw new ArgumentNullException(nameof(templateInformationCoordinator));
+            _hostSpecificDataLoader = hostSpecificDataLoader ?? throw new ArgumentNullException(nameof(hostSpecificDataLoader));
+            _invoker = new TemplateInvoker(_environment, _telemetryLogger, _inputGetter, _callbacks);
         }
 
-        internal async Task<New3CommandStatus> CoordinateInvocationOrAcquisitionAsync(ITemplateMatchInfo templateToInvoke, CancellationToken cancellationToken)
+        internal async Task<New3CommandStatus> CoordinateInvocationOrAcquisitionAsync(INewCommandInput commandInput, CancellationToken cancellationToken)
         {
-            TemplatePackageCoordinator packageCoordinator = new TemplatePackageCoordinator(_telemetryLogger, _environment, _templatePackageManager);
+            TemplateResolutionResult templateResolutionResult = TemplateResolver.GetTemplateResolutionResult(
+                await _templatePackageManager.GetTemplatesAsync(default).ConfigureAwait(false),
+                _hostSpecificDataLoader,
+                commandInput,
+                _defaultLanguage);
 
-            // start checking for updates
-            var checkForUpdateTask = packageCoordinator.CheckUpdateForTemplate(templateToInvoke.Info, _commandInput, cancellationToken);
-
-            // start creation of template
-            var templateCreationTask = InvokeTemplateAsync(templateToInvoke);
-
-            // await for both tasks to finish
-            await Task.WhenAll(checkForUpdateTask, templateCreationTask).ConfigureAwait(false);
-
-            if (checkForUpdateTask.Result != null)
+            if (templateResolutionResult.ResolutionStatus == TemplateResolutionResult.Status.SingleMatch && templateResolutionResult.TemplateToInvoke != null)
             {
-                // print if there is update for this template
-                packageCoordinator.DisplayUpdateCheckResult(checkForUpdateTask.Result, _commandInput);
+                TemplatePackageCoordinator packageCoordinator = new TemplatePackageCoordinator(_telemetryLogger, _environment, _templatePackageManager, _templateInformationCoordinator);
+
+                // start checking for updates
+                var checkForUpdateTask = packageCoordinator.CheckUpdateForTemplate(templateResolutionResult.TemplateToInvoke.Info, commandInput, cancellationToken);
+                // start creation of template
+                var templateCreationTask = _invoker.InvokeTemplate(templateResolutionResult.TemplateToInvoke, commandInput);
+
+                // await for both tasks to finish
+                await Task.WhenAll(checkForUpdateTask, templateCreationTask).ConfigureAwait(false);
+
+                if (checkForUpdateTask.Result != null)
+                {
+                    // print if there is update for this template
+                    packageCoordinator.DisplayUpdateCheckResult(checkForUpdateTask.Result, commandInput);
+                }
+
+                // return creation result
+                return templateCreationTask.Result;
             }
-
-            // return creation result
-            return templateCreationTask.Result;
-        }
-
-        private Task<New3CommandStatus> InvokeTemplateAsync(ITemplateMatchInfo templateToInvoke)
-        {
-            TemplateInvoker invoker = new TemplateInvoker(_environment, _commandInput, _telemetryLogger, _commandName, _inputGetter, _callbacks);
-            return invoker.InvokeTemplate(templateToInvoke);
+            else
+            {
+                return await _templateInformationCoordinator.CoordinateAmbiguousTemplateResolutionDisplayAsync(templateResolutionResult, commandInput, default).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -28,17 +28,20 @@ namespace Microsoft.TemplateEngine.Cli
         private readonly ITelemetryLogger _telemetryLogger;
         private readonly IEngineEnvironmentSettings _engineEnvironmentSettings;
         private readonly TemplatePackageManager _templatePackageManager;
+        private readonly TemplateInformationCoordinator _templateInformationCoordinator;
         private string _defaultLanguage;
 
         internal TemplatePackageCoordinator(
             ITelemetryLogger telemetryLogger,
             IEngineEnvironmentSettings environmentSettings,
             TemplatePackageManager templatePackageManager,
+            TemplateInformationCoordinator templateInformationCoordinator,
             string? defaultLanguage = null)
         {
             _telemetryLogger = telemetryLogger ?? throw new ArgumentNullException(nameof(telemetryLogger));
             _engineEnvironmentSettings = environmentSettings ?? throw new ArgumentNullException(nameof(environmentSettings));
             _templatePackageManager = templatePackageManager ?? throw new ArgumentNullException(nameof(templatePackageManager));
+            _templateInformationCoordinator = templateInformationCoordinator ?? throw new ArgumentNullException(nameof(templateInformationCoordinator));
             if (string.IsNullOrWhiteSpace(defaultLanguage))
             {
                 defaultLanguage = string.Empty;
@@ -606,7 +609,7 @@ namespace Microsoft.TemplateEngine.Cli
                         string.Format(
                             LocalizableStrings.TemplatePackageCoordinator_lnstall_Info_Success,
                             result.TemplatePackage.DisplayName));
-                    HelpForTemplateResolution.DisplayTemplateList(templates, _engineEnvironmentSettings, commandInput, _defaultLanguage);
+                    _templateInformationCoordinator.DisplayTemplateList(templates, commandInput);
                 }
                 else
                 {

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateListResolutionResult.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,13 +19,13 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
     {
         private readonly IReadOnlyCollection<ITemplateMatchInfo> _coreMatchedTemplates;
 
-        private IReadOnlyCollection<ITemplateMatchInfo> _exactMatchedTemplates;
+        private IReadOnlyCollection<ITemplateMatchInfo>? _exactMatchedTemplates;
 
-        private IReadOnlyCollection<ITemplateMatchInfo> _partiallyMatchedTemplates;
+        private IReadOnlyCollection<ITemplateMatchInfo>? _partiallyMatchedTemplates;
 
-        private IReadOnlyCollection<TemplateGroup> _exactMatchedTemplateGroups;
+        private IReadOnlyCollection<TemplateGroup>? _exactMatchedTemplateGroups;
 
-        private IReadOnlyCollection<TemplateGroup> _partiallyMatchedTemplateGroups;
+        private IReadOnlyCollection<TemplateGroup>? _partiallyMatchedTemplateGroups;
 
         internal TemplateListResolutionResult(IReadOnlyCollection<ITemplateMatchInfo> coreMatchedTemplates)
         {
@@ -136,16 +138,6 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         }
 
         /// <summary>
-        /// Returns true when at least one template in unambiguous matches default language.
-        /// </summary>
-        internal bool HasUnambiguousTemplateGroupForDefaultLanguage => UnambiguousTemplatesForDefaultLanguage.Any();
-
-        /// <summary>
-        /// Returns collecion of templates from unamgibuous group that matches default language.
-        /// </summary>
-        internal IReadOnlyCollection<ITemplateMatchInfo> UnambiguousTemplatesForDefaultLanguage => UnambiguousTemplateGroup.Where(t => t.HasDefaultLanguageMatch()).ToList();
-
-        /// <summary>
         /// Returns true when at least one template exactly or partially matched templates by name and exactly matched language, filter, baseline (if specified in command paramaters).
         /// </summary>
         internal bool HasExactMatches => ExactMatchedTemplates.Any();
@@ -164,40 +156,5 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// Returns list of templates for unambiguous template group, otherwise empty list.
         /// </summary>
         internal IReadOnlyCollection<ITemplateMatchInfo> UnambiguousTemplateGroup => HasUnambiguousTemplateGroup ? ExactMatchedTemplates : new List<ITemplateMatchInfo>();
-
-        /// <summary>
-        /// Returns true if all the templates in unambiguous group have templates in same language.
-        /// </summary>
-        internal bool AllTemplatesInUnambiguousTemplateGroupAreSameLanguage
-        {
-            get
-            {
-                if (UnambiguousTemplateGroup.Count == 0)
-                {
-                    return false;
-                }
-
-                if (UnambiguousTemplateGroup.Count == 1)
-                {
-                    return true;
-                }
-
-                HashSet<string> languagesFound = new HashSet<string>();
-                foreach (ITemplateMatchInfo template in UnambiguousTemplateGroup)
-                {
-                    string language = template.Info.GetLanguage();
-                    if (!string.IsNullOrEmpty(language))
-                    {
-                        languagesFound.Add(language);
-                    }
-
-                    if (languagesFound.Count > 1)
-                    {
-                        return false;
-                    }
-                }
-                return true;
-            }
-        }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolutionResult.cs
@@ -247,7 +247,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         {
             EvaluateUnambiguousTemplateGroup();
             switch (GroupResolutionStatus)
-            { 
+            {
                 case UnambiguousTemplateGroupStatus.NotEvaluated:
                     throw new ArgumentException($"{nameof(GroupResolutionStatus)} should not be {nameof(UnambiguousTemplateGroupStatus.NotEvaluated)} after running {nameof(EvaluateUnambiguousTemplateGroup)}");
                 case UnambiguousTemplateGroupStatus.NoMatch:

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolutionResult.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,11 +21,11 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
     /// - the templates in the group may have different parameters and different choices for parameter symbols defined<br/>
     /// Template resolution is done in several steps:<br/>
     /// 1) the list of matched templates is defined based on command input (template name and filters used)<br/>
-    /// 2) the unambiguous template group to use is defined. In case of ambiguity, if the user didn't specify language to use, the groups with the templates defined in default language are preferred. In case unambiguous template group cannot be resolved, the template to instatiate cannot be resolved as well.<br/>
+    /// 2) the unambiguous template group to use is defined. In case of ambiguity, if the user didn't specify language to use, the groups with the templates defined in default language are preferred. In case unambiguous template group cannot be resolved, the template to instantiate cannot be resolved as well.<br/>
     /// 3) the template to invoke inside the group is defined:<br/>
     /// -- the template that matches template specific options in command input is preferred<br/>
     /// -- in case there are multiple templates, the one with highest precedence is selected<br/>
-    /// -- in case there are multiple templates with same precendence and user didn't specify the language to use, the default language template is preferred.<br/>
+    /// -- in case there are multiple templates with same precedence and user didn't specify the language to use, the default language template is preferred.<br/>
     /// -- Note that the template will not be resolved in case the value specified for choice parameter is not exact and there is an ambiguity between template to select:<br/>
     /// --- in case at least one template in the group has more than 1 choice value which starts with specified value in the command<br/>
     /// --- in case at least two templates in the group have 1 choice value which starts with specified value in the command.<br/>
@@ -36,11 +38,11 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 
         private Status _singularInvokableMatchStatus = Status.NotEvaluated;
 
-        private IReadOnlyCollection<TemplateGroup> _templateGroups;
+        private IReadOnlyCollection<TemplateGroup>? _templateGroups;
 
-        private ITemplateMatchInfo _templateToInvoke;
+        private ITemplateMatchInfo? _templateToInvoke;
 
-        private TemplateGroup _unambiguousTemplateGroup;
+        private TemplateGroup? _unambiguousTemplateGroup;
 
         private UnambiguousTemplateGroupStatus _unambigiousTemplateGroupStatus = UnambiguousTemplateGroupStatus.NotEvaluated;
 
@@ -141,7 +143,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// Returns the template to invoke or <c>null</c> if the template to invoke cannot be determined.
         /// Has value only when <see cref="Status" /> is <see cref="Status.SingleMatch"/>.
         /// </summary>
-        internal ITemplateMatchInfo TemplateToInvoke
+        internal ITemplateMatchInfo? TemplateToInvoke
         {
             get
             {
@@ -190,7 +192,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// Returns unambiguous template group resolved; <c>null</c> if group cannot be resolved based on command input
         /// Has value only when <see cref="GroupResolutionStatus" /> is <see cref="UnambiguousTemplateGroupStatus.SingleMatch"/>.
         /// </summary>
-        internal TemplateGroup UnambiguousTemplateGroup
+        internal TemplateGroup? UnambiguousTemplateGroup
         {
             get
             {
@@ -202,8 +204,52 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             }
         }
 
+        internal IEnumerable<ITemplateMatchInfo> TemplatesForDetailedHelp
+        {
+            get
+            {
+                if (UnambiguousTemplateGroup == null || !UnambiguousTemplateGroup.InvokableTemplates.Any())
+                {
+                    return Array.Empty<ITemplateMatchInfo>();
+                }
+
+                if (_hasUserInputLanguage)
+                {
+                    return UnambiguousTemplateGroup.InvokableTemplates.Where(t => t.HasLanguageMatch());
+                }
+                else if (UnambiguousTemplateGroup.InvokableTemplates.Any(t => t.HasDefaultLanguageMatch()))
+                {
+                    return UnambiguousTemplateGroup.InvokableTemplates.Where(t => t.HasDefaultLanguageMatch());
+                }
+                else
+                {
+                    HashSet<string> languagesFound = new HashSet<string>();
+                    foreach (ITemplateMatchInfo template in UnambiguousTemplateGroup.InvokableTemplates)
+                    {
+                        string? language = template.Info.GetLanguage();
+                        if (!string.IsNullOrEmpty(language))
+                        {
+                            languagesFound.Add(language);
+                        }
+
+                        if (languagesFound.Count > 1)
+                        {
+                            //not possible to identify language to show template for
+                            return Array.Empty<ITemplateMatchInfo>();
+                        }
+                    }
+                    return UnambiguousTemplateGroup.InvokableTemplates;
+                }
+            }
+        }
+
         private void EvaluateTemplateToInvoke()
         {
+            EvaluateUnambiguousTemplateGroup();
+            if (GroupResolutionStatus == UnambiguousTemplateGroupStatus.NotEvaluated)
+            {
+                throw new ArgumentException($"{nameof(GroupResolutionStatus)} should not be {nameof(UnambiguousTemplateGroupStatus.NotEvaluated)} after running {nameof(EvaluateUnambiguousTemplateGroup)}");
+            }
             //if no template groups were matched - no match
             if (GroupResolutionStatus == UnambiguousTemplateGroupStatus.NoMatch)
             {
@@ -217,9 +263,14 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                 return;
             }
 
+            if (GroupResolutionStatus == UnambiguousTemplateGroupStatus.SingleMatch && UnambiguousTemplateGroup == null)
+            {
+                throw new ArgumentException($"{nameof(UnambiguousTemplateGroup)} should not be null if running {nameof(GroupResolutionStatus)} is {nameof(UnambiguousTemplateGroupStatus.SingleMatch)}");
+            }
+
             //checking template options match
             //if any template in the group has ambiguous parameter value match - cannot resolve template to instantiate
-            if (UnambiguousTemplateGroup.Templates.Any(x => x.HasAmbiguousParameterValueMatch()))
+            if (UnambiguousTemplateGroup!.Templates.Any(x => x.HasAmbiguousParameterValueMatch()))
             {
                 _singularInvokableMatchStatus = Status.AmbiguousParameterValueChoice;
                 return;
@@ -256,7 +307,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             }
 
             IEnumerable<ITemplateMatchInfo> highestPrecedenceTemplates = UnambiguousTemplateGroup.GetHighestPrecedenceInvokableTemplates(!_hasUserInputLanguage);
-            IEnumerable<string> templateLanguages = highestPrecedenceTemplates.Select(t => t.Info.GetLanguage()).Distinct(StringComparer.OrdinalIgnoreCase);
+            IEnumerable<string?> templateLanguages = highestPrecedenceTemplates.Select(t => t.Info.GetLanguage()).Distinct(StringComparer.OrdinalIgnoreCase);
 
             if (templateLanguages.Count() > 1)
             {

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolutionResult.cs
@@ -246,31 +246,30 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         private void EvaluateTemplateToInvoke()
         {
             EvaluateUnambiguousTemplateGroup();
-            if (GroupResolutionStatus == UnambiguousTemplateGroupStatus.NotEvaluated)
-            {
-                throw new ArgumentException($"{nameof(GroupResolutionStatus)} should not be {nameof(UnambiguousTemplateGroupStatus.NotEvaluated)} after running {nameof(EvaluateUnambiguousTemplateGroup)}");
-            }
-            //if no template groups were matched - no match
-            if (GroupResolutionStatus == UnambiguousTemplateGroupStatus.NoMatch)
-            {
-                _singularInvokableMatchStatus = Status.NoMatch;
-                return;
-            }
-
-            if (GroupResolutionStatus == UnambiguousTemplateGroupStatus.Ambiguous)
-            {
-                _singularInvokableMatchStatus = Status.AmbiguousTemplateGroupChoice;
-                return;
-            }
-
-            if (GroupResolutionStatus == UnambiguousTemplateGroupStatus.SingleMatch && UnambiguousTemplateGroup == null)
-            {
-                throw new ArgumentException($"{nameof(UnambiguousTemplateGroup)} should not be null if running {nameof(GroupResolutionStatus)} is {nameof(UnambiguousTemplateGroupStatus.SingleMatch)}");
+            switch (GroupResolutionStatus)
+            { 
+                case UnambiguousTemplateGroupStatus.NotEvaluated:
+                    throw new ArgumentException($"{nameof(GroupResolutionStatus)} should not be {nameof(UnambiguousTemplateGroupStatus.NotEvaluated)} after running {nameof(EvaluateUnambiguousTemplateGroup)}");
+                case UnambiguousTemplateGroupStatus.NoMatch:
+                    _singularInvokableMatchStatus = Status.NoMatch;
+                    return;
+                case UnambiguousTemplateGroupStatus.Ambiguous:
+                    _singularInvokableMatchStatus = Status.AmbiguousTemplateGroupChoice;
+                    return;
+                case UnambiguousTemplateGroupStatus.SingleMatch:
+                    if (UnambiguousTemplateGroup == null)
+                    {
+                        throw new ArgumentException($"{nameof(UnambiguousTemplateGroup)} should not be null if running {nameof(GroupResolutionStatus)} is {nameof(UnambiguousTemplateGroupStatus.SingleMatch)}");
+                    }
+                    //valid state to proceed
+                    break;
+                default:
+                    throw new ArgumentException($"Unexpected value of {nameof(UnambiguousTemplateGroup)}: {GroupResolutionStatus}.");
             }
 
             //checking template options match
             //if any template in the group has ambiguous parameter value match - cannot resolve template to instantiate
-            if (UnambiguousTemplateGroup!.Templates.Any(x => x.HasAmbiguousParameterValueMatch()))
+            if (UnambiguousTemplateGroup.Templates.Any(x => x.HasAmbiguousParameterValueMatch()))
             {
                 _singularInvokableMatchStatus = Status.AmbiguousParameterValueChoice;
                 return;

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
@@ -77,22 +77,16 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             return new TemplateResolutionResult(commandInput.Language, coreMatchedTemplates);
         }
 
-        internal static TemplateListResolutionResult GetTemplateResolutionResultForListOrHelp(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string? defaultLanguage)
+        internal static TemplateListResolutionResult GetTemplateResolutionResultForList(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string? defaultLanguage)
         {
-            IReadOnlyCollection<ITemplateMatchInfo> coreMatchedTemplates;
-
-            //we need different set of templates for help and list
-            //for list we need to show all exact and partial names by name
-            //for help if there is an exact match by shortname or name we need to show help for that exact template and also apply default language mapping in case language is not specified
-            if (commandInput.IsListFlagSpecified)
-            {
-                coreMatchedTemplates = PerformCoreTemplateQueryForList(templateInfo, hostDataLoader, commandInput);
-            }
-            else
-            {
-                coreMatchedTemplates = PerformCoreTemplateQueryForHelp(templateInfo, hostDataLoader, commandInput, defaultLanguage);
-            }
+            IReadOnlyCollection<ITemplateMatchInfo> coreMatchedTemplates = PerformCoreTemplateQueryForList(templateInfo, hostDataLoader, commandInput);
             return new TemplateListResolutionResult(coreMatchedTemplates);
+        }
+
+        internal static TemplateResolutionResult GetTemplateResolutionResultForHelp(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput, string? defaultLanguage)
+        {
+            IReadOnlyCollection<ITemplateMatchInfo> coreMatchedTemplates = PerformCoreTemplateQueryForHelp(templateInfo, hostDataLoader, commandInput, defaultLanguage);
+            return new TemplateResolutionResult(commandInput.Language, coreMatchedTemplates);
         }
 
         internal static IReadOnlyCollection<ITemplateMatchInfo> PerformCoreTemplateQueryForList(IReadOnlyList<ITemplateInfo> templateInfo, IHostSpecificDataLoader hostDataLoader, INewCommandInput commandInput)
@@ -131,8 +125,8 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 #pragma warning disable CS0618 // Type or member is obsolete
             IReadOnlyList<ITemplateMatchInfo> coreMatchedTemplates = TemplateListFilter.GetTemplateMatchInfo(
                 filterableTemplateInfo,
-                WellKnownSearchFilters.MatchesAtLeastOneCriteria,
-                CliNameFilter(commandInput.TemplateName),
+                WellKnownSearchFilters.MatchesAllCriteria,
+                CliExactShortNameFilter(commandInput.TemplateName),
                 WellKnownSearchFilters.LanguageFilter(commandInput.Language),
                 WellKnownSearchFilters.TypeFilter(commandInput.TypeFilter),
                 WellKnownSearchFilters.BaselineFilter(commandInput.BaselineName),
@@ -140,20 +134,6 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             )
 #pragma warning restore CS0618 // Type or member is obsolete
             .Where(x => !IsTemplateHiddenByHostFile(x.Info, hostDataLoader)).ToList();
-
-            //for help if template name from CLI exactly matches the template name we should consider only that template
-            IReadOnlyList<ITemplateMatchInfo> matchesWithExactDispositionsInNameFields =
-                coreMatchedTemplates.Where(
-                    x => x.MatchDisposition.Any(
-                        y =>
-                            (y.Name == MatchInfo.BuiltIn.Name || y.Name == MatchInfo.BuiltIn.ShortName)
-                            && y.Kind == MatchKind.Exact)).ToList();
-
-            if (matchesWithExactDispositionsInNameFields.Count > 0)
-            {
-                coreMatchedTemplates = matchesWithExactDispositionsInNameFields;
-            }
-
             AddParameterMatchingToTemplates(coreMatchedTemplates, hostDataLoader, commandInput);
             return coreMatchedTemplates;
         }
@@ -204,7 +184,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             IReadOnlyCollection<ITemplateMatchInfo> templates = TemplateListFilter.GetTemplateMatchInfo(
                 filterableTemplateInfo,
                 WellKnownSearchFilters.MatchesAllCriteria,
-                CliNameFilter(commandInput.TemplateName),
+                CliExactShortNameFilter(commandInput.TemplateName),
                 WellKnownSearchFilters.LanguageFilter(commandInput.Language),
                 WellKnownSearchFilters.TypeFilter(commandInput.TypeFilter),
                 WellKnownSearchFilters.BaselineFilter(commandInput.BaselineName),
@@ -213,23 +193,8 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 #pragma warning restore CS0618 // Type or member is obsolete
             .Where(x => !IsTemplateHiddenByHostFile(x.Info, hostDataLoader)).ToList();
 
-            //select only the templates which do not have mismatches
-            //if any template has exact match for name - use those; otherwise partial name matches are also considered when resolving templates
-            IReadOnlyList<ITemplateMatchInfo> matchesWithExactDispositionsInNameFields =
-                templates.Where(
-                    x => x.MatchDisposition.Any(
-                        y =>
-                            (y.Name == MatchInfo.BuiltIn.Name || y.Name == MatchInfo.BuiltIn.ShortName)
-                            && y.Kind == MatchKind.Exact)).ToList();
-
-            if (matchesWithExactDispositionsInNameFields.Count > 0)
-            {
-                templates = matchesWithExactDispositionsInNameFields;
-            }
-
             //add specific template parameters matches to the list
             AddParameterMatchingToTemplates(templates, hostDataLoader, commandInput);
-
             return templates;
         }
 
@@ -462,6 +427,35 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                     return new MatchInfo(MatchInfo.BuiltIn.ShortName, name, MatchKind.Partial);
                 }
 
+                return new MatchInfo(MatchInfo.BuiltIn.Name, name, MatchKind.Mismatch);
+            };
+        }
+
+        /// <summary>
+        /// Filter for <see cref="TemplateListFilter.GetTemplateMatchInfo"></see>.
+        /// Filters <see cref="ITemplateInfo"/> by short name. Requires <see cref="TemplateInfoWithGroupShortNames"/> implementation.
+        /// The fields to be compared are <see cref="TemplateInfoWithGroupShortNames.GroupShortNameList"/> and they should exactly match user input.
+        /// Unlike <see cref="WellKnownSearchFilters.NameFilter(string)"/> the filter also matches other template group short names the template belongs to.
+        /// </summary>
+        /// <param name="name">the name to match with short name.</param>
+        /// <returns></returns>
+        private static Func<ITemplateInfo, MatchInfo?> CliExactShortNameFilter(string name)
+        {
+            return (template) =>
+            {
+                var groupAwareTemplate = template as TemplateInfoWithGroupShortNames ?? throw new ArgumentException("CliNameFilter filter supports only TemplateInfoWithGroupShortNames templates");
+
+                if (string.IsNullOrEmpty(name))
+                {
+                    return new MatchInfo(MatchInfo.BuiltIn.ShortName, name, MatchKind.Mismatch);
+                }
+                foreach (string shortName in groupAwareTemplate.GroupShortNameList)
+                {
+                    if (shortName.Equals(name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return new MatchInfo(MatchInfo.BuiltIn.ShortName, name, MatchKind.Exact);
+                    }
+                }
                 return new MatchInfo(MatchInfo.BuiltIn.Name, name, MatchKind.Mismatch);
             };
         }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
@@ -456,7 +456,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                         return new MatchInfo(MatchInfo.BuiltIn.ShortName, name, MatchKind.Exact);
                     }
                 }
-                return new MatchInfo(MatchInfo.BuiltIn.Name, name, MatchKind.Mismatch);
+                return new MatchInfo(MatchInfo.BuiltIn.ShortName, name, MatchKind.Mismatch);
             };
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -202,8 +202,8 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">Nedá se přeložit šablona, ze které se má vytvořit instance. Tyto šablony odpovídají vašemu vstupu:</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">Nedá se přeložit šablona, ze které se má vytvořit instance. Tyto šablony odpovídají vašemu vstupu:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">Nedá se přeložit šablona, ze které se má vytvořit instance. Následující nainstalované šablony jsou v konfliktu:</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">Nedá se přeložit šablona, ze které se má vytvořit instance. Následující nainstalované šablony jsou v konfliktu:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">Pokud chcete vypsat nainstalované šablony, spusťte příkaz dotnet {0} --list.</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">Pokud chcete vypsat nainstalované šablony, spusťte příkaz dotnet {0} --list.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Příklady:
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">Pokud chcete hledat šablony na NuGet.org, spusťte příkaz dotnet {0} {1} --search.</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -202,8 +202,8 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">Die Vorlage für die Instanziierung konnte nicht aufgelöst werden, diese Vorlagen stimmen mit der Eingabe überein:</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">Die Vorlage für die Instanziierung konnte nicht aufgelöst werden, diese Vorlagen stimmen mit der Eingabe überein:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">Die Vorlage für die Instanziierung kann nicht aufgelöst werden, die folgenden installierten Vorlagen stehen in Konflikt:</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">Die Vorlage für die Instanziierung kann nicht aufgelöst werden, die folgenden installierten Vorlagen stehen in Konflikt:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">Führen Sie "dotnet {0} --list" aus, um installierte Vorlagen aufzulisten.</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">Führen Sie "dotnet {0} --list" aus, um installierte Vorlagen aufzulisten.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Beispiele:
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">Führen Sie "dotnet {0} {1} --search" aus, um nach den Vorlagen in NuGet.org zu suchen.</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -202,8 +202,8 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">No se puede resolver la plantilla para crear una instancia, estas plantillas coinciden con la entrada:</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">No se puede resolver la plantilla para crear una instancia, estas plantillas coinciden con la entrada:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">No se puede resolver la plantilla para crear una instancia, las siguientes plantillas instaladas están en conflicto:</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">No se puede resolver la plantilla para crear una instancia, las siguientes plantillas instaladas están en conflicto:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">Para mostrar las plantillas instaladas, ejecute "dotnet {0} --list".</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">Para mostrar las plantillas instaladas, ejecute "dotnet {0} --list".</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Ejemplos:
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">Para buscar las plantillas en NuGet.org, ejecute "dotnet {0} {1} --search".</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -202,8 +202,8 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">Impossible de résoudre le modèle à instancier. Ces modèles correspondent à votre entrée :</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">Impossible de résoudre le modèle à instancier. Ces modèles correspondent à votre entrée :</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">Impossible de résoudre le modèle à instancier, les modèles installés suivants sont en conflit :</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">Impossible de résoudre le modèle à instancier, les modèles installés suivants sont en conflit :</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">Pour répertorier les modèles installés, exécutez « dotnet {0}--list ».</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">Pour répertorier les modèles installés, exécutez « dotnet {0}--list ».</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Exemples :
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">Pour rechercher les modèles sur NuGet.org, exécutez « dotnet {0} {1} --search ».</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -202,8 +202,8 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">Non è possibile risolvere il modello per creare un'istanza, questi modelli corrispondono all'input:</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">Non è possibile risolvere il modello per creare un'istanza, questi modelli corrispondono all'input:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">Non è possibile risolvere il modello per creare un'istanza, i modelli installati seguenti sono in conflitto:</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">Non è possibile risolvere il modello per creare un'istanza, i modelli installati seguenti sono in conflitto:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">Per elencare i modelli installati, eseguire 'dotnet {0} --list'.</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">Per elencare i modelli installati, eseguire 'dotnet {0} --list'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Esempi:
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">Per cercare i modelli in NuGet.org, eseguire 'dotnet {0} {1} --search '.</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -202,8 +202,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">インスタンス化するテンプレートを解決できませんでした。次のテンプレートが入力と一致しました:</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">インスタンス化するテンプレートを解決できませんでした。次のテンプレートが入力と一致しました:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">インスタンスを作成するためのテンプレートを解決できません。次のインストールされたテンプレートが競合しています:</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">インスタンスを作成するためのテンプレートを解決できません。次のインストールされたテンプレートが競合しています:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">インストールされているテンプレートを一覧表示するには、' dotnet {0}--list ' を実行してください。</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">インストールされているテンプレートを一覧表示するには、' dotnet {0}--list ' を実行してください。</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">NuGet.org のテンプレートを検索するには、'dotnet {0} {1} --search ' を実行してください。</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -202,8 +202,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">인스턴스화할 템플릿을 확인할 수 없습니다. 다음 템플릿은 입력한 내용과 일치합니다.</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">인스턴스화할 템플릿을 확인할 수 없습니다. 다음 템플릿은 입력한 내용과 일치합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">인스턴스화할 템플릿을 확인할 수 없습니다. 설치된 다음 템플릿이 충돌합니다.</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">인스턴스화할 템플릿을 확인할 수 없습니다. 설치된 다음 템플릿이 충돌합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">설치된 템플릿을 나열하려면 'dotnet{0} --목록'을 실행하세요.</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">설치된 템플릿을 나열하려면 'dotnet{0} --목록'을 실행하세요.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">NuGet.org에서 템플릿을 검색하려면 'dotnet{0}{1} --search'를 실행합니다.</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -202,8 +202,8 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">Nie można rozpoznać szablonu, aby utworzyć wystąpienie, ponieważ te szablony pasują do danych wejściowych:</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">Nie można rozpoznać szablonu, aby utworzyć wystąpienie, ponieważ te szablony pasują do danych wejściowych:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">Nie można rozpoznać szablonu w celu utworzenia wystąpienia, ponieważ następujące zainstalowane szablony powodują konflikt:</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">Nie można rozpoznać szablonu w celu utworzenia wystąpienia, ponieważ następujące zainstalowane szablony powodują konflikt:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">Aby wyświetlić listę zainstalowanych szablonów, uruchom polecenie "dotnet {0} --list".</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">Aby wyświetlić listę zainstalowanych szablonów, uruchom polecenie "dotnet {0} --list".</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Przykłady:
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">Aby wyszukać szablony na stronie NuGet.org, uruchom polecenie "dotnet {0} {1} --search".</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -202,8 +202,8 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">Não foi possível resolver o modelo para instanciar, esses modelos corresponderam à sua entrada:</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">Não foi possível resolver o modelo para instanciar, esses modelos corresponderam à sua entrada:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">Não é possível resolver o modelo para instanciar, os seguintes modelos instalados são conflitantes:</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">Não é possível resolver o modelo para instanciar, os seguintes modelos instalados são conflitantes:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">Para listar os modelos instalados, execute ' dotnet {0}--listar '.</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">Para listar os modelos instalados, execute ' dotnet {0}--listar '.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Exemplo
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">Para pesquisar os modelos no NuGet.org, execute 'dotnet {0} {1} --pesquisar'.</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -202,8 +202,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">Не удалось разрешить шаблон для создания экземпляра, эти шаблоны соответствуют введенным входным данным:</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">Не удалось разрешить шаблон для создания экземпляра, эти шаблоны соответствуют введенным входным данным:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">Не удается разрешить шаблон для создания экземпляра, следующие установленные шаблоны конфликтуют:</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">Не удается разрешить шаблон для создания экземпляра, следующие установленные шаблоны конфликтуют:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">Чтобы получить список установленных шаблонов, запустите "dotnet {0}--list".</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">Чтобы получить список установленных шаблонов, запустите "dotnet {0}--list".</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">Чтобы найти шаблоны в NuGet.org, выполните команду 'dotnet {0} {1} --search'.</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -202,8 +202,8 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">Örneği oluşturulacak şablon çözümlenemiyor. Bu şablonlar girişinizle eşleşiyor:</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">Örneği oluşturulacak şablon çözümlenemiyor. Bu şablonlar girişinizle eşleşiyor:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">Örneği oluşturulacak şablon çözümlenemiyor. Şu yüklü şablonlar çakışıyor:</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">Örneği oluşturulacak şablon çözümlenemiyor. Şu yüklü şablonlar çakışıyor:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">Yüklü şablonları listelemek için 'dotnet {0} --list' komutunu çalıştırın.</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">Yüklü şablonları listelemek için 'dotnet {0} --list' komutunu çalıştırın.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">NuGet.org sitesinde şablon aramak için “dotnet {0} {1} --search” komutunu çalıştırın.</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -202,8 +202,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">无法解析要实例化的模板，这些模板匹配你的输入:</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">无法解析要实例化的模板，这些模板匹配你的输入:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">无法解析要实例化的模板，以下已安装模板发生冲突:</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">无法解析要实例化的模板，以下已安装模板发生冲突:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">若要列出已安装的模板，请运行“dotnet {0} --列出”。</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">若要列出已安装的模板，请运行“dotnet {0} --列出”。</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">要在 NuGet.org 上搜索模板，请运行“dotnet {0} {1} --搜索”。</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -202,8 +202,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHeader">
-        <source>Unable to resolve the template to instantiate, these templates matched your input:</source>
-        <target state="translated">無法解析範本以具現化，這些範本符合您的輸入:</target>
+        <source>Unable to resolve the template, these templates matched your input:</source>
+        <target state="needs-review-translation">無法解析範本以具現化，這些範本符合您的輸入:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplateGroupListHint">
@@ -212,8 +212,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesHeader">
-        <source>Unable to resolve the template to instantiate, the following installed templates are conflicting:</source>
-        <target state="translated">無法將範本解析為具現化，下列已安裝的範本發生衝突:</target>
+        <source>Unable to resolve the template, the following installed templates are conflicting:</source>
+        <target state="needs-review-translation">無法將範本解析為具現化，下列已安裝的範本發生衝突:</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
@@ -508,8 +508,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="ListTemplatesCommand">
-        <source>To list installed templates, run 'dotnet {0} --list'.</source>
-        <target state="translated">若要列出已安裝的範本，請執行 'dotnet {0} --list'。</target>
+        <source>To list installed templates, run '{0}'.</source>
+        <target state="needs-review-translation">若要列出已安裝的範本，請執行 'dotnet {0} --list'。</target>
         <note />
       </trans-unit>
       <trans-unit id="ListsTemplates">
@@ -765,8 +765,8 @@ Examples:
         <note />
       </trans-unit>
       <trans-unit id="SearchTemplatesCommand">
-        <source>To search for the templates on NuGet.org, run 'dotnet {0} {1} --search'.</source>
-        <target state="translated">若要在範本上搜尋 NuGet.org，請執行 'dotnet {0} {1} --search'。</target>
+        <source>To search for the templates on NuGet.org, run '{0}'.</source>
+        <target state="new">To search for the templates on NuGet.org, run '{0}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="SettingsReadError">

--- a/test/Microsoft.TemplateEngine.Cli.IntegrationTests/FileRenameTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.IntegrationTests/FileRenameTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
         [InlineData("TestAssets.TemplateWithUnspecifiedSourceName --name baz", "NegativeFileRenamesTest.json")]
         [InlineData("TestAssets.TemplateWithSourceNameAndCustomSourcePath --name bar", "CustomSourcePathRenameTest.json")]
         [InlineData("TestAssets.TemplateWithSourceNameAndCustomTargetPath --name bar", "CustomTargetPathRenameTest.json")]
-        [InlineData("TestAssets.TemplateWithSourceNameAndCustomSourceAndTargetPath --name bar", "CustomSourceAndTargetPathRenameTest.json")]
+        [InlineData("TestAssets.TemplateWithSourceNameAndCustomSourceAndTargetPaths --name bar", "CustomSourceAndTargetPathRenameTest.json")]
         [InlineData("TestAssets.TemplateWithSourcePathOutsideConfigRoot --name baz", "TemplateWithSourcePathOutsideConfigRootTest.json")]
         [InlineData("TestAssets.TemplateWithSourceNameInTargetPathGetsRenamed --name baz", "TemplateWithSourceNameInTargetPathGetsRenamedTest.json")]
         [InlineData("TestAssets.TemplateWithPlaceholderFiles", "TemplateWithPlaceholderFilesTest.json")]

--- a/test/Microsoft.TemplateEngine.Cli.TestHelper/Sdk/Assertions/CommandResultAssertions.cs
+++ b/test/Microsoft.TemplateEngine.Cli.TestHelper/Sdk/Assertions/CommandResultAssertions.cs
@@ -109,7 +109,14 @@ namespace Microsoft.NET.TestFramework.Assertions
         public AndConstraint<CommandResultAssertions> HaveStdErr()
         {
             Execute.Assertion.ForCondition(!string.IsNullOrEmpty(_commandResult.StdErr))
-                .FailWith(AppendDiagnosticsTo("Command did not output anything to stderr."));
+                .FailWith(AppendDiagnosticsTo("Command did not output anything to StdErr."));
+            return new AndConstraint<CommandResultAssertions>(this);
+        }
+
+        public AndConstraint<CommandResultAssertions> HaveStdErr(string expectedOutput)
+        {
+            Execute.Assertion.ForCondition(_commandResult.StdErr.Equals(expectedOutput, StringComparison.Ordinal))
+                .FailWith(AppendDiagnosticsTo($"Command did not output the expected output to StdErr. Expected: {expectedOutput}"));
             return new AndConstraint<CommandResultAssertions>(this);
         }
 

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/TemplateInformationCoordinatorTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/TemplateInformationCoordinatorTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
 {
-    public class HelpForTemplateResolutionTests
+    public class TemplateInformationCoordinatorTests
     {
         [Fact(DisplayName = nameof(GetParametersInvalidForTemplatesInListTest))]
         public void GetParametersInvalidForTemplatesInListTest()
@@ -38,7 +38,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             ITemplateMatchInfo templateThreeMatchInfo = new TemplateMatchInfo(new MockTemplateInfo(), templateThreeDispositions);
             matchInfo.Add(templateThreeMatchInfo);
 
-            HelpForTemplateResolution.GetParametersInvalidForTemplatesInList(matchInfo, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
+            TemplateInformationCoordinator.GetParametersInvalidForTemplatesInList(matchInfo, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
 
             Assert.Equal(1, invalidForAllTemplates.Count);
             Assert.Contains("foo", invalidForAllTemplates);
@@ -65,7 +65,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             ITemplateMatchInfo templateTwoMatchInfo = new TemplateMatchInfo(new MockTemplateInfo(), templateTwoDispositions);
             matchInfo.Add(templateTwoMatchInfo);
 
-            HelpForTemplateResolution.GetParametersInvalidForTemplatesInList(matchInfo, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
+            TemplateInformationCoordinator.GetParametersInvalidForTemplatesInList(matchInfo, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
 
             Assert.Equal(0, invalidForAllTemplates.Count);
 
@@ -91,7 +91,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             ITemplateMatchInfo templateTwoMatchInfo = new TemplateMatchInfo(new MockTemplateInfo(), templateTwoDispositions);
             matchInfo.Add(templateTwoMatchInfo);
 
-            HelpForTemplateResolution.GetParametersInvalidForTemplatesInList(matchInfo, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
+            TemplateInformationCoordinator.GetParametersInvalidForTemplatesInList(matchInfo, out IReadOnlyList<string> invalidForAllTemplates, out IReadOnlyList<string> invalidForSomeTemplates);
 
             Assert.Equal(1, invalidForAllTemplates.Count);
             Assert.Contains("foo", invalidForAllTemplates);

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/ListTemplateListResolverTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
@@ -23,7 +25,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("console2").WithListOption();
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
             Assert.Equal("console2", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
@@ -40,7 +42,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption();
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.False(matchResult.HasUnambiguousTemplateGroup);
             Assert.Equal(2, matchResult.ExactMatchedTemplateGroups.Count);
@@ -59,7 +61,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption();
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.Equal(1, matchResult.ExactMatchedTemplateGroups.Count);
             Assert.Equal(3, matchResult.ExactMatchedTemplates.Count);
@@ -79,7 +81,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("c").WithListOption();
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.Equal(2, matchResult.ExactMatchedTemplateGroups.Count);
             Assert.Equal(5, matchResult.ExactMatchedTemplates.Count);
@@ -95,14 +97,13 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption();
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "L1");
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "L1");
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
             Assert.Equal(1, matchResult.ExactMatchedTemplateGroups.Count);
             Assert.Equal(2, matchResult.ExactMatchedTemplates.Count);
             Assert.NotNull(matchResult.ExactMatchedTemplates.Single(t => t.Info.Identity == "Console.App.L1"));
             Assert.NotNull(matchResult.ExactMatchedTemplates.Single(t => t.Info.Identity == "Console.App.L2"));
-            Assert.False(matchResult.HasUnambiguousTemplateGroupForDefaultLanguage);
         }
 
         [Fact(DisplayName = nameof(TestGetTemplateResolutionResult_InputLanguageIsPreferredOverDefault))]
@@ -114,7 +115,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("console", "L2").WithListOption();
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "L1");
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, "L1");
             Assert.True(matchResult.HasExactMatches);
             Assert.True(matchResult.HasUnambiguousTemplateGroup);
             Assert.Equal("console", matchResult.UnambiguousTemplateGroup.Single().Info.ShortNameList.Single());
@@ -135,7 +136,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("console", "L2").WithListOption();
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
             Assert.Equal(0, matchResult.ExactMatchedTemplateGroups.Count);
             Assert.Equal(0, matchResult.ExactMatchedTemplates.Count);
@@ -160,7 +161,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("console", type: "item").WithListOption();
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
             Assert.Equal(0, matchResult.ExactMatchedTemplateGroups.Count);
             Assert.Equal(0, matchResult.ExactMatchedTemplates.Count);
@@ -185,7 +186,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption().WithCommandOption("--baseline", "core");
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
             Assert.Equal(0, matchResult.ExactMatchedTemplateGroups.Count);
             Assert.Equal(0, matchResult.ExactMatchedTemplates.Count);
@@ -210,7 +211,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("console", "L2", "item").WithListOption().WithCommandOption("--baseline", "core");
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
             Assert.Equal(0, matchResult.ExactMatchedTemplateGroups.Count);
             Assert.Equal(0, matchResult.ExactMatchedTemplates.Count);
@@ -235,7 +236,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("zzzzz", "L1", "project").WithListOption().WithCommandOption("--baseline", "app");
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
             Assert.False(matchResult.HasPartialMatches);
             Assert.Equal(0, matchResult.ExactMatchedTemplateGroups.Count);
@@ -263,7 +264,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput().WithListOption().WithCommandOption("--tag", "Common");
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.Equal(1, matchResult.ExactMatchedTemplateGroups.Count);
             Assert.Equal(1, matchResult.ExactMatchedTemplates.Count);
@@ -292,7 +293,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("Test").WithListOption();
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.Equal(1, matchResult.ExactMatchedTemplateGroups.Count);
             Assert.Equal(1, matchResult.ExactMatchedTemplates.Count);
@@ -322,7 +323,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("Console").WithListOption();
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.True(matchResult.HasExactMatches);
             Assert.Equal(1, matchResult.ExactMatchedTemplateGroups.Count);
             Assert.Equal(1, matchResult.ExactMatchedTemplates.Count);
@@ -350,7 +351,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 .WithCommandOption("--language", "L2")
                 .WithCommandOption("--type", "item");
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
             Assert.Equal(0, matchResult.ExactMatchedTemplateGroups.Count);
             Assert.Equal(0, matchResult.ExactMatchedTemplates.Count);
@@ -384,7 +385,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("console").WithListOption().WithCommandOption("--author", commandAuthor);
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
 
             if (matchExpected)
             {
@@ -440,7 +441,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             MockNewCommandInput userInputs = new MockNewCommandInput("console").WithListOption().WithCommandOption("--tag", commandTag);
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
 
             if (matchExpected)
             {
@@ -479,7 +480,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             INewCommandInput userInputs = new MockNewCommandInput("console", type: "item").WithListOption();
 
-            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForListOrHelp(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
+            TemplateListResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResultForList(templatesToSearch, new MockHostSpecificDataLoader(), userInputs, null);
             Assert.False(matchResult.HasExactMatches);
             Assert.Equal(0, matchResult.ExactMatchedTemplateGroups.Count);
             Assert.Equal(0, matchResult.ExactMatchedTemplates.Count);

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/MultiShortNameResolutionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/MultiShortNameResolutionTests.cs
@@ -77,10 +77,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     defaultLanguage);
 
                 Assert.Equal(TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, matchResult.GroupResolutionStatus);
-                Assert.Equal(3, matchResult.UnambiguousTemplateGroup.Templates.Count);
-                Assert.True(matchResult.UnambiguousTemplateGroup.Templates.All(t => WellKnownSearchFilters.MatchesAllCriteria(t)));
+                Assert.Equal(3, matchResult.UnambiguousTemplateGroup?.Templates.Count);
+                Assert.True(matchResult.UnambiguousTemplateGroup?.Templates.All(t => WellKnownSearchFilters.MatchesAllCriteria(t)));
 
-                foreach (ITemplateMatchInfo templateMatchInfo in matchResult.UnambiguousTemplateGroup.Templates)
+                foreach (ITemplateMatchInfo templateMatchInfo in matchResult.UnambiguousTemplateGroup!.Templates)
                 {
                     Assert.Equal("MultiName.Test", templateMatchInfo.Info.GroupIdentity);
                     if (templateMatchInfo.Info.GetLanguage()?.Equals(defaultLanguage, StringComparison.OrdinalIgnoreCase) ?? false)
@@ -107,8 +107,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
                 TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), userInputs, "C#");
                 Assert.Equal(TemplateResolutionResult.Status.SingleMatch, matchResult.ResolutionStatus);
-                Assert.Equal("MultiName.Test.High.CSharp", matchResult.TemplateToInvoke.Info.Identity);
-                Assert.Equal(_shortNamesForGroup, matchResult.UnambiguousTemplateGroup.ShortNames);
+                Assert.Equal("MultiName.Test.High.CSharp", matchResult.TemplateToInvoke?.Info.Identity);
+                Assert.Equal(_shortNamesForGroup, matchResult.UnambiguousTemplateGroup?.ShortNames);
             }
         }
 
@@ -120,8 +120,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 INewCommandInput userInputs = new MockNewCommandInput(testShortName, "F#");
                 TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), userInputs, "C#");
                 Assert.Equal(TemplateResolutionResult.Status.SingleMatch, matchResult.ResolutionStatus);
-                Assert.Equal("Multiname.Test.Only.FSharp", matchResult.TemplateToInvoke.Info.Identity);
-                Assert.Equal(_shortNamesForGroup, matchResult.UnambiguousTemplateGroup.ShortNames);
+                Assert.Equal("Multiname.Test.Only.FSharp", matchResult.TemplateToInvoke?.Info.Identity);
+                Assert.Equal(_shortNamesForGroup, matchResult.UnambiguousTemplateGroup?.ShortNames);
             }
         }
 
@@ -138,8 +138,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), commandInput, "C#");
             Assert.Equal(TemplateResolutionResult.Status.SingleMatch, matchResult.ResolutionStatus);
-            Assert.Equal(expectedIdentity, matchResult.TemplateToInvoke.Info.Identity);
-            Assert.Equal(_shortNamesForGroup, matchResult.UnambiguousTemplateGroup.ShortNames);
+            Assert.Equal(expectedIdentity, matchResult.TemplateToInvoke?.Info.Identity);
+            Assert.Equal(_shortNamesForGroup, matchResult.UnambiguousTemplateGroup?.ShortNames);
         }
 
         [Theory(DisplayName = nameof(ParameterExistenceDisambiguatesMatchesWithMultipleShortNames))]
@@ -155,8 +155,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(MultiShortNameGroupTemplateInfo, new MockHostSpecificDataLoader(), commandInput, "C#");
             Assert.Equal(TemplateResolutionResult.Status.SingleMatch, matchResult.ResolutionStatus);
-            Assert.Equal(expectedIdentity, matchResult.TemplateToInvoke.Info.Identity);
-            Assert.Equal(_shortNamesForGroup, matchResult.UnambiguousTemplateGroup.ShortNames);
+            Assert.Equal(expectedIdentity, matchResult.TemplateToInvoke?.Info.Identity);
+            Assert.Equal(_shortNamesForGroup, matchResult.UnambiguousTemplateGroup?.ShortNames);
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateResolverTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,10 +20,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
     // MockNewCommandInput doesn't support everything in the interface, just enough for this type of testing.
     public class TemplateResolverTests
     {
-        public static IEnumerable<object[]> Get_TemplateResolution_UnambiguousGroup_TestData()
+        public static IEnumerable<object?[]> Get_TemplateResolution_UnambiguousGroup_TestData()
         {
             //TestPerformCoreTemplateQuery_UniqueNameMatchesCorrectly
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("Template2"),
                 new MockTemplateInfo[]
@@ -35,7 +37,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //TestPerformCoreTemplateQuery_InputLanguageIsPreferredOverDefault
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo", "LISP"),
                 new MockTemplateInfo[]
@@ -51,7 +53,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //TestPerformCoreTemplateQuery_GroupIsFound
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo"),
                 new MockTemplateInfo[]
@@ -66,7 +68,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //TestPerformCoreTemplateQuery_ParameterNameDisambiguates
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo").WithTemplateOption("baz", "whatever"),
                 new MockTemplateInfo[]
@@ -80,7 +82,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //TestPerformCoreTemplateQuery_ParameterValueDisambiguates
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo").WithTemplateOption("framework", "netcoreapp2.1"),
                 new MockTemplateInfo[]
@@ -94,7 +96,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //TestPerformCoreTemplateQuery_UnknownParameterNameInvalidatesMatch
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo").WithTemplateOption("baz"),
                 new MockTemplateInfo[]
@@ -107,7 +109,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //TestPerformCoreTemplateQuery_InvalidChoiceValueInvalidatesMatch
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo").WithTemplateOption("framework", "netcoreapp3.0"),
                 new MockTemplateInfo[]
@@ -122,7 +124,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             //SingularInvokableMatchTests
             //MultipleTemplatesInGroupHavingSingleStartsWithOnSameParamIsAmbiguous
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"),
                 new MockTemplateInfo[]
@@ -138,7 +140,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //MultipleTemplatesInGroupParamPartiaMatch_TheOneHavingSingleStartsWithIsTheSingularInvokableMatch
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"),
                 new MockTemplateInfo[]
@@ -154,7 +156,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //MultipleTemplatesInGroupHavingAmbiguousParamMatchOnSameParamIsAmbiguous
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"),
                 new MockTemplateInfo[]
@@ -170,7 +172,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //MultipleTemplatesInGroupHavingSingularStartMatchesOnDifferentParams_HighPrecedenceIsChosen
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_").WithTemplateOption("OtherChoice", "foo_"),
                 new MockTemplateInfo[]
@@ -188,7 +190,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //GivenOneInvokableTemplateWithNonDefaultLanguage_ItIsChosen
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo"),
                 new MockTemplateInfo[]
@@ -202,7 +204,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //GivenTwoInvokableTemplatesNonDefaultLanguage_HighPrecedenceIsChosen
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo"),
                 new MockTemplateInfo[]
@@ -218,7 +220,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //GivenMultipleHighestPrecedenceTemplates_ResultIsAmbiguous
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo"),
                 new MockTemplateInfo[]
@@ -239,46 +241,46 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("Template1", identity: "Template1"),
                     new MockTemplateInfo("Template2", identity: "Template2")
             };
-            yield return new object[] { new MockNewCommandInput("Template2"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "Template2" } };
-            yield return new object[] { new MockNewCommandInput("Template3"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.NoMatch, Array.Empty<string>() };
-            yield return new object[] { new MockNewCommandInput("Template"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.Ambiguous, Array.Empty<string>() };
+            yield return new object?[] { new MockNewCommandInput("Template2"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "Template2" } };
+            yield return new object?[] { new MockNewCommandInput("Template3"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.NoMatch, Array.Empty<string>() };
+            yield return new object?[] { new MockNewCommandInput("Template"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.NoMatch, Array.Empty<string>() };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("ShortName1", identity: "Template1", groupIdentity: "Group", precedence: 100),
                     new MockTemplateInfo("ShortName2", identity: "Template2", groupIdentity: "Group", precedence: 200)
             };
-            yield return new object[] { new MockNewCommandInput("ShortName1"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "Template1", "Template2" } };
-            yield return new object[] { new MockNewCommandInput("ShortName2"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "Template1", "Template2" } };
-            yield return new object[] { new MockNewCommandInput("ShortName"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "Template1", "Template2" } };
+            yield return new object?[] { new MockNewCommandInput("ShortName1"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "Template1", "Template2" } };
+            yield return new object?[] { new MockNewCommandInput("ShortName2"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "Template1", "Template2" } };
+            yield return new object?[] { new MockNewCommandInput("ShortName"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.NoMatch, Array.Empty<string>() };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("ShortName1", identity: "Template1", groupIdentity: "Group"),
                     new MockTemplateInfo("ShortName2", identity: "Template2", groupIdentity: "Group")
             };
-            yield return new object[] { new MockNewCommandInput("ShortName1"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "Template1", "Template2" } };
-            yield return new object[] { new MockNewCommandInput("ShortName2"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "Template1", "Template2" } };
-            yield return new object[] { new MockNewCommandInput("ShortName"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "Template1", "Template2" } };
+            yield return new object?[] { new MockNewCommandInput("ShortName1"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "Template1", "Template2" } };
+            yield return new object?[] { new MockNewCommandInput("ShortName2"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "Template1", "Template2" } };
+            yield return new object?[] { new MockNewCommandInput("ShortName"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.NoMatch, Array.Empty<string>() };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.Perl", groupIdentity: "foo.group").WithTag("language", "Perl"),
             };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, "Perl", (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl" } };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl" } };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, "C#", (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl" } };
-            yield return new object[] { new MockNewCommandInput("foo", language: "Perl"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl" } };
-            yield return new object[] { new MockNewCommandInput("foo", language: "Perl"), templates, "Perl", (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl" } };
-            yield return new object[] { new MockNewCommandInput("foo", language: "Perl"), templates, "C#", (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl" } };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, "Perl", (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl" } };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl" } };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, "C#", (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl" } };
+            yield return new object?[] { new MockNewCommandInput("foo", language: "Perl"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl" } };
+            yield return new object?[] { new MockNewCommandInput("foo", language: "Perl"), templates, "Perl", (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl" } };
+            yield return new object?[] { new MockNewCommandInput("foo", language: "Perl"), templates, "C#", (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl" } };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.Perl", groupIdentity: "foo.group").WithTag("language", "Perl"),
                     new MockTemplateInfo("foo", identity: "foo.Lisp", groupIdentity: "foo.group").WithTag("language", "LISP")
             };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, "Perl", (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl", "foo.Lisp" } };
-            yield return new object[] { new MockNewCommandInput("foo", language: "LISP"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Lisp" } };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, "Perl", (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Perl", "foo.Lisp" } };
+            yield return new object?[] { new MockNewCommandInput("foo", language: "LISP"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.Lisp" } };
 
             templates = new MockTemplateInfo[]
             {
@@ -287,16 +289,16 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("bar", identity: "bar.200", groupIdentity: "bar.group", precedence: 200),
             };
 
-            yield return new object[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.100", "foo.200" } };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.100", "foo.200" } };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.bar", groupIdentity: "foo.group").WithParameters("bar"),
                     new MockTemplateInfo("foo", identity: "foo.baz", groupIdentity: "foo.group").WithParameters("baz"),
             };
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("baz", "whatever"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.bar", "foo.baz" } };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("baz", "whatever"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.bar", "foo.baz" } };
 
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("bat", "whatever"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.bar", "foo.baz" } };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("bat", "whatever"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.bar", "foo.baz" } };
 
             templates = new MockTemplateInfo[]
             {
@@ -304,8 +306,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithChoiceParameter("framework", "net5.0"),
             };
 
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("framework", "net5.0"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.1", "foo.2" } };
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("framework", "netcoreapp2.0"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.1", "foo.2" } };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("framework", "net5.0"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.1", "foo.2" } };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("framework", "netcoreapp2.0"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.1", "foo.2" } };
 
             templates = new MockTemplateInfo[]
             {
@@ -313,15 +315,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithChoiceParameter("MyChoice", "value_2_example", "value_3_example"),
             };
 
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.1", "foo.2" } };
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_1"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.1", "foo.2" } };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.1", "foo.2" } };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_1"), templates, null, (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch, new string[] { "foo.1", "foo.2" } };
         }
 
-        public static IEnumerable<object[]> Get_TemplateResolution_TemplateToInvoke_TestData()
+        public static IEnumerable<object?[]> Get_TemplateResolution_TemplateToInvoke_TestData()
         {
             //SingularInvokableMatchTests
             //MultipleTemplatesInGroupHavingSingleStartsWithOnSameParamIsAmbiguous
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"),
                 new MockTemplateInfo[]
@@ -337,7 +339,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //MultipleTemplatesInGroupParamPartiaMatch_TheOneHavingSingleStartsWithIsTheSingularInvokableMatch
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"),
                 new MockTemplateInfo[]
@@ -353,7 +355,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //MultipleTemplatesInGroupHavingAmbiguousParamMatchOnSameParamIsAmbiguous
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"),
                 new MockTemplateInfo[]
@@ -369,7 +371,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //MultipleTemplatesInGroupHavingSingularStartMatchesOnDifferentParams_HighPrecedenceIsChosen
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_").WithTemplateOption("OtherChoice", "foo_"),
                 new MockTemplateInfo[]
@@ -387,7 +389,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //GivenOneInvokableTemplateWithNonDefaultLanguage_ItIsChosen
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo"),
                 new MockTemplateInfo[]
@@ -401,7 +403,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //GivenTwoInvokableTemplatesNonDefaultLanguage_HighPrecedenceIsChosen
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo"),
                 new MockTemplateInfo[]
@@ -417,7 +419,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
             };
 
             //GivenMultipleHighestPrecedenceTemplates_ResultIsAmbiguous
-            yield return new object[]
+            yield return new object?[]
             {
                 new MockNewCommandInput("foo"),
                 new MockTemplateInfo[]
@@ -438,53 +440,53 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("Template1", identity: "Template1"),
                     new MockTemplateInfo("Template2", identity: "Template2")
             };
-            yield return new object[] { new MockNewCommandInput("Template2"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "Template2" };
-            yield return new object[] { new MockNewCommandInput("Template3"), templates, null, (int)TemplateResolutionResult.Status.NoMatch, null };
-            yield return new object[] { new MockNewCommandInput("Template"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousTemplateGroupChoice, null };
+            yield return new object?[] { new MockNewCommandInput("Template2"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "Template2" };
+            yield return new object?[] { new MockNewCommandInput("Template3"), templates, null, (int)TemplateResolutionResult.Status.NoMatch, null };
+            yield return new object?[] { new MockNewCommandInput("Template"), templates, null, (int)TemplateResolutionResult.Status.NoMatch, null };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("Template", identity: "Template1"),
                     new MockTemplateInfo("Template", identity: "Template2")
             };
-            yield return new object[] { new MockNewCommandInput("Template"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousTemplateGroupChoice, null };
+            yield return new object?[] { new MockNewCommandInput("Template"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousTemplateGroupChoice, null };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("ShortName1", identity: "Template1", groupIdentity: "Group", precedence: 100),
                     new MockTemplateInfo("ShortName2", identity: "Template2", groupIdentity: "Group", precedence: 200)
             };
-            yield return new object[] { new MockNewCommandInput("ShortName1"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "Template2" };
-            yield return new object[] { new MockNewCommandInput("ShortName2"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "Template2" };
-            yield return new object[] { new MockNewCommandInput("ShortName"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "Template2" };
+            yield return new object?[] { new MockNewCommandInput("ShortName1"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "Template2" };
+            yield return new object?[] { new MockNewCommandInput("ShortName2"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "Template2" };
+            yield return new object?[] { new MockNewCommandInput("ShortName"), templates, null, (int)TemplateResolutionResult.Status.NoMatch, null };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("ShortName1", identity: "Template1", groupIdentity: "Group"),
                     new MockTemplateInfo("ShortName2", identity: "Template2", groupIdentity: "Group")
             };
-            yield return new object[] { new MockNewCommandInput("ShortName1"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousTemplateChoice, null };
-            yield return new object[] { new MockNewCommandInput("ShortName2"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousTemplateChoice, null };
-            yield return new object[] { new MockNewCommandInput("ShortName"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousTemplateChoice, null };
+            yield return new object?[] { new MockNewCommandInput("ShortName1"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousTemplateChoice, null };
+            yield return new object?[] { new MockNewCommandInput("ShortName2"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousTemplateChoice, null };
+            yield return new object?[] { new MockNewCommandInput("ShortName"), templates, null, (int)TemplateResolutionResult.Status.NoMatch, null };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.Perl", groupIdentity: "foo.group").WithTag("language", "Perl"),
             };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, "Perl", (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
-            yield return new object[] { new MockNewCommandInput("foo", language: "Perl"), templates, "Perl", (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
-            yield return new object[] { new MockNewCommandInput("foo", language: "Perl"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, "C#", (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
-            yield return new object[] { new MockNewCommandInput("foo", language: "Perl"), templates, "C#", (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, "Perl", (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
+            yield return new object?[] { new MockNewCommandInput("foo", language: "Perl"), templates, "Perl", (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
+            yield return new object?[] { new MockNewCommandInput("foo", language: "Perl"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, "C#", (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
+            yield return new object?[] { new MockNewCommandInput("foo", language: "Perl"), templates, "C#", (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.Perl", groupIdentity: "foo.group").WithTag("language", "Perl"),
                     new MockTemplateInfo("foo", identity: "foo.Lisp", groupIdentity: "foo.group").WithTag("language", "LISP")
             };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, "Perl", (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
-            yield return new object[] { new MockNewCommandInput("foo", language: "LISP"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.Lisp" };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, "Perl", (int)TemplateResolutionResult.Status.SingleMatch, "foo.Perl" };
+            yield return new object?[] { new MockNewCommandInput("foo", language: "LISP"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.Lisp" };
 
             templates = new MockTemplateInfo[]
             {
@@ -493,16 +495,16 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("bar", identity: "bar.200", groupIdentity: "bar.group", precedence: 200),
             };
 
-            yield return new object[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.200" };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.200" };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.bar", groupIdentity: "foo.group").WithParameters("bar"),
                     new MockTemplateInfo("foo", identity: "foo.baz", groupIdentity: "foo.group").WithParameters("baz"),
             };
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("baz", "whatever"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.baz" };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("baz", "whatever"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.baz" };
 
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("bat", "whatever"), templates, null, (int)TemplateResolutionResult.Status.InvalidParameter, null };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("bat", "whatever"), templates, null, (int)TemplateResolutionResult.Status.InvalidParameter, null };
 
             templates = new MockTemplateInfo[]
             {
@@ -510,8 +512,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithChoiceParameter("framework", "net5.0"),
             };
 
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("framework", "net5.0"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.2" };
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("framework", "netcoreapp2.0"), templates, null, (int)TemplateResolutionResult.Status.InvalidParameter, null };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("framework", "net5.0"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.2" };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("framework", "netcoreapp2.0"), templates, null, (int)TemplateResolutionResult.Status.InvalidParameter, null };
 
             templates = new MockTemplateInfo[]
             {
@@ -519,20 +521,20 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group", precedence: 200).WithChoiceParameter("MyChoice", "value_2"),
             };
 
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousParameterValueChoice, null };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousParameterValueChoice, null };
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group", precedence: 100).WithChoiceParameter("MyChoice", "value_1"),
                     new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group", precedence: 200).WithChoiceParameter("MyChoice", "value_2", "value_3"),
             };
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousParameterValueChoice, null };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousParameterValueChoice, null };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group", precedence: 100).WithChoiceParameter("MyChoice", "value_1", "value_2"),
                     new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group", precedence: 200).WithChoiceParameter("MyChoice", "value_3", "value_4"),
             };
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousParameterValueChoice, null };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousParameterValueChoice, null };
 
             templates = new MockTemplateInfo[]
             {
@@ -544,14 +546,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                         .WithChoiceParameter("MyChoice", "value_")
                         .WithChoiceParameter("OtherChoice", "foo_", "bar_1"),
             };
-            yield return new object[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_").WithTemplateOption("OtherChoice", "foo_"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.2" };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_").WithTemplateOption("OtherChoice", "foo_"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.2" };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.1.FSharp", groupIdentity: "foo.group", precedence: 100)
                         .WithTag("language", "F#")
             };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.1.FSharp" };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.1.FSharp" };
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.1.FSharp", groupIdentity: "foo.group", precedence: 100)
@@ -559,7 +561,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("foo", identity: "foo.1.VB", groupIdentity: "foo.group", precedence: 200)
                         .WithTag("language", "VB")
             };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.1.VB" };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.SingleMatch, "foo.1.VB" };
 
             templates = new MockTemplateInfo[]
             {
@@ -568,7 +570,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("foo", identity: "foo.1.VB", groupIdentity: "foo.group", precedence: 200)
                         .WithTag("language", "VB")
             };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousLanguageChoice, null };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousLanguageChoice, null };
 
             templates = new MockTemplateInfo[]
             {
@@ -577,7 +579,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("foo", identity: "foo.1.VB", groupIdentity: "foo.group", precedence: 200)
                         .WithTag("language", "")
             };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousLanguageChoice, null };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousLanguageChoice, null };
 
             templates = new MockTemplateInfo[]
             {
@@ -585,14 +587,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                         .WithTag("language", "F#"),
                     new MockTemplateInfo("foo", identity: "foo.1.VB", groupIdentity: "foo.group", precedence: 200)
             };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousLanguageChoice, null };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousLanguageChoice, null };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.1.FSharp", groupIdentity: "foo.group", precedence: 200),
                     new MockTemplateInfo("foo", identity: "foo.1.VB", groupIdentity: "foo.group", precedence: 200)
             };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousTemplateChoice, null };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousTemplateChoice, null };
 
             templates = new MockTemplateInfo[]
             {
@@ -601,12 +603,12 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("foo", identity: "foo.1.VB", groupIdentity: "foo.group", precedence: 200)
                         .WithTag("language", "F#")
             };
-            yield return new object[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousTemplateChoice, null };
+            yield return new object?[] { new MockNewCommandInput("foo"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousTemplateChoice, null };
         }
 
         [Theory(DisplayName = nameof(TemplateResolution_UnambiguousGroup_Test))]
         [MemberData(nameof(Get_TemplateResolution_UnambiguousGroup_TestData))]
-        internal void TemplateResolution_UnambiguousGroup_Test(MockNewCommandInput command, MockTemplateInfo[] templateSet, string defaultLanguage, int expectedStatus, string[] expectedIdentities)
+        internal void TemplateResolution_UnambiguousGroup_Test(MockNewCommandInput command, MockTemplateInfo[] templateSet, string? defaultLanguage, int expectedStatus, string[]? expectedIdentities)
         {
             var matchResult = TemplateResolver.GetTemplateResolutionResult(templateSet, new MockHostSpecificDataLoader(), command, defaultLanguage);
 
@@ -614,11 +616,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             if (expectedStatus == (int)TemplateResolutionResult.UnambiguousTemplateGroupStatus.SingleMatch)
             {
-                var identities = matchResult.UnambiguousTemplateGroup.Templates.Select(t => t.Info.Identity);
-                Assert.Equal(expectedIdentities.Length, identities.Count());
-                foreach (string identity in expectedIdentities)
+                Assert.NotNull(matchResult.UnambiguousTemplateGroup);
+                var identities = matchResult.UnambiguousTemplateGroup!.Templates.Select(t => t.Info.Identity);
+                if (expectedIdentities != null)
                 {
-                    Assert.Single(identities.Where(i => i == identity));
+                    Assert.Equal(expectedIdentities.Length, identities.Count());
+                    foreach (string identity in expectedIdentities)
+                    {
+                        Assert.Single(identities.Where(i => i == identity));
+                    }
                 }
             }
             else
@@ -629,14 +635,15 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
         [Theory(DisplayName = nameof(TemplateResolution_TemplateToInvoke_Test))]
         [MemberData(nameof(Get_TemplateResolution_TemplateToInvoke_TestData))]
-        internal void TemplateResolution_TemplateToInvoke_Test(MockNewCommandInput command, MockTemplateInfo[] templateSet, string defaultLanguage, int expectedStatus, string expectedIdentity)
+        internal void TemplateResolution_TemplateToInvoke_Test(MockNewCommandInput command, MockTemplateInfo[] templateSet, string? defaultLanguage, int expectedStatus, string? expectedIdentity)
         {
             TemplateResolutionResult matchResult = TemplateResolver.GetTemplateResolutionResult(templateSet, new MockHostSpecificDataLoader(), command, defaultLanguage);
 
             Assert.Equal(expectedStatus, (int)matchResult.ResolutionStatus);
             if (expectedStatus == (int)TemplateResolutionResult.Status.SingleMatch)
             {
-                Assert.Equal(expectedIdentity, matchResult.TemplateToInvoke.Info.Identity);
+                Assert.NotNull(matchResult.TemplateToInvoke);
+                Assert.Equal(expectedIdentity, matchResult.TemplateToInvoke!.Info.Identity);
             }
             else
             {

--- a/test/dotnet-new3.UnitTests/AllWebProjectsWork.cs
+++ b/test/dotnet-new3.UnitTests/AllWebProjectsWork.cs
@@ -25,11 +25,11 @@ namespace Dotnet_new3.IntegrationTests
         [InlineData("emptyweb_cs-50", "web")]
         [InlineData("mvc_cs-50", "mvc")]
         [InlineData("mvc_fs-50", "mvc", "-lang", "F#")]
-        [InlineData("api_cs-50", "api")]
+        [InlineData("api_cs-50", "webapi")]
         [InlineData("emptyweb_cs-31", "web", "-f", "netcoreapp3.1")]
         [InlineData("mvc_cs-31", "mvc", "-f", "netcoreapp3.1")]
         [InlineData("mvc_fs-31", "mvc", "-lang", "F#", "-f", "netcoreapp3.1")]
-        [InlineData("api_cs-31", "api", "-f", "netcoreapp3.1")]
+        [InlineData("api_cs-31", "webapi", "-f", "netcoreapp3.1")]
         public void AllWebProjectsRestoreAndBuild(string testName, params string[] args)
         {
             string workingDir = Path.Combine(_fixture.BaseWorkingDirectory, testName);

--- a/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
@@ -185,5 +185,183 @@ Options:
                 .And.HaveStdOut(ClassLibHelp)
                 .And.NotHaveStdOutContaining(HelpOutput);
         }
+
+        [Fact]
+        public void CannotShowHelpForTemplate_PartialNameMatch()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "class", "-h")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should().Fail()
+                .And.HaveStdErr(
+@"No templates found matching: 'class'.
+To list installed templates, run 'dotnet new3 --list'.
+To search for the templates on NuGet.org, run 'dotnet new3 class --search'.");
+        }
+
+        [Fact]
+        public void CannotShowHelpForTemplate_WhenAmbiguousLanguageChoice()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+            Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicFSharp", _log, workingDirectory, home);
+            Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicVB", _log, workingDirectory, home);
+
+            new DotnetNewCommand(_log, "basic", "--help")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .Fail()
+                .And.NotHaveStdOut()
+                .And.HaveStdErrContaining("Unable to resolve the template, these templates matched your input:")
+                .And.HaveStdErrContaining("Re-run the command specifying the language to use with --language option.")
+                .And.HaveStdErrContaining("basic").And.HaveStdErrContaining("F#").And.HaveStdErrContaining("VB");
+        }
+
+        [Fact]
+        public void CanShowHelpForTemplate_MatchOnChoice()
+        {
+            const string ConsoleHelp =
+@"Console Application (C#)
+Author: Microsoft
+Description: A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS
+Options:                                                                            
+  --langVersion  Sets the LangVersion property in the created project file          
+                 text - Optional                                                    
+
+  --no-restore   If specified, skips the automatic restore of the project on create.
+                 bool - Optional                                                    
+                 Default: false                                                     ";
+
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "console", "--help", "--framework", "net5.0")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should().Pass()
+                .And.NotHaveStdErr()
+                .And.HaveStdOut(ConsoleHelp)
+                .And.NotHaveStdOutContaining(HelpOutput);
+        }
+
+        [Fact]
+        public void CannotShowHelpForTemplate_MatchOnChoiceWithoutValue()
+        {
+            string expectedOutput =
+@"Error: Invalid option(s):
+--framework 
+   '' is not a valid value for --framework. The possible values are:
+      net5.0          - Target net5.0
+      net6.0          - Target net6.0
+      netcoreapp1.0   - Target netcoreapp1.0
+      netcoreapp1.1   - Target netcoreapp1.1
+      netcoreapp2.0   - Target netcoreapp2.0
+      netcoreapp2.1   - Target netcoreapp2.1
+      netcoreapp2.2   - Target netcoreapp2.2
+      netcoreapp3.0   - Target netcoreapp3.0
+      netcoreapp3.1   - Target netcoreapp3.1
+
+For more information, run 'dotnet new3 console --help'.";
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "console", "--help", "--framework")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should().Fail()
+                .And.NotHaveStdOut()
+                .And.HaveStdErr(expectedOutput);
+        }
+
+        [Fact]
+        public void CannotShowHelpForTemplate_MatchOnUnexistingParam()
+        {
+            string expectedOutput =
+@"Error: Invalid option(s):
+--do-not-exist
+   '--do-not-exist' is not a valid option
+
+For more information, run 'dotnet new3 console --help'.";
+
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "console", "--help", "--do-not-exist")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should().Fail()
+                .And.NotHaveStdOut()
+                .And.HaveStdErr(expectedOutput);
+        }
+
+        [Fact]
+        public void CanShowHelpForTemplate_MatchOnNonChoiceParam()
+        {
+            const string ConsoleHelp =
+@"Console Application (C#)
+Author: Microsoft
+Description: A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS
+Options:                                                                             
+  -f|--framework  The target framework for the project.                              
+                      net6.0           - Target net6.0                               
+                      net5.0           - Target net5.0                               
+                      netcoreapp3.1    - Target netcoreapp3.1                        
+                      netcoreapp3.0    - Target netcoreapp3.0                        
+                      netcoreapp2.2    - Target netcoreapp2.2                        
+                      netcoreapp2.1    - Target netcoreapp2.1                        
+                      netcoreapp2.0    - Target netcoreapp2.0                        
+                      netcoreapp1.0    - Target netcoreapp1.0                        
+                      netcoreapp1.1    - Target netcoreapp1.1                        
+                  Default: net6.0                                                    
+
+  --langVersion   Sets the LangVersion property in the created project file          
+                  text - Optional                                                    
+                  Configured Value: 8.0                                              
+
+  --no-restore    If specified, skips the automatic restore of the project on create.
+                  bool - Optional                                                    
+                  Default: false                                                     ";
+
+        string home = TestUtils.CreateTemporaryFolder("Home");
+        string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+        new DotnetNewCommand(_log, "console", "--help", "--langVersion", "8.0")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should().Pass()
+                .And.NotHaveStdErr()
+                .And.HaveStdOut(ConsoleHelp)
+                .And.NotHaveStdOutContaining(HelpOutput);
+        }
+
+        [Fact]
+        public void CannotShowHelpForTemplate_MatchOnNonChoiceParamWithoutValue()
+        {
+            string expectedOutput =
+@"Error: Invalid option(s):
+--langVersion 
+   '' is not a valid value for --langVersion.";
+
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "console", "--help", "--langVersion")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should().Fail()
+                .And.NotHaveStdOut()
+                .And.HaveStdErr(expectedOutput);
+        }
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
@@ -204,6 +204,23 @@ To search for the templates on NuGet.org, run 'dotnet new3 class --search'.");
         }
 
         [Fact]
+        public void CannotShowHelpForTemplate_FullNameMatch()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "Console Application", "-h")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should().Fail()
+                .And.HaveStdErr(
+@"No templates found matching: 'Console Application'.
+To list installed templates, run 'dotnet new3 --list'.
+To search for the templates on NuGet.org, run 'dotnet new3 'Console Application' --search'.");
+        }
+
+        [Fact]
         public void CannotShowHelpForTemplate_WhenAmbiguousLanguageChoice()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
@@ -133,6 +133,24 @@ namespace Dotnet_new3.IntegrationTests
         }
 
         [Fact]
+        public void CannotInstantiateTemplate_WhenFullNameIsUsed()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "Console Application")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should().Fail()
+                .And.NotHaveStdOut()
+                .And.NotHaveStdOutContaining("The template \"Console Application\" was created successfully.")
+                .And.HaveStdErrContaining("No templates found matching: 'Console Application'.")
+                .And.HaveStdErrContaining("To list installed templates, run 'dotnet new3 --list'.")
+                .And.HaveStdErrContaining("To search for the templates on NuGet.org, run 'dotnet new3 'Console Application' --search'.");
+        }
+
+        [Fact]
         public void CannotInstantiateTemplate_WhenParameterIsInvalid()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
@@ -56,7 +56,7 @@ namespace Dotnet_new3.IntegrationTests
         }
 
         [Fact]
-        public void CanInstantiateTemplateWithSingleNonDefaultLanguageChoice()
+        public void CanInstantiateTemplate_WithSingleNonDefaultLanguageChoice()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -73,7 +73,7 @@ namespace Dotnet_new3.IntegrationTests
         }
 
         [Fact]
-        public void CannotInstantiateTemplateWhenAmbiguousLanguageChoice()
+        public void CannotInstantiateTemplate_WhenAmbiguousLanguageChoice()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -87,27 +87,38 @@ namespace Dotnet_new3.IntegrationTests
                 .Should()
                 .Fail()
                 .And.NotHaveStdOut()
-                .And.HaveStdErrContaining("Unable to resolve the template to instantiate, these templates matched your input:")
+                .And.HaveStdErrContaining("Unable to resolve the template, these templates matched your input:")
                 .And.HaveStdErrContaining("Re-run the command specifying the language to use with --language option.")
                 .And.HaveStdErrContaining("basic").And.HaveStdErrContaining("F#").And.HaveStdErrContaining("VB");
         }
 
         [Fact]
-        public void CannotInstantiateTemplateWhenAmbiguousGroupChoice()
+        public void CannotInstantiateTemplate_OnAmbiguousGroupChoice()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
             string workingDirectory = TestUtils.CreateTemporaryFolder();
 
-            new DotnetNewCommand(_log, "conf", "--quiet")
+            new DotnetNewCommand(_log, "class")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should().Fail()
+                .And.NotHaveStdOut()
+                .And.NotHaveStdOutContaining("The template \"Class Library\" was created successfully.")
+                .And.HaveStdErrContaining("No templates found matching: 'class'.")
+                .And.HaveStdErrContaining("To list installed templates, run 'dotnet new3 --list'.")
+                .And.HaveStdErrContaining("To search for the templates on NuGet.org, run 'dotnet new3 class --search'.");
+
+            new DotnetNewCommand(_log, "conf")
                 .WithCustomHive(home)
                 .WithWorkingDirectory(workingDirectory)
                 .Execute()
                 .Should()
                 .Fail()
                 .And.NotHaveStdOut()
-                .And.HaveStdErrContaining("Unable to resolve the template to instantiate, these templates matched your input:")
-                .And.HaveStdErrContaining("Re-run the command using the template's exact short name.")
-                .And.HaveStdErrContaining("webconfig").And.HaveStdErrContaining("nugetconfig").And.NotHaveStdErrContaining("classlib");
+                .And.HaveStdErrContaining("No templates found matching: 'conf'.")
+                .And.HaveStdErrContaining("To list installed templates, run 'dotnet new3 --list'.")
+                .And.HaveStdErrContaining("To search for the templates on NuGet.org, run 'dotnet new3 conf --search'.");
 
             new DotnetNewCommand(_log, "file")
                 .WithCustomHive(home)
@@ -116,13 +127,13 @@ namespace Dotnet_new3.IntegrationTests
                 .Should()
                 .Fail()
                 .And.NotHaveStdOut()
-                .And.HaveStdErrContaining("Unable to resolve the template to instantiate, these templates matched your input:")
-                .And.HaveStdErrContaining("Re-run the command using the template's exact short name.")
-                .And.HaveStdErrContaining("tool-manifest").And.HaveStdErrContaining("sln").And.NotHaveStdErrContaining("console");
+                .And.HaveStdErrContaining("No templates found matching: 'file'.")
+                .And.HaveStdErrContaining("To list installed templates, run 'dotnet new3 --list'.")
+                .And.HaveStdErrContaining("To search for the templates on NuGet.org, run 'dotnet new3 file --search'.");
         }
 
         [Fact]
-        public void CannotInstantiateTemplateWhenParameterIsInvalid()
+        public void CannotInstantiateTemplate_WhenParameterIsInvalid()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -180,7 +191,7 @@ namespace Dotnet_new3.IntegrationTests
         }
 
         [Fact]
-        public void CannotInstantiateTemplateWhenPrecedenceIsSame()
+        public void CannotInstantiateTemplate_WhenPrecedenceIsSame()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -194,7 +205,7 @@ namespace Dotnet_new3.IntegrationTests
                 .Should()
                 .Fail()
                 .And.NotHaveStdOut()
-                .And.HaveStdErrContaining("Unable to resolve the template to instantiate, the following installed templates are conflicting:")
+                .And.HaveStdErrContaining("Unable to resolve the template, the following installed templates are conflicting:")
                 .And.HaveStdErrContaining("Uninstall the templates or the packages to keep only one template from the list.")
                 .And.HaveStdErrContaining("TestAssets.SamePrecedenceGroup.BasicTemplate2")
                 .And.HaveStdErrContaining("TestAssets.SamePrecedenceGroup.BasicTemplate1")
@@ -207,7 +218,7 @@ namespace Dotnet_new3.IntegrationTests
         }
 
         [Fact]
-        public void CanInstantiateTemplateWithAlias()
+        public void CanInstantiateTemplate_WithAlias()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
             string workingDirectory = TestUtils.CreateTemporaryFolder();


### PR DESCRIPTION
### Problem
fixes dotnet/templating#3113

### Solution
Disables partial matching on name for instantiation and --help
Refactoring:
- HelpForTemplateResolution -> TemplateInformationCoordinator and made non-static
- split handling for help and list
- removed some unreachable code in help flow

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)