### PR TITLE
changed ordering in tables to be case-insensitive

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/HelpForTemplateResolution.cs
@@ -476,7 +476,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                     .DefineColumn(t => t.Type, LocalizableStrings.ColumnNameType, NewCommandInputCli.TypeColumnFilter, defaultColumn: false)
                     .DefineColumn(t => t.Author, LocalizableStrings.ColumnNameAuthor, NewCommandInputCli.AuthorColumnFilter, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)
                     .DefineColumn(t => t.Classifications, out object tagsColumn, LocalizableStrings.ColumnNameTags, NewCommandInputCli.TagsColumnFilter, defaultColumn: true)
-                    .OrderBy(nameColumn);
+                    .OrderBy(nameColumn, StringComparer.OrdinalIgnoreCase);
 
             Reporter reporter = useErrorOutput ? Reporter.Error : Reporter.Output;
             reporter.WriteLine(formatter.Layout());

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -499,7 +499,7 @@ namespace Microsoft.TemplateEngine.Cli
                        .DefineColumn(r => r.Identifier, out object packageColumn, LocalizableStrings.ColumnNamePackage, showAlways: true)
                        .DefineColumn(r => r.CurrentVersion, LocalizableStrings.ColumnNameCurrentVersion, showAlways: true)
                        .DefineColumn(r => r.LatestVersion, LocalizableStrings.ColumnNameLatestVersion, showAlways: true)
-                       .OrderBy(packageColumn);
+                       .OrderBy(packageColumn, StringComparer.OrdinalIgnoreCase);
                 Reporter.Output.WriteLine(formatter.Layout());
                 Reporter.Output.WriteLine();
 

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -107,7 +108,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                     .DefineColumn(r => r.TemplateGroupInfo.Classifications, LocalizableStrings.ColumnNameTags, NewCommandInputCli.TagsColumnFilter, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)
                     .DefineColumn(r => r.PackageName, out object packageColumn, LocalizableStrings.ColumnNamePackage, showAlways: true)
                     .DefineColumn(r => r.PrintableTotalDownloads, LocalizableStrings.ColumnNameTotalDownloads, showAlways: true, rightAlign: true)
-                    .OrderBy(nameColumn);
+                    .OrderBy(nameColumn, StringComparer.OrdinalIgnoreCase);
 
             Reporter.Output.WriteLine(formatter.Layout());
         }

--- a/test/dotnet-new3.UnitTests/DotnetNewList.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewList.cs
@@ -71,22 +71,22 @@ namespace Dotnet_new3.IntegrationTests
 @"Template Name                                 Short Name     Language    Tags                  
 --------------------------------------------  -------------  ----------  ----------------------
 ASP.NET Core Empty                            web            [C#],F#     Web/Empty             
+ASP.NET Core gRPC Service                     grpc           [C#]        Web/gRPC              
 ASP.NET Core Web API                          webapi         [C#],F#     Web/WebAPI            
 ASP.NET Core Web App                          webapp         [C#]        Web/MVC/Razor Pages   
 ASP.NET Core Web App (Model-View-Controller)  mvc            [C#],F#     Web/MVC               
-ASP.NET Core gRPC Service                     grpc           [C#]        Web/gRPC              
 Blazor Server App                             blazorserver   [C#]        Web/Blazor            
 Blazor WebAssembly App                        blazorwasm     [C#]        Web/Blazor/WebAssembly
 Class Library                                 classlib       [C#],F#,VB  Common/Library        
 Console Application                           console        [C#],F#,VB  Common/Console        
+dotnet gitignore file                         gitignore                  Config                
 Dotnet local tool manifest file               tool-manifest              Config                
+global.json file                              globaljson                 Config                
 NuGet Config                                  nugetconfig                Config                
 Razor Class Library                           razorclasslib  [C#]        Web/Razor/Library     
 Solution File                                 sln                        Solution              
 Web Config                                    webconfig                  Config                
-Worker Service                                worker         [C#],F#     Common/Worker/Web     
-dotnet gitignore file                         gitignore                  Config                
-global.json file                              globaljson                 Config                ";
+Worker Service                                worker         [C#],F#     Common/Worker/Web     ";
 
             string home = TestUtils.CreateTemporaryFolder();
             Helpers.InstallNuGetTemplate("Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0", _log, null, home);

--- a/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
@@ -521,18 +521,18 @@ Examples:
                 bool rightIsShrunk = right.EndsWith("...");
                 if (!(leftIsShrunk ^ rightIsShrunk))
                 {
-                    return string.Compare(left, right, StringComparison.Ordinal);
+                    return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
                 }
                 
-                if (rightIsShrunk && left.StartsWith(right.Substring(0, right.Length - 3), StringComparison.Ordinal))
+                if (rightIsShrunk && left.StartsWith(right.Substring(0, right.Length - 3), StringComparison.OrdinalIgnoreCase))
                 {
                     return -1;
                 }
-                if (leftIsShrunk && right.StartsWith(left.Substring(0, left.Length - 3), StringComparison.Ordinal))
+                if (leftIsShrunk && right.StartsWith(left.Substring(0, left.Length - 3), StringComparison.OrdinalIgnoreCase))
                 {
                     return 1;
                 }
-                return string.Compare(left, right, StringComparison.Ordinal);
+                return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
             }
         }
     }


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/3035 was fixed using case-sensitive comparer. Changed it to be case-insensitive.


### Checks:
- [ ] Added unit tests - exists
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - NA