### PR TITLE
Removed support of multiple short names from JSON schema

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
@@ -701,8 +701,8 @@
       }
     },
     "shortName": {
-      "description": "A shorthand name or a list of names for selecting the template (applies to environments where the template name is specified by the user - not selected via a GUI). The first entry is the preferred short name.",
-      "type": [ "string", "array" ],
+      "description": "A shorthand name for selecting the template (applies to environments where the template name is specified by the user - not selected via a GUI).",
+      "type": [ "string" ],
       "minLength": 1
     },
     "sourceName": {


### PR DESCRIPTION
### Problem
partially addresses #3118 

### Solution
Removed array type and adjusted description for `shortName` property in `template.json` schema
