### PR TITLE
temporarily remove error message on ambiguous template group error

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
@@ -76,7 +76,9 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 case TemplateResolutionResult.Status.AmbiguousTemplateGroupChoice:
                     Reporter.Error.WriteLine(LocalizableStrings.AmbiguousTemplateGroupListHeader.Bold().Red());
                     DisplayTemplateList(resolutionResult.TemplateGroups, commandInput, useErrorOutput: true);
-                    Reporter.Error.WriteLine(LocalizableStrings.AmbiguousTemplateGroupListHint.Bold().Red());
+                    //TODO: https://github.com/dotnet/templating/issues/3275
+                    //revise error handling: this message is not the best CTA
+                    //Reporter.Error.WriteLine(LocalizableStrings.AmbiguousTemplateGroupListHint.Bold().Red());
                     return Task.FromResult(New3CommandStatus.NotFound);
                 case TemplateResolutionResult.Status.AmbiguousParameterValueChoice:
                     if (resolutionResult.UnambiguousTemplateGroup == null)


### PR DESCRIPTION
### Problem
related to #3275 
error message on ambiguous group error on template resolution is not applicable for the case when the template from different groups have same short name

### Solution
temporarily remove error message on ambiguous template group when resolving the template as it is not applicable for all possible cases. the proper fix will be made in preview 7
