### PR TITLE
 disable partial matching for template option value

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/InvalidParameterInfo.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/InvalidParameterInfo.cs
@@ -42,11 +42,6 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             /// The default name is invalid.
             /// </summary>
             InvalidDefaultValue,
-
-            /// <summary>
-            /// The value provided leads to ambiguous choice (for choice parameters only).
-            /// </summary>
-            AmbiguousParameterValue
         }
 
         /// <summary>
@@ -111,19 +106,6 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 {
                     invalidParamsErrorText.AppendLine(invalidParam.InputFormat);
                     invalidParamsErrorText.Append(' ', padWidth).AppendLine(string.Format(LocalizableStrings.InvalidParameterNameDetail, invalidParam.InputFormat));
-                }
-                else if (invalidParam.ErrorKind == Kind.AmbiguousParameterValue)
-                {
-                    invalidParamsErrorText.AppendLine(invalidParam.InputFormat + ' ' + invalidParam.SpecifiedValue);
-                    string header = string.Format(LocalizableStrings.AmbiguousParameterDetail, invalidParam.InputFormat, invalidParam.SpecifiedValue);
-                    if (templateGroup != null)
-                    {
-                        DisplayValidValues(invalidParamsErrorText, header, templateGroup.GetAmbiguousValuesForChoiceParameter(invalidParam.Canonical, invalidParam.SpecifiedValue), padWidth);
-                    }
-                    else
-                    {
-                        invalidParamsErrorText.Append(' ', padWidth).AppendLine(header);
-                    }
                 }
                 else if (invalidParam.ErrorKind == Kind.InvalidParameterValue)
                 {

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
@@ -78,24 +78,17 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                     DisplayTemplateList(resolutionResult.TemplateGroups, commandInput, useErrorOutput: true);
                     Reporter.Error.WriteLine(LocalizableStrings.AmbiguousTemplateGroupListHint.Bold().Red());
                     return Task.FromResult(New3CommandStatus.NotFound);
-                case TemplateResolutionResult.Status.AmbiguousParameterValueChoice:
-                    if (resolutionResult.UnambiguousTemplateGroup == null)
-                    {
-                        throw new ArgumentException($"{nameof(resolutionResult.UnambiguousTemplateGroup)} should not be null if {nameof(resolutionResult.ResolutionStatus)} is {nameof(TemplateResolutionResult.Status.AmbiguousParameterValueChoice)}");
-                    }
-                    Reporter.Verbose.WriteLine(LocalizableStrings.Authoring_AmbiguousChoiceParameterValue);
-                    return Task.FromResult(DisplayInvalidParameterError(resolutionResult.UnambiguousTemplateGroup, commandInput));
                 case TemplateResolutionResult.Status.AmbiguousTemplateChoice:
                     if (resolutionResult.UnambiguousTemplateGroup == null)
                     {
-                        throw new ArgumentException($"{nameof(resolutionResult.UnambiguousTemplateGroup)} should not be null if {nameof(resolutionResult.ResolutionStatus)} is {nameof(TemplateResolutionResult.Status.AmbiguousParameterValueChoice)}");
+                        throw new ArgumentException($"{nameof(resolutionResult.UnambiguousTemplateGroup)} should not be null if {nameof(resolutionResult.ResolutionStatus)} is {nameof(TemplateResolutionResult.Status.AmbiguousTemplateChoice)}");
                     }
                     Reporter.Verbose.WriteLine(LocalizableStrings.Authoring_AmbiguousBestPrecedence);
                     return DisplayAmbiguousPrecedenceErrorAsync(resolutionResult.UnambiguousTemplateGroup, commandInput, cancellationToken);
                 case TemplateResolutionResult.Status.InvalidParameter:
                     if (resolutionResult.UnambiguousTemplateGroup == null)
                     {
-                        throw new ArgumentException($"{nameof(resolutionResult.UnambiguousTemplateGroup)} should not be null if {nameof(resolutionResult.ResolutionStatus)} is {nameof(TemplateResolutionResult.Status.AmbiguousParameterValueChoice)}");
+                        throw new ArgumentException($"{nameof(resolutionResult.UnambiguousTemplateGroup)} should not be null if {nameof(resolutionResult.ResolutionStatus)} is {nameof(TemplateResolutionResult.Status.InvalidParameter)}");
                     }
                     return Task.FromResult(DisplayInvalidParameterError(resolutionResult.UnambiguousTemplateGroup, commandInput));
             }
@@ -334,7 +327,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
         /// <summary>
         /// Displays the help in case <paramref name="commandInput"/> contains invalid parameters for resolved <paramref name="unambiguousTemplateGroup"/>.
         /// </summary>
-        /// <param name="unambiguousTemplateGroup">the unambigious template group to use based on the command input.</param>
+        /// <param name="unambiguousTemplateGroup">the unambiguous template group to use based on the command input.</param>
         /// <param name="commandInput">the command input.</param>
         /// <returns><see cref="New3CommandStatus.InvalidParamValues"/>.</returns>
         /// <exception cref="ArgumentNullException">when <paramref name="unambiguousTemplateGroup"/>is <see langword="null" />.</exception>

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateListResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateListResolutionResult.cs
@@ -71,9 +71,9 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                 {
                     // condition is required to filter matches on custom parameters
                     // TODO: when matching on custom parameters is refactored keep IsMatch condition only
-                    if (_coreMatchedTemplates.Where(t => t.IsInvokableMatch()).Any())
+                    if (_coreMatchedTemplates.Where(t => t.IsFilterableMatch()).Any())
                     {
-                        _exactMatchedTemplates = _coreMatchedTemplates.Where(t => t.IsInvokableMatch()).ToList();
+                        _exactMatchedTemplates = _coreMatchedTemplates.Where(t => t.IsFilterableMatch()).ToList();
                     }
                     else
                     {

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateMatchInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateMatchInfoExtensions.cs
@@ -16,18 +16,13 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             return templateMatchInfo.MatchDisposition.Any(x => x.Name == TemplateResolver.DefaultLanguageMatchParameterName && x.Kind == MatchKind.Exact);
         }
 
-        //https://github.com/dotnet/templating/issues/2494
-        //after tab completion is implemented we no longer will be using this match kind - only exact matches will be allowed
-        internal static bool HasAmbiguousParameterValueMatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool IsInvokableMatch(this ITemplateMatchInfo templateMatchInfo)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            return templateMatchInfo.MatchDisposition.Any(x => x.Kind == MatchKind.AmbiguousValue);
-#pragma warning restore CS0618 // Type or member is obsolete
+            return templateMatchInfo.MatchDisposition.Count > 0
+                            && templateMatchInfo.MatchDisposition.All(x => x.Kind == MatchKind.Exact);
         }
 
-        //https://github.com/dotnet/templating/issues/2494
-        //after tab completion is implemented we no longer will be using this match kind - only exact matches will be allowed
-        internal static bool IsInvokableMatch(this ITemplateMatchInfo templateMatchInfo)
+        internal static bool IsFilterableMatch(this ITemplateMatchInfo templateMatchInfo)
         {
             return templateMatchInfo.MatchDisposition.Count > 0
                             && templateMatchInfo.MatchDisposition.All(x =>
@@ -37,11 +32,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                                     x.Kind == MatchKind.Partial
                                     && (x.Name == MatchInfo.BuiltIn.Name
                                         || x.Name == MatchInfo.BuiltIn.ShortName
-                                        || x.Name == MatchInfo.BuiltIn.Classification
-                                        || x.Name == MatchInfo.BuiltIn.Author)
-#pragma warning disable CS0618 // Type or member is obsolete
-                                || x.Kind == MatchKind.SingleStartsWith);
-#pragma warning restore CS0618 // Type or member is obsolete
+                                        || x.Name == MatchInfo.BuiltIn.Author));
         }
 
         internal static bool HasInvalidParameterName(this ITemplateMatchInfo templateMatchInfo)
@@ -60,13 +51,10 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         // This is analogous to INewCommandInput.InputTemplateParams
         internal static IReadOnlyDictionary<string, string?> GetValidTemplateParameters(this ITemplateMatchInfo templateMatchInfo)
         {
-            //https://github.com/dotnet/templating/issues/2494
-            //after tab completion is implemented we no longer will be using this match kind - only exact matches will be allowed
             //the method should be revised as valid parameters should be taken from command and not from match dispositionS
-            return templateMatchInfo.MatchDisposition.OfType<ParameterMatchInfo>().Where(
-#pragma warning disable CS0618 // Type or member is obsolete
-                x => x.Kind == MatchKind.Exact || x.Kind == MatchKind.SingleStartsWith)
-#pragma warning restore CS0618 // Type or member is obsolete
+            return templateMatchInfo.MatchDisposition
+                .OfType<ParameterMatchInfo>()
+                .Where(x => x.Kind == MatchKind.Exact)
                 .ToDictionary(x => x.Name, x => x.Value);
         }
     }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolutionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolutionResult.cs
@@ -73,17 +73,12 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             SingleMatch,
 
             /// <summary>
-            /// multiple template groups were resolved; not possible to determing the group to use.
+            /// multiple template groups were resolved; not possible to determine the group to use.
             /// </summary>
             AmbiguousTemplateGroupChoice,
 
             /// <summary>
-            /// single template group was resolved, but it is not possible to resolve choice parameter value to use.
-            /// </summary>
-            AmbiguousParameterValueChoice,
-
-            /// <summary>
-            /// single template group was resolved, but there is an ambiguous choice for template inside the group and the templates are of same language. Ususlly means that the installed templates are conflicting and the confict should be resolved by uninistalling some of templates.
+            /// single template group was resolved, but there is an ambiguous choice for template inside the group and the templates are of same language. Usually means that the installed templates are conflicting and the conflict should be resolved by uninistalling some of templates.
             /// </summary>
             AmbiguousTemplateChoice,
 
@@ -119,7 +114,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             SingleMatch,
 
             /// <summary>
-            /// multiple template groups were resolved; not possible to determing the group to use.
+            /// multiple template groups were resolved; not possible to determining the group to use.
             /// </summary>
             Ambiguous
         }
@@ -267,14 +262,6 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                     throw new ArgumentException($"Unexpected value of {nameof(UnambiguousTemplateGroup)}: {GroupResolutionStatus}.");
             }
 
-            //checking template options match
-            //if any template in the group has ambiguous parameter value match - cannot resolve template to instantiate
-            if (UnambiguousTemplateGroup.Templates.Any(x => x.HasAmbiguousParameterValueMatch()))
-            {
-                _singularInvokableMatchStatus = Status.AmbiguousParameterValueChoice;
-                return;
-            }
-
             //if no templates are invokable there is a problem with parameter name or value - cannot resolve template to instantiate
             if (!UnambiguousTemplateGroup.InvokableTemplates.Any())
             {
@@ -286,16 +273,6 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
             {
                 _templateToInvoke = UnambiguousTemplateGroup.InvokableTemplates.Single();
                 _singularInvokableMatchStatus = Status.SingleMatch;
-                return;
-            }
-
-            // if multiple templates in the group have single starts with matches on the same parameter, it's ambiguous.
-            // For the case where one template has single starts with, and another has ambiguous - on the same param:
-            //      The one with single starts with is chosen as invokable because if the template with an ambiguous match
-            //      was not installed, the one with the singluar invokable would be chosen.
-            if (UnambiguousTemplateGroup.GetAmbiguousSingleStartsWithParameters().Any())
-            {
-                _singularInvokableMatchStatus = Status.AmbiguousParameterValueChoice;
                 return;
             }
 

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateResolver.cs
@@ -162,7 +162,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 #pragma warning restore CS0618 // Type or member is obsolete
 
             AddParameterMatchingToTemplates(matchedTemplates, hostDataLoader, commandInput);
-            return matchedTemplates.Where(t => t.IsInvokableMatch()).ToList();
+            return matchedTemplates.Where(t => t.IsFilterableMatch()).ToList();
         }
 
         /// <summary>
@@ -254,7 +254,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                             if (paramDetails.IsChoice() && paramDetails.Choices != null)
                             {
                                 if (string.IsNullOrEmpty(paramValue)
-                                && !string.IsNullOrEmpty(paramDetails.DefaultIfOptionWithoutValue))
+                                    && !string.IsNullOrEmpty(paramDetails.DefaultIfOptionWithoutValue))
                                 {
                                     // The user provided the parameter switch on the command line, without a value.
                                     // In this case, the DefaultIfOptionWithoutValue is the effective value.
@@ -270,27 +270,9 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                                 {
                                     matchKind = MatchKind.Exact;
                                 }
-                                //https://github.com/dotnet/templating/issues/2494
-                                //after tab completion is implemented we no longer will be using this match kind - only exact matches will be allowed
                                 else
                                 {
-                                    int startsWithCount = paramDetails.Choices.Count(x => x.Key.StartsWith(paramValue, StringComparison.OrdinalIgnoreCase));
-                                    if (startsWithCount == 1)
-                                    {
-#pragma warning disable CS0618 // Type or member is obsolete
-                                        matchKind = MatchKind.SingleStartsWith;
-#pragma warning restore CS0618 // Type or member is obsolete
-                                    }
-                                    else if (startsWithCount > 1)
-                                    {
-#pragma warning disable CS0618 // Type or member is obsolete
-                                        matchKind = MatchKind.AmbiguousValue;
-#pragma warning restore CS0618 // Type or member is obsolete
-                                    }
-                                    else
-                                    {
-                                        matchKind = MatchKind.InvalidValue;
-                                    }
+                                    matchKind = MatchKind.InvalidValue;
                                 }
                             }
                             else // other parameter

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateGroupTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateGroupTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 },
                 new MockInvalidParameterInfo[]
                 {
-                    new MockInvalidParameterInfo(InvalidParameterInfo.Kind.AmbiguousParameterValue, "framework", "net")
+                    new MockInvalidParameterInfo(InvalidParameterInfo.Kind.InvalidParameterValue, "framework", "net")
                 }
             };
 
@@ -69,7 +69,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 },
                 new MockInvalidParameterInfo[]
                 {
-                    new MockInvalidParameterInfo(InvalidParameterInfo.Kind.AmbiguousParameterValue, "framework", "net")
+                    new MockInvalidParameterInfo(InvalidParameterInfo.Kind.InvalidParameterValue, "framework", "net")
                 }
             };
 
@@ -83,63 +83,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 },
                 new MockInvalidParameterInfo[]
                 {
-                    new MockInvalidParameterInfo(InvalidParameterInfo.Kind.AmbiguousParameterValue, "framework", "net"),
+                    new MockInvalidParameterInfo(InvalidParameterInfo.Kind.InvalidParameterValue, "framework", "net"),
                     new MockInvalidParameterInfo(InvalidParameterInfo.Kind.InvalidParameterName, "fake", null),
                     new MockInvalidParameterInfo(InvalidParameterInfo.Kind.InvalidParameterValue, "OtherChoice", "fake")
-                }
-            };
-        }
-
-        public static IEnumerable<object[]> GetAmbiguousSingleStartsWithParametersTestData()
-        {
-            yield return new object[]
-            {
-                new MockNewCommandInput("foo").WithTemplateOption("framework", "netcoreapp3.1"),
-                new MockTemplateInfo[]
-                {
-                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithChoiceParameter("framework", "netcoreapp2.1", "netcoreapp3.1"),
-                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithChoiceParameter("framework", "net5.0"),
-                },
-                System.Array.Empty<MockInvalidParameterInfo>()
-            };
-
-            yield return new object[]
-            {
-                new MockNewCommandInput("foo").WithTemplateOption("framework", "net"),
-                new MockTemplateInfo[]
-                {
-                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithChoiceParameter("framework", "netcoreapp2.1", "netcoreapp3.1"),
-                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithChoiceParameter("framework", "net5.0"),
-                },
-                System.Array.Empty<MockInvalidParameterInfo>()
-            };
-
-            yield return new object[]
-            {
-                new MockNewCommandInput("foo").WithTemplateOption("framework", "net"),
-                new MockTemplateInfo[]
-                {
-                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithChoiceParameter("framework", "netcoreapp2.1"),
-                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithChoiceParameter("framework", "net5.0"),
-                },
-                new MockInvalidParameterInfo[]
-                {
-                    new MockInvalidParameterInfo(InvalidParameterInfo.Kind.AmbiguousParameterValue, "framework", "net")
-                }
-            };
-
-            yield return new object[]
-            {
-                new MockNewCommandInput("foo").WithTemplateOption("framework", "net").WithTemplateOption("OtherChoice", "val1"),
-                new MockTemplateInfo[]
-                {
-                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithChoiceParameter("framework", "netcoreapp2.1").WithChoiceParameter("OtherChoice", "val1", "val2"),
-                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithChoiceParameter("framework", "net5.0").WithChoiceParameter("OtherChoice", "val1", "val2"),
-                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithChoiceParameter("framework", "net").WithChoiceParameter("OtherChoice", "val1", "val2"),
-                },
-                new MockInvalidParameterInfo[]
-                {
-                    new MockInvalidParameterInfo(InvalidParameterInfo.Kind.AmbiguousParameterValue, "framework", "net"),
                 }
             };
         }
@@ -233,22 +179,6 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
 
             TemplateGroup templateGroup = matchedTemplates.UnambiguousTemplateGroup;
             IEnumerable<InvalidParameterInfo> invalidParameters = templateGroup.GetInvalidParameterList();
-
-            Assert.Equal(expectedInvalidParams.Length, invalidParameters.Count());
-            foreach (MockInvalidParameterInfo exp in expectedInvalidParams)
-            {
-                Assert.Single(invalidParameters.Where(param => param.ErrorKind == exp.Kind && param.InputFormat == exp.InputFormat && param.SpecifiedValue == exp.SpecifiedValue));
-            }
-        }
-
-        [Theory(DisplayName = nameof(GetAmbiguousSingleStartsWithParametersTest))]
-        [MemberData(nameof(GetAmbiguousSingleStartsWithParametersTestData))]
-        internal void GetAmbiguousSingleStartsWithParametersTest(MockNewCommandInput command, MockTemplateInfo[] templates, MockInvalidParameterInfo[] expectedInvalidParams)
-        {
-            TemplateResolutionResult matchedTemplates = TemplateResolver.GetTemplateResolutionResult(templates, new MockHostSpecificDataLoader(), command, null);
-
-            TemplateGroup templateGroup = matchedTemplates.UnambiguousTemplateGroup;
-            IEnumerable<InvalidParameterInfo> invalidParameters = templateGroup.GetAmbiguousSingleStartsWithParameters();
 
             Assert.Equal(expectedInvalidParams.Length, invalidParameters.Count());
             foreach (MockInvalidParameterInfo exp in expectedInvalidParams)

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateMatchInfoTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateMatchInfoTests.cs
@@ -21,7 +21,6 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.False(WellKnownSearchFilters.MatchesAllCriteria(templateMatchInfo));
             Assert.False(WellKnownSearchFilters.MatchesAtLeastOneCriteria(templateMatchInfo));
             Assert.False(templateMatchInfo.IsInvokableMatch());
-            Assert.False(templateMatchInfo.HasAmbiguousParameterValueMatch());
             Assert.Empty(templateMatchInfo.GetInvalidParameterNames());
             Assert.Equal(0, templateMatchInfo.GetValidTemplateParameters().Count);
         }
@@ -35,7 +34,6 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.True(WellKnownSearchFilters.MatchesAllCriteria(templateMatchInfo));
             Assert.True(WellKnownSearchFilters.MatchesAtLeastOneCriteria(templateMatchInfo));
             Assert.True(templateMatchInfo.IsInvokableMatch());
-            Assert.False(templateMatchInfo.HasAmbiguousParameterValueMatch());
         }
 
         [Fact(DisplayName = nameof(NamePartialMatch_ReportsCorrectly))]
@@ -46,8 +44,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             templateMatchInfo.AddMatchDisposition(new MatchInfo(MatchInfo.BuiltIn.Name, "test", MatchKind.Partial));
             Assert.True(WellKnownSearchFilters.MatchesAllCriteria(templateMatchInfo));
             Assert.True(WellKnownSearchFilters.MatchesAtLeastOneCriteria(templateMatchInfo));
-            Assert.True(templateMatchInfo.IsInvokableMatch());
-            Assert.False(templateMatchInfo.HasAmbiguousParameterValueMatch());
+            Assert.False(templateMatchInfo.IsInvokableMatch());
+            Assert.True(templateMatchInfo.IsFilterableMatch());
         }
 
         [Fact(DisplayName = nameof(NameMismatch_ReportsCorrectly))]
@@ -59,7 +57,6 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.False(WellKnownSearchFilters.MatchesAllCriteria(templateMatchInfo));
             Assert.False(WellKnownSearchFilters.MatchesAtLeastOneCriteria(templateMatchInfo));
             Assert.False(templateMatchInfo.IsInvokableMatch());
-            Assert.False(templateMatchInfo.HasAmbiguousParameterValueMatch());
         }
 
         [Fact(DisplayName = nameof(TypeMatch_ReportsCorrectly))]
@@ -71,7 +68,6 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.True(WellKnownSearchFilters.MatchesAllCriteria(templateMatchInfo));
             Assert.True(WellKnownSearchFilters.MatchesAtLeastOneCriteria(templateMatchInfo));
             Assert.True(templateMatchInfo.IsInvokableMatch());
-            Assert.False(templateMatchInfo.HasAmbiguousParameterValueMatch());
         }
 
         [Fact(DisplayName = nameof(TypeMismatch_ReportsCorrectly))]
@@ -83,7 +79,6 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.False(WellKnownSearchFilters.MatchesAllCriteria(templateMatchInfo));
             Assert.False(WellKnownSearchFilters.MatchesAtLeastOneCriteria(templateMatchInfo));
             Assert.False(templateMatchInfo.IsInvokableMatch());
-            Assert.False(templateMatchInfo.HasAmbiguousParameterValueMatch());
         }
 
         [Fact(DisplayName = nameof(TypeMatch_NameMatch_ReportsCorrectly))]
@@ -96,7 +91,6 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.True(WellKnownSearchFilters.MatchesAllCriteria(templateMatchInfo));
             Assert.True(WellKnownSearchFilters.MatchesAtLeastOneCriteria(templateMatchInfo));
             Assert.True(templateMatchInfo.IsInvokableMatch());
-            Assert.False(templateMatchInfo.HasAmbiguousParameterValueMatch());
         }
 
         [Fact(DisplayName = nameof(TypeMatch_NameMismatch_ReportsCorrectly))]
@@ -109,7 +103,6 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.False(WellKnownSearchFilters.MatchesAllCriteria(templateMatchInfo));
             Assert.True(WellKnownSearchFilters.MatchesAtLeastOneCriteria(templateMatchInfo));
             Assert.False(templateMatchInfo.IsInvokableMatch());
-            Assert.False(templateMatchInfo.HasAmbiguousParameterValueMatch());
         }
 
         [Fact(DisplayName = nameof(TypeMatch_NamePartialMatch_ReportsCorrectly))]
@@ -121,8 +114,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             templateMatchInfo.AddMatchDisposition(new MatchInfo(MatchInfo.BuiltIn.Type, "test", MatchKind.Exact));
             Assert.True(WellKnownSearchFilters.MatchesAllCriteria(templateMatchInfo));
             Assert.True(WellKnownSearchFilters.MatchesAtLeastOneCriteria(templateMatchInfo));
-            Assert.True(templateMatchInfo.IsInvokableMatch());
-            Assert.False(templateMatchInfo.HasAmbiguousParameterValueMatch());
+            Assert.False(templateMatchInfo.IsInvokableMatch());
+            Assert.True(templateMatchInfo.IsFilterableMatch());
         }
 
         [Fact(DisplayName = nameof(TypeMismatch_NameMatch_ReportsCorrectly))]
@@ -135,7 +128,6 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.False(WellKnownSearchFilters.MatchesAllCriteria(templateMatchInfo));
             Assert.True(WellKnownSearchFilters.MatchesAtLeastOneCriteria(templateMatchInfo));
             Assert.False(templateMatchInfo.IsInvokableMatch());
-            Assert.False(templateMatchInfo.HasAmbiguousParameterValueMatch());
         }
 
         [Fact(DisplayName = nameof(TypeMismatch_NamePartialMatch_ReportsCorrectly))]
@@ -148,7 +140,6 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.False(WellKnownSearchFilters.MatchesAllCriteria(templateMatchInfo));
             Assert.True(WellKnownSearchFilters.MatchesAtLeastOneCriteria(templateMatchInfo));
             Assert.False(templateMatchInfo.IsInvokableMatch());
-            Assert.False(templateMatchInfo.HasAmbiguousParameterValueMatch());
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateResolverTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateResolverTests.cs
@@ -334,7 +334,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                                     .WithChoiceParameter("MyChoice", "value_2")
                 },
                 null,
-                TemplateResolutionResult.Status.AmbiguousParameterValueChoice,
+                TemplateResolutionResult.Status.InvalidParameter,
                 null
             };
 
@@ -350,7 +350,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                                     .WithChoiceParameter("MyChoice", "value_2", "value_3")
                 },
                 null,
-                TemplateResolutionResult.Status.AmbiguousParameterValueChoice,
+                TemplateResolutionResult.Status.InvalidParameter,
                 null
             };
 
@@ -366,7 +366,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                                     .WithChoiceParameter("MyChoice", "value_3", "value_4")
                 },
                 null,
-                TemplateResolutionResult.Status.AmbiguousParameterValueChoice,
+                TemplateResolutionResult.Status.InvalidParameter,
                 null
             };
 
@@ -521,20 +521,20 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                     new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group", precedence: 200).WithChoiceParameter("MyChoice", "value_2"),
             };
 
-            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousParameterValueChoice, null };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.Status.InvalidParameter, null };
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group", precedence: 100).WithChoiceParameter("MyChoice", "value_1"),
                     new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group", precedence: 200).WithChoiceParameter("MyChoice", "value_2", "value_3"),
             };
-            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousParameterValueChoice, null };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.Status.InvalidParameter, null };
 
             templates = new MockTemplateInfo[]
             {
                     new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group", precedence: 100).WithChoiceParameter("MyChoice", "value_1", "value_2"),
                     new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group", precedence: 200).WithChoiceParameter("MyChoice", "value_3", "value_4"),
             };
-            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.Status.AmbiguousParameterValueChoice, null };
+            yield return new object?[] { new MockNewCommandInput("foo").WithTemplateOption("MyChoice", "value_"), templates, null, (int)TemplateResolutionResult.Status.InvalidParameter, null };
 
             templates = new MockTemplateInfo[]
             {

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
@@ -188,7 +188,8 @@ namespace Dotnet_new3.IntegrationTests
                 .Fail()
                 .And.NotHaveStdOut()
                 .And.HaveStdErrContaining("Error: Invalid option(s):")
-                .And.HaveStdErrContaining("   The value 'netcoreapp' is ambiguous for option --framework. The possible values are:")
+                .And.HaveStdErrContaining("--framework netcoreapp")
+                .And.HaveStdErrContaining("   'netcoreapp' is not a valid value for --framework. The possible values are:")
                 .And.HaveStdErrContaining("      netcoreapp2.1   - Target netcoreapp2.1")
                 .And.HaveStdErrContaining("      netcoreapp3.1   - Target netcoreapp3.1")
                 .And.HaveStdErrContaining("For more information, run 'dotnet new3 console --help'.");
@@ -201,7 +202,7 @@ namespace Dotnet_new3.IntegrationTests
                 .Fail()
                 .And.NotHaveStdOut()
                 .And.HaveStdErrContaining("Error: Invalid option(s):")
-                .And.HaveStdErrContaining("   The value 'netcoreapp' is ambiguous for option --framework. The possible values are:")
+                .And.HaveStdErrContaining("   'netcoreapp' is not a valid value for --framework. The possible values are:")
                 .And.HaveStdErrContaining("      netcoreapp2.1   - Target netcoreapp2.1")
                 .And.HaveStdErrContaining("      netcoreapp3.1   - Target netcoreapp3.1")
                 .And.HaveStdErrContaining("   '--fake' is not a valid option")


### PR DESCRIPTION
### Problem
fixes dotnet/templating #3114

### Solution
 Disabled partial matching for template option value, removed not needed code, adjusted unit tests

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)