### PR TITLE
Turn on loc PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ stages:
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
-        CreatePr: false
+        MirrorRepo: templating
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-TEMPLATING'
   - template: /eng/common/templates/jobs/jobs.yml


### PR DESCRIPTION
### Problem
Currently OneLocBuild does not automatically make PRs back to GitHub with translations.

### Solution
This turns on automatic PRs back to GitHub. See documentation [here](https://github.com/dotnet/arcade/blob/main/Documentation/OneLocBuild.md).

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)