### PR TITLE
Introduce ITemplateInfoHostJsonCache

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HostSpecificDataLoader.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HostSpecificDataLoader.cs
@@ -4,6 +4,7 @@
 using System.IO;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -24,6 +25,11 @@ namespace Microsoft.TemplateEngine.Cli
         public HostSpecificTemplateData ReadHostSpecificTemplateData(ITemplateInfo templateInfo)
         {
             IMountPoint? mountPoint = null;
+
+            if (templateInfo is ITemplateInfoHostJsonCache withCache)
+            {
+                return withCache.HostData?.ToObject<HostSpecificTemplateData>() ?? HostSpecificTemplateData.Default;
+            }
 
             try
             {

--- a/src/Microsoft.TemplateEngine.Cli/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Cli/PublicAPI.Shipped.txt
@@ -8,7 +8,6 @@ Microsoft.TemplateEngine.Cli.HostSpecificDataLoader.ReadHostSpecificTemplateData
 Microsoft.TemplateEngine.Cli.HostSpecificTemplateData
 Microsoft.TemplateEngine.Cli.HostSpecificTemplateData.HiddenParameterNames.get -> System.Collections.Generic.HashSet<string!>!
 Microsoft.TemplateEngine.Cli.HostSpecificTemplateData.IsHidden.get -> bool
-Microsoft.TemplateEngine.Cli.HostSpecificTemplateData.IsHidden.set -> void
 Microsoft.TemplateEngine.Cli.HostSpecificTemplateData.LongNameOverrides.get -> System.Collections.Generic.Dictionary<string!, string!>!
 Microsoft.TemplateEngine.Cli.HostSpecificTemplateData.ParametersToAlwaysShow.get -> System.Collections.Generic.HashSet<string!>!
 Microsoft.TemplateEngine.Cli.HostSpecificTemplateData.ShortNameOverrides.get -> System.Collections.Generic.Dictionary<string!, string!>!

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvocationCoordinator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.TemplateEngine.Cli
             _templatePackageManager = templatePackageManager ?? throw new ArgumentNullException(nameof(templatePackageManager));
             _templateInformationCoordinator = templateInformationCoordinator ?? throw new ArgumentNullException(nameof(templateInformationCoordinator));
             _hostSpecificDataLoader = hostSpecificDataLoader ?? throw new ArgumentNullException(nameof(hostSpecificDataLoader));
-            _invoker = new TemplateInvoker(_environment, _telemetryLogger, _inputGetter, _callbacks);
+            _invoker = new TemplateInvoker(_environment, _telemetryLogger, _inputGetter, _callbacks, _hostSpecificDataLoader);
         }
 
         internal async Task<New3CommandStatus> CoordinateInvocationAsync(INewCommandInput commandInput, CancellationToken cancellationToken)

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -32,7 +32,12 @@ namespace Microsoft.TemplateEngine.Cli
         private readonly IHostSpecificDataLoader _hostDataLoader;
         private readonly PostActionDispatcher _postActionDispatcher;
 
-        internal TemplateInvoker(IEngineEnvironmentSettings environment, ITelemetryLogger telemetryLogger, Func<string> inputGetter, New3Callbacks callbacks)
+        internal TemplateInvoker(
+            IEngineEnvironmentSettings environment,
+            ITelemetryLogger telemetryLogger,
+            Func<string> inputGetter,
+            New3Callbacks callbacks,
+            IHostSpecificDataLoader hostDataLoader)
         {
             _environment = environment;
             _telemetryLogger = telemetryLogger;
@@ -40,7 +45,7 @@ namespace Microsoft.TemplateEngine.Cli
             _callbacks = callbacks;
 
             _templateCreator = new TemplateCreator(_environment);
-            _hostDataLoader = new HostSpecificDataLoader(_environment);
+            _hostDataLoader = hostDataLoader;
             _postActionDispatcher = new PostActionDispatcher(_environment, _callbacks, _inputGetter);
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateInfoWithGroupShortNames.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/TemplateInfoWithGroupShortNames.cs
@@ -7,6 +7,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Cli.TemplateResolution
 {
@@ -14,7 +16,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
     /// In addition to <see cref="ITemplateInfo"/> the class contains <see cref="GroupShortNameList"/> property which contains the short names of other templates in the template group.
     /// The class is used for template filtering using specific TemplateResolver.CliNameFilter which takes into account the short names of template group when matching names.
     /// </summary>
-    internal class TemplateInfoWithGroupShortNames : ITemplateInfo
+    internal class TemplateInfoWithGroupShortNames : ITemplateInfo, ITemplateInfoHostJsonCache
     {
         private ITemplateInfo _parent;
 
@@ -70,6 +72,8 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         public IReadOnlyDictionary<string, IBaselineInfo> BaselineInfo => _parent.BaselineInfo;
 
         public IReadOnlyDictionary<string, string> TagsCollection => _parent.TagsCollection;
+
+        public JObject? HostData => (_parent as ITemplateInfoHostJsonCache)?.HostData;
 
         bool ITemplateInfo.HasScriptRunningPostActions { get; set; }
 

--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;

--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsData.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsData.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions.Installer;
-using Newtonsoft.Json;
 
 namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
 {

--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsData.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsData.cs
@@ -13,13 +13,5 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
     internal sealed class GlobalSettingsData
     {
         public IReadOnlyList<TemplatePackageData> Packages { get; set; }
-
-        /// <summary>
-        /// If older TemplateEngine loads this file and saves it back
-        /// it will include new settings that new TemplateEngine depends on,
-        /// without this field, data would be lost in process of loading and saving.
-        /// </summary>
-        [JsonExtensionData]
-        public IDictionary<string, Newtonsoft.Json.Linq.JToken> AdditionalData { get; set; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Shipped.txt
@@ -42,8 +42,6 @@ Microsoft.TemplateEngine.Edge.Settings.Scanner.Scanner(Microsoft.TemplateEngine.
 Microsoft.TemplateEngine.Edge.Settings.ScanResult
 Microsoft.TemplateEngine.Edge.Settings.ScanResult.Components.get -> System.Collections.Generic.IReadOnlyList<(string! AssemblyPath, System.Type! InterfaceType, Microsoft.TemplateEngine.Abstractions.IIdentifiedComponent! Instance)>!
 Microsoft.TemplateEngine.Edge.Settings.ScanResult.Localizations.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ILocalizationLocator!>!
-Microsoft.TemplateEngine.Edge.Settings.ScanResult.MountPointUri.get -> string!
-Microsoft.TemplateEngine.Edge.Settings.ScanResult.ScanResult(string! mountPointUri, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ITemplate!>! templates, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ILocalizationLocator!>! localizations, System.Collections.Generic.IReadOnlyList<(string! AssemblyPath, System.Type! InterfaceType, Microsoft.TemplateEngine.Abstractions.IIdentifiedComponent! Instance)>! components) -> void
 Microsoft.TemplateEngine.Edge.Settings.ScanResult.Templates.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ITemplate!>!
 Microsoft.TemplateEngine.Edge.Settings.TemplatePackageManager
 Microsoft.TemplateEngine.Edge.Settings.TemplatePackageManager.Dispose() -> void
@@ -144,7 +142,6 @@ static Microsoft.TemplateEngine.Edge.TemplateListFilter.FilterTemplates(System.C
 static Microsoft.TemplateEngine.Edge.TemplateListFilter.GetTemplateMatchInfo(System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!>! templateList, System.Func<Microsoft.TemplateEngine.Abstractions.TemplateFiltering.ITemplateMatchInfo!, bool>! matchFilter, params System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo?>![]! filters) -> System.Collections.Generic.IReadOnlyCollection<Microsoft.TemplateEngine.Abstractions.TemplateFiltering.ITemplateMatchInfo!>!
 static Microsoft.TemplateEngine.Edge.TemplateListFilter.GetTemplateMatchInfo(System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!>! templateList, System.Func<Microsoft.TemplateEngine.Edge.Template.ITemplateMatchInfo!, bool>! matchFilter, params System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Edge.Template.MatchInfo?>![]! filters) -> System.Collections.Generic.IReadOnlyCollection<Microsoft.TemplateEngine.Edge.Template.ITemplateMatchInfo!>!
 static Microsoft.TemplateEngine.Edge.TemplateListFilter.PartialMatchFilter.get -> System.Func<Microsoft.TemplateEngine.Edge.Template.ITemplateMatchInfo!, bool>!
-static readonly Microsoft.TemplateEngine.Edge.Settings.ScanResult.Empty -> Microsoft.TemplateEngine.Edge.Settings.ScanResult!
 virtual Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.BuiltInComponents.get -> System.Collections.Generic.IReadOnlyList<(System.Type! InterfaceType, Microsoft.TemplateEngine.Abstractions.IIdentifiedComponent! Instance)>!
 virtual Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.TryGetHostParamDefault(string! paramName, out string? value) -> bool
 ~Microsoft.TemplateEngine.Edge.FilterableTemplateInfo.Author.get -> string

--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
@@ -11,3 +11,8 @@ Microsoft.TemplateEngine.Edge.DefaultPathInfo.GlobalSettingsDir.get -> string!
 Microsoft.TemplateEngine.Edge.DefaultPathInfo.HostSettingsDir.get -> string!
 Microsoft.TemplateEngine.Edge.DefaultPathInfo.HostVersionSettingsDir.get -> string!
 Microsoft.TemplateEngine.Edge.DefaultPathInfo.UserProfileDir.get -> string!
+Microsoft.TemplateEngine.Edge.Settings.ITemplateInfoHostJsonCache
+Microsoft.TemplateEngine.Edge.Settings.ITemplateInfoHostJsonCache.HostData.get -> Newtonsoft.Json.Linq.JObject?
+Microsoft.TemplateEngine.Edge.Settings.ScanResult.Dispose() -> void
+Microsoft.TemplateEngine.Edge.Settings.ScanResult.MountPoint.get -> Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint!
+Microsoft.TemplateEngine.Edge.Settings.ScanResult.ScanResult(Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint! mountPoint, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ITemplate!>! templates, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ILocalizationLocator!>! localizations, System.Collections.Generic.IReadOnlyList<(string! AssemblyPath, System.Type! InterfaceType, Microsoft.TemplateEngine.Abstractions.IIdentifiedComponent! Instance)>! components) -> void

--- a/src/Microsoft.TemplateEngine.Edge/Settings/ITemplateInfoHostJsonCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/ITemplateInfoHostJsonCache.cs
@@ -1,0 +1,21 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Microsoft.TemplateEngine.Abstractions;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Edge.Settings
+{
+    /// <summary>
+    /// Extension interface of <see cref="ITemplateInfo"/> which stores .host.json data in cache so host doesn't need to re-load it from .nupkg every time.
+    /// </summary>
+    public interface ITemplateInfoHostJsonCache
+    {
+        /// <summary>
+        /// Full content of .host.json file.
+        /// </summary>
+        JObject? HostData { get; }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/ScanResult.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/ScanResult.cs
@@ -6,38 +6,32 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Mount;
 
 namespace Microsoft.TemplateEngine.Edge.Settings
 {
     /// <summary>
     /// Returned by <see cref="Scanner.Scan"/>.
     /// </summary>
-    public class ScanResult
+    public class ScanResult : IDisposable
     {
-        public static readonly ScanResult Empty = new(
-            string.Empty,
-            Array.Empty<ITemplate>(),
-            Array.Empty<ILocalizationLocator>(),
-            Array.Empty<(string AssemblyPath, Type InterfaceType, IIdentifiedComponent Instance)>()
-            );
-
         public ScanResult(
-            string mountPointUri,
+            IMountPoint mountPoint,
             IReadOnlyList<ITemplate> templates,
             IReadOnlyList<ILocalizationLocator> localizations,
             IReadOnlyList<(string AssemblyPath, Type InterfaceType, IIdentifiedComponent Instance)> components
             )
         {
-            MountPointUri = mountPointUri;
+            MountPoint = mountPoint;
             Templates = templates;
             Localizations = localizations;
             Components = components;
         }
 
         /// <summary>
-        /// Uri of mountpoint that was scanned.
+        /// Mountpoint that was scanned.
         /// </summary>
-        public string MountPointUri { get; }
+        public IMountPoint MountPoint { get; }
 
         /// <summary>
         /// All components found inside mountpoint.
@@ -56,5 +50,10 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         /// All templates found inside mountpoint.
         /// </summary>
         public IReadOnlyList<ITemplate> Templates { get; }
+
+        /// <summary>
+        /// Disposes <see cref="MountPoint"/> that was scanned.
+        /// </summary>
+        public void Dispose() => MountPoint.Dispose();
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/ScanResult.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/ScanResult.cs
@@ -29,7 +29,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         }
 
         /// <summary>
-        /// Mountpoint that was scanned.
+        /// Gets the mount point that was scanned.
         /// </summary>
         public IMountPoint MountPoint { get; }
 

--- a/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
@@ -38,6 +38,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         /// <summary>
         /// Scans mount point for templates, localizations and components.
         /// </summary>
+        /// <remarks>
+        /// The mount point will not be disposed by the <see cref="Scanner"/>. Use <see cref="ScanResult.Dispose"/> to dispose mount point.
+        /// </remarks>
         public ScanResult Scan(string mountPointUri)
         {
             if (string.IsNullOrWhiteSpace(mountPointUri))

--- a/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
@@ -47,11 +47,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             MountPointScanSource source = GetOrCreateMountPointScanInfoForInstallSource(mountPointUri);
 
             ScanForComponents(source);
-            var scanResult = ScanMountPointForTemplatesAndLangpacks(source);
-
-            source.MountPoint.Dispose();
-
-            return scanResult;
+            return ScanMountPointForTemplatesAndLangpacks(source);
         }
 
         private MountPointScanSource GetOrCreateMountPointScanInfoForInstallSource(string sourceLocation)
@@ -194,7 +190,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 source.FoundTemplates |= templateList.Count > 0 || localizationInfo.Count > 0;
             }
 
-            return new ScanResult(source.MountPoint.MountPointUri, templates, localizationLocators, Array.Empty<(string, Type, IIdentifiedComponent)>());
+            return new ScanResult(source.MountPoint, templates, localizationLocators, Array.Empty<(string, Type, IIdentifiedComponent)>());
         }
 
         /// <summary>

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 {
     internal class TemplateCache
     {
-        public TemplateCache(IEnumerable<ScanResult> scanResults, Dictionary<string, DateTime> mountPoints)
+        public TemplateCache(ScanResult?[] scanResults, Dictionary<string, DateTime> mountPoints)
         {
             // We need this dictionary to de-duplicate templates that have same identity
             // notice that IEnumerable<ScanResult> that we get in is order by priority which means
@@ -27,6 +27,10 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
             foreach (var scanResult in scanResults)
             {
+                if (scanResult == null)
+                {
+                    continue;
+                }
                 foreach (ILocalizationLocator locator in scanResult.Localizations)
                 {
                     if (uiLocale != locator.Locale &&

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -101,7 +101,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             {
                 foreach (var entry in dict)
                 {
-                    mountPointInfo.Add(entry.Key, entry.Value.ToObject<DateTime>());
+                    mountPointInfo.Add(entry.Key, entry.Value.Value<DateTime>());
                 }
             }
 

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
@@ -72,7 +72,8 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         /// </summary>
         /// <param name="template">unlocalized template.</param>
         /// <param name="localizationInfo">localization information.</param>
-        internal TemplateInfo(ITemplate template, ILocalizationLocator? localizationInfo)
+        /// <param name="logger"></param>
+        internal TemplateInfo(ITemplate template, ILocalizationLocator? localizationInfo, ILogger logger)
         {
             if (template is null)
             {
@@ -112,7 +113,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 }
                 catch (Exception ex)
                 {
-                    template.TemplateSourceRoot.MountPoint.EnvironmentSettings.Host.Logger.LogDebug(ex, $"Failed to load HostConfig in {template.TemplateSourceRoot.MountPoint.MountPointUri} at {template.HostConfigPlace}.");
+                    logger.LogDebug(ex, $"Failed to load HostConfig in {template.TemplateSourceRoot.MountPoint.MountPointUri} at {template.HostConfigPlace}.");
                 }
             }
         }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReader.cs
@@ -89,6 +89,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     }
                     info.TagsCollection = tags;
                 }
+
+                info.HostData = entry.Get<JObject>(nameof(info.HostData));
+
                 return info;
             }
 

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
@@ -294,7 +294,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 return cache;
             }
 
-            var scanResults = new ScanResult[allTemplatePackages.Count];
+            var scanResults = new ScanResult?[allTemplatePackages.Count];
             Parallel.For(0, allTemplatePackages.Count, (int index) =>
             {
                 try
@@ -304,7 +304,6 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 }
                 catch (Exception ex)
                 {
-                    scanResults[index] = ScanResult.Empty;
                     _logger.LogWarning(LocalizableStrings.TemplatePackageManager_Error_FailedToScan, allTemplatePackages[index].MountPointUri, ex);
                 }
             });
@@ -313,6 +312,10 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 scanResults,
                 mountPoints
                 );
+            foreach (var scanResult in scanResults)
+            {
+                scanResult?.Dispose();
+            }
             JObject serialized = JObject.FromObject(cache);
             _paths.WriteAllText(_paths.TemplateCacheFile, serialized.ToString());
             return _userTemplateCache = cache;

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
@@ -235,7 +235,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             Task<IReadOnlyList<ITemplatePackage>> getTemplatePackagesTask = GetTemplatePackagesAsync(needsRebuild, cancellationToken);
             if (!(_userTemplateCache is TemplateCache cache))
             {
-                cache = new TemplateCache(JObject.Parse(_paths.ReadAllText(_paths.TemplateCacheFile, "{}")));
+                cache = new TemplateCache(JObject.Parse(_paths.ReadAllText(_paths.TemplateCacheFile, "{}")), _logger);
             }
 
             if (cache.Version == null)
@@ -308,10 +308,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 }
             });
             cancellationToken.ThrowIfCancellationRequested();
-            cache = new TemplateCache(
-                scanResults,
-                mountPoints
-                );
+            cache = new TemplateCache(scanResults, mountPoints, _logger);
             foreach (var scanResult in scanResults)
             {
                 scanResult?.Dispose();

--- a/src/Microsoft.TemplateEngine.Utils/IFileSystemInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Utils/IFileSystemInfoExtensions.cs
@@ -6,9 +6,9 @@
 using System.IO;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 
-namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
+namespace Microsoft.TemplateEngine.Utils
 {
-    internal static class IFileSystemInfoExtensions
+    public static class IFileSystemInfoExtensions
     {
         /// <summary>
         /// Returns full path to <paramref name="fileSystemInfo"/> including mount point URI in a format
@@ -20,7 +20,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         /// Full path to <paramref name="fileSystemInfo"/> including mount point URI.
         /// If mount point is not a directory, the path is returned as 'mount point URI(path inside mount point)'.
         /// </returns>
-        internal static string GetDisplayPath(this IFileSystemInfo fileSystemInfo)
+        public static string GetDisplayPath(this IFileSystemInfo fileSystemInfo)
         {
             string result = string.Empty;
             if (fileSystemInfo.MountPoint.EnvironmentSettings.Host.FileSystem.DirectoryExists(fileSystemInfo.MountPoint.MountPointUri))

--- a/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
-﻿
+﻿Microsoft.TemplateEngine.Utils.IFileSystemInfoExtensions
+static Microsoft.TemplateEngine.Utils.IFileSystemInfoExtensions.GetDisplayPath(this Microsoft.TemplateEngine.Abstractions.Mount.IFileSystemInfo! fileSystemInfo) -> string!

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/HostDataLoaderTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/HostDataLoaderTests.cs
@@ -1,0 +1,116 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.IO;
+using FakeItEasy;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.TestHelper;
+using Microsoft.TemplateEngine.Utils;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests
+{
+    public class HostDataLoaderTests : IClassFixture<EnvironmentSettingsHelper>
+    {
+        private readonly EnvironmentSettingsHelper _environmentSettingsHelper;
+
+        public HostDataLoaderTests(EnvironmentSettingsHelper environmentSettingsHelper)
+        {
+            _environmentSettingsHelper = environmentSettingsHelper;
+        }
+
+        [Fact]
+        public void CanLoadHostDataFile()
+        {
+            IEngineEnvironmentSettings engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            HostSpecificDataLoader hostSpecificDataLoader = new HostSpecificDataLoader(engineEnvironmentSettings);
+            Assert.True(engineEnvironmentSettings.TryGetMountPoint(Directory.GetCurrentDirectory(), out IMountPoint? mountPoint));
+            Assert.NotNull(mountPoint);
+            IFile dataFile = mountPoint!.FileInfo("/Resources/dotnetcli.host.json");
+
+            ITemplateInfo template = A.Fake<ITemplateInfo>();
+            A.CallTo(() => template.MountPointUri).Returns(Directory.GetCurrentDirectory());
+            A.CallTo(() => template.HostConfigPlace).Returns("/Resources/dotnetcli.host.json");
+
+            HostSpecificTemplateData data = hostSpecificDataLoader.ReadHostSpecificTemplateData(template);
+            Assert.NotNull(data);
+
+            Assert.False(data.IsHidden);
+            Assert.Equal(2, data.UsageExamples?.Count);
+            Assert.Contains("--framework netcoreapp3.1 --langVersion '9.0'", data.UsageExamples);
+            Assert.Equal(4, data.SymbolInfo?.Count);
+            Assert.Contains("TargetFrameworkOverride", data.HiddenParameterNames);
+            Assert.Contains("Framework", data.ParametersToAlwaysShow);
+            Assert.True(data.LongNameOverrides.ContainsKey("skipRestore"));
+            Assert.Equal("no-restore", data.LongNameOverrides["skipRestore"]);
+            Assert.True(data.ShortNameOverrides.ContainsKey("skipRestore"));
+            Assert.Equal("", data.ShortNameOverrides["skipRestore"]);
+            Assert.Equal("no-restore", data.DisplayNameForParameter("skipRestore"));
+        }
+
+        [Fact]
+        public void CanReadHostDataFromITemplateInfo()
+        {
+            IEngineEnvironmentSettings engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            HostSpecificDataLoader hostSpecificDataLoader = new HostSpecificDataLoader(engineEnvironmentSettings);
+            Assert.True(engineEnvironmentSettings.TryGetMountPoint(Directory.GetCurrentDirectory(), out IMountPoint? mountPoint));
+            Assert.NotNull(mountPoint);
+            IFile dataFile = mountPoint!.FileInfo("/Resources/dotnetcli.host.json");
+            JObject json = dataFile.ReadJObjectFromIFile();
+
+            ITemplateInfo template = A.Fake<ITemplateInfo>(builder => builder.Implements<ITemplateInfoHostJsonCache>().Implements<ITemplateInfo>());
+            A.CallTo(() => ((ITemplateInfoHostJsonCache)template).HostData).Returns(json);
+
+            HostSpecificTemplateData data = hostSpecificDataLoader.ReadHostSpecificTemplateData(template);
+            Assert.NotNull(data);
+
+            Assert.False(data.IsHidden);
+            Assert.Equal(2, data.UsageExamples?.Count);
+            Assert.Contains("--framework netcoreapp3.1 --langVersion '9.0'", data.UsageExamples);
+            Assert.Equal(4, data.SymbolInfo?.Count);
+            Assert.Contains("TargetFrameworkOverride", data.HiddenParameterNames);
+            Assert.Contains("Framework", data.ParametersToAlwaysShow);
+            Assert.True(data.LongNameOverrides.ContainsKey("skipRestore"));
+            Assert.Equal("no-restore", data.LongNameOverrides["skipRestore"]);
+            Assert.True(data.ShortNameOverrides.ContainsKey("skipRestore"));
+            Assert.Equal("", data.ShortNameOverrides["skipRestore"]);
+            Assert.Equal("no-restore", data.DisplayNameForParameter("skipRestore"));
+        }
+
+        [Fact]
+        public void ReturnDefaultForInvalidEntry()
+        {
+            IEngineEnvironmentSettings engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            HostSpecificDataLoader hostSpecificDataLoader = new HostSpecificDataLoader(engineEnvironmentSettings);
+
+            ITemplateInfo template = A.Fake<ITemplateInfo>(builder => builder.Implements<ITemplateInfoHostJsonCache>().Implements<ITemplateInfo>());
+            A.CallTo(() => ((ITemplateInfoHostJsonCache)template).HostData).Returns(null);
+
+            HostSpecificTemplateData data = hostSpecificDataLoader.ReadHostSpecificTemplateData(template);
+            Assert.NotNull(data);
+            Assert.Equal(HostSpecificTemplateData.Default, data);
+        }
+
+        [Fact]
+        public void ReturnDefaultForInvalidFile()
+        {
+            IEngineEnvironmentSettings engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            HostSpecificDataLoader hostSpecificDataLoader = new HostSpecificDataLoader(engineEnvironmentSettings);
+
+            ITemplateInfo template = A.Fake<ITemplateInfo>();
+            A.CallTo(() => template.MountPointUri).Returns(Directory.GetCurrentDirectory());
+            A.CallTo(() => template.HostConfigPlace).Returns("unknown");
+
+            HostSpecificTemplateData data = hostSpecificDataLoader.ReadHostSpecificTemplateData(template);
+            Assert.NotNull(data);
+            Assert.Equal(HostSpecificTemplateData.Default, data);
+        }
+
+    }
+}

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
@@ -18,4 +18,10 @@
     <ProjectReference Include="$(TestDir)Microsoft.TemplateEngine.Mocks\Microsoft.TemplateEngine.Mocks.csproj" />
     <ProjectReference Include="$(TestDir)Microsoft.TemplateEngine.TestHelper\Microsoft.TemplateEngine.TestHelper.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Resources\dotnetcli.host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/Resources/dotnetcli.host.json
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/Resources/dotnetcli.host.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "TargetFrameworkOverride": {
+      "isHidden": "true",
+      "longName": "target-framework-override",
+      "shortName": ""
+    },
+    "Framework": {
+        "longName": "framework",
+        "alwaysShow" :  true
+    },
+    "skipRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    },
+    "langVersion": {
+      "longName": "langVersion",
+      "shortName": ""
+    }
+  },
+    "usageExamples": [
+        "--framework net5.0",
+        "--framework netcoreapp3.1 --langVersion '9.0'"
+    ]
+}


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/2742
During resolution of templates Microsoft.TemplateEngine.Cli.HostSpecificDataLoader.ReadHostSpecificTemplateData is called which is slows since it needs to open zip files to check host .json file... Find a way to cache this data in templateCache

### Solution
Introduce ITemplateInfoHostJsonCache that can also be used by VisualStudio and other hosts and store this data in templateCache.json.

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)