### PR TITLE
reverted setting CheckForOverflowUnderflow in project file for app and classlib template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/App-CSharp/Company.Application1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/App-CSharp/Company.Application1.csproj
@@ -6,7 +6,6 @@
     <TargetFramework Condition="'$(target-framework-override)' != ''">target-framework-override</TargetFramework>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
     <Nullable Condition="'$(nullable)' == 'true'">enable</Nullable>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/Company.ClassLibrary1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/Company.ClassLibrary1.csproj
@@ -6,7 +6,6 @@
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ClassLibrary1</RootNamespace>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
     <Nullable Condition="'$(Nullable)' == 'true'">enable</Nullable>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
   </PropertyGroup>
 
 </Project>

--- a/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
+++ b/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
@@ -224,7 +224,7 @@ Restore succeeded\.");
 
         [Theory]
         [InlineData("Nullable", "enable", "Simple Console Application", "app", null, null)]
-        [InlineData("CheckForOverflowUnderflow", "true", "Simple Console Application", "app", null, null)]
+        [InlineData("CheckForOverflowUnderflow", null, "Simple Console Application", "app", null, null)]
         [InlineData("LangVersion", null, "Simple Console Application", "app", null, null)]
         [InlineData("TargetFramework", "net6.0", "Simple Console Application", "app", null, null)]
 
@@ -245,7 +245,7 @@ Restore succeeded\.");
         [InlineData("TargetFramework", "net6.0", "Console Application", "console", "VB", null)]
 
         [InlineData("Nullable", "enable", "Class Library", "classlib", null, null)]
-        [InlineData("CheckForOverflowUnderflow", "true", "Class Library", "classlib", null, null)]
+        [InlineData("CheckForOverflowUnderflow", null, "Class Library", "classlib", null, null)]
         [InlineData("LangVersion", null, "Class Library", "classlib", null, null)]
         [InlineData("TargetFramework", "net6.0", "Class Library", "classlib", null, null)]
 


### PR DESCRIPTION
## Description

We added integer overflow checking to templates because very most users do not know what happens when you add 1 to an integer max value (or subtract 1 from an integer min value). We have encountered internal questions about changing a feature that has been in place so long, and one external customer that had more broken tests than expected when he added this manually to an existing project

## Customer Impact

No. This feature was recently added and has not appeared in previous preview releases.

## Regression?
- [ ] Yes
- [x] No

Not a regression. It's a new feature we want to roll out with more PM effort later.

## Risk
- [ ] High
- [ ] Medium
- [x] Low

Very low. We are reverting to a previous state.

## Verification
- [x] Manual (required)
- [x] Automated

Tested manually and in automated tests.