### PR TITLE
Fix cache not being set if nothing changed in TemplatePackageManager

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Alias/AliasRegistry.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Alias/AliasRegistry.cs
@@ -141,8 +141,7 @@ namespace Microsoft.TemplateEngine.Cli.Alias
                 _aliases = new AliasModel();
                 return;
             }
-            string sourcesText = _environmentSettings.Host.FileSystem.ReadAllText(_aliasesFilePath);
-            JObject parsed = JObject.Parse(sourcesText);
+            JObject parsed = _environmentSettings.Host.FileSystem.ReadObject(_aliasesFilePath);
             IReadOnlyDictionary<string, IReadOnlyList<string>> commandAliases = ToStringListDictionary(parsed, StringComparer.OrdinalIgnoreCase, "CommandAliases");
 
             _aliases = new AliasModel(commandAliases);
@@ -150,8 +149,14 @@ namespace Microsoft.TemplateEngine.Cli.Alias
 
         private void Save()
         {
-            JObject serialized = JObject.FromObject(_aliases);
-            _environmentSettings.Host.FileSystem.WriteAllText(_aliasesFilePath, serialized.ToString());
+            if (_aliases is AliasModel { CommandAliases: { Count: > 0 } })
+            {
+                _environmentSettings.Host.FileSystem.WriteObject(_aliasesFilePath, _aliases);
+            }
+            else
+            {
+                _environmentSettings.Host.FileSystem.FileDelete(_aliasesFilePath);
+            }
         }
 
         // reads a dictionary whose values can either be string literals, or arrays of strings.

--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -7,6 +7,9 @@
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Shared\JExtensions.cs" Link="JExtensions.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="CommandParsing\NewCommandInputCli.cs" />

--- a/src/Microsoft.TemplateEngine.Edge/EngineEnvironmentSettings.cs
+++ b/src/Microsoft.TemplateEngine.Edge/EngineEnvironmentSettings.cs
@@ -51,6 +51,11 @@ namespace Microsoft.TemplateEngine.Edge
                 Host.VirtualizeDirectory(Paths.GlobalSettingsDir);
             }
             Components = componentManager ?? new ComponentManager(this);
+            // In past we created this folder as some file was created
+            // Checking if folder exists/create folder consumes time + is error prone(we could forget)
+            // Hence it should be done once, question is when and by who...
+            // It feels like this is sane place to do it
+            host.FileSystem.CreateDirectory(Paths.HostVersionSettingsDir);
         }
 
         [Obsolete("ISettingsLoader is obsolete, see obsolete messages for individual properties/methods of ISettingsLoader for details.")]

--- a/src/Microsoft.TemplateEngine.Edge/Settings/ComponentManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/ComponentManager.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;
-using Newtonsoft.Json.Linq;
 #if !NETFULL
 using System.Runtime.Loader;
 #endif
@@ -22,9 +21,11 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         private readonly Dictionary<Type, HashSet<Guid>> _componentIdsByType;
         private readonly SettingsStore _settings;
         private readonly SettingsFilePaths _paths;
+        private readonly IEngineEnvironmentSettings _engineEnvironmentSettings;
 
         public ComponentManager(IEngineEnvironmentSettings engineEnvironmentSettings)
         {
+            _engineEnvironmentSettings = engineEnvironmentSettings;
             _paths = new SettingsFilePaths(engineEnvironmentSettings);
             _settings = SettingsStore.Load(engineEnvironmentSettings, _paths);
             _loadLocations.AddRange(_settings.ProbingPaths);
@@ -235,8 +236,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             {
                 try
                 {
-                    JObject serialized = JObject.FromObject(_settings);
-                    _paths.WriteAllText(_paths.SettingsFile, serialized.ToString());
+                    _engineEnvironmentSettings.Host.FileSystem.WriteObject(_paths.SettingsFile, _settings);
                     successfulWrite = true;
                 }
                 catch (IOException)

--- a/src/Microsoft.TemplateEngine.Edge/Settings/SettingsFilePaths.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/SettingsFilePaths.cs
@@ -135,23 +135,6 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             return Path.GetFileName(path);
         }
 
-        internal string ReadAllText(string path, string defaultValue = "")
-        {
-            return Exists(path) ? _environmentSettings.Host.FileSystem.ReadAllText(path) : defaultValue;
-        }
-
-        internal void WriteAllText(string path, string value)
-        {
-            string parentDir = Path.GetDirectoryName(path);
-
-            if (!Exists(parentDir))
-            {
-                _environmentSettings.Host.FileSystem.CreateDirectory(parentDir);
-            }
-
-            _environmentSettings.Host.FileSystem.WriteAllText(path, value);
-        }
-
         private void CreateDirectory(string path, string parent)
         {
             string[] parts = path.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);

--- a/src/Microsoft.TemplateEngine.Edge/Settings/SettingsStore.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/SettingsStore.cs
@@ -5,8 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json;
@@ -94,35 +92,12 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 return new SettingsStore(null);
             }
 
-            const int MaxLoadAttempts = 20;
-            string? userSettings = null;
-            using (Timing.Over(engineEnvironmentSettings.Host.Logger, "Read settings"))
-            {
-                for (int i = 0; i < MaxLoadAttempts; ++i)
-                {
-                    try
-                    {
-                        userSettings = paths.ReadAllText(paths.SettingsFile, "{}");
-                        break;
-                    }
-                    catch (IOException)
-                    {
-                        if (i == MaxLoadAttempts - 1)
-                        {
-                            throw;
-                        }
-
-                        Task.Delay(2).Wait();
-                    }
-                }
-            }
-
             JObject parsed;
             using (Timing.Over(engineEnvironmentSettings.Host.Logger, "Parse settings"))
             {
                 try
                 {
-                    parsed = JObject.Parse(userSettings);
+                    parsed = engineEnvironmentSettings.Host.FileSystem.ReadObject(paths.SettingsFile);
                 }
                 catch (Exception ex)
                 {

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -75,17 +75,17 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             MountPointsInfo = mountPoints;
         }
 
-        public TemplateCache(JObject contentJobject, ILogger logger)
+        public TemplateCache(JObject? contentJobject, ILogger logger)
         {
             _logger = logger;
-            if (contentJobject.TryGetValue(nameof(Version), StringComparison.OrdinalIgnoreCase, out JToken versionToken))
+            if (contentJobject != null && contentJobject.TryGetValue(nameof(Version), StringComparison.OrdinalIgnoreCase, out JToken versionToken))
             {
                 Version = versionToken.ToString();
             }
             else
             {
                 Version = null;
-                TemplateInfo = new List<TemplateInfo>();
+                TemplateInfo = Array.Empty<TemplateInfo>();
                 MountPointsInfo = new Dictionary<string, DateTime>();
                 Locale = string.Empty;
                 return;

--- a/src/Shared/JExtensions.cs
+++ b/src/Shared/JExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -301,6 +302,27 @@ namespace Microsoft.TemplateEngine
             using (JsonReader r = new JsonTextReader(tr))
             {
                 return JObject.Load(r);
+            }
+        }
+
+        internal static JObject ReadObject(this IPhysicalFileSystem fileSystem, string path)
+        {
+            using (var fileStream = fileSystem.OpenRead(path))
+            using (var textReader = new StreamReader(fileStream, System.Text.Encoding.UTF8, true))
+            using (var jsonReader = new JsonTextReader(textReader))
+            {
+                return JObject.Load(jsonReader);
+            }
+        }
+
+        internal static void WriteObject(this IPhysicalFileSystem fileSystem, string path, object obj)
+        {
+            using (var fileStream = fileSystem.CreateFile(path))
+            using (var textWriter = new StreamWriter(fileStream, System.Text.Encoding.UTF8))
+            using (var jsonWriter = new JsonTextWriter(textWriter))
+            {
+                var serializer = new JsonSerializer();
+                serializer.Serialize(jsonWriter, obj);
             }
         }
 


### PR DESCRIPTION
### Problem
Problem was that `_userTemplateCache` was never set if nothing changed, so it was re-read multiple times, mostly noticable by VS and not so much by `dotnet new` since we only call 1x... most of time...

### Solution
Added unit test, fixed https://github.com/dotnet/templating/issues/3326 (store cache as minimized json, no whitespaces)..
Also converted to using `JsonTextReader` to avoid loading 100KB+ long string into memory...

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)