### PR TITLE
Fixes #3324: Utils and Edge projects shouldn't depend on Microsoft.Extensions.Logging

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs
@@ -40,9 +40,7 @@ namespace Microsoft.TemplateEngine.Edge
 
             if (loggerFactory == null)
             {
-                loggerFactory = Extensions.Logging.LoggerFactory.Create(
-                    builder
-                        => builder.AddProvider(NullLoggerProvider.Instance));
+                loggerFactory = NullLoggerFactory.Instance;
             }
             _loggerFactory = loggerFactory;
             _logger = _loggerFactory.CreateLogger("Template Engine") ?? NullLogger.Instance;

--- a/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
+++ b/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="NuGet.Configuration" Version="5.8.1" />
     <PackageReference Include="NuGet.Credentials" Version="5.8.1" />
     <PackageReference Include="NuGet.Protocol" Version="5.8.1" />

--- a/src/Microsoft.TemplateEngine.Utils/DefaultTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Utils/DefaultTemplateEngineHost.cs
@@ -49,7 +49,7 @@ namespace Microsoft.TemplateEngine.Utils
             _hostBuiltInComponents = builtIns ?? NoComponents;
             FallbackHostTemplateConfigNames = fallbackHostTemplateConfigNames ?? new List<string>();
             _diagnosticLoggers = new Dictionary<string, Action<string, string[]>>();
-            _loggerFactory = Extensions.Logging.LoggerFactory.Create(builder => builder.AddProvider(NullLoggerProvider.Instance));
+            _loggerFactory = NullLoggerFactory.Instance;
             _logger = _loggerFactory.CreateLogger("Template Engine") ?? NullLogger.Instance;
         }
 

--- a/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
+++ b/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
@@ -11,7 +11,7 @@
     <Compile Include="..\Shared\JExtensions.cs" Link="JExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Newtonsoft.Json" />
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
   </ItemGroup>


### PR DESCRIPTION
### Problem
We require from VS integration to pull in 5+ dlls that are not needed, idea behind using Abstractions is that it only provides interfaces and its up to host to provide it...

### Solution
Only depend on Abstractions library.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)