### PR TITLE
Fix failing test

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
 {
     internal sealed class GlobalSettings : IGlobalSettings, IDisposable
     {
-        private const int FileReadWriteRetries = 5;
+        private const int FileReadWriteRetries = 20;
         private readonly SettingsFilePaths _paths;
         private readonly IEngineEnvironmentSettings _environmentSettings;
         private readonly string _globalSettingsFile;


### PR DESCRIPTION
My assumption is that since now we are doing serialization under `using` of file open vs. just doing WriteAllText, file is open for writing longer time(can take 100ms) 1st time serializing... Hence it fails unit test... So now extend retries to 400ms... and it should work fine.