### PR TITLE
API and migration reference from .NET 3.1 / .NET 5 to .NET 6

### DIFF
--- a/docs/api/Inside-the-Template-Engine.md
+++ b/docs/api/Inside-the-Template-Engine.md
@@ -1,0 +1,340 @@
+# Inside the Template Engine
+
+The template engine is composed of several different subsystems, which are
+designed to separate gathering templates, instantiating template and processing
+templates.
+
+# Overview of the subsystems
+
+## [IEngineEnvironmentSettings](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/IEngineEnvironmentSettings.cs)
+
+This is responsible for holding all properties of environment.
+
+Template engine provides default implementation:
+[EngineEnvironmentSettings](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Edge/EngineEnvironmentSettings.cs).
+
+It has single constructor that accepts ITemplateEngineHost and set up settings
+based on TemplateEngine.Edge implementation of component manager, paths, and
+environment. All this can also be passed in as optional parameters.
+
+### [ITemplateEngineHost](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs)
+
+The interface is responsible for providing host information to template engine,
+managing file system and do the logging. Host may also provide default parameter
+values for template via TryGetHostParamDefault method.
+
+The applications using template engine are often called as “hosts”.
+dotnet/templating repo is managing one of such hosts: dotnet new CLI, which is
+part of dotnet SDK.
+
+Main host properties:
+
+-   Identifier – unique name of the host
+
+-   Version – version of the host
+
+Those properties are used to identify host to various built-in components
+explained below.
+
+If you are considering using the template engine core, you need to make
+implementation of this interface representing your host. Template engine
+provides default implementation:
+[DefaultTemplateEngineHost](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs).
+
+#### IPhysicalFileSystem
+
+Abstraction over file system, accessible from ITemplateEngineHost.
+
+Each template engine host should support physical and in-memory file system and
+virtualize file system under given path. Switch between physical and in-memory
+is done via ITemplateEngineHost.VirtualizePath method.
+
+Template engine provides default implementation of file systems:
+[PhysicalFileSystem](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Utils/PhysicalFileSystem.cs)
+and
+[InMemoryFileSystem](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs).
+
+### [IComponentManager](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/IComponentManager.cs)
+
+ComponentManager is responsible for loading components provided by Host from
+ITemplateEngineHost.BuiltIns, but additional components can be added via
+IComponentManager.AddComponent or they are dynamically loaded from
+TemplatePackage during scanning similar to templates. ComponentManager
+implementation is not publicly accessible, however it is used when default
+implementation of IEngineEnvironmentSettings is used.
+
+### [IEnvironment](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/IEnvironment.cs)
+
+Abstraction over environment variables. Default implementation uses system
+environment variables.
+
+### [IPathInfo](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/IPathInfo.cs)
+
+Provides the main paths used by template engine: global settings path, host
+settings path host version settings path.
+
+The default locations are:
+
+-   \<home directory\>/.templateengine – global settings
+
+-   \<home directory\>/.templateengine/\<host ID\> – host settings
+
+-   \<home directory\>/.templateengine/\<host ID\>/\<host version\> – host
+    version settings
+
+## [TemplatePackageManager](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs) class
+
+The class responsible for managing templates and templates packages.
+
+-   Gets available providers to install/update/uninstall template packages
+    avaliable via IComponentManager
+
+-   Gets available template packages
+
+-   TemplatePackagesChanged which is triggered when list of template packages
+    changes
+
+-   Gets available templates
+
+-   Manages template packages cache and template cache.
+
+The host need to instantiate the class when needed. Note that the first-time run
+can be time consuming, so consider creating one instance for duration of hosting
+application.
+
+## [TemplateCreator](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs) class
+
+The class responsible for template creation, including dry run. The host need to
+instantiate the class when needed.
+
+# Template Engine packages
+
+Template engine publishes the following packages:
+
+-   Microsoft.TemplateEngine.Abstractions – contains interfaces to work with
+    template engine
+
+-   Microsoft.TemplateEngine.Egde – enables hosting the template engine in the
+    application
+
+-   Microsoft.TemplateEngine.IDE – lightweight API over Edge (optional to use)
+
+-   Microsoft.TemplateEngine.Orchestrator.RunnableProjects – template engine
+    default generator (a.k.a. the generator of template.json format)
+
+-   Microsoft.TemplateEngine.Utils – different utilities useful for template
+    engine usage
+
+# Components
+
+Main purpose of components is to allow template authors and host implementers to
+supply their own implementations of different interfaces and to invoke them by
+specifying GUID or name that defines component in template.json. Components can
+be split into two main categories:
+
+-   the components required to run templates:
+
+    -   macros
+
+    -   post actions (TBD)
+
+    -   generators
+
+-   the components required by the host:
+
+    -   template package providers: managed and non-managed
+
+    -   installers
+
+    -   mount points
+
+## Template package providers 
+
+Template package providers responsible for providing template packages the
+template engine needs to manage. There are two kinds of providers:
+
+-   Non-managed
+    ([ITemplatePackageProvider](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/TemplatePackage/ITemplatePackageProvider.cs))
+    – the template engine uses the packages provided by provider however cannot
+    modify them
+
+-   Managed
+    ([IManagedTemplatePackageProvider](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/TemplatePackage/IManagedTemplatePackageProvider.cs))
+    – the template engine can install/update/uninstall packages to provider.
+
+Template engine provides the following providers:
+
+-   Global settings managed provider – the packages available to all template
+    engine hosts using built in implementation.
+
+-   (not available yet) host managed provider - the packages available to
+    current host.
+
+-   (not available yet) host version managed provider - the packages available
+    to current host version.
+
+Template engine also provides [default non-managed provider
+implementation](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Utils/DefaultTemplatePackageProvider.cs)
+that can be used by other hosts to build simple providers or base implementation
+on. Here are two examples:
+[SdkTemplates](https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/commands/dotnet-new/BuiltInTemplatePackageProvider.cs)
+and
+[OptionalWorkloads](https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/commands/dotnet-new/OptionalWorkloadProvider.cs).
+
+### Prioritizing the providers
+
+Template providers can implement the
+[IPrioritizedComponent](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/IPrioritizedComponent.cs)
+interface to setup the provider priority. The providers will be read following
+the priority with the priority with largest value of priority to be preferred in
+case the providers have same templates defined.
+
+The default priority of Global Settings provider is 1000. If priority is not
+defined, the provider will be treated as provider with priority 0.
+
+Note: it is possible to define negative priority, then the provider will be
+lower priority than default.
+
+When implementing provider, note that the packages returned by provider will be
+processed exactly in the same order they provided, in case of template is
+available in several packages, the last package will win.
+
+## [Installer](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/Installer/IInstaller.cs)
+
+Installer installs, updates and uninstall the template packages that can be feed
+to template package providers.
+
+Template engine provides two installer implementations:
+
+-   NuGet – installs the template package from NuGet feed
+
+-   Folder – installs the template package from given folder path
+
+You can use them when implementing your own providers, they are available from
+IComponentManager.
+
+## [Mount point](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPoint.cs)
+
+Template package location is represented by mount point URI. Mount point that
+can load certain type of URI are also components.
+
+Template engine provides two mountpoint factory implementations:
+
+-   Zip/NuGet – manages zip package/NuGet package
+
+-   File System – manages folder on local file system
+
+They are available from IComponentManager.
+
+It is possible to get mount point using bool TryGetMountPoint(string
+mountPointUri, out IMountPoint mountPoint) method of IEngineEnvironmentSettings.
+
+## Registering the components
+
+When creating template engine host, all built in components will be registered.
+
+If you’d like to use the runnable projects (template.json) generator available
+from Microsoft.TemplateEngine.Orchestrator.RunnableProjects, you need to add it
+using AddComponent method of IComponentManager.
+
+You can implement the following own components and register them:
+
+-   [ITemplateEngineProvider](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/TemplatePackage/ITemplatePackageProvider.cs)
+    – non-managed template package provider, via
+    [ITemplatePackageProviderFactory](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/TemplatePackage/ITemplatePackageProviderFactory.cs)
+
+-   [IManagedTemplateEngineProvider](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/TemplatePackage/IManagedTemplatePackageProvider.cs)
+    – managed template package provider, via
+    [ITemplatePackageProviderFactory](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/TemplatePackage/ITemplatePackageProviderFactory.cs)
+
+-   [IMountPoint](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPoint.cs)
+    – mount point implementation, via
+    [IMountPointFactory](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPointFactory.cs)
+
+-   [IInstaller](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/Installer/IInstaller.cs)
+    – template package installer, via
+    [IInstallerFactory](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/Installer/IInstallerFactory.cs)
+
+It is possible to register additional components to in the following way:
+
+-   Components of
+    [ITemplateEngineHost.BuiltInComponents](https://github.com/dotnet/templating/blob/6ab649522414baa8fe31d08b449a5063e5572291/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs#L21)
+    will be added when loading environment settings. For
+    DefaultTemplateEngineHost they can be passed to constructor.
+
+-   You can use
+    [IComponentManager.AddComponent](https://github.com/dotnet/templating/blob/6ab649522414baa8fe31d08b449a5063e5572291/src/Microsoft.TemplateEngine.Abstractions/IComponentManager.cs#L58)
+    method to add the component in runtime.
+
+Note that components are not persisted, so they should be added each time
+EngineEnvironmentSettings instance is created.
+
+# Microsoft.TemplateEngine.IDE 
+
+The package provides
+[Bootstrapper](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs)
+class allowing to setup and access main functionality of template engine via
+single entry point.
+
+Note that it is not mandatory to use
+[Bootstrapper](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs)
+class to use template engine, however if you don’t need advanced features it
+might be easier to start with using this API.
+
+Basic workflow:
+
+1.  The application hosting template engine should implement and instantiate
+    [ITemplateEngineHost](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs),
+    or instantiate default implementation
+    ([DefaultTemplateEngineHost](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs)).
+
+2.  The application creates the instance of Bootstrapper:
+
+    1.  If session state doesn’t need to be persisted use
+        virtualizeConfiguration set to true – all the settings will be stored in
+        memory only.
+
+    2.  If the host assumes running default infrastructure, use
+        loadDefaultComponents set to true – this will load the default generator
+        and default infrastructure (providers, installers, mount points)
+
+3.  If the application has the templates specific to it, the application should
+    implement
+    [ITemplatePackageProvider](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/TemplatePackage/ITemplatePackageProvider.cs)
+    returning available template packages and register it via
+    Bootstrapper.AddComponent method or provide it via built-in components of
+    the host.
+
+4.  To get template packages, use GetTemplatePackages method.
+
+    Note: these templates are available to all template engine hosting
+    applications for the current user.
+
+5.  To manage template packages installed globally, use
+    InstallTemplatePackagesAsync, GetLatestVersionAsync,
+    UpdateTemplatePackagesAsync, UninstallTemplatePackagesAsync methods.
+
+    Installation supports installing local sources (folder, packages) as well as
+    installing NuGet packages from remote feeds.
+
+    Note: these actions impact set of template packages available to all
+    template engine hosting applications for the current user.
+
+6.  To available list all templates, use GetTemplatesAsync method.
+
+    The method also supports filters and criterias to filter templates. The
+    default filters are available in
+    [Utils.WellKnownSearchFilters](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Utils/WellKnownSearchFilters.cs)
+    class.
+
+7.  To dry run the template, use GetCreationEffectsAsync method.
+
+    This method needs template definition (ITemplateInfo) that can be obtained
+    through GetTemplatesAsync.
+
+8.  To run the template, use CreateAsync method.
+
+    This method needs template definition (ITemplateInfo) that can be obtained
+    through GetTemplatesAsync.
+
+Note: Bootstrapper class needs to be disposed.

--- a/docs/api/Inside-the-Template-Engine.md
+++ b/docs/api/Inside-the-Template-Engine.md
@@ -3,9 +3,21 @@
 The template engine is composed of several different subsystems, which are
 designed to separate gathering, instantiating and processing templates.
 
+- [Overview of the subsystems](#overview-of-the-subsystems)
+  - [IEngineEnvironmentSettings](#iengineenvironmentsettings)
+  - [TemplatePackageManager class](#templatepackagemanager-class)
+  - [TemplateCreator class](#templatecreator-class)
+- [Template Engine packages](#template-engine-packages)
+- [Components](#components)
+  - [Template package providers](#template-package-providers)
+  - [Installer](#installer)
+  - [Mount point](#mount-point)
+  - [Registering the components](#registering-the-components)
+- [Microsoft.TemplateEngine.IDE](#microsofttemplateengineide)
+
 # Overview of the subsystems
 
-## [IEngineEnvironmentSettings](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/IEngineEnvironmentSettings.cs)
+## [IEngineEnvironmentSettings](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/IEngineEnvironmentSettings.cs) 
 
 This is responsible for holding all properties of the environment.
 
@@ -40,8 +52,7 @@ implementation of this interface representing your host. Template engine
 provides the default implementation:
 [DefaultTemplateEngineHost](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs).
 
-#### IPhysicalFileSystem
-
+#### [IPhysicalFileSystem](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/PhysicalFileSystem/IPhysicalFileSystem.cs)
 Abstraction over file system, accessible from ITemplateEngineHost.
 
 Each template engine host should support physical and in-memory file system and
@@ -55,10 +66,10 @@ and
 
 ### [IComponentManager](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/IComponentManager.cs)
 
-`ComponentManager` is responsible for loading components provided by the host from
+`ComponentManager` is responsible for loading [components](#components) provided by the host from
 `ITemplateEngineHost.BuiltIns`. Additional components can be added via
 `IComponentManager.AddComponent`. Similar to templates, components are also 
-dynamically loaded from `TemplatePackage`s during scanning. `ComponentManager`
+dynamically loaded from template packages during scanning. `ComponentManager`
 implementation is not publicly accessible; however, it is used when default
 implementation of `IEngineEnvironmentSettings` is used.
 
@@ -110,18 +121,18 @@ instantiate the class when needed.
 
 Template engine publishes the following packages:
 
--   Microsoft.TemplateEngine.Abstractions – contains interfaces to work with
+-   [Microsoft.TemplateEngine.Abstractions](https://www.nuget.org/packages/Microsoft.TemplateEngine.Abstractions) – contains interfaces to work with
     template engine
 
--   Microsoft.TemplateEngine.Egde – enables hosting the template engine in the
+-   [Microsoft.TemplateEngine.Egde](https://www.nuget.org/packages/Microsoft.TemplateEngine.Edge) – enables hosting the template engine in the
     application
 
--   Microsoft.TemplateEngine.IDE – lightweight API over Edge (optional to use)
+-   [Microsoft.TemplateEngine.IDE](https://www.nuget.org/packages/Microsoft.TemplateEngine.IDE) – lightweight API over Edge (optional to use)
 
--   Microsoft.TemplateEngine.Orchestrator.RunnableProjects – template engine
+-   [Microsoft.TemplateEngine.Orchestrator.RunnableProjects](https://www.nuget.org/packages/Microsoft.TemplateEngine.Orchestrator.RunnableProjects) – template engine
     default generator (a.k.a. the generator of template.json format)
 
--   Microsoft.TemplateEngine.Utils – different utilities useful for template
+-   [Microsoft.TemplateEngine.Utils](https://www.nuget.org/packages/Microsoft.TemplateEngine.Utils) – different utilities useful for template
     engine usage
 
 # Components

--- a/docs/api/Inside-the-Template-Engine.md
+++ b/docs/api/Inside-the-Template-Engine.md
@@ -1,31 +1,30 @@
 # Inside the Template Engine
 
 The template engine is composed of several different subsystems, which are
-designed to separate gathering templates, instantiating template and processing
-templates.
+designed to separate gathering, instantiating and processing templates.
 
 # Overview of the subsystems
 
 ## [IEngineEnvironmentSettings](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/IEngineEnvironmentSettings.cs)
 
-This is responsible for holding all properties of environment.
+This is responsible for holding all properties of the environment.
 
-Template engine provides default implementation:
+Template engine provides a default implementation:
 [EngineEnvironmentSettings](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Edge/EngineEnvironmentSettings.cs).
 
-It has single constructor that accepts ITemplateEngineHost and set up settings
+It has a single constructor that accepts ITemplateEngineHost and set up settings
 based on TemplateEngine.Edge implementation of component manager, paths, and
 environment. All this can also be passed in as optional parameters.
 
 ### [ITemplateEngineHost](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs)
 
 The interface is responsible for providing host information to template engine,
-managing file system and do the logging. Host may also provide default parameter
-values for template via TryGetHostParamDefault method.
+managing file system and logging. Host may also provide default parameter
+values for templates via `TryGetHostParamDefault` method.
 
-The applications using template engine are often called as “hosts”.
+Applications using template engine are often called “hosts”.
 dotnet/templating repo is managing one of such hosts: dotnet new CLI, which is
-part of dotnet SDK.
+part of .NET SDK.
 
 Main host properties:
 
@@ -36,9 +35,9 @@ Main host properties:
 Those properties are used to identify host to various built-in components
 explained below.
 
-If you are considering using the template engine core, you need to make
+If you are considering using the template engine core, you need to create an
 implementation of this interface representing your host. Template engine
-provides default implementation:
+provides the default implementation:
 [DefaultTemplateEngineHost](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs).
 
 #### IPhysicalFileSystem
@@ -46,8 +45,8 @@ provides default implementation:
 Abstraction over file system, accessible from ITemplateEngineHost.
 
 Each template engine host should support physical and in-memory file system and
-virtualize file system under given path. Switch between physical and in-memory
-is done via ITemplateEngineHost.VirtualizePath method.
+virtualize the file system under a given path. Switching between physical and in-memory
+file systems is done via `ITemplateEngineHost.VirtualizePath` method.
 
 Template engine provides default implementation of file systems:
 [PhysicalFileSystem](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Utils/PhysicalFileSystem.cs)
@@ -56,12 +55,12 @@ and
 
 ### [IComponentManager](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/IComponentManager.cs)
 
-ComponentManager is responsible for loading components provided by Host from
-ITemplateEngineHost.BuiltIns, but additional components can be added via
-IComponentManager.AddComponent or they are dynamically loaded from
-TemplatePackage during scanning similar to templates. ComponentManager
-implementation is not publicly accessible, however it is used when default
-implementation of IEngineEnvironmentSettings is used.
+`ComponentManager` is responsible for loading components provided by the host from
+`ITemplateEngineHost.BuiltIns`. Additional components can be added via
+`IComponentManager.AddComponent`. Similar to templates, components are also 
+dynamically loaded from `TemplatePackage`s during scanning. `ComponentManager`
+implementation is not publicly accessible; however, it is used when default
+implementation of `IEngineEnvironmentSettings` is used.
 
 ### [IEnvironment](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/IEnvironment.cs)
 
@@ -71,7 +70,7 @@ environment variables.
 ### [IPathInfo](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/IPathInfo.cs)
 
 Provides the main paths used by template engine: global settings path, host
-settings path host version settings path.
+settings path, host version settings path.
 
 The default locations are:
 

--- a/docs/api/api-migration-from-net-5-to-net-6.md
+++ b/docs/api/api-migration-from-net-5-to-net-6.md
@@ -1,0 +1,195 @@
+# Template Engine API: Migration from .NET 3.1/.NET 5 to .NET 6
+
+In .NET 6 the available API set has significantly changed with breaking changes
+involved. The required changes when migrating from the earlier versions to .NET
+6 are given below.
+
+## Bootstrapper implementation
+
+Most of the methods of
+[Bootstrapper](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs)
+are obsolete now, preserving backward compatibility when possible. Please ensure
+you use new methods when migrating to .NET 6, the obsolete messages in the code
+will point to new version of method.
+
+## Template package management
+
+With .NET 6 a new way of template package management was introduced. Now the
+template packages are managed using providers with ability to support several
+providers and adding custom implementations of providers when implementing the
+host. This was done to fix a bug that CLI templates disappeared on SDK version
+update, support Optional Workloads and provide more future flexibility.
+
+Template engine delivers one provider out of box in .NET 6 – global settings
+template provider. The templates installed to this provider are available to all
+the hosts using IDE/Edge implementations to work with template engine
+generators.
+
+(Now obsolete) Install and Uninstall methods of Bootstrapper now install
+templates to the global settings template provider, this means the templates
+installed via these methods will be available to all the hosts (including dotnet
+new host), and other hosts may update or uninstall them. If you wish to
+contribute to the common share of templates, so that templates you install are
+also available to users of the .NET CLI, Visual Studio and all other hosts, you
+do not need to anything immediately, but please replace use of the obsolete
+methods at your next opportunity.
+
+If your host implementation requires the template to be installed specifically
+for your host without other hosts having access to them, you need to manage it
+via template package provider, starting in .NET 6. The basic workflow is:
+
+-   Implement ITemplatePackageProviderFactory and ITemplatePackageProvider
+    interface.
+
+    ITemplatePackageProviderFactory has the following members:
+
+    -   property ID – unique Guid representing the component ID.
+
+    -   property DisplayName – string – the display name for the provider
+
+    -   method CreateProvider – creates implemented ITemplatePackageProvider
+        with passing IEngineEnvironmentSettings.
+
+ITemplatePackageProvider interface has the following members:
+
+-   method: GetAllTemplatePackagesAsync which returns the list of
+    ITemplatePackage. ITemplatePackage has the following properties:
+
+    1.  string MountPointUri – the location of template package (can be local
+        folder or local NuGet package).
+
+        1.  DateTime LastChangeTime – date/time the package was changed.
+
+        2.  ITemplatePackageProvider – provider returning the package (itself).
+
+[The default implementation of
+ITemplatePackage](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/TemplatePackage/TemplatePackage.cs)
+is available in Abstractions assembly.
+
+-   event TemplatePackagesChanged – the event that should be raised if template
+    packages returned by provider has changed. Triggering this event will
+    trigger update template engine cache in TemplatePackageManager. Implementing
+    this event is not mandatory but recommended. If the event is not
+    implemented, the cache should be reloaded manually passing force parameter
+    when getting packages or templates, or TemplatePackageManager should be
+    recreated.
+
+1.  Register the factory using AddComponent method of Bootstrapper or
+    IEngineEnvironmentSettings.ComponentManager. The component should be added
+    each time Bootstrapper or EngineEnvironmentSettings is instantiated - it is
+    not cached by template engine.
+
+The host may implement as many providers as needed.
+
+In future releases we are considering a built-in host template provider and host
+version template provider allowing you to install the templates available to
+specific host or host version.
+
+## ITemplateEngineHost updates 
+
+[ITemplateEngineHost](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs)
+interface and its default implementation
+[DefaultTemplateEngineHost](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs)
+was changed:
+
+-   ILogger Logger and ILoggerFactory LoggerFactory properties were added.
+    Template Engine now uses Microsoft.Extensions.Logging to log messages of
+    different levels. At the moment, logging is not done in many components,
+    however we plan to revise it in next versions and increase the logging
+    coverage.
+
+-   Previous logging methods and events are now obsolete.
+    OnCriticalError/OnNonCriticalError are now replaced with error/warning log
+    messages, respectively. In case you need more details on how to replace
+    them, please reach us out in GitHub.
+
+## Loading the components
+
+Boostrapper/IComponentManager methos Register and RegisterMany are now
+deprecated. This way of loading components was not performant due to reflection
+usage.
+
+If you were using these methods to load default components
+(Microsoft.TemplateEngine.Edge, Microsoft.TemplateEngine.RunnableProjects), use
+LoadDefaultComponents method instead or pass loadDefaultComponents set to true
+in Bootstrapper constructor.
+
+If you were using these methods to load other components, use AddComponent
+method instead (pay attention that this should be done each time
+Bootstrapper/EngineEnvironmentSettings are instantiated) or pass them in
+BuiltInComponents property of you ITemplateEngineHost.
+
+Advanced: if you want to load only some components of
+Microsoft.TemplateEngine.Edge or Microsoft.TemplateEngine.RunnableProjects
+projects, you may use Components.AllComponents property in these assemblies to
+get the list of available components, and then load required components via
+AddComponent methods.
+
+The list of components defined in
+[Microsoft.TemplateEngine.Edge:](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Edge/Components.cs)
+
+-   Providers (ITemplatePackageProviderFactory)
+
+    -   global settings provider
+
+-   Mount points (IMountPointFactory)
+
+    -   Zip (also supports NuGet packages)
+
+    -   Folder (FileSystemMountPointFactory)
+
+-   Installers (IInstallerFactory)
+
+    -   Folder
+
+    -   NuGet
+
+If you don’t need global settings provider to be loaded, do not include it when
+loading the components. In this case installers are not used as well, include
+them only if needed for the host. It is recommended to always include default
+mount point implementations.
+
+The list of components defined in
+[Microsoft.TemplateEngine.Orchestrator.RunnableProjects](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Components.cs):
+
+-   Generators
+
+    -   Runnable project generator (template.json generator)
+
+-   Macros supported by runnable project generator
+
+-   Operation configs supported by runnable project generator
+
+If you are using runnable project generator, consider adding macros and
+operation configs implementation to enable these features.
+
+## ISettingsLoader
+
+(This section is only applicable for those who did not use Bootstrapper class
+before)
+
+ISettingsLoader and its implementation is no longer available. It was
+multi-purpose and overloaded, that’s why we decided to split it in logical
+parts.
+
+For components management, please use IComponentManager and
+IEngineEnvironmentSettings.ComponentManager.
+
+For template package and template cache, use new class
+[TemplatePackageManager](https://github.com/dotnet/templating/blob/main/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs).
+It is required to instantiate this class to work with it. It reads all template
+packages available to engine and maintains the template cache.
+TemplatePackageManager maintains the cache for information received from
+providers and read from template cache, so it’s quite performant after the first
+call unless providers triggered events on template package change, then
+TemplatePackageManager will do rescan available templates and save the updates
+to template cache.
+
+## Closing notes
+
+Previously, the Template Engine packages had many public members, including
+implementations which were unneeded. This meant future changes had breaking
+change concerns, even though we believe these methods do not have a useful
+public purpose. We made a lot of implementations and members internal. *If the
+class/member you need is not available now, please reach us out via GitHub
+issues to find a solution.*


### PR DESCRIPTION
The PR adds "Inside the Template Engine" doc that explains the how template engine is built and its APIs.
Also adds migration reference from .NET 3.1 / .NET 5 to .NET 6