### PR TITLE
add the hint on how see the the help for other template languages

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInputExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInputExtensions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             return $"dotnet {command.CommandName} {templateName}";
         }
 
-        internal static string HelpCommandExample(this INewCommandInput command, string? templateName = null)
+        internal static string HelpCommandExample(this INewCommandInput command, string? templateName = null, string? language = null)
         {
             if (string.IsNullOrWhiteSpace(templateName))
             {
@@ -104,7 +104,12 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             {
                 templateName = $"'{templateName}'";
             }
-            return $"dotnet {command.CommandName} {templateName} -h";
+            string commandStr = $"dotnet {command.CommandName} {templateName} -h";
+            if (!string.IsNullOrWhiteSpace(language))
+            {
+                commandStr += $" --language {language}";
+            }
+            return commandStr;
         }
 
         internal static string New3CommandExample(this INewCommandInput command)

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1494,6 +1494,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to To see help for other template languages ({0}), use --language option:.
+        /// </summary>
+        internal static string TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint {
+            get {
+                return ResourceManager.GetString("TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not find the template package containing template &apos;{0}&apos;.
         /// </summary>
         internal static string TemplatePackageCoordinator_Error_PackageForTemplateNotFound {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -746,4 +746,8 @@ The supported columns are: language, tags, author, type.</value>
   <data name="Generic_ExamplesHeader" xml:space="preserve">
     <value>Examples:</value>
   </data>
+  <data name="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint" xml:space="preserve">
+    <value>To see help for other template languages ({0}), use --language option:</value>
+    <comment>{0} is comma-separated list of supported programming languages by template.</comment>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -814,6 +814,11 @@ Podporované sloupce: language, tags, author, type</target>
         <target state="translated">Běžné šablony:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Nepovedlo se najít balíček šablony obsahující šablonu {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -814,6 +814,11 @@ Die unterstützten Spalten sind: Sprache, Tags, Autor, Typ.</target>
         <target state="translated">Allgemeine Vorlagen:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Das Vorlagenpaket mit der Vorlage "{0}" wurde nicht gefunden.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -814,6 +814,11 @@ Las columnas admitidas son: idioma, etiquetas, autor y tipo.</target>
         <target state="translated">Las plantillas comunes son:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">No encontró el paquete de plantillas que contiene la plantilla "{0}"</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -814,6 +814,11 @@ Les colonnes prises en charge sont : Langage, balises, auteur, type.</target>
         <target state="translated">Les modèles courants sont les suivants :</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Le package de modèle contenant le modèle « {0} » est introuvable</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -814,6 +814,11 @@ Le colonne supportate sono: lingua, tag, autore, tipo.</target>
         <target state="translated">Seguono dei modelli comuni:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Non è stato possibile trovare il pacchetto di modelli contenente il modello '{0}'</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -814,6 +814,11 @@ The supported columns are: language, tags, author, type.</source>
         <target state="translated">一般的なテンプレート:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">テンプレート '{0}' を含むテンプレートパッケージが見つかりませんでした</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -814,6 +814,11 @@ The supported columns are: language, tags, author, type.</source>
         <target state="translated">일반적인 템플릿은 다음과 같습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">'{0}' 템플릿이 포함된 ‘템플릿 패키지를 찾을 수 없습니다.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -814,6 +814,11 @@ Obsługiwane kolumny to: język, tagi, autor, typ.</target>
         <target state="translated">Typowymi szablonami są:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Nie można znaleźć pakietu szablonów zawierającego szablon "{0}"</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -814,6 +814,11 @@ As colunas com suporte são: idioma, marcas, autor, tipo.</target>
         <target state="translated">Os modelos comuns são:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Não foi possível localizar o pacote de modelo contendo o modelo '{0}'</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -814,6 +814,11 @@ The supported columns are: language, tags, author, type.</source>
         <target state="translated">Общие шаблоны:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Не удалось найти пакет шаблона, содержащий шаблон "{0}"</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -814,6 +814,11 @@ Desteklenen sütunlar şunlardır: dil, etiketler, yazar ve tür.</target>
         <target state="translated">Ortak şablonlar şunlardır:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">'{0}' şablonunu içeren şablon paketi bulunamadı</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -814,6 +814,11 @@ The supported columns are: language, tags, author, type.</source>
         <target state="translated">常用模板包括:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">找不到包含模板“{0}”的模板包</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -814,6 +814,11 @@ The supported columns are: language, tags, author, type.</source>
         <target state="translated">常見範本包括:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint">
+        <source>To see help for other template languages ({0}), use --language option:</source>
+        <target state="new">To see help for other template languages ({0}), use --language option:</target>
+        <note>{0} is comma-separated list of supported programming languages by template.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">找不到包含範本 '{0}' 的範本套件</target>

--- a/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
@@ -63,7 +63,11 @@ Options:
 
   --no-restore    If specified, skips the automatic restore of the project on create.
                   bool - Optional                                                    
-                  Default: false                                                     ";
+                  Default: false                                                     
+
+
+To see help for other template languages (F#, VB), use --language option:
+   dotnet new3 console -h --language F#";
 
         private const string ClassLibHelp =
 @"Class Library (C#)
@@ -100,7 +104,11 @@ Options:
 
   --nullable      Whether to enable nullable reference types for this project.       
                   bool - Optional                                                    
-                  Default: true                                                      ";
+                  Default: true                                                      
+
+
+To see help for other template languages (F#, VB), use --language option:
+   dotnet new3 classlib -h --language F#";
 
         private const string ConsoleAppHelp =
 @"Simple Console Application (C#)
@@ -261,7 +269,11 @@ Options:
 
   --no-restore   If specified, skips the automatic restore of the project on create.
                  bool - Optional                                                    
-                 Default: false                                                     ";
+                 Default: false                                                     
+
+
+To see help for other template languages (F#, VB), use --language option:
+   dotnet new3 console -h --language F#";
 
             string home = TestUtils.CreateTemporaryFolder("Home");
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -356,7 +368,11 @@ Options:
 
   --no-restore    If specified, skips the automatic restore of the project on create.
                   bool - Optional                                                    
-                  Default: false                                                     ";
+                  Default: false                                                     
+
+
+To see help for other template languages (F#, VB), use --language option:
+   dotnet new3 console -h --language F#";
 
         string home = TestUtils.CreateTemporaryFolder("Home");
         string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -369,6 +385,63 @@ Options:
                 .And.NotHaveStdErr()
                 .And.HaveStdOut(ConsoleHelp)
                 .And.NotHaveStdOutContaining(HelpOutput);
+        }
+
+        [Fact]
+        public void CanShowHelpForTemplate_MatchOnLanguage()
+        {
+            const string ConsoleHelp =
+@"Console Application (F#)
+Author: Microsoft
+Description: A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS
+Options:                                                                             
+  -f|--framework  The target framework for the project.                              
+                      net6.0           - Target net6.0                               
+                      net5.0           - Target net5.0                               
+                      netcoreapp3.1    - Target netcoreapp3.1                        
+                      netcoreapp3.0    - Target netcoreapp3.0                        
+                      netcoreapp2.2    - Target netcoreapp2.2                        
+                      netcoreapp2.1    - Target netcoreapp2.1                        
+                      netcoreapp2.0    - Target netcoreapp2.0                        
+                      netcoreapp1.0    - Target netcoreapp1.0                        
+                      netcoreapp1.1    - Target netcoreapp1.1                        
+                  Default: net6.0                                                    
+
+  --no-restore    If specified, skips the automatic restore of the project on create.
+                  bool - Optional                                                    
+                  Default: false                                                     
+
+
+To see help for other template languages (C#, VB), use --language option:
+   dotnet new3 console -h --language C#";
+
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "console", "--help", "--language", "F#")
+                    .WithCustomHive(home)
+                    .WithWorkingDirectory(workingDirectory)
+                    .Execute()
+                    .Should().Pass()
+                    .And.NotHaveStdErr()
+                    .And.HaveStdOut(ConsoleHelp)
+                    .And.NotHaveStdOutContaining(HelpOutput);
+        }
+
+        [Fact]
+        public void WontShowLanguageHintInCaseOfOneLang()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "app", "--help", "--language", "C#")
+                    .WithCustomHive(home)
+                    .WithWorkingDirectory(workingDirectory)
+                    .Execute()
+                    .Should().Pass()
+                    .And.NotHaveStdErr()
+                    .And.HaveStdOut(ConsoleAppHelp)
+                    .And.NotHaveStdOutContaining("To see help for other template languages");
         }
 
         [Fact]


### PR DESCRIPTION
### Problem
It is not clear that when running help for the template the help for default language is shown

### Solution
In case template defined in different languages, add a hint after showing the help that other languages are available.
Example of output
```
Console Application (C#)
Author: Microsoft
Description: A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS
Options:                                                                             
  -f|--framework  The target framework for the project.                              
                      net6.0           - Target net6.0                               
                      net5.0           - Target net5.0                               
                      netcoreapp3.1    - Target netcoreapp3.1                        
                      netcoreapp3.0    - Target netcoreapp3.0                        
                      netcoreapp2.2    - Target netcoreapp2.2                        
                      netcoreapp2.1    - Target netcoreapp2.1                        
                      netcoreapp2.0    - Target netcoreapp2.0                        
                      netcoreapp1.0    - Target netcoreapp1.0                        
                      netcoreapp1.1    - Target netcoreapp1.1                        
                  Default: net6.0                                                    

  --langVersion   Sets the LangVersion property in the created project file          
                  text - Optional                                                    

  --no-restore    If specified, skips the automatic restore of the project on create.
                  bool - Optional                                                    
                  Default: false                                                     


To see help for other template languages (F#, VB), use --language option:
   dotnet new3 console -h --language F#
```
### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)