### PR TITLE
added logging for failing Microsoft.TemplateEngine.IDE.IntegrationTests test

### DIFF
--- a/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
@@ -110,7 +110,21 @@ namespace Microsoft.TemplateEngine.TestHelper
                 p.WaitForExit();
                 if (p.ExitCode != 0)
                 {
-                    throw new Exception($"Failed to pack the project {projectPath}");
+                    string? stdOut = null;
+                    string? stdErr = null;
+                    try
+                    {
+                        stdOut = p.StandardOutput.ReadToEnd();
+                        stdErr = p.StandardError.ReadToEnd();
+                    }
+                    catch
+                    {
+                        //do nothing in case streams cannot be read
+                    }
+
+                    throw new Exception($"Failed to pack the project {projectPath}: " +
+                        $"{Environment.NewLine}StdOut: {stdOut}." +
+                        $"{Environment.NewLine}StdErr: {stdErr}.");
                 }
 
                 string createdPackagePath = Directory.GetFiles(_packageLocation).Aggregate(

--- a/test/Microsoft.TemplateEngine.TestHelper/TestUtils.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/TestUtils.cs
@@ -67,8 +67,8 @@ namespace Microsoft.TemplateEngine.TestHelper
 
         public static bool CompareFiles(string file1, string file2)
         {
-            using var fs1 = new FileStream(file1, FileMode.Open);
-            using var fs2 = new FileStream(file2, FileMode.Open);
+            using var fs1 = new FileStream(file1, FileMode.Open, FileAccess.Read);
+            using var fs2 = new FileStream(file2, FileMode.Open, FileAccess.Read);
             if (fs1.Length != fs2.Length)
             {
                 return false;


### PR DESCRIPTION
### Problem
failing Microsoft.TemplateEngine.IDE.IntegrationTests test

### Solution
Added logging to see why dotnet pack fails.

