### PR TITLE
reset runtime PR https://github.com/dotnet/templating/pull/3384

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,9 +11,9 @@
       <Sha>def2e2c6dc5064319250e2868a041a3dc07f9579</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.7.21356.2">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-preview.7.21351.2">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>566b53a66b0afa573f0dae33d07c8de9685aa5c8</Sha>
+      <Sha>cf2938f44fc1494ae984c52a1568a03d51e513ca</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,6 +14,6 @@
     <MicrosoftExtensionsLoggingConsolePackageVersion>6.0.0-preview.3.21164.3</MicrosoftExtensionsLoggingConsolePackageVersion>
     <NewtonsoftJsonPackageVersion>12.0.2</NewtonsoftJsonPackageVersion>
     <SystemCommandLinePackageVersion>2.0.0-beta1.21109.1</SystemCommandLinePackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-preview.7.21356.2</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>6.0.0-preview.7.21351.2</MicrosoftNETCoreAppRefPackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
https://github.com/dotnet/templating/pull/3384 brought the issue causing CI to intermittently fail. 
Possible reason: https://github.com/dotnet/runtime/issues/54941
reverting runtime version to previous version