### PR TITLE
Proper use of Stream.Read(buffer, offset, count) in the TemplateEngine.Core

### DIFF
--- a/src/Microsoft.TemplateEngine.Core/Globals.cs
+++ b/src/Microsoft.TemplateEngine.Core/Globals.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.TemplateEngine.Core.UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileRenameGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileRenameGenerator.cs
@@ -74,15 +74,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         private static string ApplyRenameProcessorToFilename(IProcessor processor, string sourceFilename)
         {
-            using (Stream source = new MemoryStream(Encoding.UTF8.GetBytes(sourceFilename)))
-            using (Stream target = new MemoryStream())
+            using (MemoryStream source = new MemoryStream(Encoding.UTF8.GetBytes(sourceFilename)))
+            using (MemoryStream target = new MemoryStream())
             {
                 processor.Run(source, target);
-
-                byte[] targetData = new byte[target.Length];
-                target.Position = 0;
-                target.Read(targetData, 0, targetData.Length);
-                return Encoding.UTF8.GetString(targetData);
+                return Encoding.UTF8.GetString(target.ToArray());
             }
         }
 

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ChunkStreamReadTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ChunkStreamReadTests.cs
@@ -1,0 +1,166 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.Core.Operations;
+using Microsoft.TemplateEngine.Core.Util;
+using Microsoft.TemplateEngine.Mocks;
+using Microsoft.TemplateEngine.TestHelper;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Core.UnitTests
+{
+    public class ChunkStreamReadTests : TestBase, IClassFixture<EnvironmentSettingsHelper>
+    {
+        private IEngineEnvironmentSettings _engineEnvironmentSettings;
+
+        public ChunkStreamReadTests(EnvironmentSettingsHelper environmentSettingsHelper)
+        {
+            _engineEnvironmentSettings = environmentSettingsHelper.CreateEnvironment(hostIdentifier: this.GetType().Name, virtualize: true);
+        }
+
+        [Fact]
+        public void VerifyLongStreamNoReplacement()
+        {
+            Random rnd = new Random();
+            byte[] valueBytes = new byte[1024 * 1024];
+            rnd.NextBytes(valueBytes);
+            ChunkMemoryStream input = new ChunkMemoryStream(valueBytes, 512);
+            ChunkMemoryStream output = new ChunkMemoryStream(1024);
+
+            IOperationProvider[] operations = Array.Empty<IOperationProvider>();
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            IProcessor processor = Processor.Create(cfg, operations);
+
+            processor.Run(input, output, 1024);
+            Assert.Equal(input.Length, output.Length);
+
+            int file1byte;
+            int file2byte;
+            do
+            {
+                file1byte = input.ReadByte();
+                file2byte = output.ReadByte();
+            }
+            while ((file1byte == file2byte) && (file1byte != -1));
+            Assert.Equal(0, file1byte - file2byte);
+        }
+
+        [Fact]
+        public void VerifyLongStreamWithReplacement()
+        {
+            string value = @"test value test";
+            string expected = @"test foo test";
+
+            StringBuilder valueBuilder = new StringBuilder();
+            StringBuilder expectedBuilder = new StringBuilder();
+
+            for (int i = 0; i < 1024; i++)
+            {
+                valueBuilder.Append(value);
+                expectedBuilder.Append(expected);
+            }
+            value = valueBuilder.ToString();
+            expected = expectedBuilder.ToString();
+
+            byte[] valueBytes = Encoding.UTF8.GetBytes(value);
+            ChunkMemoryStream input = new ChunkMemoryStream(valueBytes, 10);
+            ChunkMemoryStream output = new ChunkMemoryStream(10);
+
+            IOperationProvider[] operations = { new Replacement("value".TokenConfig(), "foo", null, true) };
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            IProcessor processor = Processor.Create(cfg, operations);
+
+            //Changes should be made
+            bool changed = processor.Run(input, output, 1000);
+            Verify(Encoding.UTF8, output, changed, value, expected);
+        }
+
+        [Fact]
+        public void VerifyLongStreamWithReplacementBeforeAfter()
+        {
+            string value = @"test valueA before valueA after valueB valueB";
+            string expected = @"test foo before valueA after bar valueB";
+
+            StringBuilder valueBuilder = new StringBuilder();
+            StringBuilder expectedBuilder = new StringBuilder();
+
+            for (int i = 0; i < 1024; i++)
+            {
+                valueBuilder.Append(value);
+                expectedBuilder.Append(expected);
+            }
+            value = valueBuilder.ToString();
+            expected = expectedBuilder.ToString();
+
+            byte[] valueBytes = Encoding.UTF8.GetBytes(value);
+            ChunkMemoryStream input = new ChunkMemoryStream(valueBytes, 10);
+            ChunkMemoryStream output = new ChunkMemoryStream(10);
+
+            IOperationProvider[] operations =
+                {
+                    new Replacement("valueA".TokenConfigBuilder().OnlyIfBefore(" before"), "foo", null, true),
+                    new Replacement("valueB".TokenConfigBuilder().OnlyIfAfter("after "), "bar", null, true),
+                };
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            IProcessor processor = Processor.Create(cfg, operations);
+
+            //Changes should be made
+            bool changed = processor.Run(input, output, 1000);
+            Verify(Encoding.UTF8, output, changed, value, expected);
+        }
+
+        [Fact]
+        public void VerifyConsumeWholeLine()
+        {
+            MockOperation o = new MockOperation(
+                null,
+                (IProcessorState state, int length, ref int position, int token, Stream target) =>
+                {
+                    state.ConsumeWholeLine(ref length, ref position);
+                    return 0;
+                },
+                true,
+                Encoding.UTF8.GetBytes("There"));
+
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings, new VariableCollection());
+            IProcessor processor = Processor.Create(cfg, o.Provider);
+            byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There    \r\n    You");
+            Stream input = new ChunkMemoryStream(data, 1);
+            Stream output = new ChunkMemoryStream(1);
+            bool changed = processor.Run(input, output, 5);
+
+            Verify(Encoding.UTF8, output, changed, "Hello    \r\n    There    \r\n    You", "Hello    \r\n    You");
+        }
+
+        private class ChunkMemoryStream : MemoryStream
+        {
+            private readonly int _chunkSize;
+
+            internal ChunkMemoryStream(int chunkSize) : base()
+            {
+                _chunkSize = chunkSize;
+            }
+
+            internal ChunkMemoryStream(byte[] buffer, int chunkSize) : base(buffer)
+            {
+                _chunkSize = chunkSize;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                if (count > _chunkSize)
+                {
+                    count = _chunkSize;
+                }
+                return base.Read(buffer, offset, count);
+            }
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/CombinedStreamTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/CombinedStreamTests.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.IO;
+using Microsoft.TemplateEngine.Core.Util;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Core.UnitTests
+{
+    public class CombinedStreamTests
+    {
+        [Theory]
+        [InlineData(2 * 1024 * 1024)]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(10000)]
+        [InlineData(1024 * 1024 + 10000)]
+        public void CanReadStream(int requestedCount)
+        {
+            Random rnd = new Random();
+            byte[] valueBytes1 = new byte[1024 * 1024];
+            byte[] valueBytes2 = new byte[1024 * 1024];
+            rnd.NextBytes(valueBytes1);
+            rnd.NextBytes(valueBytes2);
+            Stream stream1 = new ChunkMemoryStream(valueBytes1, 1024);
+            Stream stream2 = new ChunkMemoryStream(valueBytes2, 1024);
+
+            CombinedStream stream = new CombinedStream(stream1, stream2, inner => stream2 = inner);
+
+            byte[] read = new byte[2 * 1024 * 1024];
+            int nRead = stream.Read(read, 0, requestedCount);
+
+            Assert.Equal(requestedCount, nRead);
+
+            var upperBound = requestedCount > 1024 * 1024 ? 1024 * 1024 : requestedCount;
+            for (int i = 0; i < upperBound; i++)
+            {
+                Assert.Equal(valueBytes1[i], read[i]);
+            }
+            if (requestedCount > 1024 * 1024)
+            {
+                for (int i = 0; i < requestedCount - 1024 * 1024; i++)
+                {
+                    Assert.Equal(valueBytes2[i], read[i + 1024 * 1024]);
+                }
+            }
+            for (int i = requestedCount; i < 2 * 1024 * 1024; i++)
+            {
+                Assert.Equal(0, read[i]);
+            }
+        }
+
+        private class ChunkMemoryStream : MemoryStream
+        {
+            private readonly int _chunkSize;
+
+            internal ChunkMemoryStream(int chunkSize) : base()
+            {
+                _chunkSize = chunkSize;
+            }
+
+            internal ChunkMemoryStream(byte[] buffer, int chunkSize) : base(buffer)
+            {
+                _chunkSize = chunkSize;
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                if (count > _chunkSize)
+                {
+                    count = _chunkSize;
+                }
+                return base.Read(buffer, offset, count);
+            }
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/CommonOperationsTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/CommonOperationsTests.cs
@@ -38,14 +38,11 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There");
             Stream d = new MemoryStream(data);
-            Stream result = new MemoryStream();
+            MemoryStream result = new MemoryStream();
             bool modified = processor.Run(d, result);
 
             Assert.True(modified);
-            result.Position = 0;
-            byte[] outcome = new byte[result.Length];
-            result.Read(outcome, 0, outcome.Length);
-            string outcomeString = Encoding.UTF8.GetString(outcome);
+            string outcomeString = Encoding.UTF8.GetString(result.ToArray());
             Assert.Equal("    There", outcomeString);
         }
 
@@ -66,14 +63,11 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There");
             Stream d = new MemoryStream(data);
-            Stream result = new MemoryStream();
+            MemoryStream result = new MemoryStream();
             bool modified = processor.Run(d, result);
 
             Assert.True(modified);
-            result.Position = 0;
-            byte[] outcome = new byte[result.Length];
-            result.Read(outcome, 0, outcome.Length);
-            string outcomeString = Encoding.UTF8.GetString(outcome);
+            string outcomeString = Encoding.UTF8.GetString(result.ToArray());
             Assert.Equal("Hello    \r\n", outcomeString);
         }
 
@@ -94,14 +88,11 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There    \r\n    You");
             Stream d = new MemoryStream(data);
-            Stream result = new MemoryStream();
+            MemoryStream result = new MemoryStream();
             bool modified = processor.Run(d, result);
 
             Assert.True(modified);
-            result.Position = 0;
-            byte[] outcome = new byte[result.Length];
-            result.Read(outcome, 0, outcome.Length);
-            string outcomeString = Encoding.UTF8.GetString(outcome);
+            string outcomeString = Encoding.UTF8.GetString(result.ToArray());
             Assert.Equal("Hello    \r\n    You", outcomeString);
         }
 
@@ -122,14 +113,11 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There    \r\n    You");
             Stream d = new MemoryStream(data);
-            Stream result = new MemoryStream();
+            MemoryStream result = new MemoryStream();
             bool modified = processor.Run(d, result);
 
             Assert.True(modified);
-            result.Position = 0;
-            byte[] outcome = new byte[result.Length];
-            result.Read(outcome, 0, outcome.Length);
-            string outcomeString = Encoding.UTF8.GetString(outcome);
+            string outcomeString = Encoding.UTF8.GetString(result.ToArray());
             Assert.Equal("Hello    \r\n        \r\n    You", outcomeString);
         }
 
@@ -150,14 +138,11 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There    \r\n    You");
             Stream d = new MemoryStream(data);
-            Stream result = new MemoryStream();
+            MemoryStream result = new MemoryStream();
             bool modified = processor.Run(d, result);
 
             Assert.True(modified);
-            result.Position = 0;
-            byte[] outcome = new byte[result.Length];
-            result.Read(outcome, 0, outcome.Length);
-            string outcomeString = Encoding.UTF8.GetString(outcome);
+            string outcomeString = Encoding.UTF8.GetString(result.ToArray());
             Assert.Equal("Hello    \r\n    You", outcomeString);
         }
 
@@ -186,14 +171,11 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There    \r\n    You");
             Stream d = new MemoryStream(data);
-            Stream result = new MemoryStream();
+            MemoryStream result = new MemoryStream();
             bool modified = processor.Run(d, result);
 
             Assert.True(modified);
-            result.Position = 0;
-            byte[] outcome = new byte[result.Length];
-            result.Read(outcome, 0, outcome.Length);
-            string outcomeString = Encoding.UTF8.GetString(outcome);
+            string outcomeString = Encoding.UTF8.GetString(result.ToArray());
             Assert.Equal("Hello    \r\n    You", outcomeString);
         }
 
@@ -218,14 +200,12 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There    \r\n    You");
             Stream d = new MemoryStream(data);
-            Stream result = new MemoryStream();
+            MemoryStream result = new MemoryStream();
             bool modified = processor.Run(d, result);
 
             Assert.True(modified);
             result.Position = 0;
-            byte[] outcome = new byte[result.Length];
-            result.Read(outcome, 0, outcome.Length);
-            string outcomeString = Encoding.UTF8.GetString(outcome);
+            string outcomeString = Encoding.UTF8.GetString(result.ToArray());
             Assert.Equal("Hello    \r\n    You", outcomeString);
         }
 
@@ -246,14 +226,11 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There     \r\n    You");
             Stream d = new MemoryStream(data);
-            Stream result = new MemoryStream();
+            MemoryStream result = new MemoryStream();
             bool modified = processor.Run(d, result);
 
             Assert.True(modified);
-            result.Position = 0;
-            byte[] outcome = new byte[result.Length];
-            result.Read(outcome, 0, outcome.Length);
-            string outcomeString = Encoding.UTF8.GetString(outcome);
+            string outcomeString = Encoding.UTF8.GetString(result.ToArray());
             Assert.Equal("Hello    \r\n        You", outcomeString);
         }
 
@@ -274,14 +251,11 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There     \r\n    You");
             Stream d = new MemoryStream(data);
-            Stream result = new MemoryStream();
+            MemoryStream result = new MemoryStream();
             bool modified = processor.Run(d, result);
 
             Assert.True(modified);
-            result.Position = 0;
-            byte[] outcome = new byte[result.Length];
-            result.Read(outcome, 0, outcome.Length);
-            string outcomeString = Encoding.UTF8.GetString(outcome);
+            string outcomeString = Encoding.UTF8.GetString(result.ToArray());
             Assert.Equal("Hello    \r\n     \r\n    You", outcomeString);
         }
 
@@ -302,14 +276,11 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             IProcessor processor = Processor.Create(cfg, o.Provider);
             byte[] data = Encoding.UTF8.GetBytes("Hello    \r\n    There     \r\n    You");
             Stream d = new MemoryStream(data);
-            Stream result = new MemoryStream();
+            MemoryStream result = new MemoryStream();
             bool modified = processor.Run(d, result);
 
             Assert.True(modified);
-            result.Position = 0;
-            byte[] outcome = new byte[result.Length];
-            result.Read(outcome, 0, outcome.Length);
-            string outcomeString = Encoding.UTF8.GetString(outcome);
+            string outcomeString = Encoding.UTF8.GetString(result.ToArray());
             Assert.Equal("Hello    \r\n    You", outcomeString);
         }
     }

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/TestBase.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/TestBase.cs
@@ -37,13 +37,32 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 if (preamble.Length > 0)
                 {
                     byte[] readPreamble = new byte[preamble.Length];
-                    Assert.Equal(readPreamble.Length, output.Read(readPreamble, 0, readPreamble.Length));
+                    int totalBytesRead = 0;
+                    while (totalBytesRead < readPreamble.Length)
+                    {
+                        int bytesRead = output.Read(readPreamble, totalBytesRead, readPreamble.Length - totalBytesRead);
+                        if (bytesRead == 0)
+                        {
+                            break;
+                        }
+                        totalBytesRead += bytesRead;
+                    }
                     Assert.Equal(preamble, readPreamble);
                 }
             }
 
             byte[] resultBytes = new byte[output.Length - output.Position];
-            output.Read(resultBytes, 0, resultBytes.Length);
+            int totalRead = 0;
+            while (totalRead < resultBytes.Length)
+            {
+                int bytesRead = output.Read(resultBytes, totalRead, resultBytes.Length - totalRead);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+                totalRead += bytesRead;
+            }
+
             string actual = encoding.GetString(resultBytes);
             Assert.Equal(expected, actual);
 

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/BasicTests.cs
@@ -136,9 +136,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Assert.True(TestUtils.CompareFiles(sourceImage, targetImage), $"The content of {sourceImage} and {targetImage} is not same.");
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "re-enable after https://github.com/dotnet/templating/issues/3325 is fixed")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         internal async Task Create_TemplateWithBinaryFile_Package()
         {
             Console.WriteLine(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);

--- a/test/Microsoft.TemplateEngine.Mocks/MockFileStream.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockFileStream.cs
@@ -17,9 +17,7 @@ namespace Microsoft.TemplateEngine.Mocks
 
         public override void Flush()
         {
-            byte[] buffer = new byte[Length];
-            Read(buffer, 0, buffer.Length);
-            _onFlush(buffer);
+            _onFlush(ToArray());
         }
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
@@ -5,7 +5,9 @@
 
 using System;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.TemplateEngine.TestHelper;
@@ -406,9 +408,7 @@ namespace Dotnet_new3.IntegrationTests
             Assert.True(TestUtils.CompareFiles(sourceImage, targetImage), $"The content of {sourceImage} and {targetImage} is not same.");
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "re-enable after https://github.com/dotnet/templating/issues/3325 is fixed")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CanInstantiateTemplate_WithBinaryFile_FromPackage()
         {
             string templateLocation = TestUtils.GetTestTemplateLocation("TemplateWithBinaryFile");
@@ -434,6 +434,35 @@ namespace Dotnet_new3.IntegrationTests
                 new FileInfo(sourceImage).Length,
                 new FileInfo(targetImage).Length);
             Assert.True(TestUtils.CompareFiles(sourceImage, targetImage), $"The content of {sourceImage} and {targetImage} is not same.");
+        }
+
+        [Fact]
+        public async Task CanInstantiateTemplate_Angular_CanReplaceTextInLargeFile()
+        {
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            using var packageManager = new PackageManager();
+            string packageLocation = await packageManager.GetNuGetPackage("Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0").ConfigureAwait(false);
+            Helpers.InstallNuGetTemplate(packageLocation, _log, workingDirectory, home);
+
+            new DotnetNewCommand(_log, "angular", "-o", "angular")
+               .WithCustomHive(home)
+               .WithWorkingDirectory(workingDirectory)
+               .Execute()
+               .Should().Pass();
+
+            string reactPackageLockJson = Path.Combine(workingDirectory, "angular", "ClientApp", "package-lock.json");
+            var targetText = File.ReadAllText(reactPackageLockJson);
+
+            using (ZipArchive archive = ZipFile.OpenRead(packageLocation))
+            {
+                var reactPackageLockJsonEntry = archive.GetEntry("Angular-CSharp/ClientApp/package-lock.json");
+                Assert.NotNull(reactPackageLockJsonEntry);
+                using var sourceStream = new StreamReader(reactPackageLockJsonEntry!.Open());
+                var sourceText = sourceStream.ReadToEnd();
+                //sourceText = sourceText.Replace("company.webapplication1", "angular");
+                Assert.Equal(sourceText, targetText);
+            }
         }
     }
 }


### PR DESCRIPTION
### Problem
fixes https://github.com/dotnet/templating/issues/3325
The cause of the issue is: https://github.com/dotnet/runtime/issues/53502, https://github.com/dotnet/docs/issues/24649.

### Solution
Affected code:
- `ProcessorState` - reading from stream in a loop until buffer is filled; added unit and integration tests
- `CombinedStream` - reading from stream in a loop until count is reached; added unit tests
- `Include` - reading from stream in a loop until count is reached
- in cases when MemoryStream is used replaced with using `MemoryStream.ToArray()` instead

`Include` is not covered with tests: extracted to https://github.com/dotnet/templating/issues/3438

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - partially