### PR TITLE
dotnet new F# console template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-FSharp/Program.fs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-FSharp/Program.fs
@@ -3,11 +3,14 @@
 open System
 
 // Define a function to construct a message to print
-let from whom =
-    sprintf "from %s" whom
+let helloFrom whom =
+  $"Hello world from {whom}"
 
 [<EntryPoint>]
 let main argv =
-    let message = from "F#" // Call the function
-    printfn "Hello world %s" message
+    // Get the caller from the launch arguments, or a default
+    let caller = if Array.length argv > 0 then argv.[0] else "F#"
+    // Call the function
+    printfn "%s" (helloFrom caller)
     0 // return an integer exit code
+


### PR DESCRIPTION
### Problem

The F# default "Hello World" can be improved.

- It doesn't use F# 5 string interpolation, leading some people to believe F# lacks this feature.
- It could be slightly more inspiring for the lines of code spent.

### Solution

In this PR I propose that

1. we replace the two string substitutions (in `printfn` and `sprintf`) with one single idiomatic one.
2. the (at a glance) hard to follow concatenation of "Hello world" and "from" should be done in one place.
3. we use `argv` and demonstrate the `if` statement to substitute an empty `argv` with a default value.

In my opinion 1 and 2 are very clear improvements, whereas 3 is more of a choice: how much should be showcased in a simple hello-world template. I also didn't contrive a `|>` for example, so I would understand if people thought that `Array`, `argv`, and `if` aren't worth the additional LOC.

### Checks:

Checked that the code compiles, runs, and outputs the expected text, both with and without commandline arguments.