### PR TITLE
added conditional processing for C# language features based on languageVersion / framework

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -84,6 +84,36 @@
       "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false",
       "displayName": "Skip restore"
+    },
+    "csharp10orLater": {
+      "type": "generated",
+      "generator": "regexMatch",
+      "datatype": "bool",
+      "parameters": {
+        "pattern": "^(|10\\.0|10|preview|latest|default|latestMajor)$",
+        "source": "langVersion"
+      }
+    },
+    "csharp8orLater": {
+      "type": "generated",
+      "generator": "regexMatch",
+      "datatype": "bool",
+      "parameters": {
+        "pattern": "^(|8|8\\.0|9|9\\.0|10\\.0|10|preview|latest|default|latestMajor)$",
+        "source": "langVersion"
+      }
+    },
+    "csharpFeature_ImplicitUsings": {
+      "type": "computed",
+      "value": "Framework == \"net6.0\" && csharp10orLater == \"true\""
+    },
+    "csharpFeature_FileScopedNamespaces": {
+      "type": "computed",
+      "value": "(Framework == \"net6.0\" || langVersion != \"\") && csharp10orLater == \"true\""
+    },
+    "csharpFeature_Nullable": {
+      "type": "computed",
+      "value": "(Framework != \"netstandard2.0\" || langVersion != \"\") && csharp8orLater == \"true\""
     }
   },
   "primaryOutputs": [

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/Class1.cs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/Class1.cs
@@ -1,6 +1,11 @@
-﻿namespace Company.ClassLibrary1
+﻿#if (!csharpFeature_ImplicitUsings)
+using System;
+
+#endif
+namespace Company.ClassLibrary1
 {
     public class Class1
     {
+
     }
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/Company.ClassLibrary1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/Company.ClassLibrary1.csproj
@@ -5,7 +5,8 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ClassLibrary1</RootNamespace>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
-    <Nullable Condition="('$(Framework)' != 'netstandard2.0')">enable</Nullable>
+    <DisableImplicitNamespaceImports Condition="'$(csharpFeature_ImplicitUsings)' != 'true'">true</DisableImplicitNamespaceImports>
+    <Nullable Condition="'$(csharpFeature_Nullable)' == 'true'">enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -60,6 +60,45 @@
       "description": "If specified, skips the automatic restore of the project on create.",
       "defaultValue": "false",
       "displayName": "Skip restore"
+    },
+    "csharp10orLater": {
+      "type": "generated",
+      "generator": "regexMatch",
+      "datatype": "bool",
+      "parameters": {
+        "pattern": "^(|10\\.0|10|preview|latest|default|latestMajor)$",
+        "source": "langVersion"
+      }
+    },
+    "csharp9orLater": {
+      "type": "generated",
+      "generator": "regexMatch",
+      "datatype": "bool",
+      "parameters": {
+        "pattern": "^(|9|9\\.0|10\\.0|10|preview|latest|default|latestMajor)$",
+        "source": "langVersion"
+      }
+    },
+    "csharp8orLater": {
+      "type": "generated",
+      "generator": "regexMatch",
+      "datatype": "bool",
+      "parameters": {
+        "pattern": "^(|8|8\\.0|9|9\\.0|10\\.0|10|preview|latest|default|latestMajor)$",
+        "source": "langVersion"
+      }
+    },
+    "csharpFeature_ImplicitUsings": {
+      "type": "computed",
+      "value": "csharp10orLater == \"true\""
+    },
+    "csharpFeature_Nullable": {
+      "type": "computed",
+      "value": "csharp8orLater == \"true\""
+    },
+    "csharpFeature_TopLevelProgram": {
+      "type": "computed",
+      "value": "csharp9orLater == \"true\""
     }
   },
   "primaryOutputs": [

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/Company.ConsoleApplication1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/Company.ConsoleApplication1.csproj
@@ -4,8 +4,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net6.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ConsoleApplication1</RootNamespace>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
-    <Nullable>enable</Nullable>
+    <DisableImplicitNamespaceImports Condition="'$(csharpFeature_ImplicitUsings)' != 'true'">true</DisableImplicitNamespaceImports>
+    <Nullable Condition="'$(csharpFeature_Nullable)' == 'true'">enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/Program.cs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/Program.cs
@@ -1,2 +1,21 @@
-﻿Console.WriteLine("Hello, World!");
+﻿#if (csharpFeature_TopLevelProgram)
 // See https://aka.ms/new-console-template for more information
+#endif
+#if (!csharpFeature_ImplicitUsings)
+using System;
+
+#endif
+#if (csharpFeature_TopLevelProgram)
+Console.WriteLine("Hello, World!");
+#else
+namespace Company.ConsoleApplication1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello, World!");
+        }
+    }
+}
+#endif

--- a/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
+++ b/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
@@ -66,21 +66,6 @@ namespace Dotnet_new3.IntegrationTests
         [InlineData("Class Library", "classlib", "VB", "netstandard2.0")]
         [InlineData("Class Library", "classlib", "F#", "netstandard2.0")]
 
-        [InlineData("Class Library", "classlib", "C#", "net6.0", "10.0")]
-        [InlineData("Class Library", "classlib", "C#", "net6.0", "9.0", Skip = "https://github.com/dotnet/templating/issues/3449")]
-        [InlineData("Class Library", "classlib", "C#", "net6.0", "8.0", Skip = "https://github.com/dotnet/templating/issues/3449")]
-        [InlineData("Class Library", "classlib", "C#", "net6.0", "7.3", Skip = "https://github.com/dotnet/templating/issues/3449")]
-        [InlineData("Class Library", "classlib", "C#", "net6.0", "7.2", Skip = "https://github.com/dotnet/templating/issues/3449")]
-        [InlineData("Class Library", "classlib", "C#", "net6.0", "7.1", Skip = "https://github.com/dotnet/templating/issues/3449")]
-        [InlineData("Class Library", "classlib", "C#", "net6.0", "7", Skip = "https://github.com/dotnet/templating/issues/3449")]
-
-        [InlineData("Console Application", "console", "C#", "net6.0", "10.0")]
-        [InlineData("Console Application", "console", "C#", "net6.0", "9.0", Skip = "https://github.com/dotnet/templating/issues/3449")]
-        [InlineData("Console Application", "console", "C#", "net6.0", "8.0", Skip = "https://github.com/dotnet/templating/issues/3449")]
-        [InlineData("Console Application", "console", "C#", "net6.0", "7.3", Skip = "https://github.com/dotnet/templating/issues/3449")]
-        [InlineData("Console Application", "console", "C#", "net6.0", "7.2", Skip = "https://github.com/dotnet/templating/issues/3449")]
-        [InlineData("Console Application", "console", "C#", "net6.0", "7.1", Skip = "https://github.com/dotnet/templating/issues/3449")]
-        [InlineData("Console Application", "console", "C#", "net6.0", "7", Skip = "https://github.com/dotnet/templating/issues/3449")]
         public void AllCommonProjectsCreateRestoreAndBuild(string expectedTemplateName, string templateShortName, string? language = null, string? framework = null, string? langVersion = null)
         {
             string workingDir = TestUtils.CreateTemporaryFolder();
@@ -243,6 +228,334 @@ Restore succeeded\.");
             Directory.Delete(workingDir, true);
         }
 
+        #region Project templates language features tests
+
+        /// <summary>
+        /// Creates all possible combinations for supported templates, language versions and frameworks.
+        /// </summary>
+        public static IEnumerable<object?[]> TopLevelProgramSupport_Data()
+        {
+            var templatesToTest = new[]
+            {
+                new { Name = "console",  Frameworks = new[] { null, "net6.0" } }
+            };
+
+            string[] unsupportedLanguageVersions = { "1", "ISO-1" };
+            string?[] supportedLanguageVersions = { null, "ISO-2", "2", "3", "4", "5", "6", "7", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "latest", "latestMajor", "default", "preview" };
+
+            string?[] topLevelStatementSupport = { null, "9.0", "10.0", "latest", "latestMajor", "default", "preview" };
+
+            foreach (var template in templatesToTest)
+            {
+                foreach (var langVersion in unsupportedLanguageVersions)
+                {
+                    foreach (var framework in template.Frameworks)
+                    {
+                        yield return new object?[]
+                        {
+                            template.Name,
+                            false, //dotnet build should fail
+                            framework,
+                            langVersion,
+                            topLevelStatementSupport.Contains(langVersion)
+                        };
+                    }
+                }
+                foreach (var langVersion in supportedLanguageVersions)
+                {
+                    foreach (var framework in template.Frameworks)
+                    {
+                        yield return new object?[]
+                        {
+                            template.Name,
+                            true, //dotnet build should pass
+                            framework,
+                            langVersion,
+                            topLevelStatementSupport.Contains(langVersion)
+                        };
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        //creates all possible combinations for supported templates, language versions and frameworks
+        [MemberData(nameof(TopLevelProgramSupport_Data))]
+        public void TopLevelProgramSupport(string name, bool buildPass, string? framework, string? langVersion, bool supportsFeature)
+        {
+            string workingDir = TestUtils.CreateTemporaryFolder();
+
+            List<string> args = new List<string>() { name, "-o", "MyProject" };
+            if (!string.IsNullOrWhiteSpace(framework))
+            {
+                args.Add("--framework");
+                args.Add(framework);
+            }
+            if (!string.IsNullOrWhiteSpace(langVersion))
+            {
+                args.Add("--langVersion");
+                args.Add(langVersion);
+            }
+
+            new DotnetNewCommand(_log, args.ToArray())
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(workingDir)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr();
+
+            var buildResult = new DotnetCommand(_log, "build", "MyProject")
+                .WithWorkingDirectory(workingDir)
+                .Execute();
+
+            if (buildPass)
+            {
+                buildResult.Should().ExitWith(0).And.NotHaveStdErr();
+            }
+            else
+            {
+                buildResult.Should().Fail();
+                return;
+            }
+
+            string programFileContent = File.ReadAllText(Path.Combine(workingDir, "MyProject", "Program.cs"));
+            string unexpectedTopLevelContent =
+@"namespace MyProject
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine(""Hello, World!"");
+        }
+    }
+}
+";
+            if (supportsFeature)
+            {
+                Assert.Contains("Console.WriteLine(\"Hello, World!\")", programFileContent);
+                Assert.Contains("// See https://aka.ms/new-console-template for more information", programFileContent);
+                Assert.DoesNotContain(unexpectedTopLevelContent, programFileContent);
+            }
+            else
+            {
+                Assert.DoesNotContain("// See https://aka.ms/new-console-template for more information", programFileContent);
+                Assert.Contains(unexpectedTopLevelContent, programFileContent);
+            }
+        }
+
+        /// <summary>
+        /// Creates all possible combinations for supported templates, language versions and frameworks.
+        /// </summary>
+        public static IEnumerable<object?[]> NullableSupport_Data()
+        {
+            var templatesToTest = new[]
+            {
+                new { Template = "console",  Frameworks = new[] { null, "net6.0" } },
+                new { Template = "classlib", Frameworks = new[] { null, "net6.0", "netstandard2.0", "netstandard2.1" } }
+            };
+
+            string[] unsupportedLanguageVersions = { "1", "ISO-1" };
+            string?[] supportedLanguageVersions = { null, "ISO-2", "2", "3", "4", "5", "6", "7", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "latest", "latestMajor", "default", "preview" };
+
+            string?[] supportedInFrameworkByDefault = { null, "net6.0", "netstandard2.1" };
+            string?[] supportedInLanguageVersion = { "8.0", "9.0", "10.0", "latest", "latestMajor", "default", "preview" };
+
+            foreach (var template in templatesToTest)
+            {
+                foreach (var langVersion in unsupportedLanguageVersions)
+                {
+                    foreach (var framework in template.Frameworks)
+                    {
+                        yield return new object?[]
+                        {
+                            template.Template,
+                            false,  //dotnet build should fail
+                            framework,
+                            langVersion,
+                            supportedInLanguageVersion.Contains(langVersion)
+                                || langVersion == null && supportedInFrameworkByDefault.Contains(framework)
+                        };
+                    }
+                }
+                foreach (var langVersion in supportedLanguageVersions)
+                {
+                    foreach (var framework in template.Frameworks)
+                    {
+                        yield return new object?[]
+                        {
+                            template.Template,
+                            true,   //dotnet build should pass
+                            framework,
+                            langVersion,
+                            supportedInLanguageVersion.Contains(langVersion)
+                                || langVersion == null && supportedInFrameworkByDefault.Contains(framework)
+                        };
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        //creates all possible combinations for supported templates, language versions and frameworks
+        [MemberData(nameof(NullableSupport_Data))]
+        public void NullableSupport(string name, bool buildPass, string? framework, string? langVersion, bool supportsFeature)
+        {
+            string workingDir = TestUtils.CreateTemporaryFolder();
+
+            List<string> args = new List<string>() { name, "-o", "MyProject" };
+            if (!string.IsNullOrWhiteSpace(framework))
+            {
+                args.Add("--framework");
+                args.Add(framework);
+            }
+            if (!string.IsNullOrWhiteSpace(langVersion))
+            {
+                args.Add("--langVersion");
+                args.Add(langVersion);
+            }
+
+            new DotnetNewCommand(_log, args.ToArray())
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(workingDir)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr();
+
+            var buildResult = new DotnetCommand(_log, "build", "MyProject")
+                .WithWorkingDirectory(workingDir)
+                .Execute();
+
+            if (buildPass)
+            {
+                buildResult.Should().ExitWith(0).And.NotHaveStdErr();
+            }
+            else
+            {
+                buildResult.Should().Fail();
+                return;
+            }
+
+            XDocument projectXml = XDocument.Load(Path.Combine(workingDir, "MyProject", "MyProject.csproj"));
+            XNamespace ns = projectXml.Root?.Name.Namespace ?? throw new Exception("Unexpected project file format");
+            if (supportsFeature)
+            {
+                Assert.Equal("enable", projectXml.Root?.Element(ns + "PropertyGroup")?.Element(ns + "Nullable")?.Value);
+            }
+            else
+            {
+                Assert.Null(projectXml.Root?.Element(ns + "PropertyGroup")?.Element(ns + "Nullable"));
+            }
+        }
+
+        /// <summary>
+        /// Creates all possible combinations for supported templates, language versions and frameworks.
+        /// </summary>
+        public static IEnumerable<object?[]> ImplicitUsingsSupport_Data()
+        {
+            var templatesToTest = new[]
+            {
+                new { Template = "console",  Frameworks = new[] { null, "net6.0" } },
+                new { Template = "classlib", Frameworks = new[] { null, "net6.0", "netstandard2.0", "netstandard2.1" } }
+            };
+            string[] unsupportedLanguageVersions = { "1", "ISO-1" };
+            string?[] supportedLanguageVersions = { null, "ISO-2", "2", "3", "4", "5", "6", "7", "7.1", "7.2", "7.3", "8.0", "9.0", "10.0", "latest", "latestMajor", "default", "preview" };
+
+            string?[] supportedInFramework = { null, "net6.0" };
+            string?[] supportedInLangVersion = { null, "10.0", "latest", "latestMajor", "default", "preview" };
+
+            foreach (var template in templatesToTest)
+            {
+                foreach (var langVersion in unsupportedLanguageVersions)
+                {
+                    foreach (var framework in template.Frameworks)
+                    {
+                        yield return new object?[]
+                        {
+                            template.Template,
+                            false,  //dotnet build should fail
+                            framework,
+                            langVersion,
+                            supportedInLangVersion.Contains(langVersion) && supportedInFramework.Contains(framework)
+                        };
+                    }
+                }
+                foreach (var langVersion in supportedLanguageVersions)
+                {
+                    foreach (var framework in template.Frameworks)
+                    {
+                        yield return new object?[]
+                        {
+                            template.Template,
+                            true, //dotnet build should pass
+                            framework,
+                            langVersion,
+                            supportedInLangVersion.Contains(langVersion) && supportedInFramework.Contains(framework)
+                        };
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        //creates all possible combinations for supported templates, language versions and frameworks
+        [MemberData(nameof(ImplicitUsingsSupport_Data))]
+        public void ImplicitUsingsSupport(string name, bool buildPass, string? framework, string? langVersion, bool supportsFeature)
+        {
+            string workingDir = TestUtils.CreateTemporaryFolder();
+
+            List<string> args = new List<string>() { name, "-o", "MyProject" };
+            if (!string.IsNullOrWhiteSpace(framework))
+            {
+                args.Add("--framework");
+                args.Add(framework);
+            }
+            if (!string.IsNullOrWhiteSpace(langVersion))
+            {
+                args.Add("--langVersion");
+                args.Add(langVersion);
+            }
+
+            new DotnetNewCommand(_log, args.ToArray())
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(workingDir)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr();
+
+            var buildResult = new DotnetCommand(_log, "build", "MyProject")
+                .WithWorkingDirectory(workingDir)
+                .Execute();
+
+            if (buildPass)
+            {
+                buildResult.Should().ExitWith(0).And.NotHaveStdErr();
+            }
+            else
+            {
+                buildResult.Should().Fail();
+                return;
+            }
+            string codeFileName = name == "console" ? "Program.cs" : "Class1.cs";
+            string programFileContent = File.ReadAllText(Path.Combine(workingDir, "MyProject", codeFileName));
+            XDocument projectXml = XDocument.Load(Path.Combine(workingDir, "MyProject", "MyProject.csproj"));
+            XNamespace ns = projectXml.Root?.Name.Namespace ?? throw new Exception("Unexpected project file format");
+            if (supportsFeature)
+            {
+                Assert.DoesNotContain("using System;", programFileContent);
+                Assert.Null(projectXml.Root?.Element(ns + "PropertyGroup")?.Element(ns + "DisableImplicitNamespaceImports"));
+            }
+            else
+            {
+                Assert.Contains("using System;", programFileContent);
+                Assert.Equal("true", projectXml.Root?.Element(ns + "PropertyGroup")?.Element(ns + "DisableImplicitNamespaceImports")?.Value);
+            }
+        }
+        #endregion
+
         [Theory]
         [InlineData("Nullable", "enable", "Console Application", "console", null, null)]
         [InlineData("CheckForOverflowUnderflow", null, "Console Application", "console", null, null)]
@@ -251,9 +564,6 @@ Restore succeeded\.");
         [InlineData("Nullable", null, "Console Application", "console", null, "net5.0")]
         [InlineData("Nullable", null, "Console Application", "console", null, "netcoreapp3.1")]
         [InlineData("Nullable", null, "Console Application", "console", null, "netcoreapp2.1")]
-        [InlineData("Nullable", "enable", "Console Application", "console", null, null, "9.0")]
-        [InlineData("Nullable", "enable", "Console Application", "console", null, null, "8.0")]
-        [InlineData("Nullable", "enable", "Console Application", "console", null, null, "7.3")]
 
         [InlineData("Nullable", null, "Console Application", "console", "F#", null)]
         [InlineData("CheckForOverflowUnderflow", null, "Console Application", "console", "F#", null)]
@@ -286,7 +596,7 @@ Restore succeeded\.");
         [InlineData("TargetFramework", "net6.0", "Class Library", "classlib", "VB", null)]
         [InlineData("Nullable", null, "Class Library", "classlib", "VB", "netstandard2.0")]
 
-        public void SetPropertiesByDefault(string propertyName, string? propertyValue, string expectedTemplateName, string templateShortName, string? language, string? framework, string? langVersion = null)
+        public void SetPropertiesByDefault(string propertyName, string? propertyValue, string expectedTemplateName, string templateShortName, string? language, string? framework)
         {
             string workingDir = TestUtils.CreateTemporaryFolder();
             List<string> args = new List<string>() { templateShortName, "--no-restore" };
@@ -299,11 +609,6 @@ Restore succeeded\.");
             {
                 args.Add("--framework");
                 args.Add(framework);
-            }
-            if (!string.IsNullOrWhiteSpace(langVersion))
-            {
-                args.Add("--langVersion");
-                args.Add(langVersion);
             }
 
             new DotnetNewCommand(_log, args.ToArray())


### PR DESCRIPTION
### Problem
fixes https://github.com/dotnet/templating/issues/3449

### Solution
Added conditional processing for classlib / console based on framework and language versions:
- conditions do not take into account possible value of `target-framework-override` option (option is hidden from user)
- conditions assume `latest`, `default`, `latestMajor`, `preview` language versions support all the features.

### Checks:
- [x] Added unit tests
