### PR TITLE
wrong Chinese locale is used for localizing the template content

### DIFF
--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/LocalizationTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/LocalizationTests.cs
@@ -148,10 +148,12 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         }
 
         [Theory]
-        [InlineData("de", "name_de-DE:äÄßöÖüÜ")]
+        [InlineData("de", "name")]
         [InlineData("de-de", "name_de-DE:äÄßöÖüÜ")]
-        [InlineData("de-Au", "name_de-DE:äÄßöÖüÜ")]
-        [InlineData("de-AU", "name_de-DE:äÄßöÖüÜ")]
+        [InlineData("de-AT", "name")]
+        [InlineData("de-at", "name")]
+        [InlineData("tr", "name_tr-TR:çÇğĞıIİöÖşŞüÜ")]
+        [InlineData("tr-TR", "name_tr-TR:çÇğĞıIİöÖşŞüÜ")]
         public void TestLocaleCountryFallback(string locale, string expectedName)
         {
             _ = LoadHostWithLocalizationTemplates(locale, out _, out ITemplateInfo localizationTemplate);

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/TemplateCacheTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/TemplateCacheTests.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+#if !NET6_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Linq;
+#endif
+using System.Globalization;
+using FakeItEasy;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Edge.UnitTests
+{
+    public class TemplateCacheTests
+    {
+        [Theory]
+        [InlineData("en-US", "en")]
+        [InlineData("zh-CN", "zh-Hans")]
+        [InlineData("zh-SG", "zh-Hans")]
+        [InlineData("zh-TW", "zh-Hant")]
+        [InlineData("zh-HK", "zh-Hant")]
+        [InlineData("zh-MO", "zh-Hant")]
+        [InlineData("pt-BR", "pt-BR")]
+        [InlineData("pt", null)]
+        [InlineData("uk-UA", null)]
+        [InlineData("invariant", null)]
+        public void PicksCorrectLocator (string currentCulture, string? expectedLocator)
+        {
+            CultureInfo persistedCulture = CultureInfo.CurrentUICulture;
+            try
+            {
+                if (currentCulture != "invariant")
+                {
+                    CultureInfo.CurrentUICulture = new CultureInfo(currentCulture);
+                }
+                else
+                {
+                    currentCulture = "";
+                    CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+                }
+                string[] availableLocales = new[] { "cs", "de", "en", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-Hans", "zh-Hant" };
+
+                ITemplate template = A.Fake<ITemplate>();
+                A.CallTo(() => template.Identity).Returns("testIdentity");
+                List<ILocalizationLocator> locators = new List<ILocalizationLocator>();
+                foreach (string locale in availableLocales)
+                {
+                    ILocalizationLocator locator = A.Fake<ILocalizationLocator>();
+                    A.CallTo(() => locator.Identity).Returns("testIdentity");
+                    A.CallTo(() => locator.Locale).Returns(locale);
+                    A.CallTo(() => locator.Name).Returns(locale + " name");
+                    locators.Add(locator);
+                }
+                IMountPoint mountPoint = A.Fake<IMountPoint>();
+                A.CallTo(() => mountPoint.MountPointUri).Returns("testMount");
+
+                ScanResult result = new ScanResult(mountPoint, new[] { template }, locators, Array.Empty<(string AssemblyPath, Type InterfaceType, IIdentifiedComponent Instance)>());
+
+                TemplateCache templateCache = new TemplateCache(new[] { result }, new Dictionary<string, DateTime>(), NullLogger.Instance);
+
+                Assert.Equal(currentCulture, templateCache.Locale);
+                Assert.Equal("testIdentity", templateCache.TemplateInfo.Single().Identity);
+                Assert.Equal(string.IsNullOrEmpty(expectedLocator) ? "" : expectedLocator + " name", templateCache.TemplateInfo.Single().Name);
+            }
+            finally
+            {
+                CultureInfo.CurrentUICulture = persistedCulture;
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
### Problem
fixes dotnet/templating#3460

### Solution
Template locale determination code was not correct. Fixed it to be similar to what [Resource Manager](https://source.dot.net/#System.Private.CoreLib/ResourceManager.cs) does

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)