### PR TITLE
Template discovery tool now supports legacy and current format

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
@@ -77,7 +77,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 {
                     tags[tag.Key] = new CacheTag(null, null, new Dictionary<string, ParameterChoice> { { tag.Value, new ParameterChoice(null, null) } }, tag.Value);
                 }
-                foreach (ITemplateParameter parameter in ((ITemplateInfo)this).Parameters.Where(p => p.DataType.Equals("choice", StringComparison.OrdinalIgnoreCase)))
+                foreach (ITemplateParameter parameter in ((ITemplateInfo)this).Parameters.Where(p => p.DataType != null && p.DataType.Equals("choice", StringComparison.OrdinalIgnoreCase)))
                 {
                     tags[parameter.Name] = new CacheTag(parameter.DisplayName, parameter.Description, parameter.Choices, parameter.DefaultValue);
                 }
@@ -91,7 +91,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             get
             {
                 Dictionary<string, ICacheParameter> cacheParameters = new Dictionary<string, ICacheParameter>();
-                foreach (ITemplateParameter parameter in ((ITemplateInfo)this).Parameters.Where(p => !p.DataType.Equals("choice", StringComparison.OrdinalIgnoreCase)))
+                foreach (ITemplateParameter parameter in ((ITemplateInfo)this).Parameters.Where(p => p.DataType != null && !p.DataType.Equals("choice", StringComparison.OrdinalIgnoreCase)))
                 {
                     cacheParameters[parameter.Name] = new CacheParameter()
                     {
@@ -126,7 +126,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         IFileSystemInfo ITemplate.LocaleConfiguration => _localeConfigFile;
 
-        string ITemplateInfo.LocaleConfigPlace => _localeConfigFile.FullPath;
+        string ITemplateInfo.LocaleConfigPlace => _localeConfigFile?.FullPath;
 
         //read in simple template model instead
         bool ITemplate.IsNameAgreementWithFolderPreferred => _config.PreferNameDirectory;

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyBlobTemplateInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyBlobTemplateInfo.cs
@@ -1,0 +1,237 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Utils;
+using Newtonsoft.Json;
+
+namespace Microsoft.TemplateSearch.TemplateDiscovery.Results
+{
+    internal class LegacyBlobTemplateInfo : ITemplateInfo
+    {
+        public LegacyBlobTemplateInfo(ITemplateInfo templateInfo)
+        {
+            Author = templateInfo.Author;
+            Classifications = templateInfo.Classifications;
+            DefaultName = templateInfo.DefaultName;
+            Description = templateInfo.Description;
+            Identity = templateInfo.Identity;
+            GeneratorId = templateInfo.GeneratorId;
+            GroupIdentity = templateInfo.GroupIdentity;
+            Precedence = templateInfo.Precedence;
+            Name = templateInfo.Name;
+            ShortNameList = templateInfo.ShortNameList;
+            ConfigPlace = templateInfo.ConfigPlace;
+            LocaleConfigPlace = templateInfo.LocaleConfigPlace;
+            HostConfigPlace = templateInfo.HostConfigPlace;
+            ThirdPartyNotices = templateInfo.ThirdPartyNotices;
+            BaselineInfo = templateInfo.BaselineInfo;
+
+            //new properties - not written to json
+            MountPointUri = templateInfo.MountPointUri;
+            Parameters = templateInfo.Parameters;
+            TagsCollection = templateInfo.TagsCollection;
+#pragma warning disable CS0618 // Type or member is obsolete
+            Tags = templateInfo.Tags;
+            CacheParameters = templateInfo.CacheParameters;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            //compatibility for old way to manage parameters
+            Dictionary<string, LegacyCacheTag> tags = new Dictionary<string, LegacyCacheTag>();
+            foreach (KeyValuePair<string, string> tag in TagsCollection)
+            {
+                Dictionary<string, string> choices = new Dictionary<string, string>();
+                choices.Add(tag.Value, "");
+                tags[tag.Key] = new LegacyCacheTag(null, choices, tag.Value);
+            }
+
+            foreach (ITemplateParameter choiceParam in Parameters.Where(param => param.IsChoice()))
+            {
+                Dictionary<string, string> choices = new Dictionary<string, string>();
+                if (choiceParam.Choices != null)
+                {
+                    foreach (var choice in choiceParam.Choices)
+                    {
+                        choices.Add(choice.Key, choice.Value.Description ?? string.Empty);
+                    }
+                }
+                tags[choiceParam.Name] = new LegacyCacheTag(choiceParam.Description, choices, choiceParam.DefaultValue, choiceParam.DefaultIfOptionWithoutValue);
+            }
+            LegacyTags = tags;
+
+            Dictionary<string, LegacyCacheParameter> cacheParameters = new Dictionary<string, LegacyCacheParameter>();
+            foreach (ITemplateParameter param in Parameters.Where(param => !param.IsChoice()))
+            {
+                cacheParameters[param.Name] = new LegacyCacheParameter()
+                {
+                    DataType = param.DataType,
+                    DefaultIfOptionWithoutValue = param.DefaultIfOptionWithoutValue,
+                    DefaultValue = param.DefaultValue,
+                    Description = param.Description
+                };
+            }
+            LegacyCacheParameters = cacheParameters;
+        }
+
+        [JsonProperty]
+        public Guid ConfigMountPointId { get; set; }
+
+        [JsonProperty]
+        public string? Author { get; private set; }
+
+        [JsonProperty]
+        public IReadOnlyList<string> Classifications { get; private set; }
+
+        [JsonProperty]
+        public string? DefaultName { get; private set; }
+
+        [JsonProperty]
+        public string? Description { get; private set; }
+
+        [JsonProperty]
+        public string Identity { get; private set; }
+
+        [JsonProperty]
+        public Guid GeneratorId { get; private set; }
+
+        [JsonProperty]
+        public string? GroupIdentity { get; private set; }
+
+        [JsonProperty]
+        public int Precedence { get; private set; }
+
+        [JsonProperty]
+        public string Name { get; private set; }
+
+        [JsonProperty]
+        public string ShortName
+        {
+            get
+            {
+                if (ShortNameList.Count > 0)
+                {
+                    return ShortNameList[0];
+                }
+
+                return string.Empty;
+            }
+
+            set
+            {
+                if (ShortNameList.Count > 0)
+                {
+                    throw new Exception("Can't set the short name when the ShortNameList already has entries.");
+                }
+
+                ShortNameList = new List<string>() { value };
+            }
+        }
+
+        public IReadOnlyList<string> ShortNameList { get; private set; }
+
+        [JsonProperty(nameof(Tags))]
+        public IReadOnlyDictionary<string, LegacyCacheTag> LegacyTags { get; private set; }
+
+        [JsonProperty(nameof(CacheParameters))]
+        public IReadOnlyDictionary<string, LegacyCacheParameter> LegacyCacheParameters { get; private set; }
+
+        [JsonProperty]
+        public string ConfigPlace { get; private set; }
+
+        [JsonProperty]
+        public Guid LocaleConfigMountPointId { get; private set; }
+
+        [JsonProperty]
+        public string? LocaleConfigPlace { get; private set; }
+
+        [JsonProperty]
+        public Guid HostConfigMountPointId { get; private set; }
+
+        [JsonProperty]
+        public string? HostConfigPlace { get; private set; }
+
+        [JsonProperty]
+        public string? ThirdPartyNotices { get; private set; }
+
+        [JsonProperty]
+        public IReadOnlyDictionary<string, IBaselineInfo> BaselineInfo { get; private set; }
+
+        [JsonProperty]
+        public bool HasScriptRunningPostActions { get; set; }
+
+        [JsonProperty]
+        public DateTime? ConfigTimestampUtc { get; private set; }
+
+        [JsonIgnore]
+        public IReadOnlyDictionary<string, string> TagsCollection { get; private set; }
+
+        [JsonIgnore]
+        public IReadOnlyList<ITemplateParameter> Parameters { get; private set; }
+
+        [JsonIgnore]
+        public string MountPointUri { get; private set; }
+
+        [JsonIgnore]
+#pragma warning disable CS0618 // Type or member is obsolete
+        public IReadOnlyDictionary<string, ICacheTag> Tags { get; private set; }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+    [JsonIgnore]
+#pragma warning disable CS0618 // Type or member is obsolete
+        public IReadOnlyDictionary<string, ICacheParameter> CacheParameters { get; private set; }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        // ShortName should get deserialized when it exists, for backwards compat.
+        // But moving forward, ShortNameList should be the definitive source.
+        // It can still be ShortName in the template.json, but in the caches it'll be ShortNameList
+        public bool ShouldSerializeShortName()
+        {
+            return false;
+        }
+
+        internal class LegacyCacheTag
+        {
+            public LegacyCacheTag(string? description, IReadOnlyDictionary<string, string> choicesAndDescriptions, string defaultValue)
+                : this(description, choicesAndDescriptions, defaultValue, null)
+            {
+            }
+
+            public LegacyCacheTag(string? description, IReadOnlyDictionary<string, string> choicesAndDescriptions, string? defaultValue, string? defaultIfOptionWithoutValue)
+            {
+                Description = description;
+                ChoicesAndDescriptions = choicesAndDescriptions.CloneIfDifferentComparer(StringComparer.OrdinalIgnoreCase);
+                DefaultValue = defaultValue;
+                DefaultIfOptionWithoutValue = defaultIfOptionWithoutValue;
+            }
+
+            public string? Description { get; }
+
+            public IReadOnlyDictionary<string, string> ChoicesAndDescriptions { get; }
+
+            public string? DefaultValue { get; }
+
+            public string? DefaultIfOptionWithoutValue { get; set; }
+
+            public bool ShouldSerializeDefaultIfOptionWithoutValue()
+            {
+                return !string.IsNullOrEmpty(DefaultIfOptionWithoutValue);
+            }
+        }
+
+        internal class LegacyCacheParameter
+        {
+            public string? DataType { get; set; }
+
+            public string? DefaultValue { get; set; }
+
+            public string? Description { get; set; }
+
+            public string? DefaultIfOptionWithoutValue { get; set; }
+
+            public bool ShouldSerializeDefaultIfOptionWithoutValue()
+            {
+                return !string.IsNullOrEmpty(DefaultIfOptionWithoutValue);
+            }
+        }
+    }
+}

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyMetadataWriter.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyMetadataWriter.cs
@@ -1,0 +1,59 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateSearch.Common;
+using Microsoft.TemplateSearch.TemplateDiscovery.AdditionalData;
+using Microsoft.TemplateSearch.TemplateDiscovery.Nuget;
+using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking.Reporting;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateSearch.TemplateDiscovery.Results
+{
+    internal partial class LegacyMetadataWriter
+    {
+        internal static string WriteLegacySearchMetadata(PackSourceCheckResult packSourceCheckResults, string outputFileName)
+        {
+            var searchMetadata = CreateLegacySearchMetadata(packSourceCheckResults);
+            JObject toSerialize = JObject.FromObject(searchMetadata);
+            File.WriteAllText(outputFileName, toSerialize.ToString());
+            Console.WriteLine($"Legacy search cache file created: {outputFileName}");
+            return outputFileName;
+        }
+
+        private static TemplateDiscoveryMetadata CreateLegacySearchMetadata(PackSourceCheckResult packSourceCheckResults)
+        {
+            List<ITemplateInfo> templateCache = packSourceCheckResults.PackCheckData.Where(r => r.AnyTemplates)
+                                                    .SelectMany(r => r.FoundTemplates)
+                                                    .Distinct(new TemplateIdentityEqualityComparer())
+                                                    .Select(t => (ITemplateInfo)new LegacyBlobTemplateInfo(t))
+                                                    .ToList();
+
+            Dictionary<string, PackToTemplateEntry> packToTemplateMap = packSourceCheckResults.PackCheckData
+                            .Where(r => r.AnyTemplates)
+                            .ToDictionary(
+                                r => r.PackInfo.Id,
+                                r =>
+                                {
+                                    PackToTemplateEntry packToTemplateEntry = new PackToTemplateEntry(
+                                            r.PackInfo.Version,
+                                            r.FoundTemplates.Select(t => new TemplateIdentificationEntry(t.Identity, t.GroupIdentity)).ToList());
+
+                                    if (r.PackInfo is NugetPackInfo npi)
+                                    {
+                                        packToTemplateEntry.TotalDownloads = npi.TotalDownloads;
+                                    }
+                                    return packToTemplateEntry;
+                                });
+
+            Dictionary<string, object> additionalData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (IAdditionalDataProducer dataProducer in packSourceCheckResults.AdditionalDataProducers)
+            {
+                additionalData[dataProducer.DataUniqueName] = dataProducer.Data;
+            }
+
+            return new TemplateDiscoveryMetadata("1.0.0.3", templateCache, packToTemplateMap, additionalData);
+        }
+    }
+}

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/TemplateIdentityEqualityComparer.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/TemplateIdentityEqualityComparer.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateSearch.TemplateDiscovery.Results
+{
+    internal class TemplateIdentityEqualityComparer : IEqualityComparer<ITemplateInfo>
+    {
+        public bool Equals(ITemplateInfo? x, ITemplateInfo? y)
+        {
+            if (x == null && y == null)
+            {
+                return true;
+            }
+            if (x == null || y == null)
+            {
+                return false;
+            }
+            return string.Equals(x.Identity, y.Identity, StringComparison.Ordinal);
+        }
+
+        public int GetHashCode(ITemplateInfo obj)
+        {
+            return obj.Identity.GetHashCode();
+        }
+    }
+}

--- a/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/TemplateDiscoveryTests.cs
+++ b/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/TemplateDiscoveryTests.cs
@@ -35,30 +35,56 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests
                 .Should()
                 .ExitWith(0);
 
-            string cacheFilePath = Path.Combine(testDir, "SearchCache", "NuGetTemplateSearchInfo.json");
-            Assert.True(File.Exists(cacheFilePath));
-
+            string[] cacheFilePaths = new[]
+            {
+                Path.Combine(testDir, "SearchCache", "NuGetTemplateSearchInfo.json"),
+                Path.Combine(testDir, "SearchCache", "NuGetTemplateSearchInfoVer2.json")
+            };
             var settingsPath = TestUtils.CreateTemporaryFolder();
 
-            new DotnetNew3Command(_log)
-                  .WithCustomHive(settingsPath)
-                  .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
-                  .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
-                  .Execute()
-                  .Should()
-                  .ExitWith(0)
-                  .And.NotHaveStdErr();
+            foreach (var cacheFilePath in cacheFilePaths)
+            {
+                Assert.True(File.Exists(cacheFilePath));
+                new DotnetNew3Command(_log)
+                      .WithCustomHive(settingsPath)
+                      .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
+                      .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
+                      .Execute()
+                      .Should()
+                      .ExitWith(0)
+                      .And.NotHaveStdErr();
 
-            new DotnetNew3Command(_log, "func", "--search")
-                .WithCustomHive(settingsPath)
-                .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
-                .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
-                .Execute()
-                .Should()
-                .ExitWith(0)
-                .And.NotHaveStdErr()
-                .And.NotHaveStdOutContaining("Exception")
-                .And.HaveStdOutContaining("Microsoft.Azure.WebJobs.ProjectTemplates");
+                new DotnetNew3Command(_log, "func", "--search")
+                    .WithCustomHive(settingsPath)
+                    .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
+                    .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
+                    .Execute()
+                    .Should()
+                    .ExitWith(0)
+                    .And.NotHaveStdErr()
+                    .And.NotHaveStdOutContaining("Exception")
+                    .And.HaveStdOutContaining("Microsoft.Azure.WebJobs.ProjectTemplates");
+
+                new DotnetNew3Command(_log)
+                      .WithCustomHive(settingsPath)
+                      .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
+                      .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
+                      .Execute()
+                      .Should()
+                      .ExitWith(0)
+                      .And.NotHaveStdErr();
+
+                new DotnetNew3Command(_log, "func", "--search")
+                    .WithCustomHive(settingsPath)
+                    .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
+                    .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
+                    .Execute()
+                    .Should()
+                    .ExitWith(0)
+                    .And.NotHaveStdErr()
+                    .And.NotHaveStdOutContaining("Exception")
+                    .And.HaveStdOutContaining("Microsoft.Azure.WebJobs.ProjectTemplates");
+            }
         }
 
         [Fact]
@@ -80,62 +106,68 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests
                 .Should()
                 .ExitWith(0);
 
-            string cacheFilePath = Path.Combine(testDir, "SearchCache", "NuGetTemplateSearchInfo.json");
-            Assert.True(File.Exists(cacheFilePath));
-
+            string[] cacheFilePaths = new[]
+            {
+                Path.Combine(testDir, "SearchCache", "NuGetTemplateSearchInfo.json"),
+                Path.Combine(testDir, "SearchCache", "NuGetTemplateSearchInfoVer2.json")
+            };
             var settingsPath = TestUtils.CreateTemporaryFolder();
 
-            new DotnetNew3Command(_log)
-                  .WithCustomHive(settingsPath)
-                  .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
-                  .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
-                  .Execute()
-                  .Should()
-                  .ExitWith(0)
-                  .And.NotHaveStdErr();
+            foreach (var cacheFilePath in cacheFilePaths)
+            {
+                Assert.True(File.Exists(cacheFilePath));
+                new DotnetNew3Command(_log)
+                      .WithCustomHive(settingsPath)
+                      .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
+                      .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
+                      .Execute()
+                      .Should()
+                      .ExitWith(0)
+                      .And.NotHaveStdErr();
 
-            new DotnetNew3Command(_log, "CliHostFile", "--search")
-                .WithCustomHive(settingsPath)
-                .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
-                .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
-                .Execute()
-                .Should()
-                .ExitWith(0)
-                .And.NotHaveStdErr()
-                .And.NotHaveStdOutContaining("Exception")
-                .And.HaveStdOutContaining("TestAssets.TemplateWithCliHostFile")
-                .And.HaveStdOutContaining("Microsoft.TemplateEngine.TestTemplates");
+                new DotnetNew3Command(_log, "CliHostFile", "--search")
+                    .WithCustomHive(settingsPath)
+                    .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
+                    .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
+                    .Execute()
+                    .Should()
+                    .ExitWith(0)
+                    .And.NotHaveStdErr()
+                    .And.NotHaveStdOutContaining("Exception")
+                    .And.HaveStdOutContaining("TestAssets.TemplateWithCliHostFile")
+                    .And.HaveStdOutContaining("Microsoft.TemplateEngine.TestTemplates");
 
-            new DotnetNew3Command(_log, "--search", "--param")
-                 .WithCustomHive(settingsPath)
-                 .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
-                 .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
-                 .Execute()
-                 .Should()
-                 .ExitWith(0)
-                 .And.NotHaveStdErr()
-                 .And.NotHaveStdOutContaining("Exception")
-                 .And.HaveStdOutContaining("TestAssets.TemplateWithCliHostFile")
-                 .And.HaveStdOutContaining("Microsoft.TemplateEngine.TestTemplates");
+                new DotnetNew3Command(_log, "--search", "--param")
+                     .WithCustomHive(settingsPath)
+                     .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
+                     .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
+                     .Execute()
+                     .Should()
+                     .ExitWith(0)
+                     .And.NotHaveStdErr()
+                     .And.NotHaveStdOutContaining("Exception")
+                     .And.HaveStdOutContaining("TestAssets.TemplateWithCliHostFile")
+                     .And.HaveStdOutContaining("Microsoft.TemplateEngine.TestTemplates");
 
-            new DotnetNew3Command(_log, "--search", "-p")
-                .WithCustomHive(settingsPath)
-                .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
-                .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
-                .Execute()
-                .Should()
-                .ExitWith(0)
-                .And.NotHaveStdErr()
-                .And.NotHaveStdOutContaining("Exception")
-                .And.HaveStdOutContaining("TestAssets.TemplateWithCliHostFile")
-                .And.HaveStdOutContaining("Microsoft.TemplateEngine.TestTemplates");
+                new DotnetNew3Command(_log, "--search", "-p")
+                    .WithCustomHive(settingsPath)
+                    .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
+                    .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
+                    .Execute()
+                    .Should()
+                    .ExitWith(0)
+                    .And.NotHaveStdErr()
+                    .And.NotHaveStdOutContaining("Exception")
+                    .And.HaveStdOutContaining("TestAssets.TemplateWithCliHostFile")
+                    .And.HaveStdOutContaining("Microsoft.TemplateEngine.TestTemplates");
 
-            new DotnetNew3Command(_log, "--search", "--test-param")
-                .WithCustomHive(settingsPath)
-                .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
-                .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
-                .Execute()
-                .Should().Fail();
+                new DotnetNew3Command(_log, "--search", "--test-param")
+                    .WithCustomHive(settingsPath)
+                    .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
+                    .WithEnvironmentVariable("DOTNET_CLI_CONTEXT_VERBOSE", "true")
+                    .Execute()
+                    .Should().Fail();
+            }
         }
     }
 }


### PR DESCRIPTION
### Problem
Template discovery tool exists in main and legacy branches and branches become more and more different. This makes them difficult to support.

### Solution
Improved template discovery tool to be able to create both formats.
Some code is intentionally copied as the v2 will change soon.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)