### PR TITLE
[Template Discovery tool] use NuGet SDK where possible, get service URI from index

### DIFF
--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -11,8 +11,9 @@
   <ItemGroup>
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Cli\Microsoft.TemplateEngine.Cli.csproj" />
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Orchestrator.RunnableProjects\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj" />
-
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NuGet.Configuration" />
+    <PackageReference Include="NuGet.Protocol" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some changes to template discovery tool from owners issue investigation

### Problem
Template discovery tool is not using NuGet SDK and uses outdated URIs.

### Solution
Download of the packages are now done via NuGet SDK.
Cannot use NuGet SDK for search and packageType queries are not working through SDK.
Fixed getting URIs from server instead of using hardcoded ones

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)