### PR TITLE
fixes dotnet/templating#3403 show all template authors in tabular output

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
@@ -125,7 +125,11 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             INewCommandInput commandInput,
             bool useErrorOutput = false)
         {
-            IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay = TemplateGroupDisplay.GetTemplateGroupsForListDisplay(templateGroups, commandInput.Language, _defaultLanguage);
+            IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay = TemplateGroupDisplay.GetTemplateGroupsForListDisplay(
+                templateGroups,
+                commandInput.Language,
+                _defaultLanguage,
+                _engineEnvironmentSettings.Environment);
             DisplayTemplateList(groupsForDisplay, commandInput, useErrorOutput);
         }
 
@@ -146,7 +150,11 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             INewCommandInput commandInput,
             bool useErrorOutput = false)
         {
-            IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay = TemplateGroupDisplay.GetTemplateGroupsForListDisplay(templates, commandInput.Language, _defaultLanguage);
+            IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay = TemplateGroupDisplay.GetTemplateGroupsForListDisplay(
+                templates,
+                commandInput.Language,
+                _defaultLanguage,
+                _engineEnvironmentSettings.Environment);
             DisplayTemplateList(groupsForDisplay, commandInput, useErrorOutput);
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/TableOutput/HelpFormatter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TableOutput/HelpFormatter.cs
@@ -57,7 +57,6 @@ namespace Microsoft.TemplateEngine.Cli
         internal string Layout()
         {
             Dictionary<int, int> columnWidthLookup = new Dictionary<int, int>();
-            Dictionary<int, int> rowHeightForRow = new Dictionary<int, int>();
             List<TextWrapper[]> grid = new List<TextWrapper[]>();
 
             TextWrapper[] header = new TextWrapper[_columns.Count];
@@ -68,8 +67,6 @@ namespace Microsoft.TemplateEngine.Cli
                 headerLines = Math.Max(headerLines, header[i].LineCount);
                 columnWidthLookup[i] = header[i].MaxWidth;
             }
-
-            int lineNumber = 0;
 
             foreach (T rowDataItem in _rowDataItems)
             {
@@ -83,7 +80,6 @@ namespace Microsoft.TemplateEngine.Cli
                     rowHeight = Math.Max(rowHeight, row[i].LineCount);
                 }
 
-                rowHeightForRow[lineNumber++] = rowHeight;
                 grid.Add(row);
             }
 
@@ -157,7 +153,7 @@ namespace Microsoft.TemplateEngine.Cli
             int currentRowIndex = 0;
             foreach (TextWrapper[] rowToRender in rows)
             {
-                for (int lineWithinRow = 0; lineWithinRow < rowHeightForRow[currentRowIndex]; ++lineWithinRow)
+                for (int lineWithinRow = 0; lineWithinRow < rowToRender.Max(row => row.LineCount); ++lineWithinRow)
                 {
                     // Render all columns except last column
                     for (int columnIndex = 0; columnIndex < _columns.Count - 1; ++columnIndex)

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -111,7 +111,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                     TemplateInformationCoordinator.GetInputParametersString(SupportedFilters, commandInput, appliedParameterMatches)));
             Reporter.Output.WriteLine();
 
-            IReadOnlyCollection<SearchResultTableRow> data = GetSearchResultsForDisplay(sourceResult, commandInput.Language, defaultLanguage);
+            IReadOnlyCollection<SearchResultTableRow> data = GetSearchResultsForDisplay(sourceResult, commandInput.Language, defaultLanguage, environmentSettings.Environment);
 
             HelpFormatter<SearchResultTableRow> formatter =
                 HelpFormatter
@@ -135,13 +135,21 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
             Reporter.Output.WriteLine(formatter.Layout());
         }
 
-        private static IReadOnlyCollection<SearchResultTableRow> GetSearchResultsForDisplay(TemplateSourceSearchResult sourceResult, string language, string? defaultLanguage)
+        private static IReadOnlyCollection<SearchResultTableRow> GetSearchResultsForDisplay(
+            TemplateSourceSearchResult sourceResult,
+            string language,
+            string? defaultLanguage,
+            IEnvironment environment)
         {
             List<SearchResultTableRow> templateGroupsForDisplay = new List<SearchResultTableRow>();
 
             foreach (TemplatePackSearchResult packSearchResult in sourceResult.PacksWithMatches.Values)
             {
-                var templateGroupsForPack = TemplateGroupDisplay.GetTemplateGroupsForListDisplay(packSearchResult.TemplateMatches.Select(mi => mi.Info), language, defaultLanguage);
+                var templateGroupsForPack = TemplateGroupDisplay.GetTemplateGroupsForListDisplay(
+                    packSearchResult.TemplateMatches.Select(mi => mi.Info),
+                    language,
+                    defaultLanguage,
+                    environment);
                 templateGroupsForDisplay.AddRange(templateGroupsForPack.Select(t => new SearchResultTableRow(t, packSearchResult.PackInfo.Name, packSearchResult.PackInfo.TotalDownloads)));
             }
 

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateGrouping/CSharpItemAuthor1/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateGrouping/CSharpItemAuthor1/.template.config/template.json
@@ -1,0 +1,15 @@
+{
+  "author": "Author1",
+  "classifications": [ "Test Asset" ],
+  "name": "Basic FSharp",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateGrouping",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateGrouping.CSharpItemAuthor1",
+  "shortName": "template-grouping",
+  "sourceName": "bar",
+  "tags": {
+    "language": "C#",
+    "type": "item"
+  }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateGrouping/FSharpItemAuthor1/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateGrouping/FSharpItemAuthor1/.template.config/template.json
@@ -1,0 +1,15 @@
+{
+  "author": "Author1",
+  "classifications": [ "Test Asset" ],
+  "name": "Basic FSharp",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateGrouping",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateGrouping.FSharpItemAuthor1",
+  "shortName": "template-grouping",
+  "sourceName": "bar",
+  "tags": {
+    "language": "F#",
+    "type": "item"
+  }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateGrouping/QSharpItemAuthor2/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateGrouping/QSharpItemAuthor2/.template.config/template.json
@@ -1,0 +1,15 @@
+{
+  "author": "Author2",
+  "classifications": [ "Test Asset" ],
+  "name": "Basic FSharp",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateGrouping",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateGrouping.QSharpItemAuthor2",
+  "shortName": "template-grouping",
+  "sourceName": "bar",
+  "tags": {
+    "language": "Q#",
+    "type": "item"
+  }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateGrouping/QSharpProjectAuthor2/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateGrouping/QSharpProjectAuthor2/.template.config/template.json
@@ -1,0 +1,15 @@
+{
+  "author": "Author2",
+  "classifications": [ "Test Asset" ],
+  "name": "Basic FSharp",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateGrouping",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateGrouping.QSharpProjectAuthor2",
+  "shortName": "template-grouping",
+  "sourceName": "bar",
+  "tags": {
+    "language": "Q#",
+    "type": "project"
+  }
+}

--- a/test/dotnet-new3.UnitTests/DotnetNewList.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewList.cs
@@ -537,5 +537,23 @@ Worker Service                                worker         [C#],F#     Common/
                 .And.HaveStdErrContaining("5 template(s) partially matched, but failed on language='unknown'.")
                 .And.HaveStdErrContaining($"To search for the templates on NuGet.org, run:{Environment.NewLine}   dotnet new3 c --search");
         }
+
+        [Fact]
+        public void TemplateGroupingTest()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDir = TestUtils.CreateTemporaryFolder();
+            Helpers.InstallTestTemplate("TemplateGrouping", _log, workingDir, home);
+
+            new DotnetNewCommand(_log, "--list", "--columns-all")
+                .WithCustomHive(home)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining("These templates matched your input:")
+                .And.HaveStdOutMatching("Basic FSharp +template-grouping +\\[C#],F# +item +Author1 +Test Asset +\\r?\\n +Q# +item,project +Author2 +Test Asset");
+        }
+
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
@@ -38,8 +38,9 @@ namespace Dotnet_new3.IntegrationTests
 
             var tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Language", "Package", "Downloads" });
             Assert.True(AllRowsContain(tableOutput, new[] { "Template Name", "Short Name" }, "console"), "'Template Name' or 'Short Name' columns do not contain the criteria");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
         }
@@ -116,8 +117,8 @@ Examples:
             var tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Language", "Type", "Tags", "Package", "Downloads" });
 
             Assert.True(AllRowsContain(tableOutput, new[] { "Template Name", "Short Name" }, "console"), "'Template Name' or 'Short Name' columns do not contain the criteria");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
         }
@@ -142,8 +143,8 @@ Examples:
 
             Assert.True(AllRowsContain(tableOutput, new[] { "Template Name", "Short Name" }, "console"), "'Template Name' or 'Short Name' columns do not contain the criteria");
             Assert.True(AllRowsContain(tableOutput, new[] { "Tags" }, "Common"), "'Tags' column does not contain the criteria");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Tags"), "'Tags' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
@@ -167,8 +168,8 @@ Examples:
 
             var tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Tags", "Package", "Downloads" });
             Assert.True(AllRowsContain(tableOutput, new[] { "Tags" }, "Common"), "'Tags' column does not contain the criteria");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Tags"), "'Tags' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
@@ -194,8 +195,8 @@ Examples:
 
             Assert.True(AllRowsContain(tableOutput, new[] { "Template Name", "Short Name" }, "console"), "'Template Name' or 'Short Name' columns do not contain the criteria");
             Assert.True(AllRowsContain(tableOutput, new[] { "Author" }, "micro"), "'Author' column does not contain the criteria");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Author"), "'Author' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
@@ -220,8 +221,8 @@ Examples:
             var tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Package", "Downloads" });
             Assert.True(AllRowsContain(tableOutput, new[] { "Author" }, "micro"), "'Author' column does not contain the criteria");
             Assert.True(SomeRowsContain(tableOutput, new[] { "Author" }, "Microsoft"), "'Author' column does not contain any rows with 'Microsoft'");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Author"), "'Author' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
@@ -248,8 +249,8 @@ Examples:
             Assert.True(AllRowsContain(tableOutput, new[] { "Template Name", "Short Name" }, "console"), "'Template Name' or 'Short Name' columns do not contain the criteria");
             Assert.True(AllRowsContain(tableOutput, new[] { "Language" }, "Q#"), "'Language' column does not contain criteria");
 
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Language"), "'Language' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
@@ -274,8 +275,8 @@ Examples:
             var tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Language", "Package", "Downloads" });
             Assert.True(AllRowsContain(tableOutput, new[] { "Language" }, "F#"), "'Language' column does not contain criteria");
 
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Language"), "'Language' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
@@ -302,8 +303,8 @@ Examples:
             Assert.True(AllRowsContain(tableOutput, new[] { "Template Name", "Short Name" }, "console"), "'Template Name' or 'Short Name' columns do not contain the criteria");
             Assert.True(AllRowsEqual(tableOutput, new[] { "Type" }, "item"), "'Type' column does not contain criteria");
 
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Type"), "'Type' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
@@ -328,8 +329,8 @@ Examples:
             var tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Type", "Package", "Downloads" });
             Assert.True(AllRowsEqual(tableOutput, new[] { "Type" }, "item"), "'Type' column does not contain criteria");
 
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Type"), "'Type' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
@@ -356,8 +357,8 @@ Examples:
             Assert.True(AllRowsContain(tableOutput, new[] { "Template Name", "Short Name" }, "console"), "'Template Name' or 'Short Name' columns do not contain the criteria");
             Assert.True(AllRowsContain(tableOutput, new[] { "Package" }, "core"), "'Package' column does not contain criteria");
 
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
         }
@@ -380,8 +381,8 @@ Examples:
 
             var tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Language", "Package", "Downloads" });
             Assert.True(AllRowsContain(tableOutput, new[] { "Package" }, "core"), "'Package' column does not contain criteria");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
         }
@@ -437,8 +438,8 @@ Examples:
 
             var tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Language", "Package", "Downloads" });
             Assert.True(AllRowsContain(tableOutput, new[] { "Template Name", "Short Name" }, "con"), "'Template Name' or 'Short Name' columns do not contain the criteria");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
 
@@ -458,8 +459,8 @@ Examples:
 
             tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Language", "Package", "Downloads" });
             Assert.True(AllRowsContain(tableOutput, new[] { "Template Name", "Short Name" }, "con"), "'Template Name' or 'Short Name' columns do not contain the criteria");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
 
@@ -478,8 +479,8 @@ Examples:
                 .And.HaveStdOutContaining("   dotnet new3 --install <PACKAGE_ID>");
 
             tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Language", "Package", "Downloads" });
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
         }
@@ -503,8 +504,8 @@ Examples:
 
             var tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Language", "Package", "Downloads" });
             Assert.True(AllRowsContain(tableOutput, new[] { "Template Name", "Short Name" }, "con"), "'Template Name' or 'Short Name' columns do not contain the criteria");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
 
@@ -523,8 +524,8 @@ Examples:
                 .And.HaveStdOutContaining("   dotnet new3 --install <PACKAGE_ID>");
 
             tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Language", "Package", "Downloads" });
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
         }
@@ -548,8 +549,8 @@ Examples:
 
             var tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Language", "Package", "Downloads" });
             Assert.True(AllRowsContain(tableOutput, new[] { "Template Name", "Short Name" }, "con"), "'Template Name' or 'Short Name' columns do not contain the criteria");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
 
@@ -568,8 +569,8 @@ Examples:
                 .And.HaveStdOutContaining("   dotnet new3 --install <PACKAGE_ID>");
 
             tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Language", "Package", "Downloads" });
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
         }
@@ -593,8 +594,8 @@ Examples:
 
             var tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Language", "Package", "Downloads" });
             Assert.True(AllRowsContain(tableOutput, new[] { "Template Name", "Short Name" }, "con"), "'Template Name' or 'Short Name' columns do not contain the criteria");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
 
@@ -613,8 +614,8 @@ Examples:
                 .And.HaveStdOutContaining("   dotnet new3 --install <PACKAGE_ID>");
 
             tableOutput = ParseTableOutput(commandResult.StdOut, expectedColumns: new[] { "Template Name", "Short Name", "Author", "Language", "Package", "Downloads" });
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
-            Assert.True(AllRowsAreNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Template Name"), "'Template Name' column contains empty values");
+            Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Short Name"), "'Short Name' column contains empty values");
             Assert.True(AllRowsAreNotEmpty(tableOutput, "Package"), "'Package' column contains empty values");
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
         }
@@ -653,6 +654,20 @@ Examples:
                 }
                 // template name can be shortened so the name criteria might be truncated.
                 if (columnsNames.Contains("Template Name") && tableOutput[i][tableOutput[0].IndexOf("Template Name")].EndsWith("..."))
+                {
+                    continue;
+                }
+
+                // if columns are template name and/or short name and they are empty - skip, grouping in done
+                bool criteriaA = columnsNames.Contains("Template Name")
+                    && string.IsNullOrWhiteSpace(tableOutput[i][tableOutput[0].IndexOf("Template Name")])
+                    || !columnsNames.Contains("Short Name");
+                bool criteriaB = columnsNames.Contains("Short Name")
+                  && string.IsNullOrWhiteSpace(tableOutput[i][tableOutput[0].IndexOf("Short Name")])
+                  || !columnsNames.Contains("Short Name");
+                bool criteriaC = columnsNames.Contains("Short Name") || columnsNames.Contains("Template Name");
+
+                if (criteriaA && criteriaB && criteriaC)
                 {
                     continue;
                 }


### PR DESCRIPTION
### Problem
fixes dotnet/templating#3403 

### Solution
Now in tabular output single author is shown (highest precedence templates). If the authors are different - show them all.
```
    These templates matched your input: 
    
    Template Name                    Short Name         Language    Type          Author     Tags          
    -------------------------------  -----------------  ----------  ------------  ---------  --------------
    Basic FSharp                     template-grouping  [C#],F#     item          Author1    Test Asset    
                                                        Q#          item,project  Author2    Test Asset   
```

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)