### PR TITLE
Resolving and expanding folder path on uninstall

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -371,8 +371,14 @@ namespace Microsoft.TemplateEngine.Cli
             New3CommandStatus result = New3CommandStatus.Success;
             IReadOnlyList<IManagedTemplatePackage> templatePackages = await _templatePackageManager.GetManagedTemplatePackagesAsync(false, cancellationToken).ConfigureAwait(false);
 
+            List<string> parsedIdentifiers = new List<string>();
+            foreach (string entry in commandInput.ToUninstallList)
+            {
+                parsedIdentifiers.AddRange(InstallRequestPathResolution.ExpandMaskedPath(entry, _engineEnvironmentSettings));
+            }
+
             var packagesToUninstall = new Dictionary<IManagedTemplatePackageProvider, List<IManagedTemplatePackage>>();
-            foreach (string templatePackageIdentifier in commandInput.ToUninstallList)
+            foreach (string templatePackageIdentifier in parsedIdentifiers)
             {
                 bool templatePackageIdentified = false;
 

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -443,15 +443,12 @@ namespace Dotnet_new3.IntegrationTests
         public void CanExpandWhenInstall()
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
-            string codebase = typeof(Program).GetTypeInfo().Assembly.Location;
-            string dir = Path.GetDirectoryName(codebase) ?? throw new System.Exception("Invalid assembly location");
-            string testTemplateLocation = Path.Combine(dir, "..", "..", "..", "..", "..", "test", "Microsoft.TemplateEngine.TestTemplates", "test_templates");
+            string testTemplateLocation = Path.Combine("..", "..", "..", "..", "..", "test", "Microsoft.TemplateEngine.TestTemplates", "test_templates");
             string testTemplateLocationAbsolute = Path.GetFullPath(testTemplateLocation);
             string pattern = testTemplateLocation + Path.DirectorySeparatorChar + "*";
 
             new DotnetNewCommand(_log, "-i", pattern)
                 .WithCustomHive(home)
-                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
                 .Should().ExitWith(0)
                 .And.NotHaveStdErr()


### PR DESCRIPTION
### Problem
fixes dotnet/templating#2383 

### Solution
Added path expansion and resolution for install (similar to uninstall).
Uninstallation is now possible with relative path

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)