### PR TITLE
fixed CanInstantiateTemplate_Angular_CanReplaceTextInLargeFile to use exact version of NuGet package

### DIFF
--- a/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
@@ -34,7 +34,7 @@ namespace Microsoft.TemplateEngine.TestHelper
             return PackNuGetPackage(projectToPack);
         }
 
-        public async Task<string> GetNuGetPackage(string templatePackName, NuGetVersion? minimumVersion = null, ILogger? logger = null)
+        public async Task<string> GetNuGetPackage(string templatePackName, string? version = null, NuGetVersion? minimumVersion = null, ILogger? logger = null)
         {
             logger = logger ?? NullLogger.Instance;
             NuGetHelper nuGetHelper = new NuGetHelper(_packageLocation, logger);
@@ -55,6 +55,7 @@ namespace Microsoft.TemplateEngine.TestHelper
                         logger.LogDebug($"[NuGet Package Manager][attempt: {retry + 1}] Downloading package {templatePackName}, minimum version: {minimumVersion?.ToNormalizedString()}");
                         string downloadedPackage = await nuGetHelper.DownloadPackageAsync(
                             templatePackName,
+                            version: version,
                             additionalSources: new [] { NuGetOrgFeed },
                             minimumVersion: minimumVersion).ConfigureAwait(false);
                         _installedPackages[templatePackName] = downloadedPackage;

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
@@ -438,7 +438,7 @@ namespace Dotnet_new3.IntegrationTests
             string workingDirectory = TestUtils.CreateTemporaryFolder();
             string home = TestUtils.CreateTemporaryFolder("Home");
             using var packageManager = new PackageManager();
-            string packageLocation = await packageManager.GetNuGetPackage("Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0").ConfigureAwait(false);
+            string packageLocation = await packageManager.GetNuGetPackage("Microsoft.DotNet.Web.Spa.ProjectTemplates.6.0", version: "6.0.0-preview.6.21355.2").ConfigureAwait(false);
             Helpers.InstallNuGetTemplate(packageLocation, _log, workingDirectory, home);
 
             new DotnetNewCommand(_log, "angular", "-o", "angular")


### PR DESCRIPTION
Fixed CanInstantiateTemplate_Angular_CanReplaceTextInLargeFile to use exact version of NuGet package

Using latest version de-stabilized the test