### PR TITLE
Improve error handling when template packages are not available.

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
@@ -326,6 +326,8 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             INewCommandInput commandInput,
             CancellationToken cancellationToken)
         {
+            IEnumerable<ITemplateInfo> curatedTemplates = await GetCuratedListAsync(commandInput, cancellationToken).ConfigureAwait(false);
+
             Reporter.Output.WriteLine(string.Format(
                 LocalizableStrings.TemplateInformationCoordinator_DotnetNew_Description,
                 commandInput.New3CommandExample()));
@@ -334,7 +336,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             Reporter.Output.WriteLine(string.Format(
               LocalizableStrings.TemplateInformationCoordinator_DotnetNew_TemplatesHeader,
               commandInput.New3CommandExample()));
-            await ShowCuratedListAsync(commandInput, cancellationToken).ConfigureAwait(false);
+            DisplayTemplateList(curatedTemplates, commandInput);
 
             Reporter.Output.WriteLine(LocalizableStrings.TemplateInformationCoordinator_DotnetNew_ExampleHeader);
             Reporter.Output.WriteCommand(commandInput.InstantiateTemplateExample("console"));
@@ -420,7 +422,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
         /// <summary>
         /// Displays curated list of templates for dotnet new command.
         /// </summary>
-        private async Task ShowCuratedListAsync(INewCommandInput commandInput, CancellationToken cancellationToken)
+        private async Task<IEnumerable<ITemplateInfo>> GetCuratedListAsync(INewCommandInput commandInput, CancellationToken cancellationToken)
         {
             string[] curatedGroupIdentityList = new[]
             {
@@ -433,8 +435,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             };
 
             IReadOnlyList<ITemplateInfo> templates = await _templatePackageManager.GetTemplatesAsync(cancellationToken).ConfigureAwait(false);
-            IEnumerable<ITemplateInfo> filteredTemplates = templates.Where(t => curatedGroupIdentityList.Contains(t.GroupIdentity, StringComparer.OrdinalIgnoreCase));
-            DisplayTemplateList(filteredTemplates, commandInput);
+            return templates.Where(t => curatedGroupIdentityList.Contains(t.GroupIdentity, StringComparer.OrdinalIgnoreCase));
         }
 
         /// <summary>

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -366,6 +366,7 @@ namespace Microsoft.TemplateEngine.Cli
             if (reinitFlag)
             {
                 EnvironmentSettings.Host.FileSystem.DirectoryDelete(EnvironmentSettings.Paths.HostVersionSettingsDir, true);
+                EnvironmentSettings.Host.FileSystem.CreateDirectory(EnvironmentSettings.Paths.HostVersionSettingsDir);
             }
 
             if (commandInput.HasDebuggingFlag("--debug:showconfig"))

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateEngine.Edge {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class LocalizableStrings {
@@ -346,6 +346,15 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Template package location {0} is not supported, or doesn&apos;t exist..
+        /// </summary>
+        internal static string Scanner_Error_TemplatePackageLocationIsNotSupported {
+            get {
+                return ResourceManager.GetString("Scanner_Error_TemplatePackageLocationIsNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not load template..
         /// </summary>
         internal static string TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate {
@@ -375,7 +384,7 @@ namespace Microsoft.TemplateEngine.Edge {
         
         /// <summary>
         ///   Looks up a localized string similar to Failed to scan {0}.
-        ///Details: {1}..
+        ///Details: {1}.
         /// </summary>
         internal static string TemplatePackageManager_Error_FailedToScan {
             get {

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -215,6 +215,9 @@ Details: {1}.</value>
     <value>Failed to check the update for the package {0}.
 Details: {1}.</value>
   </data>
+  <data name="Scanner_Error_TemplatePackageLocationIsNotSupported" xml:space="preserve">
+    <value>Template package location {0} is not supported, or doesn't exist.</value>
+  </data>
   <data name="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate" xml:space="preserve">
     <value>Could not load template.</value>
   </data>
@@ -227,6 +230,6 @@ Details: {0}.</value>
   </data>
   <data name="TemplatePackageManager_Error_FailedToScan" xml:space="preserve">
     <value>Failed to scan {0}.
-Details: {1}.</value>
+Details: {1}</value>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -231,5 +231,6 @@ Details: {0}.</value>
   <data name="TemplatePackageManager_Error_FailedToScan" xml:space="preserve">
     <value>Failed to scan {0}.
 Details: {1}</value>
+    <comment>last line should not end with a period, period is a part of the format entry</comment>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
@@ -72,7 +72,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     );
                 }
             }
-            throw new Exception($"source location {sourceLocation} is not supported, or doesn't exist.");
+            throw new Exception(string.Format(LocalizableStrings.Scanner_Error_TemplatePackageLocationIsNotSupported, sourceLocation));
         }
 
         private void ScanForComponents(MountPointScanSource source)

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
@@ -317,7 +317,8 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogWarning(LocalizableStrings.TemplatePackageManager_Error_FailedToScan, allTemplatePackages[index].MountPointUri, ex);
+                    _logger.LogWarning(LocalizableStrings.TemplatePackageManager_Error_FailedToScan, allTemplatePackages[index].MountPointUri, ex.Message);
+                    _logger.LogDebug($"Stack trace: {ex.StackTrace}");
                 }
             });
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 Podrobnosti: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">Nepovedlo se nahrát šablonu.</target>
@@ -182,8 +187,8 @@ Podrobnosti: {0}.</target>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">Balíček {0} se nepovedlo zkontrolovat. 
+Details: {1}</source>
+        <target state="needs-review-translation">Balíček {0} se nepovedlo zkontrolovat. 
 Podrobnosti: {1}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -190,7 +190,7 @@ Podrobnosti: {0}.</target>
 Details: {1}</source>
         <target state="needs-review-translation">Balíček {0} se nepovedlo zkontrolovat. 
 Podrobnosti: {1}.</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 Details: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">Die Vorlage konnte nicht geladen werden.</target>
@@ -182,8 +187,8 @@ Details: {0}.</target>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">Fehler beim Überprüfen von “{0}“.
+Details: {1}</source>
+        <target state="needs-review-translation">Fehler beim Überprüfen von “{0}“.
 Details: {1}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -190,7 +190,7 @@ Details: {0}.</target>
 Details: {1}</source>
         <target state="needs-review-translation">Fehler beim Überprüfen von “{0}“.
 Details: {1}.</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -190,7 +190,7 @@ Detalles: {0}.</target>
 Details: {1}</source>
         <target state="needs-review-translation">Error al examinar {0}:
 Detalles: {1}.</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 Detalles: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">No se pudo cargar la plantilla.</target>
@@ -182,8 +187,8 @@ Detalles: {0}.</target>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">Error al examinar {0}:
+Details: {1}</source>
+        <target state="needs-review-translation">Error al examinar {0}:
 Detalles: {1}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 Détails : {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">Impossible de charger le modèle.</target>
@@ -182,8 +187,8 @@ Détails : {0}.</target>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">Échec de l’analyse {0}.
+Details: {1}</source>
+        <target state="needs-review-translation">Échec de l’analyse {0}.
 Détails : {1}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -190,7 +190,7 @@ Détails : {0}.</target>
 Details: {1}</source>
         <target state="needs-review-translation">Échec de l’analyse {0}.
 Détails : {1}.</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 Dettagli: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">Non è stato possibile caricare il modello.</target>
@@ -182,8 +187,8 @@ Dettagli: {0}.</target>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">Non è stato possibile analizzare {0}.
+Details: {1}</source>
+        <target state="needs-review-translation">Non è stato possibile analizzare {0}.
 Dettagli: {1}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -190,7 +190,7 @@ Dettagli: {0}.</target>
 Details: {1}</source>
         <target state="needs-review-translation">Non è stato possibile analizzare {0}.
 Dettagli: {1}.</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -190,7 +190,7 @@ Details: {0}.</source>
 Details: {1}</source>
         <target state="needs-review-translation">{0} をスキャンできませんでした。
 詳細: {1}。</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 詳細: {1}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">テンプレートを読み込めませんでした。</target>
@@ -182,8 +187,8 @@ Details: {0}.</source>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">{0} をスキャンできませんでした。
+Details: {1}</source>
+        <target state="needs-review-translation">{0} をスキャンできませんでした。
 詳細: {1}。</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 세부 정보: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">템플릿을 로드할 수 없습니다.</target>
@@ -182,8 +187,8 @@ Details: {0}.</source>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">{0}을(를) 검사하지 못했습니다.
+Details: {1}</source>
+        <target state="needs-review-translation">{0}을(를) 검사하지 못했습니다.
 세부 정보: {1}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -190,7 +190,7 @@ Details: {0}.</source>
 Details: {1}</source>
         <target state="needs-review-translation">{0}을(를) 검사하지 못했습니다.
 세부 정보: {1}.</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 Szczegóły: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">Nie można załadować szablonu.</target>
@@ -182,8 +187,8 @@ Szczegóły: {0}.</target>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">Nie można zeskanować {0}.
+Details: {1}</source>
+        <target state="needs-review-translation">Nie można zeskanować {0}.
 Szczegóły: {1}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -190,7 +190,7 @@ Szczegóły: {0}.</target>
 Details: {1}</source>
         <target state="needs-review-translation">Nie można zeskanować {0}.
 Szczegóły: {1}.</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -190,7 +190,7 @@ Detalhes: {0}.</target>
 Details: {1}</source>
         <target state="needs-review-translation">Falha ao verificar{0}.
 Detalhes: {1}.</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 Detalhes: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">Não foi possível carregar o modelo.</target>
@@ -182,8 +187,8 @@ Detalhes: {0}.</target>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">Falha ao verificar{0}.
+Details: {1}</source>
+        <target state="needs-review-translation">Falha ao verificar{0}.
 Detalhes: {1}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 Сведения: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">Загрузить шаблон не удалось.</target>
@@ -182,8 +187,8 @@ Details: {0}.</source>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">Не удалось проверить {0}.
+Details: {1}</source>
+        <target state="needs-review-translation">Не удалось проверить {0}.
 Сведения: {1}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -190,7 +190,7 @@ Details: {0}.</source>
 Details: {1}</source>
         <target state="needs-review-translation">Не удалось проверить {0}.
 Сведения: {1}.</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 Ayrıntılar: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">Şablon yüklenemedi.</target>
@@ -182,8 +187,8 @@ Ayrıntılar: {0}.</target>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">{0} taranamadı.
+Details: {1}</source>
+        <target state="needs-review-translation">{0} taranamadı.
 Ayrıntılar: {1}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -190,7 +190,7 @@ Ayrıntılar: {0}.</target>
 Details: {1}</source>
         <target state="needs-review-translation">{0} taranamadı.
 Ayrıntılar: {1}.</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -190,7 +190,7 @@ Details: {0}.</source>
 Details: {1}</source>
         <target state="needs-review-translation">未能扫描 {0}"。
 : {1}。</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 详细信息: {1}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">无法加载模板。</target>
@@ -182,8 +187,8 @@ Details: {0}.</source>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">未能扫描 {0}"。
+Details: {1}</source>
+        <target state="needs-review-translation">未能扫描 {0}"。
 : {1}。</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -190,7 +190,7 @@ Details: {0}.</source>
 Details: {1}</source>
         <target state="needs-review-translation">無法掃描 {0}。
 詳細資料: {1}。</target>
-        <note />
+        <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
     </body>
   </file>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -163,6 +163,11 @@ Details: {1}.</source>
 詳細資料: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="Scanner_Error_TemplatePackageLocationIsNotSupported">
+        <source>Template package location {0} is not supported, or doesn't exist.</source>
+        <target state="new">Template package location {0} is not supported, or doesn't exist.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CouldNotLoadTemplate">
         <source>Could not load template.</source>
         <target state="translated">無法載入範本。</target>
@@ -182,8 +187,8 @@ Details: {0}.</source>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
-Details: {1}.</source>
-        <target state="translated">無法掃描 {0}。
+Details: {1}</source>
+        <target state="needs-review-translation">無法掃描 {0}。
 詳細資料: {1}。</target>
         <note />
       </trans-unit>

--- a/test/dotnet-new3.UnitTests/DotnetNewDebugOptions.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewDebugOptions.cs
@@ -13,25 +13,6 @@ namespace Dotnet_new3.IntegrationTests
 {
     public class DotnetNewDebugOptions
     {
-        private const string DotnetNewOutput =
-@"The 'dotnet new3' command creates a .NET project based on a template.
-
-Common templates are:
-Template Name        Short Name  Language    Tags          
--------------------  ----------  ----------  --------------
-Class Library        classlib    [C#],F#,VB  Common/Library
-Console Application  console     [C#],F#,VB  Common/Console
-
-An example would be:
-   dotnet new3 console
-
-Display template options with:
-   dotnet new3 console -h
-Display all installed templates with:
-   dotnet new3 --list
-Display templates available on NuGet.org with:
-   dotnet new3 web --search";
-
         private readonly ITestOutputHelper _log;
 
         public DotnetNewDebugOptions(ITestOutputHelper log)
@@ -43,32 +24,48 @@ Display templates available on NuGet.org with:
         public void CanShowBasicInfoWithDebugReinit()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
-            string workingDirectory = TestUtils.CreateTemporaryFolder();
+            string cacheFilePath = Path.Combine(home, "dotnetcli-preview", "v2.0.0", "templatecache.json");
 
-            new DotnetNewCommand(_log, "--debug:reinit")
+            var commandResult = new DotnetNewCommand(_log)
                 .WithCustomHive(home)
-                .WithWorkingDirectory(workingDirectory)
-                .Execute()
-                .Should()
-                .ExitWith(0)
-                .And.NotHaveStdErr()
-                .And.HaveStdOut(DotnetNewOutput);
+                .Execute();
+
+            commandResult.Should().ExitWith(0).And.NotHaveStdErr();
+            Assert.True(File.Exists(cacheFilePath));
+            DateTime lastUpdateDate = File.GetLastWriteTimeUtc(cacheFilePath);
+
+            var reinitCommandResult = new DotnetNewCommand(_log, "--debug:reinit")
+               .WithCustomHive(home)
+               .Execute();
+
+            reinitCommandResult.Should().ExitWith(0).And.NotHaveStdErr();
+            Assert.Equal(commandResult.StdOut, reinitCommandResult.StdOut);
+            Assert.True(File.Exists(cacheFilePath));
+            Assert.True(lastUpdateDate < File.GetLastWriteTimeUtc(cacheFilePath));
         }
 
         [Fact]
         public void CanShowBasicInfoWithDebugRebuildCache()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
-            string workingDirectory = TestUtils.CreateTemporaryFolder();
+            string cacheFilePath = Path.Combine(home, "dotnetcli-preview", "v2.0.0", "templatecache.json");
 
-            new DotnetNewCommand(_log, "--debug:rebuildcache")
+            var commandResult = new DotnetNewCommand(_log)
                 .WithCustomHive(home)
-                .WithWorkingDirectory(workingDirectory)
-                .Execute()
-                .Should()
-                .ExitWith(0)
-                .And.NotHaveStdErr()
-                .And.HaveStdOut(DotnetNewOutput);
+                .Execute();
+
+            commandResult.Should().ExitWith(0).And.NotHaveStdErr();
+            Assert.True(File.Exists(cacheFilePath));
+            DateTime lastUpdateDate = File.GetLastWriteTimeUtc(cacheFilePath);
+
+            var reinitCommandResult = new DotnetNewCommand(_log, "--debug:rebuildcache")
+               .WithCustomHive(home)
+               .Execute();
+
+            reinitCommandResult.Should().ExitWith(0).And.NotHaveStdErr();
+            Assert.Equal(commandResult.StdOut, reinitCommandResult.StdOut);
+            Assert.True(File.Exists(cacheFilePath));
+            Assert.True(lastUpdateDate < File.GetLastWriteTimeUtc(cacheFilePath));
         }
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewDebugOptions.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewDebugOptions.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using FluentAssertions;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.TemplateEngine.TestHelper;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Dotnet_new3.IntegrationTests
+{
+    public class DotnetNewDebugOptions
+    {
+        private const string DotnetNewOutput =
+@"The 'dotnet new3' command creates a .NET project based on a template.
+
+Common templates are:
+Template Name        Short Name  Language    Tags          
+-------------------  ----------  ----------  --------------
+Class Library        classlib    [C#],F#,VB  Common/Library
+Console Application  console     [C#],F#,VB  Common/Console
+
+An example would be:
+   dotnet new3 console
+
+Display template options with:
+   dotnet new3 console -h
+Display all installed templates with:
+   dotnet new3 --list
+Display templates available on NuGet.org with:
+   dotnet new3 web --search";
+
+        private readonly ITestOutputHelper _log;
+
+        public DotnetNewDebugOptions(ITestOutputHelper log)
+        {
+            _log = log;
+        }
+
+        [Fact]
+        public void CanShowBasicInfoWithDebugReinit()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "--debug:reinit")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOut(DotnetNewOutput);
+        }
+
+        [Fact]
+        public void CanShowBasicInfoWithDebugRebuildCache()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "--debug:rebuildcache")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOut(DotnetNewOutput);
+        }
+    }
+}


### PR DESCRIPTION
### Problem
#3517, #3528 

### Solution
- Warning moved to top, before dotnet new output
- Stack trace dropped to debug level
- Exception message is localized and shows it in the warning as details
- Rewording of the exception message
- Recreate an empty directory immediately after `--debug:reinit` removes it.