### PR TITLE
[draft] wrong parsing of the command in case template name is misplaced

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInputExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInputExtensions.cs
@@ -34,12 +34,18 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             return $"dotnet {command.CommandName} --update-apply";
         }
 
-        internal static string ListCommandExample(this INewCommandInput command)
+        internal static string ListCommandExample(this INewCommandInput command, bool usePlaceholder = false, bool useFilterPlaceholder = false)
         {
-            return $"dotnet {command.CommandName} --list";
+            string commandStr = usePlaceholder ? $"dotnet {command.CommandName} [TEMPLATE_NAME] --list" : $"dotnet {command.CommandName} --list";
+            return useFilterPlaceholder ? commandStr + " [FILTERS]" : commandStr;
         }
 
-        internal static string SearchCommandExample(this INewCommandInput command, string? templateName = null, IEnumerable<string>? additionalArgs = null, bool usePlaceholder = false)
+        internal static string SearchCommandExample(
+            this INewCommandInput command,
+            string? templateName = null,
+            IEnumerable<string>? additionalArgs = null,
+            bool usePlaceholder = false,
+            bool useFilterPlaceholder = false)
         {
             if (usePlaceholder)
             {
@@ -63,6 +69,10 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             if (additionalArgs?.Any() ?? false)
             {
                 commandStr += $" {string.Join(" ", additionalArgs)}";
+            }
+            else if (useFilterPlaceholder)
+            {
+                commandStr += $" [FILTERS]";
             }
             return commandStr;
         }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/TemplateCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/TemplateCommandInput.cs
@@ -101,11 +101,11 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                 IEnumerable<string> tokens;
                 if (string.IsNullOrWhiteSpace(commandInput.TemplateName))
                 {
-                    tokens = commandInput.Tokens;
+                    tokens = commandInput.Tokens.Skip(1);  //skip command name
                 }
                 else
                 {
-                    tokens = commandInput.Tokens.Skip(1);
+                    tokens = commandInput.Tokens.Skip(2);  //skip command name and template name
                 }
                 return ParseArgs(
                     commandInput.CommandName,
@@ -140,6 +140,9 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                 }
                 else
                 {
+                    //unrecognized option name, add as is.
+                    //can happen in case the unparsed tokes start with the token that does not start with '-' or '--'
+                    templateParameters[commandInput.RemainingParameters[i]] = null;
                     i++;
                 }
             }

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -861,6 +861,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Ensure that the command matches required syntax:.
+        /// </summary>
+        internal static string EnsureCommandSyntax {
+            get {
+                return ResourceManager.GetString("EnsureCommandSyntax", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to After expanding the extra args files, the command is:
         ///    dotnet {0}.
         /// </summary>
@@ -1119,6 +1128,15 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string NoTemplatesMatchingInputParameters {
             get {
                 return ResourceManager.GetString("NoTemplatesMatchingInputParameters", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No templates found matching input criteria..
+        /// </summary>
+        internal static string NoTemplatesMatchingInputParameters_NoCriteria {
+            get {
+                return ResourceManager.GetString("NoTemplatesMatchingInputParameters_NoCriteria", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -753,4 +753,10 @@ The supported columns are: language, tags, author, type.</value>
     <value>(empty)</value>
     <comment>shown when there is no data to show</comment>
   </data>
+  <data name="EnsureCommandSyntax" xml:space="preserve">
+    <value>Ensure that the command matches required syntax:</value>
+  </data>
+  <data name="NoTemplatesMatchingInputParameters_NoCriteria" xml:space="preserve">
+    <value>No templates found matching input criteria.</value>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/New3CommandStatus.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3CommandStatus.cs
@@ -63,6 +63,11 @@ namespace Microsoft.TemplateEngine.Cli
         /// <summary>
         /// Generic error when displaying help.
         /// </summary>
-        DisplayHelpFailed = unchecked((int)0x80010004)
+        DisplayHelpFailed = unchecked((int)0x80010004),
+
+        /// <summary>
+        /// The command syntax is potentially incorrect.
+        /// </summary>
+        InvalidCommandSyntax = unchecked((int)0x80010005),
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/CliFilters.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/CliFilters.cs
@@ -198,7 +198,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                         matchInfos.Add(new ParameterMatchInfo(paramName, paramValue, matchKind, mismatchKind, reparsedCommand.TemplateParamInputFormat(paramName)));
                     }
 
-                    foreach (string unmatchedParamName in reparsedCommand.RemainingParameters.Where(x => !x.Contains(':') && x.StartsWith('-'))) // filter debugging params and parameters that do not start with '-'
+                    foreach (string unmatchedParamName in reparsedCommand.RemainingParameters.Where(x => !x.Contains(':'))) // filter debugging params
                     {
                         if (reparsedCommand.TryGetCanonicalNameForVariant(unmatchedParamName, out string? canonical) && !string.IsNullOrWhiteSpace(canonical))
                         {
@@ -299,7 +299,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                         matchInfos.Add(new ParameterMatchInfo(paramName, paramValue, matchKind, mismatchKind, reparsedCommand.TemplateParamInputFormat(paramName)));
                     }
 
-                    foreach (string unmatchedParamName in reparsedCommand.RemainingParameters.Where(x => !x.Contains(':') && x.StartsWith('-'))) // filter debugging params and parameters that do not start with '-'
+                    foreach (string unmatchedParamName in reparsedCommand.RemainingParameters.Where(x => !x.Contains(':'))) // filter debugging params
                     {
                         if (reparsedCommand.TryGetCanonicalNameForVariant(unmatchedParamName, out string? canonical) && !string.IsNullOrWhiteSpace(canonical))
                         {

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -84,8 +84,20 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
             }
             else
             {
+                //the command has any unmatched tokens: can be template options or invalid syntax.
+                //since cannot evaluate what case it is, show invalid syntax help as it is more likely.
+                if (commandInput.RemainingParameters.Any())
+                {
+                    // No templates found matching input criteria.
+                    Reporter.Error.WriteLine(LocalizableStrings.NoTemplatesMatchingInputParameters_NoCriteria.Bold().Red());
+                    // Ensure that the command matches required syntax:
+                    Reporter.Error.WriteLine(LocalizableStrings.EnsureCommandSyntax);
+                    Reporter.Error.WriteCommand(commandInput.SearchCommandExample(usePlaceholder: true, useFilterPlaceholder: true));
+                    return New3CommandStatus.InvalidCommandSyntax;
+                }
+
                 IReadOnlyDictionary<string, string?>? appliedParameterMatches = TemplateCommandInput.GetTemplateParametersFromCommand(commandInput);
-                // No templates found matching the following input parameter(s): {0}.
+                // No templates found matching: {0}.
                 Reporter.Error.WriteLine(
                     string.Format(
                         LocalizableStrings.NoTemplatesMatchingInputParameters,

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -458,6 +458,11 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <target state="translated">Zobrazí souhrn toho, co by se mohlo stát, kdyby se daný příkazový řádek spustil, pokud by to vedlo k vytvoření šablony.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">Nenašly se žádné šablony, které by odpovídaly tomuto hledání: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -458,6 +458,11 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
         <target state="translated">Zeigt eine Zusammenfassung der Ergebnisse der Ausführung der angegebenen Befehlszeile an, wenn dies zu einer Vorlagenerstellung führen würde.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">Keine Vorlagen gefunden, die "{0}" entsprechen.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -458,6 +458,11 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
         <target state="translated">Muestra un resumen de lo que sucede si se ejecuta la línea de comandos dada si se crea una plantilla.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">No se encontró ninguna plantilla que coincida con: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -458,6 +458,11 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <target state="translated">Affiche un résumé de ce qui se passerait si la ligne de commande donnée était exécutée si cela aboutissait à la création d’un modèle.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">Aucun modèle trouvé correspondant : {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -458,6 +458,11 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <target state="translated">Visualizza un riepilogo di ciò che accadrebbe se la riga di comando specificata venisse eseguita se il risultato fosse la creazione di un modello.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">Nessun modello corrispondente trovato: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -458,6 +458,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">指定されたコマンドラインがテンプレートを実行した場合に発生する結果の概要を表示します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">テンプレートが見つかりません: {0}。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -458,6 +458,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">템플릿이 생성될 경우 주어진 명령 줄이 실행되면 어떤 일이 발생하는지에 대한 요약을 표시합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">일치하는 템플릿이 없음:{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -458,6 +458,11 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
         <target state="translated">Wyświetla podsumowanie co się stanie, jeśli dany wiersz polecenia zostanie uruchomiony i jeśli to spowoduje utworzenie szablonu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">Nie stwierdzono dopasowania żadnych szablonów: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -458,6 +458,11 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <target state="translated">Exibe um resumo do que aconteceria se a linha de comando especificada fosse executada se resultar em uma criação de modelo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">Nenhum modelo encontrado: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -458,6 +458,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">Отображает сводку действий, которые могли бы произойти, если бы данная командная строка была запущена, если это приведет к созданию шаблона.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">Соответствующие шаблоны не найдены: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -458,6 +458,11 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <target state="translated">Verilen komut satırı bir şablon oluşturma eylemiyle sonuçlanacak durumdayken çalıştırılsaydı olacak şeylerin özetini görüntüler.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">Eşleşen şablon bulunamadı: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -458,6 +458,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">如果运行给定命令行将导致模板创建，则显示将发生情况的摘要。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">找不到匹配的模板: {0}。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -458,6 +458,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">顯示如果執行所給予的命令列會導致範本建立，會發生什麼情況的摘要。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnsureCommandSyntax">
+        <source>Ensure that the command matches required syntax:</source>
+        <target state="new">Ensure that the command matches required syntax:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:
     dotnet {0}</source>
@@ -603,6 +608,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
       <trans-unit id="NoTemplatesMatchingInputParameters">
         <source>No templates found matching: {0}.</source>
         <target state="translated">找不到符合的範本: {0}。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="NoTemplatesMatchingInputParameters_NoCriteria">
+        <source>No templates found matching input criteria.</source>
+        <target state="new">No templates found matching input criteria.</target>
         <note />
       </trans-unit>
       <trans-unit id="NuGetSourceHelp">

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -135,6 +135,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
             get
             {
                 List<string> tokens = new List<string>();
+                tokens.Add(CommandName);
                 if (!string.IsNullOrWhiteSpace(TemplateName))
                 {
                     tokens.Add(TemplateName);

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CommandInputTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CommandInputTests.cs
@@ -53,7 +53,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             A.CallTo(() => commandInput.RemainingParameters).Returns(new[] { "paramValue2", "--param", "paramValue1", });
 
             var parameters = TemplateCommandInput.GetTemplateParametersFromCommand(commandInput);
-            Assert.Equal(1, parameters.Count);
+            Assert.Equal(2, parameters.Count);
+            Assert.Null(parameters["paramValue2"]);
             Assert.Equal("paramValue1", parameters["--param"]);
         }
     }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateGroupMatchInfoTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateResolutionTests/TemplateGroupMatchInfoTests.cs
@@ -41,7 +41,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 },
                 new MockInvalidParameterInfo[]
                 {
-                    new MockInvalidParameterInfo(InvalidParameterInfo.Kind.InvalidParameterName, "--fake", null)
+                    new MockInvalidParameterInfo(InvalidParameterInfo.Kind.InvalidParameterName, "--fake", null),
+                    new MockInvalidParameterInfo(InvalidParameterInfo.Kind.InvalidParameterName, "netcoreapp3.0", null)
                 }
             };
 
@@ -86,6 +87,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.TemplateResolutionTests
                 {
                     new MockInvalidParameterInfo(InvalidParameterInfo.Kind.InvalidParameterValue, "--framework", "net"),
                     new MockInvalidParameterInfo(InvalidParameterInfo.Kind.InvalidParameterName, "--fake", null),
+                    new MockInvalidParameterInfo(InvalidParameterInfo.Kind.InvalidParameterName, "fake", null),
                     new MockInvalidParameterInfo(InvalidParameterInfo.Kind.InvalidParameterValue, "--OtherChoice", "fake")
                 }
             };

--- a/test/dotnet-new3.UnitTests/DotnetNewList.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewList.cs
@@ -525,7 +525,7 @@ Worker Service                                worker         [C#],F#     Common/
                 .WithCustomHive(_sharedHome.HomeDirectory)
                 .Execute()
                 .Should().Fail()
-                .And.HaveStdErrContaining("No templates found matching: language='unknown'.")
+                .And.HaveStdErrContaining("No templates found matching: language='unknown', --framework='unknown'.")
                 .And.HaveStdErrContaining("8 template(s) partially matched, but failed on language='unknown'.")
                 .And.HaveStdErrContaining($"To search for the templates on NuGet.org, run:{Environment.NewLine}   dotnet new3 <TEMPLATE_NAME> --search");
 
@@ -533,7 +533,7 @@ Worker Service                                worker         [C#],F#     Common/
                 .WithCustomHive(_sharedHome.HomeDirectory)
                 .Execute()
                 .Should().Fail()
-                .And.HaveStdErrContaining("No templates found matching: 'c', language='unknown'.")
+                .And.HaveStdErrContaining("No templates found matching: 'c', language='unknown', --framework='unknown'.")
                 .And.HaveStdErrContaining("5 template(s) partially matched, but failed on language='unknown'.")
                 .And.HaveStdErrContaining($"To search for the templates on NuGet.org, run:{Environment.NewLine}   dotnet new3 c --search");
         }
@@ -553,6 +553,30 @@ Worker Service                                worker         [C#],F#     Common/
                 .And.NotHaveStdErr()
                 .And.HaveStdOutContaining("These templates matched your input:")
                 .And.HaveStdOutMatching("Basic FSharp +template-grouping +\\[C#],F# +item +Author1 +Test Asset +\\r?\\n +Q# +item,project +Author2 +Test Asset");
+        }
+
+        [Fact]
+        public void CannotListTemplates_MisplacedName()
+        {
+            new DotnetNewCommand(_log, "--list")
+                .WithCustomHive(_sharedHome.HomeDirectory)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining("These templates matched your input:")
+                .And.HaveStdOutMatching("Template Name\\s+Short Name\\s+Language\\s+Tags")
+                .And.HaveStdOutMatching("Console Application\\s+console\\s+\\[C#\\],F#,VB\\s+Common/Console")
+                .And.HaveStdOutMatching("Class Library\\s+classlib\\s+\\[C#\\],F#,VB\\s+Common/Library")
+                .And.HaveStdOutMatching("NuGet Config\\s+nugetconfig\\s+Config");
+
+            new DotnetNewCommand(_log, "--list", "console")
+                .WithCustomHive(_sharedHome.HomeDirectory)
+                .Execute()
+                .Should().Fail()
+                .And.HaveStdErrContaining("No templates found matching input criteria.")
+                .And.HaveStdErrContaining("Ensure that the command matches required syntax:")
+                .And.HaveStdErrContaining("   dotnet new3 [TEMPLATE_NAME] --list [FILTERS]");
         }
 
     }

--- a/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
@@ -642,6 +642,18 @@ Examples:
               .And.HaveStdErrContaining("No templates found matching: 'con', language='C#', --unknown.");
         }
 
+        [Fact]
+        public void CannotSearchTemplates_MisplacedName()
+        {
+            new DotnetNewCommand(_log, "--search", "console")
+                .WithCustomHive(_sharedHome.HomeDirectory)
+                .Execute()
+                .Should().Fail()
+                .And.HaveStdErrContaining("No templates found matching input criteria.")
+                .And.HaveStdErrContaining("Ensure that the command matches required syntax:")
+                .And.HaveStdErrContaining("   dotnet new3 <TEMPLATE_NAME> --search [FILTERS]");
+        }
+
         private static bool AllRowsContain(List<List<string>> tableOutput, string[] columnsNames, string value)
         {
             var columnIndexes = columnsNames.Select(columnName => tableOutput[0].IndexOf(columnName));


### PR DESCRIPTION
### Problem
fixes dotnet/templating#3552 

### Solution
fixed reparsing of template (contained command name twice)
fixed evaluating template options from the command input when first remaining parameter does not start with '-'
fixed template option filters to set the match info on invalid parameter that does not start with '-'
added special handling for no matches for --list and --search: when the base command parsing fails (can be when template options are specified or invalid syntax is used) we show help for invalid syntax

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)