### PR TITLE
Wrong parsing of the command in case template name is misplaced

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Alias/AliasSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Alias/AliasSupport.cs
@@ -6,7 +6,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
-using Microsoft.TemplateEngine.Cli.HelpAndUsage;
 
 namespace Microsoft.TemplateEngine.Cli.Alias
 {
@@ -22,8 +21,7 @@ namespace Microsoft.TemplateEngine.Cli.Alias
 
         internal static (New3CommandStatus, INewCommandInput?) CoordinateAliasExpansion(
             INewCommandInput commandInput,
-            AliasRegistry aliasRegistry,
-            TemplateInformationCoordinator templateInformationCoordinator)
+            AliasRegistry aliasRegistry)
         {
             (AliasExpansionStatus aliasExpansionStatus, INewCommandInput? expandedCommandInput) = AliasSupport.TryExpandAliases(commandInput, aliasRegistry);
             if (aliasExpansionStatus == AliasExpansionStatus.ExpansionError)
@@ -35,10 +33,10 @@ namespace Microsoft.TemplateEngine.Cli.Alias
             {
                 Reporter.Output.WriteLine(string.Format(LocalizableStrings.AliasCommandAfterExpansion, string.Join(" ", expandedCommandInput.Tokens)));
 
-                if (commandInput.HasParseError)
+                if (!expandedCommandInput.ValidateParseError())
                 {
-                    Reporter.Output.WriteLine(LocalizableStrings.AliasExpandedCommandParseError);
-                    return (templateInformationCoordinator.HandleParseError(expandedCommandInput), null);
+                    Reporter.Error.WriteLine(LocalizableStrings.AliasExpandedCommandParseError);
+                    return (New3CommandStatus.InvalidParamValues, null);
                 }
             }
 

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInput.cs
@@ -33,8 +33,6 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         bool HasColumnsParseError { get; }
 
-        bool HasParseError { get; }
-
         string HelpText { get; }
 
         IReadOnlyList<string>? InstallNuGetSourceList { get; }
@@ -50,6 +48,8 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         bool IsListFlagSpecified { get; }
 
         bool IsQuietFlagSpecified { get; }
+
+        bool IsSearchFlagSpecified { get; }
 
         bool IsShowAllFlagSpecified { get; }
 
@@ -68,8 +68,6 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
         IReadOnlyList<string> RemainingParameters { get; }
 
-        bool SearchOnline { get; }
-
         string ShowAliasesAliasName { get; }
 
         bool ShowAliasesSpecified { get; }
@@ -87,6 +85,12 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
         IReadOnlyList<string>? ToUninstallList { get; }
 
         string TypeFilter { get; }
+
+        string? SearchNameCriteria { get; }
+
+        string? ListNameCriteria { get; }
+
+        bool ValidateParseError();
 
         bool HasDebuggingFlag(string flag);
     }

--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/TemplateCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/TemplateCommandInput.cs
@@ -101,11 +101,11 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                 IEnumerable<string> tokens;
                 if (string.IsNullOrWhiteSpace(commandInput.TemplateName))
                 {
-                    tokens = commandInput.Tokens;
+                    tokens = commandInput.Tokens.Skip(1); //skip command name
                 }
                 else
                 {
-                    tokens = commandInput.Tokens.Skip(1);
+                    tokens = commandInput.Tokens.Skip(2); //skip command name and template name
                 }
                 return ParseArgs(
                     commandInput.CommandName,
@@ -135,7 +135,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                         arguments.Add(commandInput.RemainingParameters[i + 1]);
                         i++;
                     }
-                    templateParameters[optionName] = arguments.Any() ? string.Join(",", arguments) : null;
+                    templateParameters[optionName] = arguments.Any() ? arguments[0] : null;
                     i++;
                 }
                 else

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateEngine.Cli {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class LocalizableStrings {
@@ -1020,6 +1020,15 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string InvalidParameterTemplateHint {
             get {
                 return ResourceManager.GetString("InvalidParameterTemplateHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid command syntax: use &apos;{0}&apos; instead..
+        /// </summary>
+        internal static string InvalidSyntax {
+            get {
+                return ResourceManager.GetString("InvalidSyntax", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -753,4 +753,8 @@ The supported columns are: language, tags, author, type.</value>
     <value>(empty)</value>
     <comment>shown when there is no data to show</comment>
   </data>
+  <data name="InvalidSyntax" xml:space="preserve">
+    <value>Invalid command syntax: use '{0}' instead.</value>
+    <comment>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</comment>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/CliFilters.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/CliFilters.cs
@@ -43,7 +43,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         /// </summary>
         /// <param name="name">the name to match with template group name or short name.</param>
         /// <returns></returns>
-        internal static Func<TemplateGroup, MatchInfo?> NameTemplateGroupFilter(string name)
+        internal static Func<TemplateGroup, MatchInfo?> NameTemplateGroupFilter(string? name)
         {
             return (templateGroup) =>
             {

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/ListTemplateResolver.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/ListTemplateResolver.cs
@@ -41,10 +41,9 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
         internal override async Task<TemplateResolutionResult> ResolveTemplatesAsync(INewCommandInput commandInput, string? defaultLanguage, CancellationToken cancellationToken)
         {
             IEnumerable<TemplateGroup> templateGroups = await GetTemplateGroupsAsync(cancellationToken).ConfigureAwait(false);
-
             IEnumerable<Func<TemplateGroup, MatchInfo?>> groupFilters = new[]
             {
-                CliFilters.NameTemplateGroupFilter(commandInput.TemplateName)
+                CliFilters.NameTemplateGroupFilter(commandInput.ListNameCriteria)
             };
 
             IEnumerable<Func<ITemplateInfo, MatchInfo?>> templateFilters =

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliHostSpecificDataMatchFilter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliHostSpecificDataMatchFilter.cs
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
             IEnumerable<TemplateGroup> templateGroups = TemplateGroup.FromTemplateList(templates);
             IEnumerable<Func<TemplateGroup, MatchInfo?>> groupFilters = new[]
             {
-                CliFilters.NameTemplateGroupFilter(_commandInput.TemplateName)
+                CliFilters.NameTemplateGroupFilter(_commandInput.SearchNameCriteria)
             };
 
             IEnumerable<Func<ITemplateInfo, MatchInfo?>> templateFilters =

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -43,7 +43,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
         {
             if (!ValidateCommandInput(commandInput))
             {
-                return New3CommandStatus.Cancelled;
+                return New3CommandStatus.InvalidParamValues;
             }
 
             Reporter.Output.WriteLine(LocalizableStrings.CliTemplateSearchCoordinator_Info_SearchInProgress);
@@ -158,7 +158,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
 
         private static bool ValidateCommandInput(INewCommandInput commandInput)
         {
-            if (string.IsNullOrWhiteSpace(commandInput.TemplateName) && SupportedFilters.All(filter => !filter.IsFilterSet(commandInput)) && !commandInput.RemainingParameters.Any())
+            if (string.IsNullOrWhiteSpace(commandInput.SearchNameCriteria) && SupportedFilters.All(filter => !filter.IsFilterSet(commandInput)) && !commandInput.RemainingParameters.Any())
             {
                 Reporter.Error.WriteLine(LocalizableStrings.CliTemplateSearchCoordinator_Error_NoTemplateName.Red().Bold());
                 Reporter.Error.WriteLine(string.Format(LocalizableStrings.CliTemplateSearchCoordinator_Info_SearchHelp, string.Join(", ", SupportedFilters.Select(f => $"'{f.Name}'"))));
@@ -169,7 +169,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                 return false;
             }
 
-            if (!string.IsNullOrWhiteSpace(commandInput.TemplateName) && commandInput.TemplateName.Length < 2)
+            if (!string.IsNullOrWhiteSpace(commandInput.SearchNameCriteria) && commandInput.SearchNameCriteria.Length < 2)
             {
                 Reporter.Error.WriteLine(LocalizableStrings.CliTemplateSearchCoordinator_Error_TemplateNameIsTooShort.Bold().Red());
                 return false;

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -550,6 +550,11 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <target state="translated">Další informace – spusťte:</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">Filtruje šablony podle jazyka a určuje jazyk šablony, která se má vytvořit.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -550,6 +550,11 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
         <target state="translated">Für weitere Informationen, führen Sie Folgendes aus:</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">Filtert Vorlagen basierend auf der Sprache und gibt die Sprache der zu erstellenden Vorlage an.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -550,6 +550,11 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
         <target state="translated">Para obtener más información, ejecute:</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">Filtra plantillas en función del idioma y especifica el idioma de la plantilla que se va a crear.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -550,6 +550,11 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <target state="translated">Si vous souhaitez en savoir plus, exécutez :</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">Filtre les modèles en fonction de la langue et spécifie la langue du modèle à créer.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -550,6 +550,11 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <target state="translated">Per altre informazioni, eseguire:</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">Filtra i modelli in base alla lingua e specifica la lingua del modello da creare.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -550,6 +550,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">詳しい情報を見るには、以下を実行してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">言語に基づいてテンプレートをフィルター処理し、作成するテンプレートの言語を指定します。</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -550,6 +550,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">자세한 내용은 다음을 실행하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">언어에 따라 템플릿을 필터링하고 만들 템플릿의 언어를 지정합니다.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -550,6 +550,11 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
         <target state="translated">Aby uzyskać więcej informacji, uruchom:</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">Filtruje szablony na podstawie języka i określa język szablonu do utworzenia.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -550,6 +550,11 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <target state="translated">Para obter mais informações, execute:</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">Filtra modelos baseados em linguagem e especifica o idioma do modelo a ser criado.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -550,6 +550,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">Для получения дополнительных сведений запустите:</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">Фильтрует шаблоны на основе языка и указывает язык создаваемого шаблона.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -550,6 +550,11 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <target state="translated">Daha fazla bilgi için, çalıştırın:</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">Şablonları dile göre filtreler ve oluşturulacak şablonun dilini belirtir.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -550,6 +550,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">有关详细信息，请运行:</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">根据语言筛选模板，并指定要创建的模板的语言。</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -550,6 +550,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">如需詳細資訊，請執行:</target>
         <note />
       </trans-unit>
+      <trans-unit id="InvalidSyntax">
+        <source>Invalid command syntax: use '{0}' instead.</source>
+        <target state="new">Invalid command syntax: use '{0}' instead.</target>
+        <note>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</note>
+      </trans-unit>
       <trans-unit id="LanguageParameter">
         <source>Filters templates based on language and specifies the language of the template to create.</source>
         <target state="translated">根據語言篩選範本，並指定要建立之範本的語言。</target>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliMocks/MockNewCommandInput.cs
@@ -114,7 +114,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
             }
         }
 
-        public bool SearchOnline { get; }
+        public bool IsSearchFlagSpecified { get; }
 
         public string ShowAliasesAliasName { get; } = string.Empty;
 
@@ -134,7 +134,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
         {
             get
             {
-                List<string> tokens = new List<string>();
+                List<string> tokens = new List<string>() { CommandName };
                 if (!string.IsNullOrWhiteSpace(TemplateName))
                 {
                     tokens.Add(TemplateName);
@@ -167,6 +167,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
 
         public IEnumerable<string> Errors => throw new NotImplementedException();
 
+        public string? SearchNameCriteria => string.IsNullOrWhiteSpace(TemplateName)
+            ? GetCommandOption("--search")
+            : TemplateName;
+
+        public string? ListNameCriteria => string.IsNullOrWhiteSpace(TemplateName)
+            ? GetCommandOption("--list")
+            : TemplateName;
+
         public MockNewCommandInput WithTemplateOption(string optionName, string? optionValue = null)
         {
             if (!optionName.StartsWith('-'))
@@ -194,6 +202,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.CliMocks
             _commandOptions[optionName] = optionValue;
             return this;
         }
+
+        public bool ValidateParseError() => throw new NotImplementedException();
 
         public bool HasDebuggingFlag(string flag)
         {

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CommandInputTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CommandInputTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
 
             var parameters = TemplateCommandInput.GetTemplateParametersFromCommand(commandInput);
             Assert.Equal(1, parameters.Count);
-            Assert.Equal("paramValue1,paramValue2", parameters["--param"]);
+            Assert.Equal("paramValue1", parameters["--param"]);
         }
 
         [Fact]

--- a/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
@@ -19,7 +19,7 @@ namespace Dotnet_new3.IntegrationTests
 
 Options:
   -h, --help                     Displays help for this command.
-  -l, --list                     Lists templates containing the specified template name. If no name is specified, lists all templates.
+  -l, --list <PARTIAL_NAME>      Lists templates containing the specified template name. If no name is specified, lists all templates.
   -n, --name                     The name for the output being created. If no name is specified, the name of the output directory is used.
   -o, --output                   Location to place the generated output.
   -i, --install                  Installs a source or a template package.
@@ -32,7 +32,7 @@ Options:
   -lang, --language              Filters templates based on language and specifies the language of the template to create.
   --update-check                 Check the currently installed template packages for updates.
   --update-apply                 Check the currently installed template packages for update, and install the updates.
-  --search                       Searches for the templates on NuGet.org.
+  --search <PARTIAL_NAME>        Searches for the templates on NuGet.org.
   --author <AUTHOR>              Filters the templates based on the template author. Applicable only with --search or --list | -l option.
   --package <PACKAGE>            Filters the templates based on NuGet package ID. Applies to --search.
   --columns <COLUMNS_LIST>       Comma separated list of columns to display in --list and --search output.


### PR DESCRIPTION
### Problem
#3552

### Solution
`dotnet new smth --list` and `dotnet new --list smth` are treated as same commands now. 
Same for search

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)