### PR TITLE
Fixes 3124: Remove template package from packages list if file/folder doesn't exist anymore

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPoint.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPoint.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 
 namespace Microsoft.TemplateEngine.Abstractions.Mount

--- a/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPointFactory.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Mount/IMountPointFactory.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace Microsoft.TemplateEngine.Abstractions.Mount
 {
     /// <summary>
@@ -18,6 +20,16 @@ namespace Microsoft.TemplateEngine.Abstractions.Mount
         /// <param name="mountPointUri">Valid <see cref="System.Uri"/> that represents mount point.</param>
         /// <param name="mountPoint">Resulting mount point.</param>
         /// <returns><c>true</c> if mount point was successfully mounted.</returns>
-        bool TryMount(IEngineEnvironmentSettings environmentSettings, IMountPoint parent, string mountPointUri, out IMountPoint mountPoint);
+        bool TryMount(IEngineEnvironmentSettings environmentSettings, IMountPoint? parent, string mountPointUri, out IMountPoint? mountPoint);
+
+        /// <summary>
+        /// Verifies mountpoint is valid and can be mounted.
+        /// Example of use would be to verify if file, folder or other resource is still present.
+        /// </summary>
+        /// <param name="environmentSettings">Environment to be used.</param>
+        /// <param name="parent">Mount points can be mounted inside each other. Pass in parent or <c>null</c>.</param>
+        /// <param name="mountPointUri">Valid <see cref="System.Uri"/> that represents mount point.</param>
+        /// <returns><c>true</c> if mount point can be mounted.</returns>
+        bool CanMount(IEngineEnvironmentSettings environmentSettings, IMountPoint? parent, string mountPointUri);
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Shipped.txt
@@ -331,13 +331,13 @@ Microsoft.TemplateEngine.Abstractions.IComponentManager.TryGetComponent<T>(Syste
 ~Microsoft.TemplateEngine.Abstractions.Mount.IFileSystemInfo.MountPoint.get -> Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint
 ~Microsoft.TemplateEngine.Abstractions.Mount.IFileSystemInfo.Name.get -> string
 ~Microsoft.TemplateEngine.Abstractions.Mount.IFileSystemInfo.Parent.get -> Microsoft.TemplateEngine.Abstractions.Mount.IDirectory
-~Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint.DirectoryInfo(string path) -> Microsoft.TemplateEngine.Abstractions.Mount.IDirectory
-~Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint.EnvironmentSettings.get -> Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings
-~Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint.FileInfo(string path) -> Microsoft.TemplateEngine.Abstractions.Mount.IFile
-~Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint.FileSystemInfo(string path) -> Microsoft.TemplateEngine.Abstractions.Mount.IFileSystemInfo
-~Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint.MountPointUri.get -> string
-~Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint.Root.get -> Microsoft.TemplateEngine.Abstractions.Mount.IDirectory
-~Microsoft.TemplateEngine.Abstractions.Mount.IMountPointFactory.TryMount(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings environmentSettings, Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint parent, string mountPointUri, out Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint mountPoint) -> bool
+Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint.DirectoryInfo(string! path) -> Microsoft.TemplateEngine.Abstractions.Mount.IDirectory!
+Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint.EnvironmentSettings.get -> Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings!
+Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint.FileInfo(string! path) -> Microsoft.TemplateEngine.Abstractions.Mount.IFile!
+Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint.FileSystemInfo(string! path) -> Microsoft.TemplateEngine.Abstractions.Mount.IFileSystemInfo!
+Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint.MountPointUri.get -> string!
+Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint.Root.get -> Microsoft.TemplateEngine.Abstractions.Mount.IDirectory!
+Microsoft.TemplateEngine.Abstractions.Mount.IMountPointFactory.TryMount(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! environmentSettings, Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint? parent, string! mountPointUri, out Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint? mountPoint) -> bool
 ~Microsoft.TemplateEngine.Abstractions.Mount.IMountPointManager.EnvironmentSettings.get -> Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings
 ~Microsoft.TemplateEngine.Abstractions.Mount.IMountPointManager.TryDemandMountPoint(string mountPointUri, out Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint mountPoint) -> bool
 ~Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IFileLastWriteTimeSource.GetLastWriteTimeUtc(string file) -> System.DateTime

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Microsoft.TemplateEngine.Abstractions.Mount.IMountPointFactory.CanMount(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! environmentSettings, Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint? parent, string! mountPointUri) -> bool

--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsTemplatePackageProvider.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsTemplatePackageProvider.cs
@@ -71,18 +71,28 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
                 {
                     try
                     {
-                        list.Add(((ISerializableInstaller)installer).Deserialize(this, entry));
+                        var package = ((ISerializableInstaller)installer).Deserialize(this, entry);
+                        if (_environmentSettings.CanMount(package.MountPointUri))
+                        {
+                            list.Add(package);
+                        }
                     }
                     catch (Exception e)
                     {
                         _logger.LogDebug($"[{Factory.DisplayName}] Failed to deserialize template package data entry {entry.MountPointUri}, details: {e}.", DebugLogCategory);
                         //adding template package as non-managed
-                        list.Add(new TemplatePackage(this, entry.MountPointUri, entry.LastChangeTime));
+                        if (_environmentSettings.CanMount(entry.MountPointUri))
+                        {
+                            list.Add(new TemplatePackage(this, entry.MountPointUri, entry.LastChangeTime));
+                        }
                     }
                 }
                 else
                 {
-                    list.Add(new TemplatePackage(this, entry.MountPointUri, entry.LastChangeTime));
+                    if (_environmentSettings.CanMount(entry.MountPointUri))
+                    {
+                        list.Add(new TemplatePackage(this, entry.MountPointUri, entry.LastChangeTime));
+                    }
                 }
             }
             return list;

--- a/src/Microsoft.TemplateEngine.Edge/Mount/Archive/ZipFileMountPoint.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/Archive/ZipFileMountPoint.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.IO.Compression;
@@ -15,20 +17,17 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
     /// </summary>
     internal class ZipFileMountPoint : IMountPoint
     {
-        private IReadOnlyDictionary<string, IFileSystemInfo> _universe;
+        private IReadOnlyDictionary<string, IFileSystemInfo>? _universe;
 
-        internal ZipFileMountPoint(IEngineEnvironmentSettings environmentSettings, IMountPoint parent, string mountPointUri, ZipArchive archive)
+        internal ZipFileMountPoint(IEngineEnvironmentSettings environmentSettings, string mountPointUri, ZipArchive archive)
         {
             MountPointUri = mountPointUri;
-            Parent = parent;
             EnvironmentSettings = environmentSettings;
             Archive = archive;
             Root = new ZipFileDirectory(this, "/", "");
         }
 
         public IDirectory Root { get; }
-
-        public IMountPoint Parent { get; }
 
         public string MountPointUri { get; }
 
@@ -51,7 +50,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
                     {
                         string[] parts = entry.FullName.Split('/', '\\');
                         string path = "/";
-                        IDirectory parentDir = (IDirectory)universe["/"];
+                        IDirectory? parentDir = (IDirectory)universe["/"];
 
                         for (int i = 0; parentDir != null && i < parts.Length - 1; ++i)
                         {
@@ -96,13 +95,13 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
 
         public IDirectory DirectoryInfo(string path)
         {
-            if (Universe.TryGetValue(path, out IFileSystemInfo info))
+            if (Universe.TryGetValue(path, out IFileSystemInfo info) && info is IDirectory dir)
             {
-                return info as IDirectory;
+                return dir;
             }
-            else if (Universe.TryGetValue(path + "/", out info))
+            else if (Universe.TryGetValue(path + "/", out info) && info is IDirectory dirWithSlash)
             {
-                return info as IDirectory;
+                return dirWithSlash;
             }
 
             return new ZipFileDirectory(this, path, path.Substring(path.LastIndexOf('/') + 1));

--- a/src/Microsoft.TemplateEngine.Edge/Mount/Archive/ZipFileMountPointFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/Archive/ZipFileMountPointFactory.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.IO.Compression;
 using Microsoft.TemplateEngine.Abstractions;
@@ -15,7 +17,17 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
 
         public Guid Id => FactoryId;
 
-        public bool TryMount(IEngineEnvironmentSettings environmentSettings, IMountPoint parent, string mountPointUri, out IMountPoint mountPoint)
+        public bool CanMount(IEngineEnvironmentSettings environmentSettings, IMountPoint? parent, string mountPointUri)
+        {
+            return InnerTryMount(environmentSettings, parent, mountPointUri, out _, true);
+        }
+
+        public bool TryMount(IEngineEnvironmentSettings environmentSettings, IMountPoint? parent, string mountPointUri, out IMountPoint? mountPoint)
+        {
+            return InnerTryMount(environmentSettings, parent, mountPointUri, out mountPoint, false);
+        }
+
+        private bool InnerTryMount(IEngineEnvironmentSettings environmentSettings, IMountPoint? parent, string mountPointUri, out IMountPoint? mountPoint, bool skipMounting)
         {
             if (!Uri.TryCreate(mountPointUri, UriKind.Absolute, out var uri))
             {
@@ -38,6 +50,11 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
                     mountPoint = null;
                     return false;
                 }
+                if (skipMounting)
+                {
+                    mountPoint = null;
+                    return true;
+                }
 
                 try
                 {
@@ -58,6 +75,11 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
                     mountPoint = null;
                     return false;
                 }
+                if (skipMounting)
+                {
+                    mountPoint = null;
+                    return true;
+                }
 
                 try
                 {
@@ -70,7 +92,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
                 }
             }
 
-            mountPoint = new ZipFileMountPoint(environmentSettings, parent, mountPointUri, archive);
+            mountPoint = new ZipFileMountPoint(environmentSettings, mountPointUri, archive);
             return true;
         }
     }

--- a/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemMountPoint.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemMountPoint.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.IO;
 using Microsoft.TemplateEngine.Abstractions;
@@ -16,7 +18,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
     {
         private SettingsFilePaths _paths;
 
-        internal FileSystemMountPoint(IEngineEnvironmentSettings environmentSettings, IMountPoint parent, string mountPointUri, string mountPointRootPath)
+        internal FileSystemMountPoint(IEngineEnvironmentSettings environmentSettings, IMountPoint? parent, string mountPointUri, string mountPointRootPath)
         {
             MountPointUri = mountPointUri;
             MountPointRootPath = mountPointRootPath;
@@ -29,7 +31,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
 
         public IEngineEnvironmentSettings EnvironmentSettings { get; }
 
-        public IMountPoint Parent { get; }
+        public IMountPoint? Parent { get; }
 
         public Guid MountPointFactoryId => FileSystemMountPointFactory.FactoryId;
 

--- a/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
@@ -57,7 +57,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         {
             foreach (IMountPointFactory factory in _environmentSettings.Components.OfType<IMountPointFactory>().ToList())
             {
-                if (factory.TryMount(_environmentSettings, null, sourceLocation, out IMountPoint mountPoint))
+                if (factory.TryMount(_environmentSettings, null, sourceLocation, out IMountPoint? mountPoint))
                 {
                     // file-based and not originating in the scratch dir.
                     bool isLocalFlatFileSource = mountPoint is FileSystemMountPoint
@@ -65,7 +65,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
                     return new MountPointScanSource(
                         location: sourceLocation,
-                        mountPoint: mountPoint,
+                        mountPoint: mountPoint!,
                         shouldStayInOriginalLocation: isLocalFlatFileSource,
                         foundComponents: false,
                         foundTemplates: false

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
@@ -319,8 +319,8 @@ namespace Microsoft.TemplateEngine.Edge.Template
                 return null;
             }
             IFile config = mountPoint!.FileInfo(info.ConfigPlace);
-            IFile? localeConfig = string.IsNullOrEmpty(info.LocaleConfigPlace) ? null : mountPoint.FileInfo(info.LocaleConfigPlace);
-            IFile? hostTemplateConfigFile = string.IsNullOrEmpty(info.HostConfigPlace) ? null : mountPoint.FileInfo(info.HostConfigPlace);
+            IFile? localeConfig = string.IsNullOrEmpty(info.LocaleConfigPlace) ? null : mountPoint.FileInfo(info.LocaleConfigPlace!);
+            IFile? hostTemplateConfigFile = string.IsNullOrEmpty(info.HostConfigPlace) ? null : mountPoint.FileInfo(info.HostConfigPlace!);
             ITemplate template;
             using (Timing.Over(_environmentSettings.Host.Logger, $"Template from config {config.MountPoint.MountPointUri}{config.FullPath}"))
             {

--- a/src/Microsoft.TemplateEngine.Utils/EngineEnvironmentSettingsExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Utils/EngineEnvironmentSettingsExtensions.cs
@@ -32,5 +32,22 @@ namespace Microsoft.TemplateEngine.Utils
             mountPoint = null;
             return false;
         }
+
+        /// <summary>
+        /// Tries to mount a <see cref="IMountPoint"/> from specified <see cref="System.Uri"/>.
+        /// Using all <see cref="IMountPointFactory"/> in <see cref="IEngineEnvironmentSettings.Components"/>.
+        /// </summary>
+        public static bool CanMount(this IEngineEnvironmentSettings engineEnvironment, string mountPointUri)
+        {
+            foreach (var factory in engineEnvironment.Components.OfType<IMountPointFactory>())
+            {
+                if (factory.CanMount(engineEnvironment, null, mountPointUri))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 ﻿Microsoft.TemplateEngine.Utils.IFileSystemInfoExtensions
+static Microsoft.TemplateEngine.Utils.EngineEnvironmentSettingsExtensions.CanMount(this Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! engineEnvironment, string! mountPointUri) -> bool
 static Microsoft.TemplateEngine.Utils.IFileSystemInfoExtensions.GetDisplayPath(this Microsoft.TemplateEngine.Abstractions.Mount.IFileSystemInfo! fileSystemInfo) -> string!

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/TemplateJsonExistencePackFilter.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Filters/TemplateJsonExistencePackFilter.cs
@@ -22,9 +22,9 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Filters
                 EngineEnvironmentSettings environmentSettings = new EngineEnvironmentSettings(_host, virtualizeSettings: true);
                 foreach (IMountPointFactory factory in environmentSettings.Components.OfType<IMountPointFactory>())
                 {
-                    if (factory.TryMount(environmentSettings, null, packInfo.Path, out IMountPoint mountPoint))
+                    if (factory.TryMount(environmentSettings, null, packInfo.Path, out IMountPoint? mountPoint))
                     {
-                        bool hasTemplateJson = mountPoint.Root.EnumerateFiles("template.json", SearchOption.AllDirectories).Any();
+                        bool hasTemplateJson = mountPoint!.Root.EnumerateFiles("template.json", SearchOption.AllDirectories).Any();
                         mountPoint.Dispose();
 
                         if (hasTemplateJson)

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/FilterNonMicrosoftAuthors.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/FilterNonMicrosoftAuthors.cs
@@ -29,9 +29,9 @@ internal class FilterNonMicrosoftAuthors
             EngineEnvironmentSettings environmentSettings = new EngineEnvironmentSettings(_host, virtualizeSettings: true);
             foreach (IMountPointFactory factory in environmentSettings.Components.OfType<IMountPointFactory>())
             {
-                if (factory.TryMount(environmentSettings, null, packInfo.Path, out IMountPoint mountPoint))
+                if (factory.TryMount(environmentSettings, null, packInfo.Path, out IMountPoint? mountPoint))
                 {
-                    foreach (var templateJson in mountPoint.Root.EnumerateFiles("template.json", SearchOption.AllDirectories))
+                    foreach (var templateJson in mountPoint!.Root.EnumerateFiles("template.json", SearchOption.AllDirectories))
                     {
                         try
                         {

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/LocalizationTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/LocalizationTests.cs
@@ -460,9 +460,9 @@ false,
         {
             foreach (var factory in engineEnvironmentSettings.Components.OfType<IMountPointFactory>())
             {
-                if (factory.TryMount(engineEnvironmentSettings, null, path, out IMountPoint myMountPoint))
+                if (factory.TryMount(engineEnvironmentSettings, null, path, out IMountPoint? myMountPoint))
                 {
-                    return myMountPoint;
+                    return myMountPoint!;
                 }
             }
             throw new Exception($"Failed to mount the location {path}");

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -526,5 +526,41 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining($"  Source location './' is outside the specified install source location.")
                 .And.HaveStdOutContaining($"No templates were found in the package {invalidTemplatePath}.");
         }
+        
+        [Fact]
+        public void IgnoreRemovedPackages()
+        {
+            string hiveRoot = TestUtils.CreateTemporaryFolder("HiveRoot");
+            string templateLocation = TestUtils.GetTestTemplateLocation("TemplateWithSourceName");
+            string templateCopyDir = TestUtils.CreateTemporaryFolder("CopyOfTemplate");
+            TestUtils.DirectoryCopy(templateLocation, templateCopyDir, true);
+
+            new DotnetNewCommand(_log, "-i", templateCopyDir)
+                .WithCustomHive(hiveRoot)
+                .Execute()
+                .Should()
+                .NotHaveStdErr()
+                .And.ExitWith(0)
+                .And.HaveStdOutContaining("TestAssets.TemplateWithSourceName");
+
+            new DotnetNewCommand(_log, "--list")
+                .WithCustomHive(hiveRoot)
+                .Execute()
+                .Should()
+                .NotHaveStdErr()
+                .And.ExitWith(0)
+                .And.HaveStdOutContaining("TestAssets.TemplateWithSourceName");
+
+            Directory.Delete(templateCopyDir, true);
+
+            new DotnetNewCommand(_log, "--list")
+                .WithCustomHive(hiveRoot)
+                .Execute()
+                .Should()
+                .NotHaveStdErr()
+                .And.ExitWith(0)
+                .And.NotHaveStdOutContaining("TestAssets.TemplateWithSourceName");
+
+        }
     }
 }


### PR DESCRIPTION
### Problem
Remove template package from packages list if file/folder doesn't exist anymore

### Solution
Solution is to add to `IMountPointFactory` new method `CanMount` that verifies if mount point is valid or not and use it...

One questionable thing is... Should we remove globalSettings.json entry that doesn't have valid MountPoint... Answer is... lets leave it there, since maybe some other/newer host that has MountPointFactory that understands that mountPointUri...

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)