### PR TITLE
Tabular output is not displayed correctly for non-Latin chars

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,6 +15,7 @@
     <PackageReference Update="NuGet.Configuration" Version="$(NuGetConfigurationPackageVersion)" />
     <PackageReference Update="NuGet.Credentials" Version="$(NuGetCredentialsPackageVersion)" />
     <PackageReference Update="NuGet.Protocol" Version="$(NuGetProtocolPackageVersion)" />
+    <PackageReference Update="Wcwidth.Sources" Version="$(WcwidthSourcesPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(BuildingInsideVisualStudio)' != 'true'">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,5 +25,6 @@
     <MicrosoftExtensionsLoggingConsolePackageVersion>6.0.0-rc.1.21417.1</MicrosoftExtensionsLoggingConsolePackageVersion>
     <!-- Dependencies from https://github.com/dotnet/clicommandlineparser -->
     <MicrosoftDotNetCliCommandLinePackageVersion>1.0.0-preview.19208.1</MicrosoftDotNetCliCommandLinePackageVersion>
+    <WcwidthSourcesPackageVersion>0.4.0</WcwidthSourcesPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.TemplateEngine.Cli/Alias/AliasSupport.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Alias/AliasSupport.cs
@@ -6,6 +6,7 @@
 using System.Text.RegularExpressions;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Cli.TableOutput;
 
 namespace Microsoft.TemplateEngine.Cli.Alias
 {

--- a/src/Microsoft.TemplateEngine.Cli/ExternalSource/ExternalSourceSuppressions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/ExternalSource/ExternalSourceSuppressions.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Style", "IDE0005:Using directive is unnecessary.", Justification = "Code-Only packages cannot be edited to conform to project settings.", Scope = "module")]
+[assembly: SuppressMessage("ApiDesign", "RS0016:Add public types and members to the declared API", Justification = "Code-Only packages cannot be edited to conform to project settings.", Scope = "namespaceanddescendants", Target = "Wcwidth")]
+[assembly: SuppressMessage("Performance", "CA1810:Initialize reference type static fields inline", Justification = "Code-Only packages cannot be edited to conform to project settings.", Scope = "namespaceanddescendants", Target = "Wcwidth")]
+[assembly: SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Code-Only packages cannot be edited to conform to project settings.", Scope = "namespaceanddescendants", Target = "Wcwidth")]
+[assembly: SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1404:Code analysis suppression should have justification", Justification = "Code-Only packages cannot be edited to conform to project settings.", Scope = "namespaceanddescendants", Target = "Wcwidth")]

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateDetailsDisplay.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.TemplateFiltering;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Cli.TableOutput;
 using Microsoft.TemplateEngine.Cli.TemplateResolution;
 using Microsoft.TemplateEngine.Utils;
 using TemplateCreator = Microsoft.TemplateEngine.Edge.Template.TemplateCreator;

--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Wcwidth.Sources" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -45,5 +46,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>LocalizableStrings.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(PkgWcwidth_Sources)\contentFiles\cs\net5.0\**" LinkBase="ExternalSource/Wcwidth" Visible="true" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.TemplateEngine.Cli/TableOutput/HelpFormatter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TableOutput/HelpFormatter.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
 
-namespace Microsoft.TemplateEngine.Cli
+namespace Microsoft.TemplateEngine.Cli.TableOutput
 {
     internal class HelpFormatter
     {
@@ -92,13 +92,15 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 for (int j = 0; j < headerLines; ++j)
                 {
-                    for (int i = 0; i < _columns.Count - 1; ++i)
+                    for (int i = 0; i < _columns.Count; ++i)
                     {
-                        b.Append(header[i].GetTextWithPadding(j, _columns[i].CalculatedWidth, _columns[i].RightAlign));
-                        b.Append("".PadRight(_columnPadding));
+                        header[i].AppendTextWithPadding(b, j, _columns[i].CalculatedWidth, _columns[i].RightAlign);
+                        if (i != _columns.Count - 1)
+                        {
+                            b.Append(' ', _columnPadding);
+                        }
                     }
-
-                    b.AppendLine(header[_columns.Count - 1].GetTextWithPadding(j, _columns[_columns.Count - 1].CalculatedWidth, _columns[_columns.Count - 1].RightAlign));
+                    b.AppendLine();
                 }
             }
 
@@ -155,15 +157,16 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 for (int lineWithinRow = 0; lineWithinRow < rowToRender.Max(row => row.LineCount); ++lineWithinRow)
                 {
-                    // Render all columns except last column
-                    for (int columnIndex = 0; columnIndex < _columns.Count - 1; ++columnIndex)
+                    // Render all columns
+                    for (int columnIndex = 0; columnIndex < _columns.Count; ++columnIndex)
                     {
-                        b.Append(rowToRender[columnIndex].GetTextWithPadding(lineWithinRow, _columns[columnIndex].CalculatedWidth, _columns[columnIndex].RightAlign));
-                        b.Append("".PadRight(_columnPadding));
+                        rowToRender[columnIndex].AppendTextWithPadding(b, lineWithinRow, _columns[columnIndex].CalculatedWidth, _columns[columnIndex].RightAlign);
+                        if (columnIndex != _columns.Count - 1)
+                        {
+                            b.Append(' ', _columnPadding);
+                        }
                     }
-
-                    // Render last column
-                    b.AppendLine(rowToRender[_columns.Count - 1].GetTextWithPadding(lineWithinRow, _columns[_columns.Count - 1].CalculatedWidth, _columns[_columns.Count - 1].RightAlign));
+                    b.AppendLine();
                 }
 
                 if (_blankLineBetweenRows)
@@ -207,13 +210,20 @@ namespace Microsoft.TemplateEngine.Cli
 
         private static string ShrinkTextToLength(string text, int maxLength)
         {
-            if (text.Length <= maxLength)
+            if (text.GetUnicodeLength() <= maxLength)
             {
                 // The text is short enough, so return it
                 return text;
             }
             // If the text is too long, shorten it enough to allow room for the ellipsis, then add the ellipsis
-            return text.Substring(0, Math.Max(0, maxLength - ShrinkReplacement.Length)) + ShrinkReplacement;
+
+            int desiredLength = maxLength - ShrinkReplacement.Length;
+            int possibleLength = 1;
+            while (text.Substring(0, possibleLength).GetUnicodeLength() < desiredLength)
+            {
+                possibleLength++;
+            }
+            return text.Substring(0, possibleLength - 1) + ShrinkReplacement;
         }
 
         private void CalculateColumnWidth(IReadOnlyDictionary<int, int> columnWidthLookup)
@@ -346,7 +356,7 @@ namespace Microsoft.TemplateEngine.Cli
 
                         if (newlineIndex > -1)
                         {
-                            if (newlineIndex - position <= maxWidth)
+                            if (text.Substring(position, newlineIndex - position).GetUnicodeLength() <= maxWidth)
                             {
                                 lines.Add(text.Substring(position, newlineIndex - position).TrimEnd());
                                 position = newlineIndex + environmentSettings.Environment.NewLine.Length;
@@ -361,7 +371,7 @@ namespace Microsoft.TemplateEngine.Cli
                             GetLineText(text, lines, maxWidth, text.Length - 1, ref position);
                         }
 
-                        realMaxWidth = Math.Max(realMaxWidth, lines[lines.Count - 1].Length);
+                        realMaxWidth = Math.Max(realMaxWidth, lines[lines.Count - 1].GetUnicodeLength());
                     }
                 }
 
@@ -376,24 +386,24 @@ namespace Microsoft.TemplateEngine.Cli
 
             internal string RawText { get; }
 
-            internal string GetTextWithPadding(int line, int maxColumnWidth, bool rightAlign = false)
+            internal void AppendTextWithPadding(StringBuilder b, int line, int maxColumnWidth, bool rightAlign = false)
             {
                 var text = _lines.Count > line ? _lines[line] : string.Empty;
                 var abbreviatedText = ShrinkTextToLength(text, maxColumnWidth);
 
                 if (rightAlign)
                 {
-                    return abbreviatedText.PadLeft(maxColumnWidth);
+                    b.Append(' ', maxColumnWidth - abbreviatedText.GetUnicodeLength()).Append(abbreviatedText);
                 }
                 else
                 {
-                    return abbreviatedText.PadRight(maxColumnWidth);
+                    b.Append(abbreviatedText).Append(' ', maxColumnWidth - abbreviatedText.GetUnicodeLength());
                 }
             }
 
             private static void GetLineText(string text, List<string> lines, int maxLength, int end, ref int position)
             {
-                if (text.Length - position < maxLength)
+                if (text.Substring(position, text.Length - position).GetUnicodeLength() < maxLength)
                 {
                     lines.Add(text.Substring(position));
                     position = text.Length;
@@ -401,7 +411,7 @@ namespace Microsoft.TemplateEngine.Cli
                 }
 
                 int lastBreak = text.LastIndexOfAny(new[] { ' ', '-' }, end, end - position);
-                while (lastBreak > 0 && lastBreak - position > maxLength)
+                while (lastBreak > 0 && text.Substring(position, lastBreak - position).GetUnicodeLength() > maxLength)
                 {
                     --lastBreak;
                     lastBreak = text.LastIndexOfAny(new[] { ' ', '-' }, lastBreak, lastBreak - position);

--- a/src/Microsoft.TemplateEngine.Cli/TableOutput/UnicodeLength.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TableOutput/UnicodeLength.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+namespace Microsoft.TemplateEngine.Cli.TableOutput
+{
+    internal static class UnicodeLength
+    {
+        internal static int GetUnicodeLength (this string s)
+        {
+            return s.Sum(ch => GetWidth((int)ch));
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/TableOutput/UnicodeLength.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TableOutput/UnicodeLength.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TemplateEngine.Cli.TableOutput
     {
         internal static int GetUnicodeLength (this string s)
         {
-            return s.Sum(ch => GetWidth((int)ch));
+            return s.Sum(ch => Wcwidth.UnicodeCalculator.GetWidth((int)ch));
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -9,6 +9,7 @@ using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
 using Microsoft.TemplateEngine.Cli.HelpAndUsage;
 using Microsoft.TemplateEngine.Cli.NuGet;
+using Microsoft.TemplateEngine.Cli.TableOutput;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Utils;
 using NuGet.Credentials;

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -63,6 +63,7 @@ namespace Dotnet_new3
             }
 
             ConfigureLocale();
+            Console.OutputEncoding = Encoding.UTF8;
 
             DefaultTemplateEngineHost host = new DefaultTemplateEngineHost(
                 HostIdentifier,

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/HelpFormatterTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/HelpTests/HelpFormatterTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Cli.TableOutput;
 using Microsoft.TemplateEngine.Cli.UnitTests.CliMocks;
 using Microsoft.TemplateEngine.Mocks;
 using Xunit;
@@ -11,7 +12,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
 {
     public class HelpFormatterTests
     {
-        [Fact(DisplayName = nameof(CanShrinkOneColumn))]
+        [Fact]
         public void CanShrinkOneColumn()
         {
             IEngineEnvironmentSettings environmentSettings = new MockEngineEnvironmentSettings()
@@ -48,7 +49,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             Assert.Equal(expectedOutput, result);
         }
 
-        [Fact(DisplayName = nameof(CanShrinkMultipleColumnsAndBalanceShrinking))]
+        [Fact]
         public void CanShrinkMultipleColumnsAndBalanceShrinking()
         {
             IEngineEnvironmentSettings environmentSettings = new MockEngineEnvironmentSettings()
@@ -85,7 +86,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             Assert.Equal(expectedOutput, result);
         }
 
-        [Fact(DisplayName = nameof(CannotShrinkOverMinimumWidth))]
+        [Fact]
         public void CannotShrinkOverMinimumWidth()
         {
             IEngineEnvironmentSettings environmentSettings = new MockEngineEnvironmentSettings()
@@ -122,7 +123,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             Assert.Equal(expectedOutput, result);
         }
 
-        [Fact(DisplayName = nameof(CanShowDefaultColumns))]
+        [Fact]
         public void CanShowDefaultColumns()
         {
             IEngineEnvironmentSettings environmentSettings = new MockEngineEnvironmentSettings()
@@ -160,7 +161,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             Assert.Equal(expectedOutput, result);
         }
 
-        [Fact(DisplayName = nameof(CanShowUserSelectedColumns))]
+        [Fact]
         public void CanShowUserSelectedColumns()
         {
             IEngineEnvironmentSettings environmentSettings = new MockEngineEnvironmentSettings()
@@ -198,7 +199,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             Assert.Equal(expectedOutput, result);
         }
 
-        [Fact(DisplayName = nameof(CanShowAllColumns))]
+        [Fact]
         public void CanShowAllColumns()
         {
             IEngineEnvironmentSettings environmentSettings = new MockEngineEnvironmentSettings()
@@ -236,7 +237,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
             Assert.Equal(expectedOutput, result);
         }
 
-        [Fact(DisplayName = nameof(CanRightAlign))]
+        [Fact]
         public void CanRightAlign()
         {
             IEngineEnvironmentSettings environmentSettings = new MockEngineEnvironmentSettings()
@@ -268,6 +269,98 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.HelpTests
                      blankLineBetweenRows: false)
                  .DefineColumn(t => t.Item1, "Column 1")
                  .DefineColumn(t => t.Item2, "Column 2", rightAlign: true);
+
+            string result = formatter.Layout();
+            Assert.Equal(expectedOutput, result);
+        }
+
+        [Fact]
+        public void CanCalculateWidthCorrectly()
+        {
+            IEngineEnvironmentSettings environmentSettings = new MockEngineEnvironmentSettings()
+            {
+                Environment = new MockEnvironment()
+                {
+                    ConsoleBufferWidth = 100, 
+                }
+            };
+
+            INewCommandInput command = new MockNewCommandInput();
+
+            IEnumerable<Tuple<string, string>> data = new List<Tuple<string, string>>()
+            {
+                new Tuple<string, string>("dotnet gitignore 文件", "gitignore"),
+                new Tuple<string, string>("Dotnet 本地工具清单文件", "tool-manifest"),
+                new Tuple<string, string>("控制台应用程序", "console"),
+                new Tuple<string, string>("类库", "classlib"),
+            };
+
+            string expectedOutput =
+@"模板名                   短名称       
+-----------------------  -------------
+dotnet gitignore 文件    gitignore    
+Dotnet 本地工具清单文件  tool-manifest
+控制台应用程序           console      
+类库                     classlib     
+";
+
+            HelpFormatter<Tuple<string, string>> formatter =
+             HelpFormatter
+                 .For(
+                     environmentSettings,
+                     command,
+                     data,
+                     columnPadding: 2,
+                     headerSeparator: '-',
+                     blankLineBetweenRows: false)
+                 .DefineColumn(t => t.Item1, "模板名")
+                 .DefineColumn(t => t.Item2, "短名称");
+
+            string result = formatter.Layout();
+            Assert.Equal(expectedOutput, result);
+        }
+
+        [Fact]
+        public void CanShrinkWideCharsCorrectly()
+        {
+            IEngineEnvironmentSettings environmentSettings = new MockEngineEnvironmentSettings()
+            {
+                Environment = new MockEnvironment()
+                {
+                    ConsoleBufferWidth = 30,
+                }
+            };
+
+            INewCommandInput command = new MockNewCommandInput();
+
+            IEnumerable<Tuple<string, string>> data = new List<Tuple<string, string>>()
+            {
+                new Tuple<string, string>("dotnet gitignore 文件", "gitignore"),
+                new Tuple<string, string>("Dotnet 本地工具清单文件", "tool-manifest"),
+                new Tuple<string, string>("控制台应用程序", "console"),
+                new Tuple<string, string>("类库", "classlib"),
+            };
+
+            string expectedOutput =
+@"模板名          短名称       
+--------------  -------------
+dotnet git...   gitignore    
+Dotnet 本...    tool-manifest
+控制台应用程序  console      
+类库            classlib     
+";
+
+            HelpFormatter<Tuple<string, string>> formatter =
+             HelpFormatter
+                 .For(
+                     environmentSettings,
+                     command,
+                     data,
+                     columnPadding: 2,
+                     headerSeparator: '-',
+                     blankLineBetweenRows: false)
+                 .DefineColumn(t => t.Item1, "模板名", shrinkIfNeeded: true)
+                 .DefineColumn(t => t.Item2, "短名称");
 
             string result = formatter.Layout();
             Assert.Equal(expectedOutput, result);


### PR DESCRIPTION
### Problem
Fixes #3288 

### Solution
Take into account that a single character may not always occupy 1 space in the console.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)