### PR TITLE
Fixes 3224: Add rollForward option to global.json generated by 'dotnet new globaljson'

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/GlobalJson/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/GlobalJson/.template.config/dotnetcli.host.json
@@ -5,6 +5,10 @@
       "longName": "sdk-version",
       "shortName": ""
     },
+    "RollForward": {
+      "longName": "roll-forward",
+      "shortName": ""
+    },
     "dotnet-cli-version": {
       "isHidden": "true"
     }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/GlobalJson/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/GlobalJson/.template.config/template.json
@@ -45,6 +45,52 @@
         "fallbackVariableName": "dotnet-cli-version"
       },
       "replaces": "SDK_VERSION"
+    },
+    "RollForward": {
+      "type": "parameter",
+      "description": "The roll-forward policy to use when selecting an SDK version.",
+      "displayName": "Roll Forward",
+      "replaces": "ROLL_FORWARD_VALUE",
+      "defaultValue": "",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "patch",
+          "description": "Uses the specified version.\nIf not found, rolls forward to the latest patch level.\nIf not found, fails.\nThis value is the legacy behavior from the earlier versions of the SDK."
+        },
+        {
+          "choice": "feature",
+          "description": "Uses the latest patch level for the specified major, minor, and feature band.\nIf not found, rolls forward to the next higher feature band within the same major/minor and uses the latest patch level for that feature band.\nIf not found, fails."
+        },
+        {
+          "choice": "minor",
+          "description": "Uses the latest patch level for the specified major, minor, and feature band.\nIf not found, rolls forward to the next higher feature band within the same major/minor version and uses the latest patch level for that feature band.\nIf not found, rolls forward to the next higher minor and feature band within the same major and uses the latest patch level for that feature band.\nIf not found, fails."
+        },
+        {
+          "choice": "major",
+          "description": "Uses the latest patch level for the specified major, minor, and feature band.\nIf not found, rolls forward to the next higher feature band within the same major/minor version and uses the latest patch level for that feature band.\nIf not found, rolls forward to the next higher minor and feature band within the same major and uses the latest patch level for that feature band.\nIf not found, rolls forward to the next higher major, minor, and feature band and uses the latest patch level for that feature band.\nIf not found, fails."
+        },
+        {
+          "choice": "latestPatch",
+          "description": "Uses the latest installed patch level that matches the requested major, minor, and feature band with a patch level and that is greater or equal than the specified value.\nIf not found, fails."
+        },
+        {
+          "choice": "latestFeature",
+          "description": "Uses the highest installed feature band and patch level that matches the requested major and minor with a feature band and patch level that is greater or equal than the specified value.\nIf not found, fails."
+        },
+        {
+          "choice": "latestMinor",
+          "description": "Uses the highest installed minor, feature band, and patch level that matches the requested major with a minor, feature band, and patch level that is greater or equal than the specified value.\nIf not found, fails."
+        },
+        {
+          "choice": "latestMajor",
+          "description": "Uses the highest installed .NET SDK with a version that is greater or equal than the specified value.\nIf not found, fail."
+        },
+        {
+          "choice": "disable",
+          "description": "Doesn't roll forward. Exact match required."
+        }
+      ]
     }
   },
   "postActions": [

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/GlobalJson/global.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/GlobalJson/global.json
@@ -1,5 +1,8 @@
 {
   "sdk": {
+    //#if (RollForward!="")
+    "rollForward": "ROLL_FORWARD_VALUE",
+    //#endif
     "version": "SDK_VERSION"
   }
 }

--- a/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
+++ b/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
@@ -228,6 +228,46 @@ Restore succeeded\.");
             Directory.Delete(workingDir, true);
         }
 
+        [Theory]
+        [InlineData(
+@"{
+  ""sdk"": {
+    ""version"": ""5.0.200""
+  }
+}",
+            "globaljson",
+            "--sdk-version",
+            "5.0.200")]
+        [InlineData(
+@"{
+  ""sdk"": {
+    ""rollForward"": ""major"",
+    ""version"": ""5.0.200""
+  }
+}",
+            "globaljson",
+            "--sdk-version",
+            "5.0.200",
+            "--roll-forward",
+            "major")]
+        public void GlobalJsonTests( string expectedContent, params string[] parameters)
+        {
+            string workingDir = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, parameters)
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(workingDir)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOut($@"The template ""global.json file"" was created successfully.");
+
+            string globalJsonConent = File.ReadAllText(Path.Combine(workingDir, "global.json"));
+            Assert.Equal(expectedContent.Replace("\r\n", "\n"), globalJsonConent.Replace("\r\n", "\n"));
+            Directory.Delete(workingDir, true);
+        }
+
         #region Project templates language features tests
 
         /// <summary>


### PR DESCRIPTION
### Problem
Today, if user wants to set "rollForward" value in global.json file it needs to open it manually and edit global.json file...

### Solution
Give --roll-forward parameter option to do that.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)