### PR TITLE
Fixes #3195: Add `editorconfig` item template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/dotnetcli.host.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "Empty":{
+      "longName": "empty",
+      "shortName": ""
+    }
+  }
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.cs.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.de.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.en.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.es.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.fr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.it.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.ja.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.ko.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.pl.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.pt-BR.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.ru.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.tr.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,0 +1,7 @@
+{
+  "author": "Microsoft",
+  "name": "EditorConfig file",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
+  "symbols/Empty/displayName": "Empty",
+  "symbols/Empty/description": "Creates empty .editorconfig instead of the defaults for .NET."
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/template.json
@@ -6,7 +6,7 @@
   ],
   "name": "EditorConfig file",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "Creates an .editorconfig file for .NET project.",
+  "description": "Creates an .editorconfig file for configuring code style preferences.",
   "tags": {
     "type": "item"
   },
@@ -31,7 +31,7 @@
       "defaultValue": "false",
       "defaultIfOptionWithoutValue": "true",
       "displayName": "Empty",
-      "description": "Creates empty .editorconfig instead of .NET specific."
+      "description": "Creates empty .editorconfig instead of the defaults for .NET."
     }
   }
 }

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/.template.config/template.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Microsoft",
+  "classifications": [
+    "Config"
+  ],
+  "name": "EditorConfig file",
+  "generatorVersions": "[1.0.0.0-*)",
+  "description": "Creates an .editorconfig file for .NET project.",
+  "tags": {
+    "type": "item"
+  },
+  "sources": [
+    {
+      "source": "./Dotnet",
+      "target": "./",
+      "condition": "!Empty"
+    },
+    {
+      "source": "./Empty",
+      "target": "./",
+      "condition": "Empty"
+    }
+  ],
+  "identity": "Microsoft.Standard.QuickStarts.EditorConfigFile",
+  "shortName": "editorconfig",
+  "symbols": {
+    "Empty": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "defaultIfOptionWithoutValue": "true",
+      "displayName": "Empty",
+      "description": "Creates empty .editorconfig instead of .NET specific."
+    }
+  }
+}

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/Dotnet/.editorconfig
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/Dotnet/.editorconfig
@@ -1,0 +1,364 @@
+root = true
+
+# All files
+[*]
+indent_style = space
+
+# Xml files
+[*.xml]
+indent_size = 2
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+[*.{cs,vb}]
+
+# Organize usings
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first = true
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_property = false:silent
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+#### C# Coding Conventions ####
+[*.cs]
+
+# var preferences
+csharp_style_var_elsewhere = false:silent
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = false:silent
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:suggestion
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces = true:silent
+csharp_prefer_simple_using_statement = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:silent
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+[*.{cs,vb}]
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style = ipascalcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = suggestion
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style = tpascalcase
+
+dotnet_naming_rule.methods_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.methods_should_be_pascalcase.symbols = methods
+dotnet_naming_rule.methods_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.properties_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.properties_should_be_pascalcase.symbols = properties
+dotnet_naming_rule.properties_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.events_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.events_should_be_pascalcase.symbols = events
+dotnet_naming_rule.events_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style = camelcase
+
+dotnet_naming_rule.local_constants_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.local_constants_should_be_camelcase.symbols = local_constants
+dotnet_naming_rule.local_constants_should_be_camelcase.style = camelcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style = camelcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style = _camelcase
+
+dotnet_naming_rule.private_static_fields_should_be_s_camelcase.severity = suggestion
+dotnet_naming_rule.private_static_fields_should_be_s_camelcase.symbols = private_static_fields
+dotnet_naming_rule.private_static_fields_should_be_s_camelcase.style = s_camelcase
+
+dotnet_naming_rule.public_constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_constant_fields_should_be_pascalcase.symbols = public_constant_fields
+dotnet_naming_rule.public_constant_fields_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.private_constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.private_constant_fields_should_be_pascalcase.symbols = private_constant_fields
+dotnet_naming_rule.private_constant_fields_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.public_static_readonly_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_readonly_fields_should_be_pascalcase.symbols = public_static_readonly_fields
+dotnet_naming_rule.public_static_readonly_fields_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.symbols = private_static_readonly_fields
+dotnet_naming_rule.private_static_readonly_fields_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.enums_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.enums_should_be_pascalcase.symbols = enums
+dotnet_naming_rule.enums_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.local_functions_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.local_functions_should_be_pascalcase.symbols = local_functions
+dotnet_naming_rule.local_functions_should_be_pascalcase.style = pascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style = pascalcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers = 
+
+dotnet_naming_symbols.enums.applicable_kinds = enum
+dotnet_naming_symbols.enums.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.enums.required_modifiers = 
+
+dotnet_naming_symbols.events.applicable_kinds = event
+dotnet_naming_symbols.events.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.events.required_modifiers = 
+
+dotnet_naming_symbols.methods.applicable_kinds = method
+dotnet_naming_symbols.methods.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.methods.required_modifiers = 
+
+dotnet_naming_symbols.properties.applicable_kinds = property
+dotnet_naming_symbols.properties.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.properties.required_modifiers = 
+
+dotnet_naming_symbols.public_fields.applicable_kinds = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers = 
+
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers = 
+
+dotnet_naming_symbols.private_static_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_static_fields.required_modifiers = static
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+dotnet_naming_symbols.type_parameters.applicable_kinds = namespace
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers = 
+
+dotnet_naming_symbols.private_constant_fields.applicable_kinds = field
+dotnet_naming_symbols.private_constant_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_constant_fields.required_modifiers = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers = 
+
+dotnet_naming_symbols.local_constants.applicable_kinds = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers = const
+
+dotnet_naming_symbols.parameters.applicable_kinds = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers = 
+
+dotnet_naming_symbols.public_constant_fields.applicable_kinds = field
+dotnet_naming_symbols.public_constant_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_constant_fields.required_modifiers = const
+
+dotnet_naming_symbols.public_static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.public_static_readonly_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_readonly_fields.required_modifiers = readonly, static
+
+dotnet_naming_symbols.private_static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.private_static_readonly_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_static_readonly_fields.required_modifiers = readonly, static
+
+dotnet_naming_symbols.local_functions.applicable_kinds = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = *
+dotnet_naming_symbols.local_functions.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix = 
+dotnet_naming_style.pascalcase.required_suffix = 
+dotnet_naming_style.pascalcase.word_separator = 
+dotnet_naming_style.pascalcase.capitalization = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix = 
+dotnet_naming_style.ipascalcase.word_separator = 
+dotnet_naming_style.ipascalcase.capitalization = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix = 
+dotnet_naming_style.tpascalcase.word_separator = 
+dotnet_naming_style.tpascalcase.capitalization = pascal_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix = 
+dotnet_naming_style._camelcase.word_separator = 
+dotnet_naming_style._camelcase.capitalization = camel_case
+
+dotnet_naming_style.camelcase.required_prefix = 
+dotnet_naming_style.camelcase.required_suffix = 
+dotnet_naming_style.camelcase.word_separator = 
+dotnet_naming_style.camelcase.capitalization = camel_case
+
+dotnet_naming_style.s_camelcase.required_prefix = s_
+dotnet_naming_style.s_camelcase.required_suffix = 
+dotnet_naming_style.s_camelcase.word_separator = 
+dotnet_naming_style.s_camelcase.capitalization = camel_case
+

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/Empty/.editorconfig
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/EditorConfig/Empty/.editorconfig
@@ -1,0 +1,2 @@
+root = true
+

--- a/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
+++ b/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
@@ -225,6 +226,44 @@ Restore succeeded\.");
                 .And.NotHaveStdErr()
                 .And.HaveStdOut($@"The template ""{expectedTemplateName}"" was created successfully.");
 
+            Directory.Delete(workingDir, true);
+        }
+
+        [Fact]
+        public void EditorConfigTests()
+        {
+            string workingDir = TestUtils.CreateTemporaryFolder();
+
+            new DotnetNewCommand(_log, "editorconfig")
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(workingDir)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOut($@"The template ""EditorConfig file"" was created successfully.");
+
+            string path = Path.Combine(workingDir, ".editorconfig");
+            string editorConfigContent = File.ReadAllText(path);
+            Assert.Contains("dotnet_naming_rule", editorConfigContent);
+            Assert.Contains("dotnet_style_", editorConfigContent);
+            Assert.Contains("dotnet_naming_symbols", editorConfigContent);
+            File.Delete(path);
+
+            new DotnetNewCommand(_log, "editorconfig", "--empty")
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(workingDir)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOut($@"The template ""EditorConfig file"" was created successfully.");
+
+            editorConfigContent = File.ReadAllText(path);
+            Assert.DoesNotContain("dotnet_naming_rule", editorConfigContent);
+            Assert.DoesNotContain("dotnet_style_", editorConfigContent);
+            Assert.DoesNotContain("dotnet_naming_symbols", editorConfigContent);
+            Assert.Contains("root = true", editorConfigContent);
             Directory.Delete(workingDir, true);
         }
 

--- a/test/dotnet-new3.UnitTests/DotnetNewList.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewList.cs
@@ -107,6 +107,7 @@ Class Library                                 classlib       [C#],F#,VB  Common/
 Console Application                           console        [C#],F#,VB  Common/Console        
 dotnet gitignore file                         gitignore                  Config                
 Dotnet local tool manifest file               tool-manifest              Config                
+EditorConfig file                             editorconfig               Config                
 global.json file                              globaljson                 Config                
 NuGet Config                                  nugetconfig                Config                
 Razor Class Library                           razorclasslib  [C#]        Web/Razor/Library     
@@ -454,7 +455,7 @@ Worker Service                                worker         [C#],F#     Common/
                 .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining("No templates found matching: --unknown.")
-                .And.HaveStdErrContaining("8 template(s) partially matched, but failed on --unknown.")
+                .And.HaveStdErrContaining("9 template(s) partially matched, but failed on --unknown.")
                 .And.HaveStdErrContaining($"To search for the templates on NuGet.org, run:{Environment.NewLine}   dotnet new3 <TEMPLATE_NAME> --search");
 
             new DotnetNewCommand(_log, "c", "--list", "--unknown")
@@ -462,7 +463,7 @@ Worker Service                                worker         [C#],F#     Common/
                 .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining("No templates found matching: 'c', --unknown.")
-                .And.HaveStdErrContaining("5 template(s) partially matched, but failed on --unknown.")
+                .And.HaveStdErrContaining("6 template(s) partially matched, but failed on --unknown.")
                 .And.HaveStdErrContaining($"To search for the templates on NuGet.org, run:{Environment.NewLine}   dotnet new3 c --search");
 
             new DotnetNewCommand(_log, "c", "--list", "--unknown", "--language", "C#")
@@ -470,7 +471,7 @@ Worker Service                                worker         [C#],F#     Common/
               .Execute()
               .Should().Fail()
               .And.HaveStdErrContaining("No templates found matching: 'c', language='C#', --unknown.")
-              .And.HaveStdErrContaining("5 template(s) partially matched, but failed on language='C#', --unknown.")
+              .And.HaveStdErrContaining("6 template(s) partially matched, but failed on language='C#', --unknown.")
               .And.HaveStdErrContaining($"To search for the templates on NuGet.org, run:{Environment.NewLine}   dotnet new3 c --search");
         }
 
@@ -494,7 +495,7 @@ Worker Service                                worker         [C#],F#     Common/
                 .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining("No templates found matching: --framework='unknown'.")
-                .And.HaveStdErrContaining("8 template(s) partially matched, but failed on --framework='unknown'.")
+                .And.HaveStdErrContaining("9 template(s) partially matched, but failed on --framework='unknown'.")
                 .And.HaveStdErrContaining($"To search for the templates on NuGet.org, run:{Environment.NewLine}   dotnet new3 <TEMPLATE_NAME> --search");
 
             new DotnetNewCommand(_log, "c", "--list", "--framework", "unknown")
@@ -502,7 +503,7 @@ Worker Service                                worker         [C#],F#     Common/
                 .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining("No templates found matching: 'c', --framework='unknown'.")
-                .And.HaveStdErrContaining("5 template(s) partially matched, but failed on --framework='unknown'.")
+                .And.HaveStdErrContaining("6 template(s) partially matched, but failed on --framework='unknown'.")
                 .And.HaveStdErrContaining($"To search for the templates on NuGet.org, run:{Environment.NewLine}   dotnet new3 c --search");
         }
 
@@ -526,7 +527,7 @@ Worker Service                                worker         [C#],F#     Common/
                 .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining("No templates found matching: language='unknown'.")
-                .And.HaveStdErrContaining("8 template(s) partially matched, but failed on language='unknown'.")
+                .And.HaveStdErrContaining("9 template(s) partially matched, but failed on language='unknown'.")
                 .And.HaveStdErrContaining($"To search for the templates on NuGet.org, run:{Environment.NewLine}   dotnet new3 <TEMPLATE_NAME> --search");
 
             new DotnetNewCommand(_log, "c", "--list", "--language", "unknown", "--framework", "unknown")
@@ -534,7 +535,7 @@ Worker Service                                worker         [C#],F#     Common/
                 .Execute()
                 .Should().Fail()
                 .And.HaveStdErrContaining("No templates found matching: 'c', language='unknown'.")
-                .And.HaveStdErrContaining("5 template(s) partially matched, but failed on language='unknown'.")
+                .And.HaveStdErrContaining("6 template(s) partially matched, but failed on language='unknown'.")
                 .And.HaveStdErrContaining($"To search for the templates on NuGet.org, run:{Environment.NewLine}   dotnet new3 c --search");
         }
 


### PR DESCRIPTION
### Problem
Users often want to create .editorconfig file with preset .NET values

### Solution
Add such template...

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)