### PR TITLE
Fixes #3634: Re-enable supprssed unit tests and remove DisableImplicitNamespaceImports

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "6.0.100-rc.1.21379.2",
+    "dotnet": "6.0.100-rc.1.21415.3",
     "runtimes": {
       "dotnet": [
         "$(MicrosoftNETCoreAppRefPackageVersion)"

--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -6,6 +6,7 @@
     <IsShippingPackage>false</IsShippingPackage>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Shared\JExtensions.cs" Link="JExtensions.cs" />

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/Microsoft.TemplateEngine.TemplateLocalizer.csproj
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/Microsoft.TemplateEngine.TemplateLocalizer.csproj
@@ -6,6 +6,7 @@
     <Description>A tool that can be used to localize template.json files.</Description>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-template-localizer</ToolCommandName>

--- a/src/Microsoft.TemplateSearch.ScraperOutputComparison/Microsoft.TemplateSearch.ScraperOutputComparison.csproj
+++ b/src/Microsoft.TemplateSearch.ScraperOutputComparison/Microsoft.TemplateSearch.ScraperOutputComparison.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet-new3/dotnet-new3.csproj
+++ b/src/dotnet-new3/dotnet-new3.csproj
@@ -3,6 +3,7 @@
     <Description>Template Instantiation Commands for .NET Core CLI.</Description>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/Company.ClassLibrary1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/Company.ClassLibrary1.csproj
@@ -5,7 +5,6 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ClassLibrary1</RootNamespace>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
-    <DisableImplicitNamespaceImports Condition="'$(csharpFeature_ImplicitUsings)' != 'true'">true</DisableImplicitNamespaceImports>
     <ImplicitUsings Condition="'$(csharpFeature_ImplicitUsings)' == 'true'">enable</ImplicitUsings>
     <Nullable Condition="'$(csharpFeature_Nullable)' == 'true'">enable</Nullable>
   </PropertyGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/Company.ConsoleApplication1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/Company.ConsoleApplication1.csproj
@@ -6,7 +6,6 @@
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.ConsoleApplication1</RootNamespace>
     <LangVersion Condition="'$(langVersion)' != ''">$(ProjectLanguageVersion)</LangVersion>
-    <DisableImplicitNamespaceImports Condition="'$(csharpFeature_ImplicitUsings)' != 'true'">true</DisableImplicitNamespaceImports>
     <ImplicitUsings Condition="'$(csharpFeature_ImplicitUsings)' == 'true'">enable</ImplicitUsings>
     <Nullable Condition="'$(csharpFeature_Nullable)' == 'true'">enable</Nullable>
   </PropertyGroup>

--- a/test/Microsoft.TemplateEngine.Cli.IntegrationTests/Microsoft.TemplateEngine.Cli.IntegrationTests.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.IntegrationTests/Microsoft.TemplateEngine.Cli.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Cli.TestHelper/Microsoft.TemplateEngine.Cli.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.TestHelper/Microsoft.TemplateEngine.Cli.TestHelper.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <IsTestProject>false</IsTestProject>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/Microsoft.TemplateEngine.Edge.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/Microsoft.TemplateEngine.Edge.UnitTests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks Condition="'$(PackSpecific)' != 'true'">$(NETCoreTargetFramework);$(NETFullTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/Microsoft.TemplateEngine.EndToEndTestHarness.csproj
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/Microsoft.TemplateEngine.EndToEndTestHarness.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests.csproj
+++ b/test/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests/Microsoft.TemplateEngine.TemplateLocalizer.IntegrationTests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks Condition="'$(PackSpecific)' != 'true'">$(NETCoreTargetFramework);$(NETFullTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateSearch.Common.UnitTests/Microsoft.TemplateSearch.Common.UnitTests.csproj
+++ b/test/Microsoft.TemplateSearch.Common.UnitTests/Microsoft.TemplateSearch.Common.UnitTests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests.csproj
+++ b/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
+++ b/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
@@ -566,21 +566,19 @@ Restore succeeded\.");
                 .ExitWith(0)
                 .And.NotHaveStdErr();
 
-            //TODO: https://github.com/dotnet/templating/issues/3634
-            _ = buildPass; // We must use `buildPass` parameter or compiler reports an error
-            //var buildResult = new DotnetCommand(_log, "build", "MyProject")
-            //    .WithWorkingDirectory(workingDir)
-            //    .Execute();
+            var buildResult = new DotnetCommand(_log, "build", "MyProject")
+                .WithWorkingDirectory(workingDir)
+                .Execute();
 
-            //if (buildPass)
-            //{
-            //    buildResult.Should().ExitWith(0).And.NotHaveStdErr();
-            //}
-            //else
-            //{
-            //    buildResult.Should().Fail();
-            //    return;
-            //}
+            if (buildPass)
+            {
+                buildResult.Should().ExitWith(0).And.NotHaveStdErr();
+            }
+            else
+            {
+                buildResult.Should().Fail();
+                return;
+            }
             string codeFileName = name == "console" ? "Program.cs" : "Class1.cs";
             string programFileContent = File.ReadAllText(Path.Combine(workingDir, "MyProject", codeFileName));
             XDocument projectXml = XDocument.Load(Path.Combine(workingDir, "MyProject", "MyProject.csproj"));

--- a/test/dotnet-new3.UnitTests/dotnet-new3.IntegrationTests.csproj
+++ b/test/dotnet-new3.UnitTests/dotnet-new3.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Problem
DisableImplicitNamespaceImports was left enabled before temporarily so our change propagated to SDK repo

### Solution
Uncomment commented tests & remove DisableImplicitNamespaceImports

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)