### PR TITLE
Errors on reading host data are promoted to warning level

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CliConsoleFormatter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CliConsoleFormatter.cs
@@ -99,7 +99,14 @@ namespace Microsoft.TemplateEngine.Cli
         {
             if (logEntry.Exception != null)
             {
-                textWriter.WriteLine($"Details: {logEntry.Exception}");
+                if (logEntry.LogLevel == LogLevel.Debug || logEntry.LogLevel == LogLevel.Trace)
+                {
+                    textWriter.WriteLine($"Details: {logEntry.Exception}");
+                }
+                else
+                {
+                    textWriter.WriteLine($"Details: {logEntry.Exception.Message}");
+                }
             }
         }
     }

--- a/src/Microsoft.TemplateEngine.Cli/HostSpecificDataLoader.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HostSpecificDataLoader.cs
@@ -43,8 +43,10 @@ namespace Microsoft.TemplateEngine.Cli
                 }
                 catch (Exception e)
                 {
-                    _engineEnvironment.Host.Logger.LogDebug(e, $"Failed to load host data for template {templateInfo.ShortNameList?[0] ?? templateInfo.Name}: the json data in {nameof(ITemplateInfoHostJsonCache.HostData)} is incorrect.");
-                    return HostSpecificTemplateData.Default;
+                    _engineEnvironment.Host.Logger.LogWarning(
+                        e,
+                        LocalizableStrings.HostSpecificDataLoader_Warning_FailedToRead,
+                        templateInfo.ShortNameList?[0] ?? templateInfo.Name);
                 }
             }
 
@@ -70,8 +72,11 @@ namespace Microsoft.TemplateEngine.Cli
             }
             catch (Exception e)
             {
-                _engineEnvironment.Host.Logger.LogDebug(e, $"Failed to load host data for template {templateInfo.ShortNameList?[0] ?? templateInfo.Name}, file: " +
-                    $"{file?.GetDisplayPath() ?? templateInfo.MountPointUri + templateInfo.HostConfigPlace}");
+                _engineEnvironment.Host.Logger.LogWarning(
+                    e,
+                    LocalizableStrings.HostSpecificDataLoader_Warning_FailedToReadFromFile,
+                    templateInfo.ShortNameList?[0] ?? templateInfo.Name,
+                    file?.GetDisplayPath() ?? templateInfo.MountPointUri + templateInfo.HostConfigPlace);
             }
             finally
             {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -961,6 +961,24 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to load dotnet CLI host data for template {0} from cache..
+        /// </summary>
+        internal static string HostSpecificDataLoader_Warning_FailedToRead {
+            get {
+                return ResourceManager.GetString("HostSpecificDataLoader_Warning_FailedToRead", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored..
+        /// </summary>
+        internal static string HostSpecificDataLoader_Warning_FailedToReadFromFile {
+            get {
+                return ResourceManager.GetString("HostSpecificDataLoader_Warning_FailedToReadFromFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Installs a source or a template package..
         /// </summary>
         internal static string InstallHelp {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -761,4 +761,12 @@ The supported columns are: language, tags, author, type.</value>
     <value>Invalid command syntax: use '{0}' instead.</value>
     <comment>{0} - command syntax, example: dotnet new [PARTIAL_NAME] --list [FILTER_OPTIONS].</comment>
   </data>
+  <data name="HostSpecificDataLoader_Warning_FailedToRead" xml:space="preserve">
+    <value>Failed to load dotnet CLI host data for template {0} from cache.</value>
+    <comment>{0} - template short name</comment>
+  </data>
+  <data name="HostSpecificDataLoader_Warning_FailedToReadFromFile" xml:space="preserve">
+    <value>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</value>
+    <comment>{0} - template short name, {1} - file path to host data.</comment>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -515,6 +515,16 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <target state="translated">Příklady:</target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">Nainstaluje zdroj nebo balíček šablon.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -515,6 +515,16 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
         <target state="translated">Beispiele:</target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">Installiert ein Quell- oder Vorlagenpaket.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -515,6 +515,16 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
         <target state="translated">Ejemplos:</target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">Instala un paquete de origen o de plantilla.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -515,6 +515,16 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <target state="translated">Exemples :</target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">Installe une source ou un package de modèle.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -515,6 +515,16 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <target state="translated">Esempi:</target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">Installa un pacchetto di origine o di modello.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -515,6 +515,16 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">例:</target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">ソースまたはテンプレート パッケージをインストールします。</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -515,6 +515,16 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">예:</target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">소스 또는 템플릿 패키지를 설치합니다.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -515,6 +515,16 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
         <target state="translated">Przykłady:</target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">Instaluje źródło lub pakiet szablonów.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -515,6 +515,16 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <target state="translated">Exemplos:</target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">Instala um pacote de origem ou de modelo.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -515,6 +515,16 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">Примеры:</target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">Устанавливает источник или пакет шаблона.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -515,6 +515,16 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <target state="translated">Örnekler:</target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">Bir kaynak veya şablon paketi yükler.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -515,6 +515,16 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">示例: </target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">安装源或模板包。</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -515,6 +515,16 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">範例:</target>
         <note />
       </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToRead">
+        <source>Failed to load dotnet CLI host data for template {0} from cache.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from cache.</target>
+        <note>{0} - template short name</note>
+      </trans-unit>
+      <trans-unit id="HostSpecificDataLoader_Warning_FailedToReadFromFile">
+        <source>Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</source>
+        <target state="new">Failed to load dotnet CLI host data for template {0} from {1}. The host data will be ignored.</target>
+        <note>{0} - template short name, {1} - file path to host data.</note>
+      </trans-unit>
       <trans-unit id="InstallHelp">
         <source>Installs a source or a template package.</source>
         <target state="translated">安裝來源或範本套件。</target>

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
@@ -383,6 +383,15 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to load host data in {0} at {1}..
+        /// </summary>
+        internal static string TemplateInfo_Warning_FailedToReadHostData {
+            get {
+                return ResourceManager.GetString("TemplateInfo_Warning_FailedToReadHostData", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to scan {0}.
         ///Details: {1}.
         /// </summary>

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -228,6 +228,10 @@ Details: {0}.</value>
   <data name="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges" xml:space="preserve">
     <value>Destructive changes detected.</value>
   </data>
+  <data name="TemplateInfo_Warning_FailedToReadHostData" xml:space="preserve">
+    <value>Failed to load host data in {0} at {1}.</value>
+    <comment>{0} - path to template location, {1} relative path inside template location.</comment>
+  </data>
   <data name="TemplatePackageManager_Error_FailedToScan" xml:space="preserve">
     <value>Failed to scan {0}.
 Details: {1}</value>

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
@@ -113,7 +113,11 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 }
                 catch (Exception ex)
                 {
-                    logger.LogDebug(ex, $"Failed to load HostConfig in {template.TemplateSourceRoot.MountPoint.MountPointUri} at {template.HostConfigPlace}.");
+                    logger.LogWarning(
+                        ex,
+                        LocalizableStrings.TemplateInfo_Warning_FailedToReadHostData,
+                        template.MountPointUri,
+                        template.HostConfigPlace);
                 }
             }
         }

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -185,6 +185,11 @@ Podrobnosti: {0}.</target>
         <target state="translated">Rozpoznaly se destruktivní změny.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -185,6 +185,11 @@ Details: {0}.</target>
         <target state="translated">Es wurden destruktive Änderungen erkannt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -185,6 +185,11 @@ Detalles: {0}.</target>
         <target state="translated">Cambios destructivos detectados.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -185,6 +185,11 @@ Détails : {0}.</target>
         <target state="translated">Modifications destructrices détectées.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -185,6 +185,11 @@ Dettagli: {0}.</target>
         <target state="translated">Rilevate modifiche distruttive.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -185,6 +185,11 @@ Details: {0}.</source>
         <target state="translated">重大な変更が検出されました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -185,6 +185,11 @@ Details: {0}.</source>
         <target state="translated">파괴적 변경이 감지되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -185,6 +185,11 @@ Szczegóły: {0}.</target>
         <target state="translated">Wykryto niszczące zmiany.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -185,6 +185,11 @@ Detalhes: {0}.</target>
         <target state="translated">Alterações destrutivas detectadas.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -185,6 +185,11 @@ Details: {0}.</source>
         <target state="translated">Обнаружены необратимые изменения.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -185,6 +185,11 @@ Ayrıntılar: {0}.</target>
         <target state="translated">Zararlı değişiklikler algılandı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -185,6 +185,11 @@ Details: {0}.</source>
         <target state="translated">检测到破坏性更改。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -185,6 +185,11 @@ Details: {0}.</source>
         <target state="translated">偵測到破壞性變更。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateInfo_Warning_FailedToReadHostData">
+        <source>Failed to load host data in {0} at {1}.</source>
+        <target state="new">Failed to load host data in {0} at {1}.</target>
+        <note>{0} - path to template location, {1} relative path inside template location.</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateSearch.Common/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateSearch.Common/LocalizableStrings.Designer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateSearch.Common {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Local search cache {0} does not exist..
+        ///   Looks up a localized string similar to Local search cache &apos;{0}&apos; does not exist..
         /// </summary>
         internal static string BlobStoreSourceFileProvider_Exception_LocalCacheDoesNotExist {
             get {

--- a/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplateSearchCache.Json.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplateSearchCache.Json.cs
@@ -100,8 +100,6 @@ namespace Microsoft.TemplateSearch.Common
                     // This piece of data failed to read, but isn't strictly necessary.
                 }
             }
-
-            logger.LogDebug($"Successfully read {additionalData.Count} additional information entries.");
             return additionalData;
         }
 

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/InvalidHostData/.template.config/dotnetcli.host.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/InvalidHostData/.template.config/dotnetcli.host.json
@@ -1,0 +1,15 @@
+//bad json
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "SdkVersion": {
+      "longName": "sdk-version",
+      "shortName": ""
+    },
+    "RollForward": {
+      "longName": "roll-forward",
+      "shortName": ""
+    },
+    "dotnet-cli-version": {
+      "isHidden": "true"
+

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/InvalidHostData/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/InvalidHostData/.template.config/template.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Test Asset",
+  "classifications": [
+    "Config"
+  ],
+  "name": "TestAssets.Invalid.InvalidHostData",
+  "generatorVersions": "[1.0.0.0-*)",
+  "tags": {
+    "type": "item"
+  },
+  "groupIdentity": "TestAssets.Invalid.InvalidHostData",
+  "precedence": "100",
+  "identity": "TestAssets.Invalid.InvalidHostData",
+  "shortName": "TestAssets.Invalid.InvalidHostData",
+  "sourceName": "unused",
+  "primaryOutputs": [
+    {
+      "path": "global.json"
+    }
+  ],
+  "defaultName": "global.json",
+  "symbols": {
+    "HostIdentifier": {
+      "type": "bind",
+      "binding": "HostIdentifier"
+    },
+    "SdkVersion": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "The version of the .NET Core SDK to use.",
+      "displayName": "SDK version"
+    },
+    "dotnet-cli-version": {
+      "type": "parameter",
+      "datatype": "string",
+      "displayName": "dotnet CLI version"
+    },
+    "CombinedVersion": {
+      "type": "generated",
+      "generator": "coalesce",
+      "parameters": {
+        "sourceVariableName": "SdkVersion",
+        "fallbackVariableName": "dotnet-cli-version"
+      },
+      "replaces": "SDK_VERSION"
+    },
+    "RollForward": {
+      "type": "parameter",
+      "description": "The roll-forward policy to use when selecting an SDK version.",
+      "displayName": "Roll Forward",
+      "replaces": "ROLL_FORWARD_VALUE",
+      "defaultValue": "",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "patch",
+          "description": "Uses the specified version.\nIf not found, rolls forward to the latest patch level.\nIf not found, fails.\nThis value is the legacy behavior from the earlier versions of the SDK."
+        },
+        {
+          "choice": "feature",
+          "description": "Uses the latest patch level for the specified major, minor, and feature band.\nIf not found, rolls forward to the next higher feature band within the same major/minor and uses the latest patch level for that feature band.\nIf not found, fails."
+        },
+        {
+          "choice": "minor",
+          "description": "Uses the latest patch level for the specified major, minor, and feature band.\nIf not found, rolls forward to the next higher feature band within the same major/minor version and uses the latest patch level for that feature band.\nIf not found, rolls forward to the next higher minor and feature band within the same major and uses the latest patch level for that feature band.\nIf not found, fails."
+        },
+        {
+          "choice": "major",
+          "description": "Uses the latest patch level for the specified major, minor, and feature band.\nIf not found, rolls forward to the next higher feature band within the same major/minor version and uses the latest patch level for that feature band.\nIf not found, rolls forward to the next higher minor and feature band within the same major and uses the latest patch level for that feature band.\nIf not found, rolls forward to the next higher major, minor, and feature band and uses the latest patch level for that feature band.\nIf not found, fails."
+        },
+        {
+          "choice": "latestPatch",
+          "description": "Uses the latest installed patch level that matches the requested major, minor, and feature band with a patch level and that is greater or equal than the specified value.\nIf not found, fails."
+        },
+        {
+          "choice": "latestFeature",
+          "description": "Uses the highest installed feature band and patch level that matches the requested major and minor with a feature band and patch level that is greater or equal than the specified value.\nIf not found, fails."
+        },
+        {
+          "choice": "latestMinor",
+          "description": "Uses the highest installed minor, feature band, and patch level that matches the requested major with a minor, feature band, and patch level that is greater or equal than the specified value.\nIf not found, fails."
+        },
+        {
+          "choice": "latestMajor",
+          "description": "Uses the highest installed .NET SDK with a version that is greater or equal than the specified value.\nIf not found, fail."
+        },
+        {
+          "choice": "disable",
+          "description": "Doesn't roll forward. Exact match required."
+        }
+      ]
+    }
+  },
+  "postActions": [
+    {
+      "id": "open-file",
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens global.json in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "0"
+      },
+      "continueOnError": true
+    }
+  ]
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/InvalidHostData/global.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/InvalidHostData/global.json
@@ -1,0 +1,8 @@
+{
+  "sdk": {
+    //#if (RollForward!="")
+    "rollForward": "ROLL_FORWARD_VALUE",
+    //#endif
+    "version": "SDK_VERSION"
+  }
+}

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -526,5 +526,22 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining($"  Source location './' is outside the specified install source location.")
                 .And.HaveStdOutContaining($"No templates were found in the package {invalidTemplatePath}.");
         }
+
+        [Fact]
+        public void CanShowWarning_WhenHostDataIsIncorrect()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string invalidTemplatePath = TestUtils.GetTestTemplateLocation("Invalid/InvalidHostData");
+            new DotnetNewCommand(_log, "-i", invalidTemplatePath)
+                .WithCustomHive(home)
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining("Warning: Failed to load host data ")
+                .And.HaveStdOutContaining($"Success: {invalidTemplatePath} installed the following templates:")
+                .And.HaveStdOutContaining("TestAssets.Invalid.InvalidHostData");
+        }
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
@@ -460,5 +460,23 @@ namespace Dotnet_new3.IntegrationTests
                 Assert.Equal(sourceText, targetText);
             }
         }
+
+        [Fact]
+        public void CanShowWarning_WhenHostDataIsIncorrect()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+            Helpers.InstallTestTemplate("Invalid/InvalidHostData", _log, workingDirectory, home);
+
+            new DotnetNewCommand(_log, "TestAssets.Invalid.InvalidHostData")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.HaveStdOutContaining("The template \"TestAssets.Invalid.InvalidHostData\" was created successfully.")
+                .And.HaveStdOutContaining("Warning: Failed to load dotnet CLI host data ");
+        }
     }
 }


### PR DESCRIPTION
### Problem
fixes dotnet/templating#3627 

### Solution
- log errors as warnings
- localize text
- removed useless logging
- removed showing exception stack trace on error/warning logging
- fallback to reading host data from file if data in cache is incorrect
- tests

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)