### PR TITLE
Fixes #3606: Inotify instances user limit has been reached

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CliEnvironment.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CliEnvironment.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Cli
+{
+    internal class CliEnvironment : IEnvironment
+    {
+        private const int DefaultBufferWidth = 160;
+        private readonly IReadOnlyDictionary<string, string> _environmentVariables;
+
+        public CliEnvironment()
+        {
+            Dictionary<string, string> variables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "TEMPLATE_ENGINE_DISABLE_FILEWATCHER", "1" }
+            };
+            var env = Environment.GetEnvironmentVariables();
+            foreach (string key in env.Keys.OfType<string>())
+            {
+                variables[key] = (env[key] as string) ?? string.Empty;
+            }
+
+            _environmentVariables = variables;
+        }
+
+        /// <inheritdoc/>
+        public string NewLine { get; } = Environment.NewLine;
+
+        /// <inheritdoc/>
+        // Console.BufferWidth can throw if there's no console, such as when output is redirected, so
+        // first check if it is redirected, and fall back to a default value if needed.
+        public int ConsoleBufferWidth => Console.IsOutputRedirected ? DefaultBufferWidth : Console.BufferWidth;
+
+        /// <inheritdoc/>
+        public string ExpandEnvironmentVariables(string name)
+        {
+            return Environment.ExpandEnvironmentVariables(name);
+        }
+
+        /// <inheritdoc/>
+        public string? GetEnvironmentVariable(string name)
+        {
+            _environmentVariables.TryGetValue(name, out string? result);
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public IReadOnlyDictionary<string, string> GetEnvironmentVariables()
+        {
+            return _environmentVariables;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/New3Command.cs
+++ b/src/Microsoft.TemplateEngine.Cli/New3Command.cs
@@ -36,7 +36,11 @@ namespace Microsoft.TemplateEngine.Cli
         {
             _telemetryLogger = telemetryLogger;
             _host = new CliTemplateEngineHost(host, commandInput);
-            EnvironmentSettings = new EngineEnvironmentSettings(_host, settingsLocation: hivePath, virtualizeSettings: virtualize);
+            EnvironmentSettings = new EngineEnvironmentSettings(
+                _host,
+                settingsLocation: hivePath,
+                virtualizeSettings: virtualize,
+                environment: new CliEnvironment());
             _templatePackageManager = new TemplatePackageManager(EnvironmentSettings);
             _templateCreator = new TemplateCreator(EnvironmentSettings);
             _aliasRegistry = new AliasRegistry(EnvironmentSettings);

--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
@@ -31,7 +31,10 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
             _globalSettingsFile = globalSettingsFile ?? throw new ArgumentNullException(nameof(globalSettingsFile));
             _paths = new SettingsFilePaths(environmentSettings);
             environmentSettings.Host.FileSystem.CreateDirectory(Path.GetDirectoryName(_globalSettingsFile));
-            _watcher = environmentSettings.Host.FileSystem.WatchFileChanges(_globalSettingsFile, FileChanged);
+            if (environmentSettings.Environment.GetEnvironmentVariable("TEMPLATE_ENGINE_DISABLE_FILEWATCHER") != "1")
+            {
+                _watcher = environmentSettings.Host.FileSystem.WatchFileChanges(_globalSettingsFile, FileChanged);
+            }
         }
 
         public event Action? SettingsChanged;

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/GlobalSettingsTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/GlobalSettingsTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions.Installer;
 using Microsoft.TemplateEngine.Edge.BuiltInManagedProvider;
+using Microsoft.TemplateEngine.Mocks;
 using Microsoft.TemplateEngine.TestHelper;
 using Xunit;
 
@@ -110,6 +111,21 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             #endregion Open3Load
 
             mutex2.Dispose();
+        }
+
+        [Fact]
+        public void TestDisablingFilewatcher()
+        {
+            var envSettings = _helper.CreateEnvironment(environment: new MockEnvironment(new Dictionary<string, string> { { "TEMPLATE_ENGINE_DISABLE_FILEWATCHER", "1" } }));
+            var settingsFile = Path.Combine(_helper.CreateTemporaryFolder(), "settings.json");
+            using var globalSettings1 = new GlobalSettings(envSettings, settingsFile);
+            Assert.Empty(((MonitoredFileSystem)envSettings.Host.FileSystem).FilesWatched);
+
+            envSettings = _helper.CreateEnvironment();
+            settingsFile = Path.Combine(_helper.CreateTemporaryFolder(), "settings.json");
+            using var globalSettings2 = new GlobalSettings(envSettings, settingsFile);
+            Assert.Single(((MonitoredFileSystem)envSettings.Host.FileSystem).FilesWatched);
+            Assert.Equal(settingsFile, ((MonitoredFileSystem)envSettings.Host.FileSystem).FilesWatched.Single());
         }
 
         public void Dispose()

--- a/test/Microsoft.TemplateEngine.Mocks/MockEngineEnvironmentSettings.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockEngineEnvironmentSettings.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Mocks
@@ -23,23 +24,44 @@ namespace Microsoft.TemplateEngine.Mocks
 
     public class MockEnvironment : IEnvironment
     {
+        private readonly Dictionary<string, string> _environmentVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        public MockEnvironment(Dictionary<string, string> environmentVariablesToOverride = null)
+        {
+            var env = Environment.GetEnvironmentVariables();
+            foreach (string key in env.Keys.OfType<string>())
+            {
+                _environmentVariables[key] = (env[key] as string) ?? string.Empty;
+            }
+
+            if (environmentVariablesToOverride == null)
+            {
+                return;
+            }
+
+            foreach (var item in environmentVariablesToOverride)
+            {
+                _environmentVariables[item.Key] = item.Value;
+            }
+        }
+
         public string NewLine { get; set; } = Environment.NewLine;
 
         public int ConsoleBufferWidth { get; set; } = 160;
 
         public string ExpandEnvironmentVariables(string name)
         {
-            throw new NotImplementedException();
+            return Environment.ExpandEnvironmentVariables(name);
         }
 
         public string GetEnvironmentVariable(string name)
         {
-            throw new NotImplementedException();
+            return _environmentVariables[name];
         }
 
         public IReadOnlyDictionary<string, string> GetEnvironmentVariables()
         {
-            throw new NotImplementedException();
+            return _environmentVariables;
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.TestHelper/MonitoredFileSystem.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/MonitoredFileSystem.cs
@@ -16,6 +16,7 @@ namespace Microsoft.TemplateEngine.TestHelper
         private readonly IPhysicalFileSystem _baseFileSystem;
         private ConcurrentBag<DirectoryScanParameters> _directoriesScanned = new();
         private ConcurrentBag<string> _filesOpened = new();
+        private ConcurrentBag<string> _filesWatched = new();
 
         public MonitoredFileSystem(IPhysicalFileSystem baseFileSystem)
         {
@@ -24,7 +25,9 @@ namespace Microsoft.TemplateEngine.TestHelper
 
         public IReadOnlyList<DirectoryScanParameters> DirectoriesScanned => _directoriesScanned.ToArray();
 
-        public IReadOnlyList<string> FilesOpened => _filesOpened.ToArray();
+        public IEnumerable<string> FilesOpened => _filesOpened;
+
+        public IEnumerable<string> FilesWatched => _filesWatched;
 
         public void CreateDirectory(string path) => _baseFileSystem.CreateDirectory(path);
 
@@ -74,7 +77,11 @@ namespace Microsoft.TemplateEngine.TestHelper
 
         public void WriteAllText(string path, string value) => _baseFileSystem.WriteAllText(path, value);
 
-        public IDisposable WatchFileChanges(string filepath, FileSystemEventHandler fileChanged) => _baseFileSystem.WatchFileChanges(filepath, fileChanged);
+        public IDisposable WatchFileChanges(string filepath, FileSystemEventHandler fileChanged)
+        {
+            _filesWatched.Add(filepath);
+            return _baseFileSystem.WatchFileChanges(filepath, fileChanged);
+        }
 
         public DateTime GetLastWriteTimeUtc(string file) => _baseFileSystem.GetLastWriteTimeUtc(file);
 


### PR DESCRIPTION
### Problem
I wanted to disable filewatcher in `dotnet new` scenario for some time, primarily because it has some perf hit ~50ms+...
There is also issue with default filewatcher causing bug with Inotifiy limit on Docker

### Solution
Set environment variable in CLI, that GlobalSettingsProvider respects...

If you agree with API change I will add unit test for it, or would it be better to roll CLI specific implementation?

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)