### PR TITLE
added support for automatic decompression when downloading search cache

### DIFF
--- a/src/Microsoft.TemplateSearch.Common/Providers/NuGetMetadataSearchProvider.cs
+++ b/src/Microsoft.TemplateSearch.Common/Providers/NuGetMetadataSearchProvider.cs
@@ -161,7 +161,11 @@ namespace Microsoft.TemplateSearch.Common.Providers
                 cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
-                    using (HttpClient client = new HttpClient())
+                    HttpClientHandler handler = new HttpClientHandler()
+                    {
+                        AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+                    };
+                    using (HttpClient client = new HttpClient(handler))
                     {
                         string etagFileLocation = searchMetadataFileLocation + ETagFileSuffix;
                         if (_environmentSettings.Host.FileSystem.FileExists(etagFileLocation))


### PR DESCRIPTION
### Problem
HttpClient won't decompress gzip by default
related to: https://github.com/dotnet/templating/issues/3231

### Solution
Added HttpClientHandler with settings on automatic decompression, so we can store search cache as gzip

### Checks:
- [ ] Added unit tests - NA
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - NA