### PR TITLE
Template discovery tool: added support for gziping cache files

### DIFF
--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyMetadataWriter.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyMetadataWriter.cs
@@ -11,16 +11,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Results
 {
     internal partial class LegacyMetadataWriter
     {
-        internal static string WriteLegacySearchMetadata(PackSourceCheckResult packSourceCheckResults, string outputFileName)
-        {
-            var searchMetadata = CreateLegacySearchMetadata(packSourceCheckResults);
-            File.WriteAllText(outputFileName, searchMetadata.ToJObject().ToString(Newtonsoft.Json.Formatting.None));
-            Console.WriteLine($"Legacy search cache file created: {outputFileName}");
-            return outputFileName;
-        }
-
 #pragma warning disable CS0618 // Type or member is obsolete
-        private static TemplateDiscoveryMetadata CreateLegacySearchMetadata(PackSourceCheckResult packSourceCheckResults)
+        internal static TemplateDiscoveryMetadata CreateLegacySearchMetadata(PackSourceCheckResult packSourceCheckResults)
         {
             List<ITemplateInfo> templateCache = packSourceCheckResults.PackCheckData.Where(r => r.AnyTemplates)
                                                     .SelectMany(r => r.FoundTemplates)


### PR DESCRIPTION
### Solution
Added creation of gzip version for search cache for template discovery tool.
related to https://github.com/dotnet/templating/issues/3231

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)