### PR TITLE
Added extraction of NuGet owner and verified flag to search cache

### DIFF
--- a/src/Microsoft.TemplateSearch.Common/Abstractions/ITemplatePackageInfo.cs
+++ b/src/Microsoft.TemplateSearch.Common/Abstractions/ITemplatePackageInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+
 namespace Microsoft.TemplateSearch.Common.Abstractions
 {
     /// <summary>
@@ -23,5 +25,18 @@ namespace Microsoft.TemplateSearch.Common.Abstractions
         /// Optional, might be 0 in case search provider cannot provide number of downloads.
         /// </summary>
         public long TotalDownloads { get; }
+
+        /// <summary>
+        /// Gets the list of template package owners.
+        /// </summary>
+        public IReadOnlyList<string> Owners { get; }
+
+        /// <summary>
+        /// Gets the indication if the package is verified.
+        /// </summary>
+        /// <remarks>
+        /// For NuGet.org 'verified' means that package ID is under reserved namespaces, see  <see href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation"/>.
+        /// </remarks>
+        public bool Verified { get; }
     }
 }

--- a/src/Microsoft.TemplateSearch.Common/Abstractions/TemplatePackageSearchData.cs
+++ b/src/Microsoft.TemplateSearch.Common/Abstractions/TemplatePackageSearchData.cs
@@ -29,6 +29,8 @@ namespace Microsoft.TemplateSearch.Common
                 : throw new ArgumentException($"{nameof(packInfo.Name)} should not be null or empty", nameof(packInfo));
             Version = packInfo.Version;
             TotalDownloads = packInfo.TotalDownloads;
+            Owners = packInfo.Owners;
+            Verified = packInfo.Verified;
             Templates = templates.ToList();
             AdditionalData = data ?? new Dictionary<string, object>();
         }
@@ -41,6 +43,12 @@ namespace Microsoft.TemplateSearch.Common
 
         /// <inheritdoc/>
         public long TotalDownloads { get; }
+
+        /// <inheritdoc/>
+        public IReadOnlyList<string> Owners { get; }
+
+        /// <inheritdoc/>
+        public bool Verified { get; }
 
         /// <summary>
         /// Gets the list of templates in template package.

--- a/src/Microsoft.TemplateSearch.Common/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateSearch.Common/PublicAPI.Unshipped.txt
@@ -1,6 +1,8 @@
 ﻿Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo
 Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.Name.get -> string!
+Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.Owners.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.TotalDownloads.get -> long
+Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.Verified.get -> bool
 Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.Version.get -> string?
 Microsoft.TemplateSearch.Common.Abstractions.ITemplateSearchProvider
 Microsoft.TemplateSearch.Common.Abstractions.ITemplateSearchProvider.Factory.get -> Microsoft.TemplateSearch.Common.Abstractions.ITemplateSearchProviderFactory!
@@ -17,9 +19,11 @@ Microsoft.TemplateSearch.Common.SearchResult.Success.get -> bool
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData.AdditionalData.get -> System.Collections.Generic.IDictionary<string!, object!>!
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData.Name.get -> string!
+Microsoft.TemplateSearch.Common.TemplatePackageSearchData.Owners.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData.TemplatePackageSearchData(Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo! packInfo, System.Collections.Generic.IEnumerable<Microsoft.TemplateSearch.Common.TemplateSearchData!>! templates, System.Collections.Generic.IDictionary<string!, object!>? data = null) -> void
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData.Templates.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateSearch.Common.TemplateSearchData!>!
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData.TotalDownloads.get -> long
+Microsoft.TemplateSearch.Common.TemplatePackageSearchData.Verified.get -> bool
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData.Version.get -> string?
 Microsoft.TemplateSearch.Common.TemplateSearchCoordinator
 Microsoft.TemplateSearch.Common.TemplateSearchCoordinator.SearchAsync(System.Func<Microsoft.TemplateSearch.Common.TemplatePackageSearchData!, bool>! packFilter, System.Func<Microsoft.TemplateSearch.Common.TemplatePackageSearchData!, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!>!>! matchingTemplatesFilter, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Microsoft.TemplateSearch.Common.SearchResult!>!>!

--- a/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/LegacySearchCacheReader.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/LegacySearchCacheReader.cs
@@ -54,7 +54,7 @@ namespace Microsoft.TemplateSearch.Common
                         templateData.Add(new TemplateSearchData(foundTemplate));
                     }
                 }
-                packageData.Add(new TemplatePackageSearchData(new PackInfo(package.Key, package.Value.Version, package.Value.TotalDownloads), templateData));
+                packageData.Add(new TemplatePackageSearchData(new PackInfo(package.Key, package.Value.Version, package.Value.TotalDownloads, package.Value.Owners, package.Value.Verified), templateData));
             }
             return new TemplateSearchCache(packageData);
         }

--- a/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/PackInfo.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/PackInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.TemplateSearch.Common.Abstractions;
 using Newtonsoft.Json;
 
@@ -16,11 +18,13 @@ namespace Microsoft.TemplateSearch.Common
             Version = version;
         }
 
-        internal PackInfo(string name, string version, long totalDownloads)
+        internal PackInfo(string name, string version, long totalDownloads, IEnumerable<string> owners, bool verified = false)
         {
             Name = name;
             Version = version;
             TotalDownloads = totalDownloads;
+            Owners = owners.ToList();
+            Verified = verified;
         }
 
         [JsonProperty]
@@ -31,5 +35,11 @@ namespace Microsoft.TemplateSearch.Common
 
         [JsonProperty]
         public long TotalDownloads { get; }
+
+        [JsonProperty]
+        public IReadOnlyList<string> Owners { get; } = Array.Empty<string>();
+
+        [JsonProperty]
+        public bool Verified { get; }
     }
 }

--- a/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/PackToTemplateEntry.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/PackToTemplateEntry.cs
@@ -23,6 +23,12 @@ namespace Microsoft.TemplateSearch.Common
         internal long TotalDownloads { get; set; }
 
         [JsonProperty]
+        internal IReadOnlyList<string> Owners { get; set; } = Array.Empty<string>();
+
+        [JsonProperty]
+        internal bool Verified { get; set; }
+
+        [JsonProperty]
         internal IReadOnlyList<TemplateIdentificationEntry> TemplateIdentificationEntry { get; }
     }
 }

--- a/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplatePackageSearchData.Json.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplatePackageSearchData.Json.cs
@@ -30,6 +30,8 @@ namespace Microsoft.TemplateSearch.Common
                 : throw new ArgumentException($"{nameof(jObject)} doesn't have {nameof(Name)} property or it is not a string.", nameof(jObject));
             Version = jObject.ToString(nameof(Version));
             TotalDownloads = jObject.ToInt32(nameof(TotalDownloads));
+            Owners = jObject.Get<JToken>(nameof(Owners)).JTokenStringOrArrayToCollection(Array.Empty<string>());
+            Verified = jObject.ToBool(nameof(Verified));
 
             JArray? templatesData = jObject.Get<JArray>(nameof(Templates));
             if (templatesData == null)
@@ -87,6 +89,29 @@ namespace Microsoft.TemplateSearch.Common
                 {
                     writer.WritePropertyName(nameof(TotalDownloads));
                     writer.WriteValue(value.TotalDownloads);
+                }
+                if (value.Owners.Any())
+                {
+                    writer.WritePropertyName(nameof(Owners));
+                    if (value.Owners.Count == 1)
+                    {
+                        writer.WriteValue(value.Owners[0]);
+                    }
+                    else
+                    {
+                        writer.WriteStartArray();
+                        foreach (string owner in value.Owners)
+                        {
+                            writer.WriteValue(owner);
+                        }
+                        writer.WriteEndArray();
+                    }
+                }
+
+                if (value.Verified)
+                {
+                    writer.WritePropertyName(nameof(Verified));
+                    writer.WriteValue(value.Verified);
                 }
 
                 writer.WritePropertyName(nameof(Templates));

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NuGetPackSourceCheckerFactory.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NuGetPackSourceCheckerFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking.Reporting;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackProviders;
 
-namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
+namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
 {
     internal static class NuGetPackSourceCheckerFactory
     {
@@ -27,13 +27,13 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
             }
             else if (!config.Queries.Any())
             {
-                providers.AddRange(SupportedProviders.Select(kvp => new NugetPackProvider(kvp.Key.ToString(), kvp.Value, config.OutputPath, config.PageSize, config.RunOnlyOnePage, config.IncludePreviewPacks)));
+                providers.AddRange(SupportedProviders.Select(kvp => new NuGetPackProvider(kvp.Key.ToString(), kvp.Value, config.OutputPath, config.PageSize, config.RunOnlyOnePage, config.IncludePreviewPacks)));
             }
             else
             {
                 foreach (SupportedQueries provider in config.Queries.Distinct())
                 {
-                    providers.Add(new NugetPackProvider(provider.ToString(), SupportedProviders[provider], config.OutputPath, config.PageSize, config.RunOnlyOnePage, config.IncludePreviewPacks));
+                    providers.Add(new NuGetPackProvider(provider.ToString(), SupportedProviders[provider], config.OutputPath, config.PageSize, config.RunOnlyOnePage, config.IncludePreviewPacks));
                 }
             }
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackInfo.cs
@@ -28,5 +28,9 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
         public string Path { get; private set; }
 
         public long TotalDownloads => _info.TotalDownloads;
+
+        public IReadOnlyList<string> Owners => _info.Owners;
+
+        public bool Verified => _info.Verified;
     }
 }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackInfo.cs
@@ -4,13 +4,13 @@
 using Microsoft.TemplateSearch.Common.Abstractions;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackProviders;
 
-namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
+namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
 {
-    public class NugetPackInfo : IDownloadedPackInfo
+    public class NuGetPackInfo : IDownloadedPackInfo
     {
         private ITemplatePackageInfo _info;
 
-        internal NugetPackInfo(ITemplatePackageInfo info, string filePath)
+        internal NuGetPackInfo(ITemplatePackageInfo info, string filePath)
         {
             if (string.IsNullOrWhiteSpace(filePath))
             {

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
@@ -41,7 +41,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
                 throw new Exception($"{NuGetOrgFeed} does not support search API (SearchQueryService)");
             }
 
-            _searchUriFormat = $"{searchResources[0].Uri}?{query}&skip={{0}}&take={{1}}&prerelease={includePreviewPacks}";
+            _searchUriFormat = $"{searchResources[0].Uri}?{query}&skip={{0}}&take={{1}}&prerelease={includePreviewPacks}&semVerLevel=2.0.0";
 
             if (Directory.Exists(_packageTempPath))
             {

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
@@ -10,9 +10,9 @@ using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
 
-namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
+namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
 {
-    internal class NugetPackProvider : IPackProvider
+    internal class NuGetPackProvider : IPackProvider
     {
         private const string NuGetOrgFeed = "https://api.nuget.org/v3/index.json";
         private const string DownloadPackageFileNameFormat = "{0}.{1}.nupkg";
@@ -25,7 +25,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
         private readonly FindPackageByIdResource _downloadResource;
         private string _searchUriFormat;
 
-        internal NugetPackProvider(string name, string query, DirectoryInfo packageTempBasePath, int pageSize, bool runOnlyOnePage, bool includePreviewPacks)
+        internal NuGetPackProvider(string name, string query, DirectoryInfo packageTempBasePath, int pageSize, bool runOnlyOnePage, bool includePreviewPacks)
         {
             Name = name;
             _pageSize = pageSize;
@@ -72,13 +72,13 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
                     {
                         string responseText = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
 
-                        NugetPackageSearchResult resultsForPage = NugetPackageSearchResult.FromJObject(JObject.Parse(responseText));
+                        NuGetPackageSearchResult resultsForPage = NuGetPackageSearchResult.FromJObject(JObject.Parse(responseText));
 
                         if (resultsForPage.Data.Count > 0)
                         {
                             skip += _pageSize;
                             packCount += resultsForPage.Data.Count;
-                            foreach (NugetPackageSourceInfo sourceInfo in resultsForPage.Data)
+                            foreach (NuGetPackageSourceInfo sourceInfo in resultsForPage.Data)
                             {
                                 yield return sourceInfo;
                             }
@@ -113,7 +113,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
                     NullLogger.Instance,
                     token).ConfigureAwait(false))
                 {
-                    return new NugetPackInfo(packinfo, outputPackageFileNameFullPath);
+                    return new NuGetPackInfo(packinfo, outputPackageFileNameFullPath);
                 }
                 else
                 {
@@ -140,7 +140,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
             {
                 response.EnsureSuccessStatusCode();
                 string responseText = await response.Content.ReadAsStringAsync(token).ConfigureAwait(false);
-                NugetPackageSearchResult resultsForPage = NugetPackageSearchResult.FromJObject(JObject.Parse(responseText));
+                NuGetPackageSearchResult resultsForPage = NuGetPackageSearchResult.FromJObject(JObject.Parse(responseText));
                 return resultsForPage.TotalHits;
             }
         }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSearchResult.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSearchResult.cs
@@ -12,11 +12,12 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
 
         internal List<NuGetPackageSourceInfo> Data { get; private set; } = new List<NuGetPackageSourceInfo>();
 
+        //property names are explained here: https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource
         internal static NuGetPackageSearchResult FromJObject(JObject entry)
         {
             NuGetPackageSearchResult searchResult = new NuGetPackageSearchResult();
-            searchResult.TotalHits = entry.ToInt32(nameof(TotalHits));
-            var dataArray = entry.Get<JArray>(nameof(Data));
+            searchResult.TotalHits = entry.ToInt32("totalHits");
+            var dataArray = entry.Get<JArray>("data");
             if (dataArray != null)
             {
                 foreach (JToken data in dataArray)

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSearchResult.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSearchResult.cs
@@ -4,17 +4,17 @@
 using Microsoft.TemplateEngine;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
+namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
 {
-    internal class NugetPackageSearchResult
+    internal class NuGetPackageSearchResult
     {
         internal int TotalHits { get; private set; }
 
-        internal List<NugetPackageSourceInfo> Data { get; private set; } = new List<NugetPackageSourceInfo>();
+        internal List<NuGetPackageSourceInfo> Data { get; private set; } = new List<NuGetPackageSourceInfo>();
 
-        internal static NugetPackageSearchResult FromJObject(JObject entry)
+        internal static NuGetPackageSearchResult FromJObject(JObject entry)
         {
-            NugetPackageSearchResult searchResult = new NugetPackageSearchResult();
+            NuGetPackageSearchResult searchResult = new NuGetPackageSearchResult();
             searchResult.TotalHits = entry.ToInt32(nameof(TotalHits));
             var dataArray = entry.Get<JArray>(nameof(Data));
             if (dataArray != null)
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
                     JObject? dataObj = data as JObject;
                     if (dataObj != null)
                     {
-                        searchResult.Data.Add(NugetPackageSourceInfo.FromJObject(dataObj));
+                        searchResult.Data.Add(NuGetPackageSourceInfo.FromJObject(dataObj));
                     }
                 }
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSourceInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSourceInfo.cs
@@ -6,11 +6,11 @@ using Microsoft.TemplateSearch.Common.Abstractions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
+namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
 {
-    internal class NugetPackageSourceInfo : ITemplatePackageInfo, IEquatable<ITemplatePackageInfo>
+    internal class NuGetPackageSourceInfo : ITemplatePackageInfo, IEquatable<ITemplatePackageInfo>
     {
-        internal NugetPackageSourceInfo(string id, string version)
+        internal NuGetPackageSourceInfo(string id, string version)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
@@ -35,11 +35,11 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
         [JsonProperty]
         public long TotalDownloads { get; set; }
 
-        internal static NugetPackageSourceInfo FromJObject (JObject entry)
+        internal static NuGetPackageSourceInfo FromJObject (JObject entry)
         {
             string id = entry.ToString("id") ?? throw new ArgumentException($"{nameof(entry)} doesn't have \"id\" property.", nameof(entry));
             string version = entry.ToString(nameof(Version)) ?? throw new ArgumentException($"{nameof(entry)} doesn't have {nameof(Version)} property.", nameof(entry));
-            NugetPackageSourceInfo sourceInfo = new NugetPackageSourceInfo(id, version);
+            NuGetPackageSourceInfo sourceInfo = new NuGetPackageSourceInfo(id, version);
             sourceInfo.TotalDownloads = entry.ToInt32(nameof(TotalDownloads));
             return sourceInfo;
         }
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Nuget
         public override bool Equals(object? obj)
 #pragma warning restore SA1202 // Elements should be ordered by access
         {
-            if (obj is NugetPackageSourceInfo info)
+            if (obj is NuGetPackageSourceInfo info)
             {
                 return Name.Equals(info.Name, StringComparison.OrdinalIgnoreCase) && Version.Equals(info.Version, StringComparison.OrdinalIgnoreCase);
             }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/TestPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/TestPackProvider.cs
@@ -58,6 +58,10 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackProviders
             public long TotalDownloads => 0;
 
             public string Path { get; }
+
+            public IReadOnlyList<string> Owners => new[] { "TestAuthor" };
+
+            public bool Verified => false;
         }
     }
 }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Program.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Program.cs
@@ -3,7 +3,7 @@
 
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using Microsoft.TemplateSearch.TemplateDiscovery.Nuget;
+using Microsoft.TemplateSearch.TemplateDiscovery.NuGet;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking.Reporting;
 using Microsoft.TemplateSearch.TemplateDiscovery.Results;

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyMetadataWriter.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyMetadataWriter.cs
@@ -4,7 +4,7 @@
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateSearch.Common;
 using Microsoft.TemplateSearch.TemplateDiscovery.AdditionalData;
-using Microsoft.TemplateSearch.TemplateDiscovery.Nuget;
+using Microsoft.TemplateSearch.TemplateDiscovery.NuGet;
 using Microsoft.TemplateSearch.TemplateDiscovery.PackChecking.Reporting;
 
 namespace Microsoft.TemplateSearch.TemplateDiscovery.Results
@@ -38,7 +38,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Results
                                             r.PackInfo.Version ?? "",
                                             r.FoundTemplates.Select(t => new TemplateIdentificationEntry(t.Identity, t.GroupIdentity)).ToList());
 
-                                    if (r.PackInfo is NugetPackInfo npi)
+                                    if (r.PackInfo is NuGetPackInfo npi)
                                     {
                                         packToTemplateEntry.TotalDownloads = npi.TotalDownloads;
                                     }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyMetadataWriter.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyMetadataWriter.cs
@@ -37,11 +37,9 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Results
                                     PackToTemplateEntry packToTemplateEntry = new PackToTemplateEntry(
                                             r.PackInfo.Version ?? "",
                                             r.FoundTemplates.Select(t => new TemplateIdentificationEntry(t.Identity, t.GroupIdentity)).ToList());
-
-                                    if (r.PackInfo is NuGetPackInfo npi)
-                                    {
-                                        packToTemplateEntry.TotalDownloads = npi.TotalDownloads;
-                                    }
+                                    packToTemplateEntry.TotalDownloads = r.PackInfo.TotalDownloads;
+                                    packToTemplateEntry.Owners = r.PackInfo.Owners;
+                                    packToTemplateEntry.Verified = r.PackInfo.Verified;
                                     return packToTemplateEntry;
                                 });
 

--- a/test/Microsoft.TemplateEngine.Mocks/MockTemplatePackageInfo.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockTemplatePackageInfo.cs
@@ -4,13 +4,15 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.TemplateSearch.Common.Abstractions;
 
 namespace Microsoft.TemplateEngine.Mocks
 {
     public class MockTemplatePackageInfo : ITemplatePackageInfo
     {
-        public MockTemplatePackageInfo(string name, string? version = null, long totalDownloads = 0)
+        public MockTemplatePackageInfo(string name, string? version = null, long totalDownloads = 0, IEnumerable<string>? owners = null)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
@@ -20,6 +22,7 @@ namespace Microsoft.TemplateEngine.Mocks
             Name = name;
             Version = version;
             TotalDownloads = totalDownloads;
+            Owners = owners?.ToArray() ?? Array.Empty<string>();
         }
 
         public string Name { get; }
@@ -27,5 +30,9 @@ namespace Microsoft.TemplateEngine.Mocks
         public string? Version { get; }
 
         public long TotalDownloads { get; }
+
+        public IReadOnlyList<string> Owners { get; }
+
+        public bool Verified => false;
     }
 }

--- a/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/TemplateDiscoveryTests.cs
+++ b/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/TemplateDiscoveryTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.NET.TestFramework.Commands;
 using Microsoft.TemplateEngine.TestHelper;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -168,6 +169,31 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests
                     .Execute()
                     .Should().Fail();
             }
+        }
+
+        [Fact]
+        public void CanReadAuthor()
+        {
+            string testDir = TestUtils.CreateTemporaryFolder();
+            using var packageManager = new PackageManager();
+            string packageLocation = packageManager.PackTestTemplatesNuGetPackage();
+
+            new DotnetCommand(
+                _log,
+                "Microsoft.TemplateSearch.TemplateDiscovery.dll",
+                "--basePath",
+                testDir,
+                "--packagesPath",
+                Path.GetDirectoryName(packageLocation),
+                "-v")
+                .Execute()
+                .Should()
+                .ExitWith(0);
+
+            var jObjectV1 = JObject.Parse(File.ReadAllText(Path.Combine(testDir, "SearchCache", "NuGetTemplateSearchInfo.json")));
+            Assert.Equal("TestAuthor", jObjectV1["PackToTemplateMap"].Children<JProperty>().Single(p => p.Name.StartsWith("Microsoft.TemplateEngine.TestTemplates")).Value["Owners"].Values().Single());
+            var jObjectV2 = JObject.Parse(File.ReadAllText(Path.Combine(testDir, "SearchCache", "NuGetTemplateSearchInfoVer2.json")));
+            Assert.Equal("TestAuthor", jObjectV2["TemplatePackages"][0]["Owners"].Value<string>());
         }
     }
 }


### PR DESCRIPTION
### Problem
part of https://github.com/dotnet/templating/issues/3456

### Solution
Now that `owners` data is available from NuGet API, added extracting it and `verified` flag to search cache

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)