### PR TITLE
Template discovery tool - disabled scanning for components

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
@@ -13,6 +13,7 @@ Microsoft.TemplateEngine.Edge.DefaultPathInfo.HostVersionSettingsDir.get -> stri
 Microsoft.TemplateEngine.Edge.DefaultPathInfo.UserProfileDir.get -> string!
 Microsoft.TemplateEngine.Edge.Settings.ITemplateInfoHostJsonCache
 Microsoft.TemplateEngine.Edge.Settings.ITemplateInfoHostJsonCache.HostData.get -> Newtonsoft.Json.Linq.JObject?
+Microsoft.TemplateEngine.Edge.Settings.Scanner.Scan(string! mountPointUri, bool scanForComponents) -> Microsoft.TemplateEngine.Edge.Settings.ScanResult!
 Microsoft.TemplateEngine.Edge.Settings.ScanResult.Dispose() -> void
 Microsoft.TemplateEngine.Edge.Settings.ScanResult.MountPoint.get -> Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint!
 Microsoft.TemplateEngine.Edge.Settings.ScanResult.ScanResult(Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint! mountPoint, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ITemplate!>! templates, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ILocalizationLocator!>! localizations, System.Collections.Generic.IReadOnlyList<(string! AssemblyPath, System.Type! InterfaceType, Microsoft.TemplateEngine.Abstractions.IIdentifiedComponent! Instance)>! components) -> void

--- a/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
@@ -43,13 +43,27 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         /// </remarks>
         public ScanResult Scan(string mountPointUri)
         {
+            return Scan(mountPointUri, scanForComponents: true);
+        }
+
+        /// <summary>
+        /// Same as <see cref="Scan(string)"/>, however allows to enable or disable components scanning via <paramref name="scanForComponents"/>.
+        /// </summary>
+        /// <remarks>
+        /// The mount point will not be disposed by the <see cref="Scanner"/>. Use <see cref="ScanResult.Dispose"/> to dispose mount point.
+        /// </remarks>
+        public ScanResult Scan(string mountPointUri, bool scanForComponents)
+        {
             if (string.IsNullOrWhiteSpace(mountPointUri))
             {
                 throw new ArgumentException($"{nameof(mountPointUri)} should not be null or empty");
             }
             MountPointScanSource source = GetOrCreateMountPointScanInfoForInstallSource(mountPointUri);
 
-            ScanForComponents(source);
+            if (scanForComponents)
+            {
+                ScanForComponents(source);
+            }
             return ScanMountPointForTemplatesAndLangpacks(source);
         }
 


### PR DESCRIPTION
### Problem
Template discovery tool uses `Scanner` for scanning for templates inside the package.
`Scanner` also scans for components which causes exceptions on loading due to not fully supporting loading components in virtualized environment and attempting to load some components twice.

### Solution
- made another overload for `Scanner` allowing to disable components scan
- disabled components scan in discovery tool
- refactoring

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)