### PR TITLE
Added quotes to uninstall command example when packageID contains spaces

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInputExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/INewCommandInputExtensions.cs
@@ -21,11 +21,20 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
 
             if (string.IsNullOrWhiteSpace(version))
             {
+                if (packageID.Any(char.IsWhiteSpace))
+                {
+                    packageID = $"'{packageID}'";
+                }
                 return $"dotnet {command.CommandName} --install {packageID}";
             }
             else
             {
-                return $"dotnet {command.CommandName} --install {packageID}::{version}";
+                string packageAndVersion = $"{packageID}::{version}";
+                if (packageAndVersion.Any(char.IsWhiteSpace))
+                {
+                    packageAndVersion = $"'{packageAndVersion}'";
+                }
+                return $"dotnet {command.CommandName} --install {packageAndVersion}";
             }
         }
 
@@ -77,6 +86,11 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             if (string.IsNullOrWhiteSpace(packageId))
             {
                 return $"dotnet {command.CommandName} --uninstall <PACKAGE_ID>";
+            }
+
+            if (packageId.Any(char.IsWhiteSpace))
+            {
+                packageId = $"'{packageId}'";
             }
             return $"dotnet {command.CommandName} --uninstall {packageId}";
         }

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -591,7 +591,7 @@ namespace Microsoft.TemplateEngine.Cli
 
                 // uninstall command:
                 Reporter.Output.WriteLine($"{LocalizableStrings.TemplatePackageCoordinator_Uninstall_Info_UninstallCommandHint}".Indent(level: 2));
-                Reporter.Output.WriteCommand(commandInput.UninstallCommandExample(managedSource.Identifier));
+                Reporter.Output.WriteCommand(commandInput.UninstallCommandExample(managedSource.Identifier), indentLevel: 2);
 
                 Reporter.Output.WriteLine();
             }

--- a/test/dotnet-new3.UnitTests/Helpers.cs
+++ b/test/dotnet-new3.UnitTests/Helpers.cs
@@ -13,7 +13,7 @@ namespace Dotnet_new3.IntegrationTests
         internal static void InstallNuGetTemplate(string packageName, ITestOutputHelper log, string workingDirectory, string homeDirectory)
         {
             new DotnetNewCommand(log, "-i", packageName)
-                  .WithCustomHive(homeDirectory).WithDebug()
+                  .WithCustomHive(homeDirectory)
                   .WithWorkingDirectory(workingDirectory)
                   .Execute()
                   .Should()


### PR DESCRIPTION
### Problem
fixes dotnet/templating#2127

### Solution
Added quotes to uninstall command example when packageID contains spaces

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)