### PR TITLE
Fix target branch for release/6.0.1xx localizations

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,10 +45,11 @@ stages:
 - stage: build
   displayName: Build
   jobs:
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+  - ${{ if and( ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or( eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         MirrorRepo: templating
+        MirrorBranch: release/6.0.1xx
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-TEMPLATING'
   - template: /eng/common/templates/jobs/jobs.yml


### PR DESCRIPTION
### Problem
Localizations for release/6.0.1xx branch are flowing into main.

### Solution
This PR makes sure that the PRs will be created against release/6.0.1xx.

MirrorBranch value can be calculated using Build.SourceBranch variable, but requires a little more complicated logic: We need to transform "/refs/heads/branch_name" into "branch_name" and there is no out-of-the-box `Substring` operation that we can use. Therefore, this will come in a separate PR.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)