### PR TITLE
switch to v2 search cache and v1 as fallback

### DIFF
--- a/src/Microsoft.TemplateSearch.Common/Providers/NuGetMetadataSearchProvider.cs
+++ b/src/Microsoft.TemplateSearch.Common/Providers/NuGetMetadataSearchProvider.cs
@@ -49,6 +49,18 @@ namespace Microsoft.TemplateSearch.Common.Providers
             _logger = _environmentSettings.Host.LoggerFactory.CreateLogger<NuGetMetadataSearchProvider>();
         }
 
+        /// <summary>
+        /// Test constructor allowing override search cache uris.
+        /// </summary>
+        internal NuGetMetadataSearchProvider(
+            ITemplateSearchProviderFactory factory,
+            IEngineEnvironmentSettings environmentSettings,
+            IReadOnlyDictionary<string, Func<object, object>> additionalDataReaders,
+            IEnumerable<string> searchCacheUri) : this (factory, environmentSettings, additionalDataReaders)
+        {
+            _searchMetadataUris = searchCacheUri.Select(s => new Uri(s)).ToArray();
+        }
+
         public ITemplateSearchProviderFactory Factory { get; }
 
         public async Task<IReadOnlyList<(ITemplatePackageInfo PackageInfo, IReadOnlyList<ITemplateInfo> MatchedTemplates)>> SearchForTemplatePackagesAsync(

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCoordinatorTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCoordinatorTests.cs
@@ -410,27 +410,6 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             }
         }
 
-        [Fact]
-        public async Task CanReadSearchMetadata_FromBlob()
-        {
-            using EnvironmentSettingsHelper environmentSettingsHelper = new EnvironmentSettingsHelper();
-            var environmentSettings = environmentSettingsHelper.CreateEnvironment(virtualize: true);
-            var sourceFileProvider = new NuGetMetadataSearchProvider(
-                A.Fake<ITemplateSearchProviderFactory>(),
-                environmentSettings,
-                new Dictionary<string, Func<object, object>>());
-            await sourceFileProvider.GetSearchFileAsync(default).ConfigureAwait(false);
-            string content = environmentSettings.Host.FileSystem.ReadAllText(Path.Combine(environmentSettings.Paths.HostVersionSettingsDir, "nugetTemplateSearchInfo.json"));
-            var jObj = JObject.Parse(content);
-#pragma warning disable CS0618 // Type or member is obsolete
-            Assert.True(LegacySearchCacheReader.TryReadDiscoveryMetadata(
-#pragma warning restore CS0618 // Type or member is obsolete
-                jObj,
-                environmentSettings.Host.Logger,
-                null,
-                out _));
-        }
-
 #pragma warning disable CS0618 // Type or member is obsolete
         private static string SetupDiscoveryMetadata(string fileLocation, bool includehostData = false)
 

--- a/test/Microsoft.TemplateSearch.Common.UnitTests/Microsoft.TemplateSearch.Common.UnitTests.csproj
+++ b/test/Microsoft.TemplateSearch.Common.UnitTests/Microsoft.TemplateSearch.Common.UnitTests.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateSearch.Common\Microsoft.TemplateSearch.Common.csproj" />
     <ProjectReference Include="$(TestDir)Microsoft.TemplateEngine.Mocks\Microsoft.TemplateEngine.Mocks.csproj" />
     <ProjectReference Include="$(TestDir)Microsoft.TemplateEngine.TestHelper\Microsoft.TemplateEngine.TestHelper.csproj" />

--- a/test/Microsoft.TemplateSearch.Common.UnitTests/TemplateSearchCacheReaderTests.cs
+++ b/test/Microsoft.TemplateSearch.Common.UnitTests/TemplateSearchCacheReaderTests.cs
@@ -1,8 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using FakeItEasy;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.TestHelper;
+using Microsoft.TemplateSearch.Common.Abstractions;
+using Microsoft.TemplateSearch.Common.Providers;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -69,6 +72,39 @@ namespace Microsoft.TemplateSearch.Common.UnitTests
 
             Assert.IsAssignableFrom<ITemplateInfo>(parsedCache.TemplatePackages[0].Templates[0]);
             Assert.Equal("Microsoft.AzureFunctions.ProjectTemplate.CSharp.3.x", ((ITemplateInfo)parsedCache.TemplatePackages[0].Templates[0]).Identity);
+        }
+
+        [Fact]
+        public async Task CanReadSearchMetadata_FromBlob()
+        {
+            using EnvironmentSettingsHelper environmentSettingsHelper = new EnvironmentSettingsHelper();
+            var environmentSettings = environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            var sourceFileProvider = new NuGetMetadataSearchProvider(
+                A.Fake<ITemplateSearchProviderFactory>(),
+                environmentSettings,
+                new Dictionary<string, Func<object, object>>());
+            await sourceFileProvider.GetSearchFileAsync(default).ConfigureAwait(false);
+            string content = environmentSettings.Host.FileSystem.ReadAllText(Path.Combine(environmentSettings.Paths.HostVersionSettingsDir, "nugetTemplateSearchInfo.json"));
+            var jObj = JObject.Parse(content);
+            Assert.NotNull(TemplateSearchCache.FromJObject(jObj, environmentSettings.Host.Logger, null));
+        }
+
+        [Fact]
+        public async Task CanReadLegacySearchMetadata_FromBlob()
+        {
+            using EnvironmentSettingsHelper environmentSettingsHelper = new EnvironmentSettingsHelper();
+            var environmentSettings = environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            var sourceFileProvider = new NuGetMetadataSearchProvider(
+                A.Fake<ITemplateSearchProviderFactory>(),
+                environmentSettings,
+                new Dictionary<string, Func<object, object>>(),
+                new[] { "https://go.microsoft.com/fwlink/?linkid=2087906&clcid=0x409" });  //v1 search cache
+            await sourceFileProvider.GetSearchFileAsync(default).ConfigureAwait(false);
+            string content = environmentSettings.Host.FileSystem.ReadAllText(Path.Combine(environmentSettings.Paths.HostVersionSettingsDir, "nugetTemplateSearchInfo.json"));
+            var jObj = JObject.Parse(content);
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.True(LegacySearchCacheReader.TryReadDiscoveryMetadata(jObj, environmentSettings.Host.Logger, null, out _));
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }


### PR DESCRIPTION
### Problem
.NET 6 still using v1 search cache as primary source.

### Solution
switching to v2 as primary source

Note: to be merged when v2 auto-update is enabled

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)