### PR TITLE
Template Discovery tool fixes

### DIFF
--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
@@ -97,7 +97,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
             while (!done && !_runOnlyOnePage);
         }
 
-        public async Task<IDownloadedPackInfo?> DownloadPackageAsync(ITemplatePackageInfo packinfo, CancellationToken token)
+        public async Task<IDownloadedPackInfo> DownloadPackageAsync(ITemplatePackageInfo packinfo, CancellationToken token)
         {
             string packageFileName = string.Format(DownloadPackageFileNameFormat, packinfo.Name, packinfo.Version);
             string outputPackageFileNameFullPath = Path.Combine(_packageTempPath, packageFileName);
@@ -127,7 +127,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
             catch (Exception e)
             {
                 Console.WriteLine($"Failed to download package {packinfo.Name} {packinfo.Version}, reason: {e}.");
-                return null;
+                throw;
             }
         }
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
@@ -49,12 +49,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
                         }
                         alreadySeenPacks.Add(sourceInfo);
 
-                        IDownloadedPackInfo? packInfo = await packProvider.DownloadPackageAsync(sourceInfo, token).ConfigureAwait(false);
-                        if (packInfo == null)
-                        {
-                            Console.WriteLine($"Package {sourceInfo.Name}::{sourceInfo.Version} is not processed.");
-                            continue;
-                        }
+                        IDownloadedPackInfo packInfo = await packProvider.DownloadPackageAsync(sourceInfo, token).ConfigureAwait(false);
 
                         PackCheckResult preFilterResult = PrefilterPackInfo(packInfo);
                         if (preFilterResult.PreFilterResults.ShouldBeFiltered)

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/IPackProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackProviders
 
         IAsyncEnumerable<ITemplatePackageInfo> GetCandidatePacksAsync(CancellationToken token);
 
-        Task<IDownloadedPackInfo?> DownloadPackageAsync(ITemplatePackageInfo packinfo, CancellationToken token);
+        Task<IDownloadedPackInfo> DownloadPackageAsync(ITemplatePackageInfo packinfo, CancellationToken token);
 
         Task<int> GetPackageCountAsync(CancellationToken token);
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/TestPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackProviders/TestPackProvider.cs
@@ -23,9 +23,9 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackProviders
             return Task.FromResult(0);
         }
 
-        public Task<IDownloadedPackInfo?> DownloadPackageAsync(ITemplatePackageInfo packinfo, CancellationToken token)
+        public Task<IDownloadedPackInfo> DownloadPackageAsync(ITemplatePackageInfo packinfo, CancellationToken token)
         {
-            return Task.FromResult((IDownloadedPackInfo?)packinfo);
+            return Task.FromResult((IDownloadedPackInfo)packinfo);
         }
 
         public async IAsyncEnumerable<ITemplatePackageInfo> GetCandidatePacksAsync([EnumeratorCancellation]CancellationToken token)

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Program.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Program.cs
@@ -61,6 +61,11 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery
             catch (TaskCanceledException)
             {
                 Console.WriteLine("Operation was cancelled.");
+                return 2;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Error occured: {e}");
                 return 1;
             }
 


### PR DESCRIPTION
### Problem
Template Discovery tool can "swallow" errors on:
- package download
- retrieving search results

### Solution
If error responses are received, they will be thrown instead.

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)