### PR TITLE
Prevent cache update to run on push

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -9,6 +9,12 @@ schedules:
     - main
   always: true # Trigger even when there are no code changes.
 
+parameters:
+- name: publishToBlob
+  displayName: Publish to blob?
+  type: boolean
+  default: true
+
 pool:
     name: Hosted Ubuntu 1604
 
@@ -63,24 +69,25 @@ steps:
 - bash: az config set extension.use_dynamic_install=yes_without_prompt
   displayName: Disable Azure CLI prompts
 
-- bash: >
-    az storage azcopy blob upload 
-    -c $(CacheFileStorageContainer)
-    --account-name $(CacheFileStorageAccount) 
-    -s '$(System.DefaultWorkingDirectory)/ArtifactsToPublish/NuGetTemplateSearchInfoVer2.json' 
-    --sas-token "$(CacheFileStorageSasToken)"
-    -d NuGetTemplateSearchInfoVer2.json
-    | tee upload.log
-    && grep ".*Number of Transfers Completed: 1" upload.log || (echo ; echo "Cache file upload failed"; false)
-  displayName: Upload to blob storage
+- ${{ if eq(parameters.publishToBlob, true) }}:
+  - bash: >
+      az storage azcopy blob upload 
+      -c $(CacheFileStorageContainer)
+      --account-name $(CacheFileStorageAccount) 
+      -s '$(System.DefaultWorkingDirectory)/ArtifactsToPublish/NuGetTemplateSearchInfoVer2.json' 
+      --sas-token "$(CacheFileStorageSasToken)"
+      -d NuGetTemplateSearchInfoVer2.json
+      | tee upload.log
+      && grep ".*Number of Transfers Completed: 1" upload.log || (echo ; echo "Cache file upload failed"; false)
+    displayName: Upload to blob storage
 
-- bash: >
-    az storage azcopy blob upload 
-    -c $(LegacyCacheFileStorageContainer)
-    --account-name $(LegacyCacheFileStorageAccount) 
-    -s '$(System.DefaultWorkingDirectory)/ArtifactsToPublish/NuGetTemplateSearchInfo.json' 
-    --sas-token "$(LegacyCacheFileStorageSasToken)"
-    -d NuGetTemplateSearchInfo.json
-    | tee upload-legacy.log
-    && grep ".*Number of Transfers Completed: 1" upload-legacy.log || (echo ; echo "Legacy cache file upload failed"; false)
-  displayName: Upload legacy file to blob storage
+  - bash: >
+      az storage azcopy blob upload 
+      -c $(LegacyCacheFileStorageContainer)
+      --account-name $(LegacyCacheFileStorageAccount) 
+      -s '$(System.DefaultWorkingDirectory)/ArtifactsToPublish/NuGetTemplateSearchInfo.json' 
+      --sas-token "$(LegacyCacheFileStorageSasToken)"
+      -d NuGetTemplateSearchInfo.json
+      | tee upload-legacy.log
+      && grep ".*Number of Transfers Completed: 1" upload-legacy.log || (echo ; echo "Legacy cache file upload failed"; false)
+    displayName: Upload legacy file to blob storage


### PR DESCRIPTION
### Problem
<!-- Add the issue number if exists. Describe the problem otherwise. -->
Search cache updater pipeline is now running whenever something is pushed to main.
We only want it to run according to the fixed schedule.

### Solution
<!-- Describe the solution. -->
Disabled triggers for CI.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)