### PR TITLE
add CleanBlazor Available-templates-for-dotnet-new

### DIFF
--- a/docs/Available-templates-for-dotnet-new.md
+++ b/docs/Available-templates-for-dotnet-new.md
@@ -12,6 +12,7 @@ Here is a list (alpha sorted) of templates which are available for use with `dot
 | [Blazor](http://blazor.net) - Full stack web development with C# and WebAssembly | `dotnet new -i "Microsoft.AspNetCore.Blazor.Templates::3.0.0-*"`|
 | [Cake.Frosting](https://github.com/cake-build/cake) | `dotnet new -i "Cake.Frosting.Template::*"` |
 | [Carter](https://github.com/CarterCommunity/Carter) - Carter is a library that allows Nancy-esque routing for use with ASP.Net Core. | `dotnet new -i "CarterTemplate::*"`|
+| [CleanBlazor](https://github.com/fvilches17/CleanBlazor) - Minimal Blazor projects. Standard Blazor project templates minus any boilerplate assets (e.g. Bootstrap, Counter.razor, etc.)  | `dotnet new -i "FriscoVInc.DotNet.Templates.CleanBlazor::*"` |
 | [cloudscribe](https://www.cloudscribe.com/docs/introduction) | `dotnet new -i "cloudscribe.templates::*"` |
 | [DotVVM](https://github.com/riganti/dotvvm) - Open source MVVM framework for line of business web applications | `dotnet new -i "DotVVM.Templates::*"` |
 | [Eto.Forms](https://github.com/picoe/Eto) | `dotnet new -i "Eto.Forms.Templates::*"` |


### PR DESCRIPTION
### Problem
The out of the box Microsoft Blazor project templates are great for getting familiar with Blazor or creating PoC apps.

However, for brand new custom Blazor projects we will usually want to remove some of the boilerplate assets (e.g. Bootstrap, the Counter component, etc.).

### Solution
The CleanBlazor project templates save you some time by providing minimal Blazor server and wasm templates (dotnet CLI and Visual Studio). Use to start out of the box Microsoft Blazor projects minus any boilerplate and unecessary html/css/js/razor.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)

marking checks as done as this is just a doc update