### PR TITLE
Fix #3128: GuidMacro defaultFormat doesn't respect casing format

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GuidMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GuidMacroConfig.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
@@ -9,13 +11,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
     {
         internal const string DefaultFormats = "ndbpxNDPBX";
 
-        internal GuidMacroConfig(string variableName, string dataType, string format, string defaultFormat)
+        internal GuidMacroConfig(string variableName, string dataType, string? format, string? defaultFormat)
         {
             DataType = dataType;
             VariableName = variableName;
             Type = "guid";
             Format = format;
-            DefaultFormat = string.IsNullOrWhiteSpace(defaultFormat) ? "D" : defaultFormat;
+            DefaultFormat = string.IsNullOrWhiteSpace(defaultFormat) ? "D" : defaultFormat!;
         }
 
         public string VariableName { get; private set; }
@@ -26,6 +28,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         internal string DefaultFormat { get; private set; }
 
-        internal string Format { get; private set; }
+        internal string? Format { get; private set; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GuidMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GuidMacroConfig.cs
@@ -17,17 +17,17 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
             VariableName = variableName;
             Type = "guid";
             Format = format;
-            DefaultFormat = string.IsNullOrWhiteSpace(defaultFormat) ? "D" : defaultFormat!;
+            DefaultFormat = defaultFormat;
         }
 
-        public string VariableName { get; private set; }
+        public string VariableName { get; }
 
-        public string Type { get; private set; }
+        public string Type { get; }
 
         internal string DataType { get; }
 
-        internal string DefaultFormat { get; private set; }
+        internal string? DefaultFormat { get; }
 
-        internal string? Format { get; private set; }
+        internal string? Format { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GuidMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GuidMacro.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
@@ -18,7 +20,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig, IParameterSet parameters, ParameterSetter setter)
         {
-            GuidMacroConfig config = rawConfig as GuidMacroConfig;
+            var config = rawConfig as GuidMacroConfig;
 
             if (config == null)
             {
@@ -28,7 +30,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             string guidFormats;
             if (!string.IsNullOrEmpty(config.Format))
             {
-                guidFormats = config.Format;
+                guidFormats = config.Format!;
             }
             else
             {
@@ -70,24 +72,27 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
                 };
             }
 
-            vars[config.VariableName] = g.ToString(config.DefaultFormat);
-            setter(pd, g.ToString(config.DefaultFormat));
+            string defaultValue = char.IsUpper(config.DefaultFormat[0]) ?
+                g.ToString(config.DefaultFormat).ToUpperInvariant() :
+                g.ToString(config.DefaultFormat).ToLowerInvariant();
+            vars[config.VariableName] = defaultValue;
+            setter(pd, defaultValue);
         }
 
         public IMacroConfig CreateConfig(IEngineEnvironmentSettings environmentSettings, IMacroConfig rawConfig)
         {
-            GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
+            var deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
             if (deferredConfig == null)
             {
                 throw new InvalidCastException("Couldn't cast the rawConfig as a GeneratedSymbolDeferredMacroConfig");
             }
 
-            deferredConfig.Parameters.TryGetValue("format", out JToken formatToken);
-            string format = formatToken?.ToString();
+            deferredConfig.Parameters.TryGetValue("format", out JToken? formatToken);
+            string? format = formatToken?.ToString();
 
             deferredConfig.Parameters.TryGetValue("defaultFormat", out JToken defaultFormatToken);
-            string defaultFormat = defaultFormatToken?.ToString();
+            string? defaultFormat = defaultFormatToken?.ToString();
 
             IMacroConfig realConfig = new GuidMacroConfig(deferredConfig.VariableName, deferredConfig.DataType, format, defaultFormat);
             return realConfig;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GuidMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GuidMacro.cs
@@ -71,8 +71,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
                     Name = config.VariableName
                 };
             }
-
-            string defaultValue = char.IsUpper(config.DefaultFormat[0]) ?
+            var defaultFormat = string.IsNullOrEmpty(config.DefaultFormat) ? "D" : config.DefaultFormat!;
+            string defaultValue = char.IsUpper(defaultFormat[0]) ?
                 g.ToString(config.DefaultFormat).ToUpperInvariant() :
                 g.ToString(config.DefaultFormat).ToLowerInvariant();
             vars[config.VariableName] = defaultValue;

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/GuidMacroTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/GuidMacroTests.cs
@@ -83,9 +83,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
         public void TestDefaultFormatIsCaseSensetive()
         {
             string paramNameLower = "TestGuidLower";
-            IMacroConfig macroConfigLower = new GuidMacroConfig(paramNameLower, "string", string.Empty, "d");
+            IMacroConfig macroConfigLower = new GuidMacroConfig(paramNameLower, "string", string.Empty, "n");
             string paramNameUpper = "TestGuidUPPER";
-            IMacroConfig macroConfigUpper = new GuidMacroConfig(paramNameUpper, "string", string.Empty, "D");
+            IMacroConfig macroConfigUpper = new GuidMacroConfig(paramNameUpper, "string", string.Empty, "N");
 
             IVariableCollection variables = new VariableCollection();
             IRunnableProjectConfig config = new SimpleConfigModel(_engineEnvironmentSettings.Host.LoggerFactory);
@@ -96,20 +96,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
             guidMacro.EvaluateConfig(_engineEnvironmentSettings, variables, macroConfigLower, parameters, setter);
             guidMacro.EvaluateConfig(_engineEnvironmentSettings, variables, macroConfigUpper, parameters, setter);
 
-            // Logic of below might be a bit confusing...
-            // We are just making sure that no UPPER case char is present in lower case and vice-versa
-            // Reason is... In theory GUID could be all numbers, hence can't check if UPPER char is present in UPPER guid...
-
             Assert.True(parameters.TryGetParameterDefinition(paramNameLower, out var setParamLower));
             Assert.All(((string)parameters.ResolvedValues[setParamLower]).ToCharArray(), (c) =>
             {
-                Assert.False(char.IsUpper(c));
+                Assert.True(char.IsLower(c) || char.IsDigit(c));
             });
 
             Assert.True(parameters.TryGetParameterDefinition(paramNameUpper, out var setParamUpper));
             Assert.All(((string)parameters.ResolvedValues[setParamUpper]).ToCharArray(), (c) =>
             {
-                Assert.False(char.IsLower(c));
+                Assert.True(char.IsUpper(c) || char.IsDigit(c));
             });
         }
     }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/GuidMacroTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/GuidMacroTests.cs
@@ -78,5 +78,39 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
                 Assert.Equal(paramValue, testValue);
             }
         }
+
+        [Fact]
+        public void TestDefaultFormatIsCaseSensetive()
+        {
+            string paramNameLower = "TestGuidLower";
+            IMacroConfig macroConfigLower = new GuidMacroConfig(paramNameLower, "string", string.Empty, "d");
+            string paramNameUpper = "TestGuidUPPER";
+            IMacroConfig macroConfigUpper = new GuidMacroConfig(paramNameUpper, "string", string.Empty, "D");
+
+            IVariableCollection variables = new VariableCollection();
+            IRunnableProjectConfig config = new SimpleConfigModel(_engineEnvironmentSettings.Host.LoggerFactory);
+            IParameterSet parameters = new ParameterSet(config);
+            ParameterSetter setter = MacroTestHelpers.TestParameterSetter(_engineEnvironmentSettings, parameters);
+
+            GuidMacro guidMacro = new GuidMacro();
+            guidMacro.EvaluateConfig(_engineEnvironmentSettings, variables, macroConfigLower, parameters, setter);
+            guidMacro.EvaluateConfig(_engineEnvironmentSettings, variables, macroConfigUpper, parameters, setter);
+
+            // Logic of below might be a bit confusing...
+            // We are just making sure that no UPPER case char is present in lower case and vice-versa
+            // Reason is... In theory GUID could be all numbers, hence can't check if UPPER char is present in UPPER guid...
+
+            Assert.True(parameters.TryGetParameterDefinition(paramNameLower, out var setParamLower));
+            Assert.All(((string)parameters.ResolvedValues[setParamLower]).ToCharArray(), (c) =>
+            {
+                Assert.False(char.IsUpper(c));
+            });
+
+            Assert.True(parameters.TryGetParameterDefinition(paramNameUpper, out var setParamUpper));
+            Assert.All(((string)parameters.ResolvedValues[setParamUpper]).ToCharArray(), (c) =>
+            {
+                Assert.False(char.IsLower(c));
+            });
+        }
     }
 }


### PR DESCRIPTION
### Problem
GuidMacro is respecting lower vs upper format "D" vs "d"... But this does not happen for "defaultFormat"...

### Solution
Respect it.. :)

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)