### PR TITLE
[release/6.0.1xx] Fixes for RTM and stabilization

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -21,7 +21,7 @@
     <FrameworkReference
         Update="Microsoft.NETCore.App"
         TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
-        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRefPackageVersion)" />
+        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)" />
   </ItemGroup>
 
   <!-- Leave this file here, even if it's empty. It stops chaining imports. -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,6 +11,14 @@
       <Sha>def2e2c6dc5064319250e2868a041a3dc07f9579</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.6.0" Version="6.0.0-rc.2.21451.6">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>cdc7f20305d81dab761474832b04f022b4f9dadc</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="6.0.0-rc.2.21451.6">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>cdc7f20305d81dab761474832b04f022b4f9dadc</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="6.0.0-rc.2.21451.6">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>cdc7f20305d81dab761474832b04f022b4f9dadc</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,6 +7,11 @@
     <VersionPrefix>6.0.100</VersionPrefix>
     <PreReleaseVersionLabel>rc</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
+    <!--
+        When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
+    -->
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <PackSpecific Condition="'$(OS)' != 'Windows_NT'">true</PackSpecific>
     <NewtonsoftJsonPackageVersion>12.0.2</NewtonsoftJsonPackageVersion>
     <SystemDiagnosticsProcessPackageVersion>4.3.0</SystemDiagnosticsProcessPackageVersion>
@@ -20,6 +25,8 @@
     <NuGetProtocolPackageVersion>6.0.0-preview.3.179</NuGetProtocolPackageVersion>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
     <MicrosoftNETCoreAppRefPackageVersion>6.0.0-rc.2.21451.6</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.0-rc.2.21451.6</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>6.0.0-rc.2.21451.6</VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>6.0.0-rc.2.21451.6</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>6.0.0-rc.2.21451.6</MicrosoftExtensionsLoggingPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>6.0.0-rc.2.21451.6</MicrosoftExtensionsLoggingConsolePackageVersion>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "6.0.100-rc.1.21415.3",
     "runtimes": {
       "dotnet": [
-        "$(MicrosoftNETCoreAppRefPackageVersion)"
+        "$(VSRedistCommonNetCoreSharedFrameworkx6460PackageVersion)"
       ]
     }
   },


### PR DESCRIPTION
- Use correct package for runtime version in global.json (VS.Redist package which doesn't stabilize)
- Use correct targeting pack version
- Use correct runtime framework version
- Add missing stabilization properties.