### PR TITLE
[main] Fixes for RTM and stabilization

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -21,7 +21,7 @@
     <FrameworkReference
         Update="Microsoft.NETCore.App"
         TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
-        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRefPackageVersion)" />
+        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)" />
   </ItemGroup>
 
   <!-- Leave this file here, even if it's empty. It stops chaining imports. -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,6 +11,14 @@
       <Sha>def2e2c6dc5064319250e2868a041a3dc07f9579</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
+    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.7.0" Version="7.0.0-alpha.1.21451.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>c570efdbfb47fdffe9b5b04d47f069b31f5d7f78</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-alpha.1.21451.1">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>c570efdbfb47fdffe9b5b04d47f069b31f5d7f78</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-alpha.1.21451.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>c570efdbfb47fdffe9b5b04d47f069b31f5d7f78</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,6 +7,11 @@
     <VersionPrefix>7.0.100</VersionPrefix>
     <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
+    <!--
+        When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
+    -->
+    <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
+    <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
     <PackSpecific Condition="'$(OS)' != 'Windows_NT'">true</PackSpecific>
     <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
     <SystemDiagnosticsProcessPackageVersion>4.3.0</SystemDiagnosticsProcessPackageVersion>
@@ -20,6 +25,8 @@
     <NuGetProtocolPackageVersion>6.0.0-preview.4.221</NuGetProtocolPackageVersion>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
     <MicrosoftNETCoreAppRefPackageVersion>7.0.0-alpha.1.21451.1</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>7.0.0-alpha.1.21451.1</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion>7.0.0-alpha.1.21451.1</VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion>
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>7.0.0-alpha.1.21451.1</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>7.0.0-alpha.1.21451.1</MicrosoftExtensionsLoggingPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>7.0.0-alpha.1.21451.1</MicrosoftExtensionsLoggingConsolePackageVersion>

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "dotnet": "6.0.100-rc.1.21415.3",
     "runtimes": {
       "dotnet": [
-        "$(MicrosoftNETCoreAppRefPackageVersion)"
+        "$(VSRedistCommonNetCoreSharedFrameworkx6470PackageVersion)"
       ]
     }
   },


### PR DESCRIPTION
- Use correct package for runtime version in global.json (VS.Redist package which doesn't stabilize)
- Use correct targeting pack version
- Use correct runtime framework version
- Add missing stabilization properties.