### PR TITLE
upload nonTemplatePacks.json to Azure during search-cache-pipeline run

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -58,9 +58,11 @@ steps:
 
 - task: CopyFiles@2
   inputs:
-    sourceFolder: $(System.DefaultWorkingDirectory)/NugetDownloadDirectory/SearchCache/
-    contents: 'NuGetTemplateSearchInfo*.json'
-    targetFolder: $(System.DefaultWorkingDirectory)/ArtifactsToPublish/
+    SourceFolder: $(System.DefaultWorkingDirectory)/NugetDownloadDirectory/SearchCache/
+    Contents: | 
+      NuGetTemplateSearchInfo*.json
+      nonTemplatePacks.json
+    TargetFolder: $(System.DefaultWorkingDirectory)/ArtifactsToPublish/
 
 - publish: $(System.DefaultWorkingDirectory)/ArtifactsToPublish/
   artifact: outputs
@@ -91,3 +93,14 @@ steps:
       | tee upload-legacy.log
       && grep ".*Number of Transfers Completed: 1" upload-legacy.log || (echo ; echo "Legacy cache file upload failed"; false)
     displayName: Upload legacy file to blob storage
+
+  - bash: >
+      az storage azcopy blob upload 
+      -c $(NonTemplatePacksFileStorageContainer)
+      --account-name $(NonTemplatePacksFileStorageAccount) 
+      -s '$(System.DefaultWorkingDirectory)/ArtifactsToPublish/nonTemplatePacks.json' 
+      --sas-token "$(NonTemplatePacksFileStorageSasToken)"
+      -d nonTemplatePacks.json
+      | tee upload-non-template-packs.log
+      && grep ".*Number of Transfers Completed: 1" upload-non-template-packs.log || (echo ; echo "Legacy cache file upload failed"; false)
+    displayName: Upload non template packages file to blob storage

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NuGetPackSourceCheckerFactory.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NuGetPackSourceCheckerFactory.cs
@@ -61,7 +61,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
         private static async Task<IEnumerable<FilteredPackageInfo>?> LoadKnownPackagesListAsync (CommandArgs config, CancellationToken cancellationToken)
         {
             Verbose.WriteLine($"Loading existing non-packages information.");
-            const string uri = "https://dotnettemplating.blob.core.windows.net/search/nonTemplatePacks_test.json";
+            const string uri = "https://dotnettemplating.blob.core.windows.net/search/nonTemplatePacks.json";
 
             FileInfo? fileLocation = config.DiffOverrideKnownPackagesLocation;
             if (fileLocation == null)


### PR DESCRIPTION
### Problem
at the moment  nonTemplatePacks.json is updated only manually, added update during pipeline run

### Solution
upload nonTemplatePacks.json to Azure during search-cache-pipeline run

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)