### PR TITLE
Dev/bozturk/run loc on single branch 6.0.1xx

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ stages:
 - stage: build
   displayName: Build
   jobs:
-  - ${{ if and( ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), or( eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))) }}:
+  - ${{ if and( ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/release/6.0.1xx')) }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         MirrorRepo: templating

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,13 +45,14 @@ stages:
 - stage: build
   displayName: Build
   jobs:
-  - ${{ if and( ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/release/6.0.1xx')) }}:
+  - ${{ if and( ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - template: /eng/common/templates/job/onelocbuild.yml
       parameters:
         MirrorRepo: templating
-        MirrorBranch: release/6.0.1xx
+        MirrorBranch: $(OneLocBuildBranch)
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-TEMPLATING'
+        condition: eq(variables['Build.SourceBranch'], format('{0}{1}', 'refs/heads/', variables['OneLocBuildBranch'] ))
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true


### PR DESCRIPTION
### Problem
OneLocBuild is not able to handle multiple branches pushing texts to be localized at the same time.
We need to allow pushing only from a single branch.

### Solution
<!-- Describe the solution. -->
Modified the check to only accept the branch that is defined in pipeline settings.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)