### PR TITLE
updated readme.md with locations for template content

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,25 @@ When `dotnet new` is invoked, it will call the Template Engine to create the art
 Template Engine is a library for manipulating streams, including operations to replace values, include/exclude 
 regions and process `if`, `else if`, `else` and `end if` style statements.
 
-# Content Repositories
-* [Class Library/Console App](https://github.com/dotnet/templating/tree/main/template_feed)
-* [Test projects](https://github.com/dotnet/test-templates/tree/master/template_feed)
-* [ASP.NET project and items](https://github.com/aspnet/AspNetCore/tree/main/src/ProjectTemplates)
+# Template Content Repositories
+
+[.NET default templates](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates) are located in several repositories.
+This repository only contains the following templates:
+- Console Application (console)
+- Class Library (classlib)
+- Common item templates (gitignore, globaljson, nugetconfig, sln, etc)
+
+Other templates are located in the following repositories:
+
+| Templates | Repository |
+|---|---|
+|ASP.NET and Blazor templates|[dotnet/aspnetcore](https://github.com/dotnet/aspnetcore)|
+|WPF templates|[dotnet/wpf](https://github.com/dotnet/wpf)|
+|Windows Forms templates|[dotnet/winforms](https://github.com/dotnet/winforms)|
+|Test templates|[dotnet/test-templates](https://github.com/dotnet/test-templates)|
+|MAUI templates|[dotnet/maui](https://github.com/dotnet/maui)|
+
+Issues for the template content should be opened in coresponding repositories.
 
 # Template Samples
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ regions and process `if`, `else if`, `else` and `end if` style statements.
 This repository only contains the following templates:
 - Console Application (console)
 - Class Library (classlib)
-- Common item templates (gitignore, globaljson, nugetconfig, sln, etc)
+- Common item templates (gitignore, globaljson, nugetconfig, sln, etc.)
 
 Other templates are located in the following repositories:
 
@@ -25,7 +25,7 @@ Other templates are located in the following repositories:
 |Test templates|[dotnet/test-templates](https://github.com/dotnet/test-templates)|
 |MAUI templates|[dotnet/maui](https://github.com/dotnet/maui)|
 
-Issues for the template content should be opened in coresponding repositories.
+Issues for the template content should be opened in the corresponding repository.
 
 # Template Samples
 


### PR DESCRIPTION
### Problem
Template content issues are often reported to this repo instead of reporting them to repo that hosts the templates.

### Solution
Updated readme.md with links to repos hosting the template content

### Checks:
- [ ] Added unit tests - NA
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) -NA