### PR TITLE
[6.0.1xx] template discovery: fixed link to non-templates list

### DIFF
--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NuGetPackSourceCheckerFactory.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NuGetPackSourceCheckerFactory.cs
@@ -61,7 +61,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
         private static async Task<IEnumerable<FilteredPackageInfo>?> LoadKnownPackagesListAsync (CommandArgs config, CancellationToken cancellationToken)
         {
             Verbose.WriteLine($"Loading existing non-packages information.");
-            const string uri = "https://dotnettemplating.blob.core.windows.net/search/nonTemplatePacks_test.json";
+            const string uri = "https://dotnettemplating.blob.core.windows.net/search/nonTemplatePacks.json";
 
             FileInfo? fileLocation = config.DiffOverrideKnownPackagesLocation;
             if (fileLocation == null)


### PR DESCRIPTION
Problem: templating-search-cache-updater runs on release/6.0.1xx branch as part of CI and fails due to incorrect link (temporary one).
Solution: switched the link to permanent.