### PR TITLE
Cache updater shouldn't run on 6.0.1xx release/branch

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -1,3 +1,6 @@
+# Don't trigger for CI events: push, PR created etc.
+trigger: none
+# Trigger periodically instead.
 schedules:
 - cron: 0 * * * *
   displayName: Run every hour


### PR DESCRIPTION
### Problem
<!-- Add the issue number if exists. Describe the problem otherwise. -->
Template cache updater is being triggered every time something is pushed to release/6.0.1xx

### Solution
<!-- Describe the solution. -->
Disabled triggers for the branch.