### PR TITLE
Changed sorting and comparison criteria to match current culture

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
@@ -446,7 +446,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                     .DefineColumn(t => t.TemplatePrecedence.ToString(), out object prcedenceColumn, LocalizableStrings.ColumnNamePrecedence, showAlways: true)
                     .DefineColumn(t => t.TemplateAuthor, LocalizableStrings.ColumnNameAuthor, showAlways: true, shrinkIfNeeded: true, minWidth: 10)
                     .DefineColumn(t => t.TemplatePackage != null ? t.TemplatePackage.Identifier : string.Empty, LocalizableStrings.ColumnNamePackage, showAlways: true)
-                    .OrderBy(identityColumn, StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(identityColumn, StringComparer.CurrentCultureIgnoreCase)
                     .OrderByDescending(prcedenceColumn, new NullOrEmptyIsLastStringComparer());
             Reporter.Error.WriteLine(formatter.Layout().Bold().Red());
 
@@ -484,7 +484,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                     .DefineColumn(t => t.Type, LocalizableStrings.ColumnNameType, BaseCommandInput.TypeColumnFilter, defaultColumn: false)
                     .DefineColumn(t => t.Author, LocalizableStrings.ColumnNameAuthor, BaseCommandInput.AuthorColumnFilter, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)
                     .DefineColumn(t => t.Classifications, out object tagsColumn, LocalizableStrings.ColumnNameTags, BaseCommandInput.TagsColumnFilter, defaultColumn: true)
-                    .OrderBy(nameColumn, StringComparer.OrdinalIgnoreCase);
+                    .OrderBy(nameColumn, StringComparer.CurrentCultureIgnoreCase);
 
             Reporter reporter = useErrorOutput ? Reporter.Error : Reporter.Output;
             reporter.WriteLine(formatter.Layout());

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -510,7 +510,7 @@ namespace Microsoft.TemplateEngine.Cli
                        .DefineColumn(r => r.Identifier, out object packageColumn, LocalizableStrings.ColumnNamePackage, showAlways: true)
                        .DefineColumn(r => r.CurrentVersion, LocalizableStrings.ColumnNameCurrentVersion, showAlways: true)
                        .DefineColumn(r => r.LatestVersion, LocalizableStrings.ColumnNameLatestVersion, showAlways: true)
-                       .OrderBy(packageColumn, StringComparer.OrdinalIgnoreCase);
+                       .OrderBy(packageColumn, StringComparer.CurrentCultureIgnoreCase);
                 Reporter.Output.WriteLine(formatter.Layout());
                 Reporter.Output.WriteLine();
 

--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/CliFilters.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/CliFilters.cs
@@ -52,7 +52,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                     return new MatchInfo(MatchInfo.BuiltIn.Name, name, MatchKind.Partial);
                 }
 
-                int nameIndex = templateGroup.Name.IndexOf(name, StringComparison.OrdinalIgnoreCase);
+                int nameIndex = templateGroup.Name.IndexOf(name, StringComparison.CurrentCultureIgnoreCase);
 
                 if (nameIndex == 0 && templateGroup.Name.Length == name.Length)
                 {

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -156,7 +156,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                     .DefineColumn(r => r.TemplateGroupInfo.Classifications, LocalizableStrings.ColumnNameTags, BaseCommandInput.TagsColumnFilter, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)
                     .DefineColumn(r => r.PackageName, out object packageColumn, LocalizableStrings.ColumnNamePackage, showAlways: true)
                     .DefineColumn(r => r.PrintableTotalDownloads, LocalizableStrings.ColumnNameTotalDownloads, showAlways: true, rightAlign: true)
-                    .OrderBy(nameColumn, StringComparer.OrdinalIgnoreCase);
+                    .OrderBy(nameColumn, StringComparer.CurrentCultureIgnoreCase);
 
             Reporter.Output.WriteLine(formatter.Layout());
         }

--- a/src/Microsoft.TemplateEngine.Utils/WellKnownSearchFilters.cs
+++ b/src/Microsoft.TemplateEngine.Utils/WellKnownSearchFilters.cs
@@ -46,7 +46,7 @@ namespace Microsoft.TemplateEngine.Utils
                     return new MatchInfo(MatchInfo.BuiltIn.Name, name, MatchKind.Partial);
                 }
 
-                int nameIndex = template.Name.IndexOf(name, StringComparison.OrdinalIgnoreCase);
+                int nameIndex = template.Name.IndexOf(name, StringComparison.CurrentCultureIgnoreCase);
 
                 if (nameIndex == 0 && template.Name.Length == name.Length)
                 {
@@ -124,7 +124,7 @@ namespace Microsoft.TemplateEngine.Utils
                 {
                     return null;
                 }
-                if (template.Classifications?.Contains(classification, StringComparer.OrdinalIgnoreCase) ?? false)
+                if (template.Classifications?.Contains(classification, StringComparer.CurrentCultureIgnoreCase) ?? false)
                 {
                     return new MatchInfo(MatchInfo.BuiltIn.Classification, classification, MatchKind.Exact);
                 }
@@ -209,7 +209,7 @@ namespace Microsoft.TemplateEngine.Utils
                     return new MatchInfo(MatchInfo.BuiltIn.Author, author, MatchKind.Mismatch);
                 }
 
-                int authorIndex = template.Author!.IndexOf(author, StringComparison.OrdinalIgnoreCase);
+                int authorIndex = template.Author!.IndexOf(author, StringComparison.CurrentCultureIgnoreCase);
 
                 if (authorIndex == 0 && template.Author.Length == author.Length)
                 {


### PR DESCRIPTION
### Solution
Table output is sorted using CurrentCultureIgnoreCase comparison
Template name, author and classification is compared using CurrentCultureIgnoreCase comparison

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)