### PR TITLE
Switch to 1ES servicing pools on release/5.0.4xx

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,8 +60,8 @@ stages:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: Hosted VS2017
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCoreInternal-Int-Pool
-            queue: buildpool.windows.10.amd64.vs2017
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals build.windows.10.amd64.vs2017
 
         variables:
         - _InternalBuildArgs: ''

--- a/global.json
+++ b/global.json
@@ -9,6 +9,6 @@
     }
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.21228.8"
+    "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.21471.4"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "5.0.100",
+    "dotnet": "5.0.400",
     "runtimes": {
       "dotnet": [
         "2.1.7",


### PR DESCRIPTION
### Problem
Tracking issue: https://github.com/dotnet/core-eng/issues/14276
We need all repos to switch off of our build pools and onto the new 1ES pools by 9/30. This accomplishes that for the release/5.0 branch.

### Solution
Switch to these pools.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)