### PR TITLE
Switch to 1ES R&D pools on main

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,8 +66,8 @@ stages:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: Hosted VS2017
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCoreInternal-Pool
-            queue: buildpool.windows.10.amd64.vs2017
+            name: NetCore1ESPool-Internal
+            demands: ImageOverride -equals build.windows.10.amd64.vs2017
 
         variables:
         - _InternalBuildArgs: ''
@@ -151,8 +151,8 @@ stages:
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         - job: Linux
           pool:
-            name:  NetCorePublic-Pool
-            queue: BuildPool.Ubuntu.1804.Amd64.Open
+            name:  NetCore1ESPool-Public
+            demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
           strategy:
             matrix:
               debug_configuration:


### PR DESCRIPTION
The same as the one for the servicing branches, but the R&D pools on main.