### PR TITLE
Switch to 1ES servicing pools on release/3.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,8 @@ stages:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: Hosted VS2017
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCoreInternal-Int-Pool
-            queue: buildpool.windows.10.amd64.vs2017
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals Build.windows.10.amd64.vs2017
           
         variables:
         - _Script: eng\common\cibuild.cmd


### PR DESCRIPTION
### Problem
Tracking issue: https://github.com/dotnet/core-eng/issues/14276
We need all repos to switch off of our build pools and onto the new 1ES pools by 9/30. This accomplishes that for the release/3.1 branch.

### Solution
Switch to these pools.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)