### PR TITLE
Switch to 1ES servicing pools on release/6.0.1xx-rc2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,8 +71,8 @@ stages:
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
             name: Hosted VS2017
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-            name: NetCoreInternal-Pool
-            queue: buildpool.windows.10.amd64.vs2017
+            name: NetCore1ESPool-Svc-Internal
+            demands: ImageOverride -equals build.windows.10.amd64.vs2017
 
         variables:
         - _InternalBuildArgs: ''


### PR DESCRIPTION
More servicing branch migration.