### PR TITLE
Template Discovery: fixed the issue when cli host data was not read from existing cache in diff mode

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Cli/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
-﻿
+﻿const Microsoft.TemplateEngine.Cli.TemplateSearch.CliHostSearchCacheData.DataName = "cliHostData" -> string!
+Microsoft.TemplateEngine.Cli.TemplateSearch.CliHostSearchCacheData
+static Microsoft.TemplateEngine.Cli.TemplateSearch.CliHostSearchCacheData.Reader.get -> System.Func<object!, object!>!

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliHostSearchCacheData.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliHostSearchCacheData.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.TemplateEngine.Cli.TemplateSearch
+{
+    public static class CliHostSearchCacheData
+    {
+        public const string DataName = "cliHostData";
+        private static readonly string[] _hostDataPropertyNames = new[] { "isHidden", "SymbolInfo", "UsageExamples" };
+
+        public static Func<object, object> Reader => (obj) =>
+        {
+            JObject? cacheObject = obj as JObject;
+            if (cacheObject == null)
+            {
+                return HostSpecificTemplateData.Default;
+            }
+            try
+            {
+                if (_hostDataPropertyNames.Contains(cacheObject.Properties().First().Name, StringComparer.OrdinalIgnoreCase))
+                {
+                    return new HostSpecificTemplateData(cacheObject);
+                }
+
+                //fallback to old behavior
+                Dictionary<string, HostSpecificTemplateData> cliData = new Dictionary<string, HostSpecificTemplateData>();
+                foreach (JProperty data in cacheObject.Properties())
+                {
+                    try
+                    {
+                        cliData[data.Name] = new HostSpecificTemplateData(data.Value as JObject);
+                    }
+                    catch (Exception ex)
+                    {
+                        Reporter.Verbose.WriteLine($"Error deserializing the cli host specific template data for template {data.Name}, details:{ex}");
+                    }
+                }
+                return cliData;
+            }
+            catch (Exception ex)
+            {
+                Reporter.Verbose.WriteLine($"Error deserializing the cli host specific template data {cacheObject}, details:{ex}");
+            }
+            return HostSpecificTemplateData.Default;
+        };
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliSearchFiltersFactory.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliSearchFiltersFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
         private static Func<TemplateSearchData, bool> IsNotHiddenBySearchFile =>
             (templateSearchData) =>
             {
-                if (templateSearchData.AdditionalData.TryGetValue(CliTemplateSearchCoordinatorFactory.CliHostDataName, out object? hostDataRaw)
+                if (templateSearchData.AdditionalData.TryGetValue(CliHostSearchCacheData.DataName, out object? hostDataRaw)
                     && hostDataRaw is HostSpecificTemplateData hostData)
                 {
                     return !hostData.IsHidden;
@@ -101,7 +101,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                 Dictionary<string, HostSpecificTemplateData> hostSpecificData = new Dictionary<string, HostSpecificTemplateData>();
                 foreach (var templateData in templatePackageSearchData.Templates)
                 {
-                    if (templateData.AdditionalData.TryGetValue(CliTemplateSearchCoordinatorFactory.CliHostDataName, out object? hostDataRaw)
+                    if (templateData.AdditionalData.TryGetValue(CliHostSearchCacheData.DataName, out object? hostDataRaw)
                         && hostDataRaw is HostSpecificTemplateData hostData)
                     {
                         hostSpecificData[((ITemplateInfo)templateData).Identity] = hostData;

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinatorFactory.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinatorFactory.cs
@@ -11,51 +11,12 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
 {
     internal static class CliTemplateSearchCoordinatorFactory
     {
-        internal const string CliHostDataName = "cliHostData";
-        private static readonly string[] _hostDataPropertyNames = new[] { "isHidden,", "SymbolInfo", "UsageExamples" };
-
-        private static readonly Func<object, object> CliHostDataReader = (obj) =>
-        {
-            JObject? cacheObject = obj as JObject;
-            if (cacheObject == null)
-            {
-                return HostSpecificTemplateData.Default;
-            }
-            try
-            {
-                if (_hostDataPropertyNames.Contains(cacheObject.Properties().First().Name, StringComparer.OrdinalIgnoreCase))
-                {
-                    return new HostSpecificTemplateData(cacheObject);
-                }
-
-                //fallback to old behavior
-                Dictionary<string, HostSpecificTemplateData> cliData = new Dictionary<string, HostSpecificTemplateData>();
-                foreach (JProperty data in cacheObject.Properties())
-                {
-                    try
-                    {
-                        cliData[data.Name] = new HostSpecificTemplateData(data.Value as JObject);
-                    }
-                    catch (Exception ex)
-                    {
-                        Reporter.Verbose.WriteLine($"Error deserializing the cli host specific template data for template {data.Name}, details:{ex}");
-                    }
-                }
-                return cliData;
-            }
-            catch (Exception ex)
-            {
-                Reporter.Verbose.WriteLine($"Error deserializing the cli host specific template data {cacheObject}, details:{ex}");
-            }
-            return HostSpecificTemplateData.Default;
-        };
-
         internal static TemplateSearchCoordinator CreateCliTemplateSearchCoordinator(
             IEngineEnvironmentSettings environmentSettings)
         {
             Dictionary<string, Func<object, object>> dataReaders = new Dictionary<string, Func<object, object>>()
             {
-                { CliHostDataName, CliHostDataReader }
+                { CliHostSearchCacheData.DataName, CliHostSearchCacheData.Reader }
             };
 
             return new TemplateSearchCoordinator(environmentSettings, dataReaders);

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NuGetPackSourceCheckerFactory.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NuGetPackSourceCheckerFactory.cs
@@ -3,6 +3,7 @@
 
 using System.Net;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.TemplateEngine.Cli.TemplateSearch;
 using Microsoft.TemplateSearch.Common;
 using Microsoft.TemplateSearch.TemplateDiscovery.AdditionalData;
 using Microsoft.TemplateSearch.TemplateDiscovery.Filters;
@@ -96,7 +97,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
             using (var textReader = new StreamReader(fileStream, System.Text.Encoding.UTF8, true))
             using (var jsonReader = new JsonTextReader(textReader))
             {
-                return TemplateSearchCache.FromJObject(JObject.Load(jsonReader), NullLogger.Instance, null);
+                return TemplateSearchCache.FromJObject(JObject.Load(jsonReader), NullLogger.Instance, new Dictionary<string, Func<object, object>>() { { CliHostSearchCacheData.DataName, CliHostSearchCacheData.Reader } });
             }
         }
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/TestProvider/TestPackCheckerFactory.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/TestProvider/TestPackCheckerFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.TemplateEngine.Cli.TemplateSearch;
 using Microsoft.TemplateSearch.Common;
 using Microsoft.TemplateSearch.TemplateDiscovery.AdditionalData;
 using Microsoft.TemplateSearch.TemplateDiscovery.Filters;
@@ -69,7 +70,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
             using (var textReader = new StreamReader(fileStream, System.Text.Encoding.UTF8, true))
             using (var jsonReader = new JsonTextReader(textReader))
             {
-                return TemplateSearchCache.FromJObject(JObject.Load(jsonReader), NullLogger.Instance, null);
+                return TemplateSearchCache.FromJObject(JObject.Load(jsonReader), NullLogger.Instance, new Dictionary<string, Func<object, object>>() { { CliHostSearchCacheData.DataName, CliHostSearchCacheData.Reader } });
             }
         }
     }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCoordinatorTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCoordinatorTests.cs
@@ -467,7 +467,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
                     { _fooTwoTemplate.Identity, fooTemplateHostData }
                 };
 
-                additionalData[CliTemplateSearchCoordinatorFactory.CliHostDataName] = cliHostData;
+                additionalData[CliHostSearchCacheData.DataName] = cliHostData;
             }
 
             TemplateDiscoveryMetadata discoveryMetadata = new TemplateDiscoveryMetadata(version, templateCache, packToTemplateMap, additionalData);
@@ -494,7 +494,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
 
             Dictionary<string, object> additionalData = new Dictionary<string, object>()
             {
-                { CliTemplateSearchCoordinatorFactory.CliHostDataName, fooTemplateHostData }
+                { CliHostSearchCacheData.DataName, fooTemplateHostData }
             };
             List<ITemplateInfo> templateCache = new List<ITemplateInfo>();
 


### PR DESCRIPTION
### Problem
CLI host data is empty in current cache (v1 and v2)
Reason: in diff mode, CLI host data was not read and therefore not added to new version of cache if the package was not changed.

### Solution
Added CLI host data reader when reading existing cache

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)