### PR TITLE
fixes dotnet/templating#3999 removes dependency to Microsoft.CSharp

### DIFF
--- a/src/Microsoft.TemplateSearch.Common/Microsoft.TemplateSearch.Common.csproj
+++ b/src/Microsoft.TemplateSearch.Common/Microsoft.TemplateSearch.Common.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/LegacySearchCacheReader.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/LegacySearchCacheReader.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -34,16 +35,10 @@ namespace Microsoft.TemplateSearch.Common
                         {
                             if (discoveryMetadata.AdditionalData.TryGetValue(reader.Key, out object? legacyData))
                             {
-                                Type legacyDataType = legacyData.GetType();
-                                if (legacyDataType.IsGenericType
-                                    && legacyDataType.GetGenericTypeDefinition() == typeof(Dictionary<,>)
-                                    && legacyDataType.GetGenericArguments()[0] == typeof(string))
+                                IDictionary? dict = legacyData as IDictionary;
+                                if (dict?.Contains(template.Identity) ?? false)
                                 {
-                                    dynamic dict = Convert.ChangeType(legacyData, legacyDataType);
-                                    if (dict.ContainsKey(template.Identity))
-                                    {
-                                        data[reader.Key] = dict[template.Identity];
-                                    }
+                                    data[reader.Key] = dict[template.Identity];
                                 }
                             }
                         }


### PR DESCRIPTION
https://github.com/dotnet/templating/pull/4009 to 6.0.2xx