### PR TITLE
[system-command-line] implements uninstall subcommand

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CommandParsing/BaseCommandInput.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CommandParsing/BaseCommandInput.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.TemplateEngine.Cli.Commands;
 
 namespace Microsoft.TemplateEngine.Cli.CommandParsing
 {
@@ -263,7 +264,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                 else
                 {
                     Reporter.Error.WriteLine(LocalizableStrings.RunHelpForInformationAboutAcceptedParameters);
-                    Reporter.Error.WriteCommand(this.HelpCommandExample());
+                    Reporter.Error.WriteCommand(CommandExamples.HelpCommandExample(this.CommandName));
                 }
             }
             return !hasError;

--- a/src/Microsoft.TemplateEngine.Cli/Commands/CommandExamples.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/CommandExamples.cs
@@ -3,20 +3,22 @@
 
 #nullable enable
 
-namespace Microsoft.TemplateEngine.Cli.CommandParsing
+namespace Microsoft.TemplateEngine.Cli.Commands
 {
+    //TODO: consider refactoring based on command definition
+
     /// <summary>
     /// Use these extensions to get examples of dotnet new commands.
     /// </summary>
-    internal static class INewCommandInputExtensions
+    internal static class CommandExamples
     {
-        internal static string InstallCommandExample(this INewCommandInput command, bool withVersion = false,  string packageID = "", string version = "")
+        internal static string InstallCommandExample(string commandName, bool withVersion = false,  string packageID = "", string version = "")
         {
             if (string.IsNullOrWhiteSpace(packageID))
             {
                 return withVersion
-                    ? $"dotnet {command.CommandName} --install <PACKAGE_ID>::<VERSION>"
-                    : $"dotnet {command.CommandName} --install <PACKAGE_ID>";
+                    ? $"dotnet {commandName} --install <PACKAGE_ID>::<VERSION>"
+                    : $"dotnet {commandName} --install <PACKAGE_ID>";
             }
 
             if (string.IsNullOrWhiteSpace(version))
@@ -25,7 +27,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                 {
                     packageID = $"'{packageID}'";
                 }
-                return $"dotnet {command.CommandName} --install {packageID}";
+                return $"dotnet {commandName} --install {packageID}";
             }
             else
             {
@@ -34,21 +36,21 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
                 {
                     packageAndVersion = $"'{packageAndVersion}'";
                 }
-                return $"dotnet {command.CommandName} --install {packageAndVersion}";
+                return $"dotnet {commandName} --install {packageAndVersion}";
             }
         }
 
-        internal static string UpdateApplyCommandExample(this INewCommandInput command)
+        internal static string UpdateApplyCommandExample(string commandName)
         {
-            return $"dotnet {command.CommandName} --update-apply";
+            return $"dotnet {commandName} --update-apply";
         }
 
-        internal static string ListCommandExample(this INewCommandInput command)
+        internal static string ListCommandExample(string commandName)
         {
-            return $"dotnet {command.CommandName} --list";
+            return $"dotnet {commandName} --list";
         }
 
-        internal static string SearchCommandExample(this INewCommandInput command, string? templateName = null, IEnumerable<string>? additionalArgs = null, bool usePlaceholder = false)
+        internal static string SearchCommandExample(string commandName, string? templateName = null, IEnumerable<string>? additionalArgs = null, bool usePlaceholder = false)
         {
             if (usePlaceholder)
             {
@@ -58,7 +60,7 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             {
                 throw new ArgumentException($"{nameof(templateName)} should not be empty when {nameof(usePlaceholder)} is false and no additional arguments is given.", nameof(templateName));
             }
-            string commandStr = $"dotnet {command.CommandName}";
+            string commandStr = $"dotnet {commandName}";
             if (!string.IsNullOrWhiteSpace(templateName))
             {
                 if (templateName?.Any(char.IsWhiteSpace) ?? false)
@@ -76,45 +78,45 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             return commandStr;
         }
 
-        internal static string UninstallCommandExample(this INewCommandInput command, string packageId = "", bool noArgs = false)
+        internal static string UninstallCommandExample(string commandName, string packageId = "", bool noArgs = false)
         {
             if (noArgs)
             {
-                return $"dotnet {command.CommandName} --uninstall";
+                return $"dotnet {commandName} --uninstall";
             }
 
             if (string.IsNullOrWhiteSpace(packageId))
             {
-                return $"dotnet {command.CommandName} --uninstall <PACKAGE_ID>";
+                return $"dotnet {commandName} --uninstall <PACKAGE_ID>";
             }
 
             if (packageId.Any(char.IsWhiteSpace))
             {
                 packageId = $"'{packageId}'";
             }
-            return $"dotnet {command.CommandName} --uninstall {packageId}";
+            return $"dotnet {commandName} --uninstall {packageId}";
         }
 
-        internal static string InstantiateTemplateExample (this INewCommandInput command, string templateName)
+        internal static string InstantiateTemplateExample (string commandName, string templateName)
         {
             if (templateName.Any(char.IsWhiteSpace))
             {
                 templateName = $"'{templateName}'";
             }
-            return $"dotnet {command.CommandName} {templateName}";
+            return $"dotnet {commandName} {templateName}";
         }
 
-        internal static string HelpCommandExample(this INewCommandInput command, string? templateName = null, string? language = null)
+        internal static string HelpCommandExample(string commandName, string? templateName = null, string? language = null)
         {
             if (string.IsNullOrWhiteSpace(templateName))
             {
-                return $"dotnet {command.CommandName} -h";
+                return $"dotnet {commandName} -h";
             }
             if (templateName.Any(char.IsWhiteSpace))
             {
                 templateName = $"'{templateName}'";
             }
-            string commandStr = $"dotnet {command.CommandName} {templateName} -h";
+            string commandStr = $"dotnet {commandName} {templateName} -h";
             if (!string.IsNullOrWhiteSpace(language))
             {
                 commandStr += $" --language {language}";
@@ -122,9 +124,9 @@ namespace Microsoft.TemplateEngine.Cli.CommandParsing
             return commandStr;
         }
 
-        internal static string New3CommandExample(this INewCommandInput command)
+        internal static string New3CommandExample(string commandName)
         {
-            return $"dotnet {command.CommandName}";
+            return $"dotnet {commandName}";
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/GlobalArgs.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/GlobalArgs.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             DebugRebuildCache = parseResult.GetValueForOption(command.DebugRebuildCacheOption);
             DebugShowConfig = parseResult.GetValueForOption(command.DebugShowConfigOption);
             //TODO: check if it gets the command name correctly.
-            CommandName = parseResult.CommandResult.Command.Name;
+            CommandName = GetNewCommandName(parseResult);
             ParseResult = parseResult;
         }
 
@@ -37,5 +37,16 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         internal bool DebugShowConfig { get; private set; }
 
         internal string? DebugCustomSettingsLocation { get; private set; }
+
+        private string GetNewCommandName(ParseResult parseResult)
+        {
+            var command = parseResult.CommandResult.Command;
+
+            while (command != null && command is not NewCommand)
+            {
+                command = (parseResult.CommandResult.Parent as CommandResult)?.Command;
+            }
+            return command?.Name ?? string.Empty;
+        }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/InstallCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/InstallCommand.cs
@@ -92,8 +92,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 TelemetryLogger,
                 environmentSettings,
                 templatePackageManager,
-                templateInformationCoordinator,
-                environmentSettings.GetDefaultLanguage());
+                templateInformationCoordinator);
 
             //TODO: we need to await, otherwise templatePackageManager will be disposed.
             return await templatePackageCoordinator.EnterInstallFlowAsync(args, context.GetCancellationToken()).ConfigureAwait(false);

--- a/src/Microsoft.TemplateEngine.Cli/Commands/NewCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/NewCommand.cs
@@ -30,9 +30,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             LegacyInstallCommand legacyInstall = new LegacyInstallCommand(this, host, telemetryLogger, callbacks);
             this.Add(legacyInstall);
             this.Add(new InstallCommand(legacyInstall, host, telemetryLogger, callbacks));
+            this.Add(new LegacyUninstallCommand(host, telemetryLogger, callbacks));
+            this.Add(new UninstallCommand(host, telemetryLogger, callbacks));
+
             //yield return (host, telemetryLogger, callbacks) => new ListCommand(host, telemetryLogger, callbacks);
             //yield return (host, telemetryLogger, callbacks) => new SearchCommand(host, telemetryLogger, callbacks);
-            //yield return (host, telemetryLogger, callbacks) => new UninstallCommand(host, telemetryLogger, callbacks);
             //yield return (host, telemetryLogger, callbacks) => new UpdateCommand(host, telemetryLogger, callbacks);
             //yield return (host, telemetryLogger, callbacks) => new AliasCommand(host, telemetryLogger, callbacks);
         }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/UninstallCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/UninstallCommand.cs
@@ -3,25 +3,87 @@
 
 #nullable enable
 
+using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Cli.Extensions;
+using Microsoft.TemplateEngine.Cli.HelpAndUsage;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.Edge.Template;
 
 namespace Microsoft.TemplateEngine.Cli.Commands
 {
-    internal class UninstallCommand : BaseCommand<UninstallCommandArgs>
+    internal class UninstallCommand : BaseUninstallCommand
     {
-        internal UninstallCommand(ITemplateEngineHost host, ITelemetryLogger logger, NewCommandCallbacks callbacks) : base(host, logger, callbacks, "uninstall") { }
+        public UninstallCommand(ITemplateEngineHost host, ITelemetryLogger logger, NewCommandCallbacks callbacks)
+            : base(host, logger, callbacks, "uninstall")
+        {
+        }
+    }
 
-        protected override Task<NewCommandStatus> ExecuteAsync(UninstallCommandArgs args, IEngineEnvironmentSettings environmentSettings, InvocationContext context) => throw new NotImplementedException();
+    internal class LegacyUninstallCommand : BaseUninstallCommand
+    {
+        public LegacyUninstallCommand(ITemplateEngineHost host, ITelemetryLogger logger, NewCommandCallbacks callbacks)
+            : base(host, logger, callbacks, "--uninstall")
+        {
+            this.IsHidden = true;
+            this.AddAlias("-u");
+        }
+    }
 
-        protected override UninstallCommandArgs ParseContext(ParseResult parseResult) => throw new NotImplementedException();
+    internal class BaseUninstallCommand : BaseCommand<UninstallCommandArgs>
+    {
+        internal BaseUninstallCommand(ITemplateEngineHost host, ITelemetryLogger logger, NewCommandCallbacks callbacks, string commandName) : base(host, logger, callbacks, commandName)
+        {
+            this.AddArgument(NameArgument);
+        }
+
+        internal Argument<IReadOnlyList<string>> NameArgument { get; } = new("name")
+        {
+            Description = "Name of NuGet package or folder to uninstall",
+            Arity = new ArgumentArity(0, 99)
+        };
+
+        protected override async Task<NewCommandStatus> ExecuteAsync(UninstallCommandArgs args, IEngineEnvironmentSettings environmentSettings, InvocationContext context)
+        {
+            using TemplatePackageManager templatePackageManager = new TemplatePackageManager(environmentSettings);
+            TemplateInformationCoordinator templateInformationCoordinator = new TemplateInformationCoordinator(
+                environmentSettings,
+                templatePackageManager,
+                new TemplateCreator(environmentSettings),
+                new HostSpecificDataLoader(environmentSettings),
+                TelemetryLogger,
+                environmentSettings.GetDefaultLanguage());
+
+            TemplatePackageCoordinator templatePackageCoordinator = new TemplatePackageCoordinator(
+                TelemetryLogger,
+                environmentSettings,
+                templatePackageManager,
+                templateInformationCoordinator);
+
+            return await templatePackageCoordinator.EnterUninstallFlowAsync(args, context.GetCancellationToken()).ConfigureAwait(false);
+        }
+
+        protected override UninstallCommandArgs ParseContext(ParseResult parseResult)
+        {
+            return new UninstallCommandArgs(this, parseResult);
+        }
     }
 
     internal class UninstallCommandArgs : GlobalArgs
     {
-        public UninstallCommandArgs(UninstallCommand uninstallCommand, ParseResult parseResult) : base(uninstallCommand, parseResult)
+        public UninstallCommandArgs(BaseUninstallCommand uninstallCommand, ParseResult parseResult) : base(uninstallCommand, parseResult)
         {
+            TemplatePackages = parseResult.GetValueForArgument(uninstallCommand.NameArgument) ?? Array.Empty<string>();
+
+            //workaround for --install source1 --install source2 case
+            if (uninstallCommand is LegacyUninstallCommand && uninstallCommand.Aliases.Any(alias => TemplatePackages.Contains(alias)))
+            {
+                TemplatePackages = TemplatePackages.Where(package => !uninstallCommand.Aliases.Contains(package)).ToList();
+            }
         }
+
+        public IReadOnlyList<string> TemplatePackages { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/HelpAndUsage/TemplateInformationCoordinator.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Cli.Commands;
 using Microsoft.TemplateEngine.Cli.TabularOutput;
 using Microsoft.TemplateEngine.Cli.TemplateResolution;
 using Microsoft.TemplateEngine.Edge.Settings;
@@ -67,10 +68,10 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                     Reporter.Error.WriteLine();
 
                     Reporter.Error.WriteLine(LocalizableStrings.ListTemplatesCommand);
-                    Reporter.Error.WriteCommand(commandInput.ListCommandExample());
+                    Reporter.Error.WriteCommand(CommandExamples.ListCommandExample(commandInput.CommandName));
 
                     Reporter.Error.WriteLine(LocalizableStrings.SearchTemplatesCommand);
-                    Reporter.Error.WriteCommand(commandInput.SearchCommandExample(commandInput.TemplateName));
+                    Reporter.Error.WriteCommand(CommandExamples.SearchCommandExample(commandInput.CommandName, commandInput.TemplateName));
                     Reporter.Error.WriteLine();
                     return Task.FromResult(NewCommandStatus.NotFound);
                 case TemplateResolutionResult.Status.AmbiguousLanguageChoice:
@@ -267,11 +268,11 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 Reporter.Error.WriteLine(LocalizableStrings.SearchTemplatesCommand);
                 if (string.IsNullOrWhiteSpace(commandInput.TemplateName))
                 {
-                    Reporter.Error.WriteCommand(commandInput.SearchCommandExample(usePlaceholder: true));
+                    Reporter.Error.WriteCommand(CommandExamples.SearchCommandExample(commandInput.CommandName, usePlaceholder: true));
                 }
                 else
                 {
-                    Reporter.Error.WriteCommand(commandInput.SearchCommandExample(commandInput.TemplateName));
+                    Reporter.Error.WriteCommand(CommandExamples.SearchCommandExample(commandInput.CommandName, commandInput.TemplateName));
                 }
                 Reporter.Error.WriteLine();
                 return NewCommandStatus.NotFound;
@@ -292,26 +293,26 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
 
             Reporter.Output.WriteLine(string.Format(
                 LocalizableStrings.TemplateInformationCoordinator_DotnetNew_Description,
-                commandInput.New3CommandExample()));
+                CommandExamples.New3CommandExample(commandInput.CommandName)));
             Reporter.Output.WriteLine();
 
             Reporter.Output.WriteLine(string.Format(
               LocalizableStrings.TemplateInformationCoordinator_DotnetNew_TemplatesHeader,
-              commandInput.New3CommandExample()));
+              CommandExamples.New3CommandExample(commandInput.CommandName)));
             DisplayTemplateList(curatedTemplates, _defaultTabularOutputSettings);
 
             Reporter.Output.WriteLine(LocalizableStrings.TemplateInformationCoordinator_DotnetNew_ExampleHeader);
-            Reporter.Output.WriteCommand(commandInput.InstantiateTemplateExample("console"));
+            Reporter.Output.WriteCommand(CommandExamples.InstantiateTemplateExample(commandInput.CommandName, "console"));
             Reporter.Output.WriteLine();
 
             Reporter.Output.WriteLine(LocalizableStrings.TemplateInformationCoordinator_DotnetNew_DisplayOptionsHint);
-            Reporter.Output.WriteCommand(commandInput.HelpCommandExample("console"));
+            Reporter.Output.WriteCommand(CommandExamples.HelpCommandExample(commandInput.CommandName, "console"));
 
             Reporter.Output.WriteLine(LocalizableStrings.TemplateInformationCoordinator_DotnetNew_ListTemplatesHint);
-            Reporter.Output.WriteCommand(commandInput.ListCommandExample());
+            Reporter.Output.WriteCommand(CommandExamples.ListCommandExample(commandInput.CommandName));
 
             Reporter.Output.WriteLine(LocalizableStrings.TemplateInformationCoordinator_DotnetNew_SearchTemplatesHint);
-            Reporter.Output.WriteCommand(commandInput.SearchCommandExample("web"));
+            Reporter.Output.WriteCommand(CommandExamples.SearchCommandExample(commandInput.CommandName, "web"));
 
             Reporter.Output.WriteLine();
 
@@ -338,7 +339,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
             if (templateGroupMatchInfo.GroupInfo.ShortNames.Any())
             {
                 Reporter.Error.WriteLine(LocalizableStrings.InvalidParameterTemplateHint);
-                Reporter.Error.WriteCommand(commandInput.HelpCommandExample(templateGroupMatchInfo.GroupInfo.ShortNames[0]));
+                Reporter.Error.WriteCommand(CommandExamples.HelpCommandExample(commandInput.CommandName, templateGroupMatchInfo.GroupInfo.ShortNames[0]));
             }
             return NewCommandStatus.InvalidParamValues;
         }
@@ -376,7 +377,7 @@ namespace Microsoft.TemplateEngine.Cli.HelpAndUsage
                 string supportedLanguagesStr = string.Join(", ", supportedLanguages.OrderBy(s => s, StringComparer.OrdinalIgnoreCase));
                 Reporter.Output.WriteLine(string.Format(LocalizableStrings.TemplateInformationCoordinator_TemplateHelp_Info_HelpForOtherLanguagesHint, supportedLanguagesStr));
                 Reporter.Output.WriteCommand(
-                    commandInput.HelpCommandExample(resolutionResult.UnambiguousTemplateGroup.ShortNames[0], supportedLanguages.First()));
+                    CommandExamples.HelpCommandExample(commandInput.CommandName, resolutionResult.UnambiguousTemplateGroup.ShortNames[0], supportedLanguages.First()));
                 Reporter.Output.WriteLine();
             }
         }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -6,6 +6,7 @@
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 using Microsoft.TemplateEngine.Cli.CommandParsing;
+using Microsoft.TemplateEngine.Cli.Commands;
 using Microsoft.TemplateEngine.Cli.HelpAndUsage;
 using Microsoft.TemplateEngine.Cli.TabularOutput;
 using Microsoft.TemplateEngine.Edge.Settings;
@@ -95,9 +96,9 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
             {
                 string packageIdToShow = EvaluatePackageToShow(searchResults);
                 Reporter.Output.WriteLine(string.Format(LocalizableStrings.CliTemplateSearchCoordinator_Info_InstallHelp, commandInput.CommandName));
-                Reporter.Output.WriteCommand(commandInput.InstallCommandExample());
+                Reporter.Output.WriteCommand(CommandExamples.InstallCommandExample(commandInput.CommandName));
                 Reporter.Output.WriteLine(LocalizableStrings.Generic_ExampleHeader);
-                Reporter.Output.WriteCommand(commandInput.InstallCommandExample(packageID: packageIdToShow));
+                Reporter.Output.WriteCommand(CommandExamples.InstallCommandExample(commandInput.CommandName, packageID: packageIdToShow));
                 return NewCommandStatus.Success;
             }
             return NewCommandStatus.NotFound;
@@ -181,9 +182,9 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
                 Reporter.Error.WriteLine(LocalizableStrings.CliTemplateSearchCoordinator_Error_NoTemplateName.Red().Bold());
                 Reporter.Error.WriteLine(string.Format(LocalizableStrings.CliTemplateSearchCoordinator_Info_SearchHelp, string.Join(", ", SupportedFilters.Select(f => $"'{f.Name}'"))));
                 Reporter.Error.WriteLine(LocalizableStrings.Generic_ExamplesHeader);
-                Reporter.Error.WriteCommand(commandInput.SearchCommandExample(usePlaceholder: true));
-                Reporter.Error.WriteCommand(commandInput.SearchCommandExample(additionalArgs: new[] { "--author", "Microsoft" }));
-                Reporter.Error.WriteCommand(commandInput.SearchCommandExample(usePlaceholder: true, additionalArgs: new[] { "--author", "Microsoft" }));
+                Reporter.Error.WriteCommand(CommandExamples.SearchCommandExample(commandInput.CommandName, usePlaceholder: true));
+                Reporter.Error.WriteCommand(CommandExamples.SearchCommandExample(commandInput.CommandName, additionalArgs: new[] { "--author", "Microsoft" }));
+                Reporter.Error.WriteCommand(CommandExamples.SearchCommandExample(commandInput.CommandName, usePlaceholder: true, additionalArgs: new[] { "--author", "Microsoft" }));
                 return false;
             }
 

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/UninstallTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/UninstallTests.cs
@@ -1,0 +1,66 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Cli.Commands;
+using Microsoft.TemplateEngine.TestHelper;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
+{
+    public class UninstallTests
+    {
+        [Theory]
+        [InlineData("--uninstall")]
+        [InlineData("-u")]
+        [InlineData("uninstall")]
+        public void Uninstall_NoArguments(string commandName)
+        {
+            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(includeTestTemplates: false));
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", host, new TelemetryLogger(null, false), new NewCommandCallbacks());
+
+            var parseResult = myCommand.Parse($"new {commandName}");
+            UninstallCommandArgs args = new UninstallCommandArgs((BaseUninstallCommand)parseResult.CommandResult.Command, parseResult);
+
+            Assert.Empty(parseResult.Errors);
+            Assert.Empty(args.TemplatePackages);
+        }
+
+        [Theory]
+        [InlineData("--uninstall")]
+        [InlineData("-u")]
+        [InlineData("uninstall")]
+        public void Uninstall_WithArgument(string commandName)
+        {
+            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(includeTestTemplates: false));
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", host, new TelemetryLogger(null, false), new NewCommandCallbacks());
+
+            var parseResult = myCommand.Parse($"new {commandName} source");
+            UninstallCommandArgs args = new UninstallCommandArgs((BaseUninstallCommand)parseResult.CommandResult.Command, parseResult);
+
+            Assert.Empty(parseResult.Errors);
+            Assert.Single(args.TemplatePackages);
+            Assert.Contains("source", args.TemplatePackages);
+        }
+
+        [Theory]
+        [InlineData("new --uninstall source1 --uninstall source2")]
+        [InlineData("new --uninstall source1 -u source2")]
+        [InlineData("new uninstall source1 source2")]
+        public void Uninstall_WithMultipleArgument(string command)
+        {
+            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(includeTestTemplates: false));
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", host, new TelemetryLogger(null, false), new NewCommandCallbacks());
+
+            var parseResult = myCommand.Parse(command);
+            UninstallCommandArgs args = new UninstallCommandArgs((BaseUninstallCommand)parseResult.CommandResult.Command, parseResult);
+
+            Assert.Empty(parseResult.Errors);
+            Assert.Equal(2, args.TemplatePackages.Count);
+            Assert.Contains("source1", args.TemplatePackages);
+            Assert.Contains("source2", args.TemplatePackages);
+        }
+
+    }
+}

--- a/test/dotnet-new3.UnitTests/DotnetNewUninstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUninstall.cs
@@ -21,14 +21,17 @@ namespace Dotnet_new3.IntegrationTests
             _log = log;
         }
 
-        [Fact]
-        public void CanListInstalledSources_Folder()
+        [Theory]
+        [InlineData("-u")]
+        [InlineData("--uninstall")]
+        [InlineData("uninstall")]
+        public void CanListInstalledSources_Folder(string commandName)
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
             string workingDirectory = TestUtils.CreateTemporaryFolder();
             string testTemplate = Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicFSharp", _log, workingDirectory, home);
 
-            new DotnetNewCommand(_log, "-u")
+            new DotnetNewCommand(_log, commandName)
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -40,8 +43,11 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining($"         dotnet new3 --uninstall {testTemplate}");
         }
 
-        [Fact]
-        public void CanListInstalledSources_NuGet()
+        [Theory]
+        [InlineData("-u")]
+        [InlineData("--uninstall")]
+        [InlineData("uninstall")]
+        public void CanListInstalledSources_NuGet(string commandName)
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0")
@@ -56,7 +62,7 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining("web")
                 .And.HaveStdOutContaining("blazorwasm");
 
-            new DotnetNewCommand(_log, "-u")
+            new DotnetNewCommand(_log, commandName)
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -71,11 +77,13 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining("         dotnet new3 --uninstall Microsoft.DotNet.Web.ProjectTemplates.5.0");
         }
 
-        [Fact]
-        public void CanListInstalledSources_WhenNothingIsInstalled()
+        [Theory]
+        [InlineData("-u")]
+        [InlineData("uninstall")]
+        public void CanListInstalledSources_WhenNothingIsInstalled(string commandName)
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
-            new DotnetNewCommand(_log, "-u")
+            new DotnetNewCommand(_log, commandName)
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -86,14 +94,17 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOut($"Currently installed items:{Environment.NewLine}(No Items)");
         }
 
-        [Fact]
-        public void CanUninstall_Folder()
+        [Theory]
+        [InlineData("-u")]
+        [InlineData("uninstall")]
+        [InlineData("--uninstall")]
+        public void CanUninstall_Folder(string commandName)
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
             string workingDirectory = TestUtils.CreateTemporaryFolder();
             string templateLocation = Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicFSharp", _log, workingDirectory, home);
 
-            new DotnetNewCommand(_log, "-u")
+            new DotnetNewCommand(_log, commandName)
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -104,7 +115,7 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining($"TemplateResolution{Path.DirectorySeparatorChar}DifferentLanguagesGroup{Path.DirectorySeparatorChar}BasicFSharp")
                 .And.HaveStdOutMatching($"^\\s*dotnet new3 --uninstall .*TemplateResolution{Regex.Escape(Path.DirectorySeparatorChar.ToString())}DifferentLanguagesGroup{Regex.Escape(Path.DirectorySeparatorChar.ToString())}BasicFSharp$", RegexOptions.Multiline);
 
-            new DotnetNewCommand(_log, "-u", templateLocation)
+            new DotnetNewCommand(_log, commandName, templateLocation)
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -114,7 +125,7 @@ namespace Dotnet_new3.IntegrationTests
                 .NotHaveStdErr()
                 .And.HaveStdOut($"Success: {templateLocation} was uninstalled.");
 
-            new DotnetNewCommand(_log, "-u")
+            new DotnetNewCommand(_log, commandName)
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -127,8 +138,11 @@ namespace Dotnet_new3.IntegrationTests
             Assert.True(Directory.Exists(templateLocation));
         }
 
-        [Fact]
-        public void CanUninstall_NuGet()
+        [Theory]
+        [InlineData("-u")]
+        [InlineData("uninstall")]
+        [InlineData("--uninstall")]
+        public void CanUninstall_NuGet(string commandName)
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0")
@@ -143,7 +157,7 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining("web")
                 .And.HaveStdOutContaining("blazorwasm");
 
-            new DotnetNewCommand(_log, "-u")
+            new DotnetNewCommand(_log, commandName)
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -158,7 +172,7 @@ namespace Dotnet_new3.IntegrationTests
 
             Assert.True(File.Exists(Path.Combine(home, "packages", "Microsoft.DotNet.Web.ProjectTemplates.5.0.5.0.0.nupkg")));
 
-            new DotnetNewCommand(_log, "-u", "Microsoft.DotNet.Web.ProjectTemplates.5.0")
+            new DotnetNewCommand(_log, commandName, "Microsoft.DotNet.Web.ProjectTemplates.5.0")
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -168,7 +182,7 @@ namespace Dotnet_new3.IntegrationTests
                 .NotHaveStdErr()
                 .And.HaveStdOut($"Success: Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0 was uninstalled.");
 
-            new DotnetNewCommand(_log, "-u")
+            new DotnetNewCommand(_log, commandName)
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -182,7 +196,7 @@ namespace Dotnet_new3.IntegrationTests
         }
 
         [Fact]
-        public void CanUninstallSeveralSources()
+        public void CanUninstallSeveralSources_LegacySyntax()
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -228,10 +242,58 @@ namespace Dotnet_new3.IntegrationTests
         }
 
         [Fact]
-        public void CannotUninstallUnknownPackage()
+        public void CanUninstallSeveralSources()
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
-            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0")
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+            string basicFSharp = Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicFSharp", _log, workingDirectory, home);
+            string basicVB = Helpers.InstallTestTemplate("TemplateResolution/DifferentLanguagesGroup/BasicVB", _log, workingDirectory, home);
+
+            new DotnetNewCommand(_log, "install", "Microsoft.DotNet.Web.ProjectTemplates.5.0", "Microsoft.DotNet.Common.ProjectTemplates.5.0")
+                .WithCustomHive(home).WithDebug()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And
+                .NotHaveStdErr()
+                .And.HaveStdOutContaining("web")
+                .And.HaveStdOutContaining("blazorwasm")
+                .And.HaveStdOutContaining("console")
+                .And.HaveStdOutContaining("classlib");
+
+            new DotnetNewCommand(_log, "uninstall", "Microsoft.DotNet.Common.ProjectTemplates.5.0", basicFSharp)
+                .WithCustomHive(home)
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And
+                .NotHaveStdErr()
+                .And.HaveStdOutMatching($"^Success: Microsoft\\.DotNet\\.Common\\.ProjectTemplates\\.5\\.0::([\\d\\.a-z-])+ was uninstalled\\.\\s*$", RegexOptions.Multiline)
+                .And.HaveStdOutContaining($"Success: {basicFSharp} was uninstalled.");
+
+            new DotnetNewCommand(_log, "uninstall")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And
+                .NotHaveStdErr()
+                .And.HaveStdOutContaining("Microsoft.DotNet.Web.ProjectTemplates.5.0")
+                .And.HaveStdOutContaining(basicVB)
+                .And.NotHaveStdOutContaining("Microsoft.DotNet.Common.ProjectTemplates.5.0")
+                .And.NotHaveStdOutContaining(basicFSharp);
+        }
+
+        [Theory]
+        [InlineData("-u")]
+        [InlineData("uninstall")]
+        public void CannotUninstallUnknownPackage(string commandName)
+        {
+            var home = TestUtils.CreateTemporaryFolder("Home");
+            new DotnetNewCommand(_log, "install", "Microsoft.DotNet.Web.ProjectTemplates.5.0::5.0.0")
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -243,7 +305,7 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining("web")
                 .And.HaveStdOutContaining("blazorwasm");
 
-            new DotnetNewCommand(_log, "-u", "Microsoft.DotNet.Common.ProjectTemplates.5.0")
+            new DotnetNewCommand(_log, commandName, "Microsoft.DotNet.Common.ProjectTemplates.5.0")
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -253,11 +315,13 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdErrContaining("   dotnet new3 --uninstall");
         }
 
-        [Fact]
-        public void CannotUninstallByTemplateName()
+        [Theory]
+        [InlineData("-u")]
+        [InlineData("uninstall")]
+        public void CannotUninstallByTemplateName(string commandName)
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
-            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
+            new DotnetNewCommand(_log, "install", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -266,7 +330,7 @@ namespace Dotnet_new3.IntegrationTests
                 .And
                 .NotHaveStdErr();
 
-            new DotnetNewCommand(_log, "-u", "console")
+            new DotnetNewCommand(_log, commandName, "console")
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -279,11 +343,13 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdErrContaining("   dotnet new3 --uninstall Microsoft.DotNet.Common.ProjectTemplates.5.0");
         }
 
-        [Fact]
-        public void CannotUninstallByTemplateName_ShowsAllPackages()
+        [Theory]
+        [InlineData("-u")]
+        [InlineData("uninstall")]
+        public void CannotUninstallByTemplateName_ShowsAllPackages(string commandName)
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
-            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
+            new DotnetNewCommand(_log, "install", "Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0")
                 .WithCustomHive(home).WithoutBuiltInTemplates()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -292,7 +358,7 @@ namespace Dotnet_new3.IntegrationTests
                 .And
                 .NotHaveStdErr();
 
-            new DotnetNewCommand(_log, "-i", "Microsoft.DotNet.Common.ProjectTemplates.3.1::5.0.0")
+            new DotnetNewCommand(_log, "install", "Microsoft.DotNet.Common.ProjectTemplates.3.1::5.0.0")
                 .WithCustomHive(home).WithoutBuiltInTemplates()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -301,7 +367,7 @@ namespace Dotnet_new3.IntegrationTests
                 .And
                 .NotHaveStdErr();
 
-            new DotnetNewCommand(_log, "-u", "console")
+            new DotnetNewCommand(_log, commandName, "console")
                 .WithCustomHive(home).WithoutBuiltInTemplates()
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -314,15 +380,17 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdErrContaining("   dotnet new3 --uninstall Microsoft.DotNet.Common.ProjectTemplates.");
         }
 
-        [Fact]
-        public void CanExpandWhenUninstall()
+        [Theory]
+        [InlineData("-u")]
+        [InlineData("uninstall")]
+        public void CanExpandWhenUninstall(string commandName)
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             string testTemplateLocation = Path.Combine("..", "..", "..", "..", "..", "test", "Microsoft.TemplateEngine.TestTemplates", "test_templates");
             string testTemplateLocationAbsolute = Path.GetFullPath(testTemplateLocation);
             string pattern = testTemplateLocation + Path.DirectorySeparatorChar + "*";
 
-            new DotnetNewCommand(_log, "-i", pattern)
+            new DotnetNewCommand(_log, "install", pattern)
                 .WithCustomHive(home).WithoutBuiltInTemplates()
                 .Execute()
                 .Should().ExitWith(0)
@@ -337,7 +405,7 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining("basic")
                 .And.HaveStdOutContaining("TestAssets.ConfigurationKitchenSink");
 
-            new DotnetNewCommand(_log, "-u")
+            new DotnetNewCommand(_log, commandName)
                 .WithCustomHive(home).WithoutBuiltInTemplates()
                 .Execute()
                 .Should().ExitWith(0)
@@ -347,7 +415,7 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining(Path.Combine(testTemplateLocationAbsolute, "TemplateResolution"))
                 .And.HaveStdOutContaining(Path.Combine(testTemplateLocationAbsolute, "TemplateWithSourceName"));
 
-            new DotnetNewCommand(_log, "-u", pattern)
+            new DotnetNewCommand(_log, commandName, pattern)
                 .WithCustomHive(home).WithoutBuiltInTemplates()
                 .Execute()
                 .Should().ExitWith(0)
@@ -356,7 +424,7 @@ namespace Dotnet_new3.IntegrationTests
                 .And.HaveStdOutContaining(Path.Combine(testTemplateLocationAbsolute, "TemplateResolution"))
                 .And.HaveStdOutContaining(Path.Combine(testTemplateLocationAbsolute, "TemplateWithSourceName"));
 
-            new DotnetNewCommand(_log, "-u")
+            new DotnetNewCommand(_log, commandName)
                 .WithCustomHive(home).WithoutBuiltInTemplates()
                 .Execute()
                 .Should().ExitWith(0)


### PR DESCRIPTION
### Problem
fixes dotnet/templating#3806 

### Solution
Implements uninstall subcommand

`CommandExamples` refactoring is moved to separate task: https://github.com/dotnet/templating/issues/4034

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)