### PR TITLE
Fixed pool in search cache pipeline

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -16,7 +16,7 @@ parameters:
   default: true
 
 pool:
-    name: Hosted Ubuntu 1604
+    vmImage: ubuntu-20.04
 
 steps:
 - checkout: self


### PR DESCRIPTION
### Problem
Search cache pipeline is failing at the moment

### Solution
Switched pool to Ubuntu 18

### Checks:
- [ ] Added unit tests - NA
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - NA