### PR TITLE
added validators for legacy options\arguments used on dotnet new level

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
@@ -141,28 +141,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             return GetSuggestions(args, environmentSettings, textToMatch);
         }
 
-        protected static string? ValidateOptionUsageInParent(CommandResult commandResult, Option option)
-        {
-            OptionResult? optionResult = commandResult.Parent?.Children.FirstOrDefault(symbol => symbol.Symbol == option) as OptionResult;
-            if (optionResult != null)
-            {
-                //Invalid command syntax: option '{0}' should be used after '{1}'.
-                return string.Format(LocalizableStrings.Commands_Validator_WrongOptionPosition, optionResult.Token?.Value, commandResult.Symbol.Name);
-            }
-            return null;
-        }
-
-        protected static string? ValidateArgumentUsageInParent(CommandResult commandResult, Argument argument)
-        {
-            var newCommandArgument = commandResult.Parent?.Children.FirstOrDefault(symbol => symbol.Symbol == argument) as ArgumentResult;
-            if (newCommandArgument != null)
-            {
-                //Invalid command syntax: argument '{0}' should be used after '{1}'.
-                return string.Format(LocalizableStrings.Commands_Validator_WrongArgumentPosition, newCommandArgument.Tokens[0].Value, commandResult.Symbol.Name);
-            }
-            return null;
-        }
-
         protected virtual IEnumerable<string> GetSuggestions(TArgs args, IEngineEnvironmentSettings environmentSettings, string? textToMatch)
         {
             return base.GetSuggestions(args.ParseResult, textToMatch);

--- a/src/Microsoft.TemplateEngine.Cli/Commands/InstallCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/InstallCommand.cs
@@ -20,18 +20,19 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 NewCommandCallbacks callbacks)
             : base(parentCommand, host, logger, callbacks, "install")
         {
-            AddValidator(symbolResult => ValidateOptionUsageInParent(symbolResult, parentCommand.InteractiveOption));
-            AddValidator(symbolResult => ValidateOptionUsageInParent(symbolResult, parentCommand.AddSourceOption));
+            parentCommand.AddNoLegacyUsageValidators(this);
         }
     }
 
     internal class LegacyInstallCommand : BaseInstallCommand
     {
-        public LegacyInstallCommand(NewCommand newCommand, ITemplateEngineHost host, ITelemetryLogger logger, NewCommandCallbacks callbacks)
-            : base(newCommand, host, logger, callbacks, "--install")
+        public LegacyInstallCommand(NewCommand parentCommand, ITemplateEngineHost host, ITelemetryLogger logger, NewCommandCallbacks callbacks)
+            : base(parentCommand, host, logger, callbacks, "--install")
         {
             this.IsHidden = true;
             this.AddAlias("-i");
+
+            parentCommand.AddNoLegacyUsageValidators(this, except: new Option[] { InteractiveOption, AddSourceOption });
         }
 
         internal override Option<bool> InteractiveOption => ParentCommand.InteractiveOption;

--- a/src/Microsoft.TemplateEngine.Cli/Commands/UninstallCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/UninstallCommand.cs
@@ -13,19 +13,30 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 {
     internal class UninstallCommand : BaseUninstallCommand
     {
-        public UninstallCommand(ITemplateEngineHost host, ITelemetryLogger logger, NewCommandCallbacks callbacks)
+        public UninstallCommand(
+            NewCommand parentCommand,
+            ITemplateEngineHost host,
+            ITelemetryLogger logger,
+            NewCommandCallbacks callbacks)
             : base(host, logger, callbacks, "uninstall")
         {
+            parentCommand.AddNoLegacyUsageValidators(this);
         }
     }
 
     internal class LegacyUninstallCommand : BaseUninstallCommand
     {
-        public LegacyUninstallCommand(ITemplateEngineHost host, ITelemetryLogger logger, NewCommandCallbacks callbacks)
+        public LegacyUninstallCommand(
+            NewCommand parentCommand,
+            ITemplateEngineHost host,
+            ITelemetryLogger logger,
+            NewCommandCallbacks callbacks)
             : base(host, logger, callbacks, "--uninstall")
         {
             this.IsHidden = true;
             this.AddAlias("-u");
+
+            parentCommand.AddNoLegacyUsageValidators(this);
         }
     }
 

--- a/src/Microsoft.TemplateEngine.Cli/Commands/UpdateCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/UpdateCommand.cs
@@ -14,15 +14,13 @@ namespace Microsoft.TemplateEngine.Cli.Commands
     internal class UpdateCommand : BaseUpdateCommand
     {
         public UpdateCommand(
-                NewCommand newCommand,
+                NewCommand parentCommand,
                 ITemplateEngineHost host,
                 ITelemetryLogger logger,
                 NewCommandCallbacks callbacks)
-            : base(newCommand, host, logger, callbacks, "update")
+            : base(parentCommand, host, logger, callbacks, "update")
         {
-            AddValidator(symbolResult => ValidateOptionUsageInParent(symbolResult, newCommand.InteractiveOption));
-            AddValidator(symbolResult => ValidateOptionUsageInParent(symbolResult, newCommand.AddSourceOption));
-
+            parentCommand.AddNoLegacyUsageValidators(this);
             this.AddOption(CheckOnlyOption);
         }
 
@@ -34,10 +32,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
     internal class LegacyUpdateApplyCommand : BaseUpdateCommand
     {
-        public LegacyUpdateApplyCommand(NewCommand newCommand, ITemplateEngineHost host, ITelemetryLogger logger, NewCommandCallbacks callbacks)
-            : base(newCommand, host, logger, callbacks, "--update-apply")
+        public LegacyUpdateApplyCommand(
+            NewCommand parentCommand,
+            ITemplateEngineHost host,
+            ITelemetryLogger logger,
+            NewCommandCallbacks callbacks)
+            : base(parentCommand, host, logger, callbacks, "--update-apply")
         {
             this.IsHidden = true;
+            parentCommand.AddNoLegacyUsageValidators(this, except: new Option[] { InteractiveOption, AddSourceOption });
         }
 
         internal override Option<bool> InteractiveOption => ParentCommand.InteractiveOption;
@@ -47,10 +50,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
     internal class LegacyUpdateCheckCommand : BaseUpdateCommand
     {
-        public LegacyUpdateCheckCommand(NewCommand newCommand, ITemplateEngineHost host, ITelemetryLogger logger, NewCommandCallbacks callbacks)
-            : base(newCommand, host, logger, callbacks, "--update-check")
+        public LegacyUpdateCheckCommand(NewCommand parentCommand, ITemplateEngineHost host, ITelemetryLogger logger, NewCommandCallbacks callbacks)
+            : base(parentCommand, host, logger, callbacks, "--update-check")
         {
             this.IsHidden = true;
+            parentCommand.AddNoLegacyUsageValidators(this, except: new Option[] { InteractiveOption, AddSourceOption });
         }
 
         internal override Option<bool> InteractiveOption => ParentCommand.InteractiveOption;

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -734,20 +734,11 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid command syntax: argument &apos;{0}&apos; should be used after &apos;{1}&apos;..
+        ///   Looks up a localized string similar to Unrecognized command or argument(s): {0}.
         /// </summary>
-        internal static string Commands_Validator_WrongArgumentPosition {
+        internal static string Commands_Validator_WrongTokens {
             get {
-                return ResourceManager.GetString("Commands_Validator_WrongArgumentPosition", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Invalid command syntax: option &apos;{0}&apos; should be used after &apos;{1}&apos;..
-        /// </summary>
-        internal static string Commands_Validator_WrongOptionPosition {
-            get {
-                return ResourceManager.GetString("Commands_Validator_WrongOptionPosition", resourceCulture);
+                return ResourceManager.GetString("Commands_Validator_WrongTokens", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -772,12 +772,8 @@ The supported columns are: language, tags, author, type.</value>
   <data name="OptionDescriptionCheckOnly" xml:space="preserve">
     <value>Only check for updates and display the template packages to be updated without applying update.</value>
   </data>
-  <data name="Commands_Validator_WrongArgumentPosition" xml:space="preserve">
-    <value>Invalid command syntax: argument '{0}' should be used after '{1}'.</value>
-    <comment>{0} - argument value, {1} - command name (list, search. etc.).</comment>
-  </data>
-  <data name="Commands_Validator_WrongOptionPosition" xml:space="preserve">
-    <value>Invalid command syntax: option '{0}' should be used after '{1}'.</value>
-    <comment>{0} - option name, {1} - command name (list, search. etc.).</comment>
+  <data name="Commands_Validator_WrongTokens" xml:space="preserve">
+    <value>Unrecognized command or argument(s): {0}</value>
+    <comment>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</comment>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -391,15 +391,10 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <target state="translated">Příkaz proběhl úspěšně.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -391,15 +391,10 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
         <target state="translated">Ausführen des Befehls erfolgreich.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -391,15 +391,10 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
         <target state="translated">El comando se ejecutó correctamente.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -391,15 +391,10 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <target state="translated">Commande réussie.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -391,15 +391,10 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <target state="translated">Comando riuscito.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -391,15 +391,10 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">コマンドが成功しました。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -391,15 +391,10 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">명령이 성공했습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -391,15 +391,10 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
         <target state="translated">Polecenie zostało pomyślnie wykonane.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -391,15 +391,10 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <target state="translated">O comando foi bem-sucedido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -391,15 +391,10 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">Команда выполнена.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -391,15 +391,10 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <target state="translated">Komut başarılı oldu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -391,15 +391,10 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">命令已成功。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -391,15 +391,10 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">命令成功。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Commands_Validator_WrongArgumentPosition">
-        <source>Invalid command syntax: argument '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: argument '{0}' should be used after '{1}'.</target>
-        <note>{0} - argument value, {1} - command name (list, search. etc.).</note>
-      </trans-unit>
-      <trans-unit id="Commands_Validator_WrongOptionPosition">
-        <source>Invalid command syntax: option '{0}' should be used after '{1}'.</source>
-        <target state="new">Invalid command syntax: option '{0}' should be used after '{1}'.</target>
-        <note>{0} - option name, {1} - command name (list, search. etc.).</note>
+      <trans-unit id="Commands_Validator_WrongTokens">
+        <source>Unrecognized command or argument(s): {0}</source>
+        <target state="new">Unrecognized command or argument(s): {0}</target>
+        <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstallTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstallTests.cs
@@ -177,18 +177,28 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         }
 
         [Theory]
-        [InlineData("--add-source my-custom-source", "--add-source")]
-        [InlineData("--interactive", "--interactive")]
-        public void Install_CanReturnParseError_OnLegacyOptionMisplacement(string optionSyntax, string expectedOptionName)
+        [InlineData("new --add-source my-custom-source install source", "'--add-source','my-custom-source'")]
+        [InlineData("new --interactive install source", "'--interactive'")]
+        [InlineData("new --language F# --install source", "'--language','F#'")]
+        [InlineData("new --language F# install source", "'--language','F#'")]
+        [InlineData("new source1 source2 source3 --install source", "'source1'|'source2','source3'")]
+        [InlineData("new source1 --install source", "'source1'")]
+        public void Install_CanReturnParseError(string command, string expectedInvalidTokens)
         {
             ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(includeTestTemplates: false));
             NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", host, new TelemetryLogger(null, false), new NewCommandCallbacks());
 
-            var parseResult = myCommand.Parse($"new {optionSyntax} install source");
+            var parseResult = myCommand.Parse(command);
+            var errorMessages = parseResult.Errors.Select(error => error.Message);
+
+            var expectedInvalidTokenSets = expectedInvalidTokens.Split("|");
 
             Assert.NotEmpty(parseResult.Errors);
-            Assert.Single(parseResult.Errors);
-            Assert.Contains($"Invalid command syntax: option '{expectedOptionName}' should be used after 'install'.", parseResult.Errors.Select(error => error.Message));
+            Assert.Equal(expectedInvalidTokenSets.Length, parseResult.Errors.Count);
+            foreach (var tokenSet in expectedInvalidTokenSets)
+            {
+                Assert.True(errorMessages.Contains($"Unrecognized command or argument(s): {tokenSet}") || errorMessages.Contains($"Unrecognized command or argument {tokenSet}"));
+            }
         }
 
     }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/SearchTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/SearchTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             var parseResult = myCommand.Parse("new smth search");
 
             Assert.NotEmpty(parseResult.Errors);
-            Assert.Equal("Invalid command syntax: argument 'smth' should be used after 'search'.", parseResult.Errors.First().Message);
+            Assert.Equal("Unrecognized command or argument(s): 'smth'", parseResult.Errors.First().Message);
         }
 
         [Theory]
@@ -150,7 +150,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             var parseResult = myCommand.Parse(command);
 
             Assert.NotEmpty(parseResult.Errors);
-            Assert.Equal($"Invalid command syntax: option '{expectedFilter}' should be used after 'search'.", parseResult.Errors.First().Message);
+            Assert.Equal($"Unrecognized command or argument(s): '{expectedFilter}','filter-value'", parseResult.Errors.First().Message);
         }
 
         [Fact]
@@ -162,7 +162,30 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             var parseResult = myCommand.Parse("new smth --search smth-else");
 
             Assert.NotEmpty(parseResult.Errors);
-            Assert.Equal("Invalid command syntax: argument 'smth' should be used after '--search'.", parseResult.Errors.First().Message);
+            Assert.Equal("Unrecognized command or argument(s): 'smth'", parseResult.Errors.First().Message);
+        }
+
+        [Theory]
+        [InlineData("new --interactive search source", "'--interactive'")]
+        [InlineData("new --interactive --search source", "'--interactive'")]
+        [InlineData("new foo bar --search source", "'foo'|'bar'")]
+        [InlineData("new foo bar search source", "'foo'|'bar'")]
+        public void Search_HandleParseErrors(string command, string expectedInvalidTokens)
+        {
+            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(includeTestTemplates: false));
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", host, new TelemetryLogger(null, false), new NewCommandCallbacks());
+
+            var parseResult = myCommand.Parse(command);
+            var errorMessages = parseResult.Errors.Select(error => error.Message);
+
+            var expectedInvalidTokenSets = expectedInvalidTokens.Split("|");
+
+            Assert.NotEmpty(parseResult.Errors);
+            Assert.Equal(expectedInvalidTokenSets.Length, parseResult.Errors.Count);
+            foreach (var tokenSet in expectedInvalidTokenSets)
+            {
+                Assert.True(errorMessages.Contains($"Unrecognized command or argument(s): {tokenSet}") || errorMessages.Contains($"Unrecognized command or argument {tokenSet}"));
+            }
         }
 
         [Theory]

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/UninstallTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/UninstallTests.cs
@@ -62,5 +62,29 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             Assert.Contains("source2", args.TemplatePackages);
         }
 
+        [Theory]
+        [InlineData("new --add-source my-custom-source uninstall source", "'--add-source','my-custom-source'")]
+        [InlineData("new --interactive uninstall source", "'--interactive'")]
+        [InlineData("new --language F# --uninstall source", "'--language','F#'")]
+        [InlineData("new --language F# uninstall source", "'--language','F#'")]
+        [InlineData("new source1 source2 source3 --uninstall source", "'source1'|'source2','source3'")]
+        [InlineData("new source1 --uninstall source", "'source1'")]
+        public void Uninstall_CanReturnParseError(string command, string expectedInvalidTokens)
+        {
+            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(includeTestTemplates: false));
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", host, new TelemetryLogger(null, false), new NewCommandCallbacks());
+
+            var parseResult = myCommand.Parse(command);
+            var errorMessages = parseResult.Errors.Select(error => error.Message);
+
+            var expectedInvalidTokenSets = expectedInvalidTokens.Split("|");
+
+            Assert.NotEmpty(parseResult.Errors);
+            Assert.Equal(expectedInvalidTokenSets.Length, parseResult.Errors.Count);
+            foreach (var tokenSet in expectedInvalidTokenSets)
+            {
+                Assert.True(errorMessages.Contains($"Unrecognized command or argument(s): {tokenSet}") || errorMessages.Contains($"Unrecognized command or argument {tokenSet}"));
+            }
+        }
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
@@ -750,38 +750,31 @@ Examples:
         [Theory]
         [InlineData("--search foo --columns-all bar", "bar", "foo")]
         [InlineData("--search foo bar", "bar", "foo")]
-        [InlineData("foo --search --columns-all --framework net6.0 bar", "bar|net6.0", "foo|--framework")]
-        [InlineData("foo --search --columns-all -other-param --framework net6.0 bar", "bar|net6.0|--framework", "foo|-other-param")]
+        [InlineData("foo --search --columns-all --framework net6.0 bar", "bar|net6.0|foo", "--framework")]
+        [InlineData("foo --search --columns-all -other-param --framework net6.0 bar", "bar|net6.0|--framework|foo", "-other-param")]
         [InlineData("search foo --columns-all bar", "bar", "foo")]
+        [InlineData("foo --search bar", "foo", "bar")]
+        [InlineData("foo --search bar --language F#", "foo", "bar")]
+        [InlineData("foo --search --columns-all bar", "foo", "bar")]
+        [InlineData("foo search bar", "foo", "bar")]
         public void CannotSearchOnParseError(string command, string invalidArguments, string validArguments)
         {
             var commandResult = new DotnetNewCommand(_log, command.Split())
              .WithCustomHive(_sharedHome.HomeDirectory)
              .Execute();
 
-            foreach (string argumentName in invalidArguments.Split('|'))
+            commandResult.Should().Fail();
+            foreach (string arg in invalidArguments.Split('|'))
             {
-                commandResult.Should().Fail()
-                     .And.HaveStdErrContaining($"Unrecognized command or argument '{argumentName}'");
+                commandResult.Should().HaveStdErrMatching($"Unrecognized command or (argument\\(s\\)\\:|argument) '{arg}'");
             }
 
-            foreach (string argumentName in validArguments.Split('|'))
+            foreach (string arg in validArguments.Split('|'))
             {
-                commandResult.Should().NotHaveStdErrContaining($"Unrecognized command or argument '{argumentName}'");
+                commandResult.Should()
+                    .NotHaveStdErrContaining($"Unrecognized command or argument '{arg}'")
+                    .And.NotHaveStdErrContaining($"Unrecognized command or argument(s): '{arg}'");
             }
-        }
-
-        [Theory]
-        [InlineData("foo --search bar", "foo")]
-        [InlineData("foo --search bar --language F#", "foo")]
-        [InlineData("foo --search --columns-all bar", "foo")]
-        public void CannotSearchOnParseError_MisplacedArgument(string command, string misplacedArgument)
-        {
-            var commandResult = new DotnetNewCommand(_log, command.Split())
-             .WithCustomHive(_sharedHome.HomeDirectory)
-             .Execute();
-
-            commandResult.Should().Fail().And.HaveStdErrContaining($"Invalid command syntax: argument '{misplacedArgument}' should be used after '--search'.");
         }
 
         private static bool AllRowsContain(List<List<string>> tableOutput, string[] columnsNames, string value)


### PR DESCRIPTION
### Problem
Addresses issue with validators described in https://github.com/dotnet/templating/pull/4066#discussion_r737060441

### Solution
Now only options/arguments required for particular legacy commands are allowed on `dotnet new` level.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)