### PR TITLE
added parser configuration for dotnet new3

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -15,7 +15,7 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>9671726c0a79d5f4cab320b32da1cd4463a0d1be</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta1.21514.1">
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta1.21525.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>6a99c895dc30df55abda72d54b0d4ea0ae542696</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <SystemIOCompressionPackageVersion>4.3.0</SystemIOCompressionPackageVersion>
     <SystemRuntimeLoaderPackageVersion>4.3.0</SystemRuntimeLoaderPackageVersion>
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
-    <SystemCommandLinePackageVersion>2.0.0-beta1.21514.1</SystemCommandLinePackageVersion>
+    <SystemCommandLinePackageVersion>2.0.0-beta1.21525.1</SystemCommandLinePackageVersion>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
     <NuGetCredentialsPackageVersion>6.0.0-preview.4.220</NuGetCredentialsPackageVersion>
     <NuGetConfigurationPackageVersion>6.0.0-preview.4.220</NuGetConfigurationPackageVersion>

--- a/src/dotnet-new3/ParserFactory.cs
+++ b/src/dotnet-new3/ParserFactory.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.Parsing;
+
+namespace Dotnet_new3
+{
+    internal static class ParserFactory
+    {
+        internal static Parser CreateParser(Command command)
+        {
+            return new CommandLineBuilder(command)
+            //.UseExceptionHandler(ExceptionHandler)
+            .UseHelp()
+            //.UseHelpBuilder(context => DotnetHelpBuilder.Instance.Value)
+            //.UseLocalizationResources(new CommandLineValidationMessages())
+            .UseParseDirective()
+            .UseSuggestDirective()
+            .DisablePosixBinding()
+            .Build();
+        }
+
+        private static CommandLineBuilder DisablePosixBinding(this CommandLineBuilder builder)
+        {
+            builder.EnablePosixBundling = false;
+            return builder;
+        }
+    }
+}

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -24,13 +24,15 @@ namespace Dotnet_new3
         public static int Main(string[] args)
         {
             Command new3Command = new New3Command();
-            ParseResult preParseResult = new3Command.Parse(args);
+            ParseResult preParseResult = ParserFactory.CreateParser(new3Command).Parse(args);
 
             DefaultTemplateEngineHost host = CreateHost(preParseResult.GetValueForOption(New3Command.DebugDisableBuiltInTemplatesOption));
             ITelemetryLogger telemetryLogger = new TelemetryLogger(null, preParseResult.GetValueForOption(New3Command.DebugEmitTelemetryOption));
             string[] remainingArgs = preParseResult.GetValueForArgument(New3Command.RemainingTokensArgument) ?? Array.Empty<string>();
 
-            return NewCommandFactory.Create(new3Command.Name, host, telemetryLogger, new NewCommandCallbacks()).Invoke(remainingArgs);
+            Command newCommand = NewCommandFactory.Create(new3Command.Name, host, telemetryLogger, new NewCommandCallbacks());
+
+            return ParserFactory.CreateParser(newCommand).Parse(remainingArgs).Invoke();
         }
 
         private static DefaultTemplateEngineHost CreateHost(bool disableSdkTemplates)


### PR DESCRIPTION
### Solution
- version update
- implemented `CommandLineBuilder` similar to [sdk](https://github.com/dotnet/sdk/blob/957ae5ca599fdeaee425d23928d42da711373a5e/src/Cli/dotnet/Parser.cs#L117)

In particular it helps to avoid the problem below
```
Command myCommand = new Command("test");
myCommand.AddOption(new Option<string>("--nuget-source")
{
    Arity = new ArgumentArity(0, 1)
});
myCommand.AddArgument(new Argument()
{
    Arity = new ArgumentArity(0, 99)
});
myCommand.Parse("test -n myname");  //success; --nuget-source is "myname"
```

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)