### PR TITLE
Switch from VS 2017 to 2019

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ stages:
           # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
           # Will eventually change this to two BYOC pools.
           ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
-            name: Hosted VS2017
+            vmImage: windows-2019
           ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
             name: NetCore1ESPool-Internal
             demands: ImageOverride -equals build.windows.10.amd64.vs2017

--- a/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
@@ -716,6 +716,11 @@ Examples:
                 {
                     continue;
                 }
+                // tags can be shortened so the tag criteria might be truncated.
+                if (columnsNames.Contains("Tags") && tableOutput[i][tableOutput[0].IndexOf("Tags")].EndsWith("..."))
+                {
+                    continue;
+                }
 
                 // if columns are template name and/or short name and they are empty - skip, grouping in done
                 bool criteriaA = columnsNames.Contains("Template Name")

--- a/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
@@ -178,8 +178,8 @@ namespace Dotnet_new3.IntegrationTests
                   .ExitWith(0)
                   .And
                   .NotHaveStdErr()
-                  .And.HaveStdOutContaining("The template \"Console Application\" was created successfully.")
-                  .And.NotHaveStdOutContaining("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0' is available")
+                  .And.HaveStdOutContaining("The template \"Console App\" was created successfully.")
+                  .And.NotHaveStdOutMatching("An update for template package 'Microsoft.DotNet.Common.ProjectTemplates.5.0::([\\d\\.a-z-])+' is available")
                   .And.NotHaveStdOutContaining("To update the package use:")
                   .And.NotHaveStdOutMatching("    dotnet new3 --install Microsoft.DotNet.Common.ProjectTemplates.5.0::([\\d\\.a-z-])+");
         }


### PR DESCRIPTION
### Problem
Originates from email. Hosted 2017 agents are being deprecated. We should move to agents with VS 2019.
Since the change only affects hosted agents, our internal pools should be OK to use still. Therefore, 2017 agent on line 70 was not changed in this PR.

### Solution
Updated the used pool.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)