### PR TITLE
[system-command-line] "Default if no option value" and "hex" implementation

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -15,7 +15,7 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>9671726c0a79d5f4cab320b32da1cd4463a0d1be</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta1.21525.1">
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta1.21561.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>6a99c895dc30df55abda72d54b0d4ea0ae542696</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <SystemIOCompressionPackageVersion>4.3.0</SystemIOCompressionPackageVersion>
     <SystemRuntimeLoaderPackageVersion>4.3.0</SystemRuntimeLoaderPackageVersion>
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
-    <SystemCommandLinePackageVersion>2.0.0-beta1.21525.1</SystemCommandLinePackageVersion>
+    <SystemCommandLinePackageVersion>2.0.0-beta1.21561.1</SystemCommandLinePackageVersion>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
     <NuGetCredentialsPackageVersion>6.0.0-preview.4.220</NuGetCredentialsPackageVersion>
     <NuGetConfigurationPackageVersion>6.0.0-preview.4.220</NuGetConfigurationPackageVersion>

--- a/src/Microsoft.TemplateEngine.Cli/CliTemplateParameter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CliTemplateParameter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.TemplateEngine.Cli
             Description = parameter.Description ?? string.Empty;
             Type = ParseType(parameter.DataType);
             DefaultValue = parameter.DefaultValue;
-            DefaultIfOptionWithoutValue = parameter.DefaultIfOptionWithoutValue ?? string.Empty;
+            DefaultIfOptionWithoutValue = parameter.DefaultIfOptionWithoutValue;
             IsRequired = parameter.Priority == TemplateParameterPriority.Required && parameter.DefaultValue == null;
             IsHidden = parameter.Priority == TemplateParameterPriority.Implicit || data.HiddenParameterNames.Contains(parameter.Name);
 
@@ -87,8 +87,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         internal IReadOnlyList<string> LongNameOverrides => _longNameOverrides;
 
-        //TODO: decide if we handle it
-        internal string DefaultIfOptionWithoutValue { get; private set; }
+        internal string? DefaultIfOptionWithoutValue { get; private set; }
 
         private static ParameterType ParseType(string dataType)
         {
@@ -100,6 +99,7 @@ namespace Microsoft.TemplateEngine.Cli
                 "float" => ParameterType.Float,
                 "int" => ParameterType.Integer,
                 "integer" => ParameterType.Integer,
+                "hex" => ParameterType.Hex,
                 _ => ParameterType.String
             };
         }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.cs
@@ -21,7 +21,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         {
             this.AddArgument(ShortNameArgument);
             this.AddArgument(RemainingArguments);
-            this.AddOption(HelpOption);
             IsHidden = true;
         }
 
@@ -30,7 +29,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             _parentCommand = parentCommand;
             this.AddArgument(ShortNameArgument);
             this.AddArgument(RemainingArguments);
-            this.AddOption(HelpOption);
         }
 
         internal Argument<string> ShortNameArgument { get; } = new Argument<string>("template-short-name")
@@ -41,11 +39,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         internal Argument<string[]> RemainingArguments { get; } = new Argument<string[]>("template-args")
         {
             Arity = new ArgumentArity(0, 999)
-        };
-
-        internal Option HelpOption { get; } = new Option(new string[] { "-h", "--help", "-?" })
-        {
-            IsHidden = true
         };
 
         internal static InstantiateCommand FromNewCommand(NewCommand parentCommand)
@@ -254,7 +247,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         {
             RemainingArguments = parseResult.GetValueForArgument(command.RemainingArguments) ?? Array.Empty<string>();
             ShortName = parseResult.GetValueForArgument(command.ShortNameArgument);
-            HelpRequested = parseResult.GetValueForOption<bool>(command.HelpOption);
 
             var tokens = new List<string>();
             if (!string.IsNullOrWhiteSpace(ShortName))
@@ -262,10 +254,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 tokens.Add(ShortName);
             }
             tokens.AddRange(RemainingArguments);
-            if (HelpRequested)
-            {
-                tokens.Add(command.HelpOption.Aliases.First());
-            }
             TokensToInvoke = tokens.ToArray();
 
         }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/ParserFactory.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/ParserFactory.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             .UseParseErrorReporting()
             .UseParseDirective()
             .UseSuggestDirective()
-            .DisablePosixBinding()
+            .DisablePosixBundling()
             .Build();
         }
 
@@ -26,11 +26,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         {
             return new CommandLineBuilder(command)
             .UseParseErrorReporting()
-            .DisablePosixBinding()
+            .DisablePosixBundling()
             .Build();
         }
 
-        private static CommandLineBuilder DisablePosixBinding(this CommandLineBuilder builder)
+        private static CommandLineBuilder DisablePosixBundling(this CommandLineBuilder builder)
         {
             builder.EnablePosixBundling = false;
             return builder;

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.Subcommand.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.Subcommand.cs
@@ -89,7 +89,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 
         [Theory]
         [MemberData(nameof(CanParseTemplateOptionsData))]
-        internal void Create_CanParseTemplateOptions(string command, string parameterName, string parameterType, string? defaultValue, string? expectedValue)
+        internal void Create_CanParseTemplateOptions(string command, string parameterName, string parameterType, string? defaultValue, string? defaultIfNoOptionValue, string? expectedValue)
         {
             //unique case for dotnet new create
             if (command == "foo -in 30")
@@ -98,7 +98,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             }
 
             var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
-                .WithParameter(parameterName, parameterType, defaultValue: defaultValue);
+                .WithParameter(parameterName, parameterType, defaultValue: defaultValue, defaultIfNoOptionValue: defaultIfNoOptionValue);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
@@ -130,10 +130,10 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 
         [Theory]
         [MemberData(nameof(CanParseChoiceTemplateOptionsData))]
-        internal void Create_CanParseChoiceTemplateOptions(string command, string parameterName, string parameterValues, string? expectedValue)
+        internal void Create_CanParseChoiceTemplateOptions(string command, string parameterName, string parameterValues, string? defaultIfNoOptionValue, string? expectedValue)
         {
             var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
-                .WithChoiceParameter(parameterName, parameterValues.Split("|"));
+                .WithChoiceParameter(parameterName, parameterValues.Split("|"), defaultIfNoOptionValue: defaultIfNoOptionValue);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
@@ -171,10 +171,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             string parameterType,
             bool isRequired,
             string? defaultValue,
+            string? defaultIfNoOptionValue,
             string expectedError)
         {
             var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
-                .WithParameter(parameterName, parameterType, isRequired, defaultValue: defaultValue);
+                .WithParameter(parameterName, parameterType, isRequired, defaultValue: defaultValue, defaultIfNoOptionValue: defaultIfNoOptionValue);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))
@@ -204,10 +205,11 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
               string parameterValues,
               bool isRequired,
               string? defaultValue,
+              string? defaultIfNoOptionValue,
               string expectedError)
         {
             var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
-                .WithChoiceParameter(parameterName, parameterValues.Split("|"), isRequired, defaultValue);
+                .WithChoiceParameter(parameterName, parameterValues.Split("|"), isRequired, defaultValue, defaultIfNoOptionValue);
 
             TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
                 CliTemplateInfo.FromTemplateInfo(new[] { template }, A.Fake<IHostSpecificDataLoader>()))

--- a/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
@@ -171,7 +171,7 @@ namespace Microsoft.TemplateEngine.Mocks
             return this;
         }
 
-        public MockTemplateInfo WithChoiceParameter(string name, string[] values, bool isRequired = false, string? defaultValue = null)
+        public MockTemplateInfo WithChoiceParameter(string name, string[] values, bool isRequired = false, string? defaultValue = null, string? defaultIfNoOptionValue = null)
         {
             _parameters.Add(name, new TemplateParameter(
                 name,
@@ -179,6 +179,7 @@ namespace Microsoft.TemplateEngine.Mocks
                 datatype: "choice",
                 priority: isRequired ? TemplateParameterPriority.Required : TemplateParameterPriority.Optional,
                 defaultValue: defaultValue,
+                defaultIfOptionWithoutValue: defaultIfNoOptionValue,
                 choices: values.ToDictionary(v => v, v => new ParameterChoice(null, null))));
             return this;
         }
@@ -215,14 +216,15 @@ namespace Microsoft.TemplateEngine.Mocks
             return this;
         }
 
-        public MockTemplateInfo WithParameter(string paramName, string paramType = "string", bool isRequired = false, string? defaultValue = null)
+        public MockTemplateInfo WithParameter(string paramName, string paramType = "string", bool isRequired = false, string? defaultValue = null, string? defaultIfNoOptionValue = null)
         {
             _parameters[paramName] = new TemplateParameter(
                 paramName,
                 "parameter",
                 paramType,
                 isRequired ? TemplateParameterPriority.Required : TemplateParameterPriority.Optional,
-                defaultValue: defaultValue);
+                defaultValue: defaultValue,
+                defaultIfOptionWithoutValue: defaultIfNoOptionValue);
             return this;
         }
 


### PR DESCRIPTION
### Solution
Implements "default if no option value" and "hex" type values for new parser

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)