### PR TITLE
Switch to NetCore1ES-Svc-Public on release/6.0.2xx

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,7 +151,7 @@ stages:
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         - job: Linux
           pool:
-            name: NetCore1ESPool-Public
+            name: NetCore1ESPool-Svc-Public
             demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
           strategy:
             matrix:


### PR DESCRIPTION
Was using the R&D pool, so this switches it to servicing.