### PR TITLE
[system-command-line] remove mutex block

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Installer;
 using Microsoft.TemplateEngine.Edge.Settings;
-using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider

--- a/src/Microsoft.TemplateEngine.Edge/Settings/AsyncMutex.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/AsyncMutex.cs
@@ -7,14 +7,14 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.TemplateEngine.Utils
+namespace Microsoft.TemplateEngine.Edge.Settings
 {
     /// <summary>
     /// Helper class to work with <see cref="Mutex"/> in <c>async</c> method, since <c>await</c>
     /// can switch to different thread and <see cref="Mutex.ReleaseMutex"/> must be called from same thread.
     /// Hence this helper class.
     /// </summary>
-    public sealed class AsyncMutex : IDisposable
+    internal sealed class AsyncMutex : IDisposable
     {
         private readonly TaskCompletionSource<AsyncMutex> _taskCompletionSource;
         private readonly ManualResetEvent _blockReleasingMutex = new ManualResetEvent(false);

--- a/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
@@ -1,8 +1,4 @@
-﻿Microsoft.TemplateEngine.Utils.AsyncMutex
-Microsoft.TemplateEngine.Utils.AsyncMutex.Dispose() -> void
-Microsoft.TemplateEngine.Utils.AsyncMutex.IsLocked.get -> bool
-Microsoft.TemplateEngine.Utils.IFileSystemInfoExtensions
-static Microsoft.TemplateEngine.Utils.AsyncMutex.WaitAsync(string! mutexName, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task<Microsoft.TemplateEngine.Utils.AsyncMutex!>!
+﻿Microsoft.TemplateEngine.Utils.IFileSystemInfoExtensions
 static Microsoft.TemplateEngine.Utils.IFileSystemInfoExtensions.GetDisplayPath(this Microsoft.TemplateEngine.Abstractions.Mount.IFileSystemInfo! fileSystemInfo) -> string!
 static Microsoft.TemplateEngine.Utils.WellKnownSearchFilters.AuthorFilter(string? author) -> System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo?>!
 static Microsoft.TemplateEngine.Utils.WellKnownSearchFilters.BaselineFilter(string? baselineName) -> System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo?>!

--- a/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
+++ b/test/Microsoft.TemplateEngine.EndToEndTestHarness/Program.cs
@@ -32,37 +32,18 @@ namespace Microsoft.TemplateEngine.EndToEndTestHarness
             VerificationLookup["file_does_not_contain"] = CheckFileDoesNotContain;
 
             int batteryCount = int.Parse(args[0], CultureInfo.InvariantCulture);
-            string[] passthroughArgs = new string[args.Length - 2 - batteryCount];
             string outputPath = args[batteryCount + 1];
 
-            for (int i = 0; i < passthroughArgs.Length; ++i)
-            {
-                passthroughArgs[i] = args[i + 2 + batteryCount];
-            }
-
-            string home = "%USERPROFILE%";
-
-            if (Path.DirectorySeparatorChar == '/')
-            {
-                home = "%HOME%";
-            }
+            List<string> passThroughArgs = new List<string>();
+            passThroughArgs.AddRange(args.Skip(2 + batteryCount));
+            passThroughArgs.Add("--debug:ephemeral-hive");
 
             ITemplateEngineHost host = CreateHost();
-            string profileDir = Environment.ExpandEnvironmentVariables(home);
-
-            if (string.IsNullOrWhiteSpace(profileDir))
-            {
-                Console.Error.WriteLine("Could not determine home directory");
-                return 0;
-            }
-
-            string hivePath = Path.Combine(profileDir, ".tetestharness");
-            host.VirtualizeDirectory(hivePath);
             host.VirtualizeDirectory(outputPath);
 
             var command = NewCommandFactory.Create(CommandName, host, new TelemetryLogger(null), new NewCommandCallbacks());
 
-            int result = ParserFactory.CreateParser(command).Parse(passthroughArgs).Invoke();
+            int result = ParserFactory.CreateParser(command).Parse(passThroughArgs.ToArray()).Invoke();
 
             bool verificationsPassed = false;
 


### PR DESCRIPTION
After discussion, we decided to remove Mutex block for executing dotnet new command in parallel.
In case of (unlikely) cache corruption, it is possible to regenerate cache - it doesn't contain any non-revertible information anymore.

Also reverted putting AsyncMutex class to Utils and fixed bug in E2E harness preventing to virtualize settings.

Up:
Will need a follow up in Edge: legacy E2E tests revealed concurrency problems with writing to template cache and missing error handling for that.  Reading and writing from cache should not be a blocking error as it always possible to regenerate it. This will be done in separate PR and to main branch.

### Checks:
- [ ] Added unit tests - NA
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - NA