### PR TITLE
AsyncMutex: start mutex thread as foreground thread

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Settings/AsyncMutex.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/AsyncMutex.cs
@@ -28,7 +28,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             _mutexName = mutexName;
             _token = token;
             _taskCompletionSource = new TaskCompletionSource<AsyncMutex>();
-            ThreadPool.QueueUserWorkItem(WaitLoop);
+            new Thread(WaitLoop).Start();
         }
 
         public bool IsLocked { get { return _isLocked; } }


### PR DESCRIPTION
### Problem
Recently when AsyncMutex was also used for blocking dotnet new, the bug was revealed. 
Since waiting for mutex was started in background thread, rarely the thread was killed before the job finished and mutex is released, causing AbandonedMutexException in the process waiting for Mutex.

### Solution
Moved waiting loop to foreground thread.

### Checks:
- [ ] Added unit tests - NA
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) -NA