### PR TITLE
[release/6.0.2xx] Update command-line-api version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -23,9 +23,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>6c5c32d56ec74280783664c2526937d23cfc3467</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta1.21406.1">
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta1.21525.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>27d86d37b34973e24d273d6d3ee00e8ee78e11de</Sha>
+      <Sha>09a24a79ef01a0c70655919ee3c59bb54a8574df</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging" Version="6.0.0-rtm.21501.9">
       <Uri>https://github.com/dotnet/runtime</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,7 +18,7 @@
     <SystemIOCompressionPackageVersion>4.3.0</SystemIOCompressionPackageVersion>
     <SystemRuntimeLoaderPackageVersion>4.3.0</SystemRuntimeLoaderPackageVersion>
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
-    <SystemCommandLinePackageVersion>2.0.0-beta1.21406.1</SystemCommandLinePackageVersion>
+    <SystemCommandLinePackageVersion>2.0.0-beta1.21525.1</SystemCommandLinePackageVersion>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
     <NuGetCredentialsPackageVersion>6.0.0-preview.3.179</NuGetCredentialsPackageVersion>
     <NuGetConfigurationPackageVersion>6.0.0-preview.3.179</NuGetConfigurationPackageVersion>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/Commands/Export/ExportCommand.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/Commands/Export/ExportCommand.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Commands.Export
             exportCommand.AddArgument(new Argument("template-path")
             {
                 Arity = ArgumentArity.OneOrMore,
-                ArgumentType = typeof(string),
+                ValueType = typeof(string),
                 Description = LocalizableStrings.command_export_help_templatePath_description,
             });
             exportCommand.AddOption(new Option("-r")


### PR DESCRIPTION
This is update is needed for source-build.  The [dotnet/sdk repo updated their version](https://github.com/dotnet/sdk/commit/0985c0cfab5de33149bb87cd782a0f7e846c0048#diff-2f70e6b441f7ffb00180be1e2832e21e98528943a3648b7fc3256e6d403500ae) which determines the version included in source-build.  There was an breaking api change therefore breaking the templating build in source-build.