### PR TITLE
[system-command-line] moved encoding check to dotnet-new3 main

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
@@ -236,14 +236,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             environmentSettings.Host.FileSystem.CreateDirectory(environmentSettings.Paths.HostVersionSettingsDir);
         }
 
-        private static Task HandleDebugRebuildCacheAsync(TArgs args, IEngineEnvironmentSettings environmentSettings, CancellationToken cancellationToken)
+        private static async Task HandleDebugRebuildCacheAsync(TArgs args, IEngineEnvironmentSettings environmentSettings, CancellationToken cancellationToken)
         {
             if (!args.DebugRebuildCache)
             {
-                return Task.FromResult(0);
+                return;
             }
             using TemplatePackageManager templatePackageManager = new TemplatePackageManager(environmentSettings);
-            return templatePackageManager.RebuildTemplateCacheAsync(cancellationToken);
+            //need to await, otherwise template package manager is disposed too early - before the task is completed
+            await templatePackageManager.RebuildTemplateCacheAsync(cancellationToken).ConfigureAwait(true);
         }
 
         private static void HandleDebugShowConfig(TArgs args, IEngineEnvironmentSettings environmentSettings)

--- a/src/dotnet-new3/Program.cs
+++ b/src/dotnet-new3/Program.cs
@@ -23,6 +23,11 @@ namespace Dotnet_new3
 
         public static int Main(string[] args)
         {
+            if (Console.IsOutputRedirected)
+            {
+                Console.OutputEncoding = System.Text.Encoding.UTF8;
+            }
+
             Command new3Command = new New3Command();
             ParseResult preParseResult = ParserFactory.CreateParser(new3Command, disableHelp: true).Parse(args);
 

--- a/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
@@ -871,7 +871,7 @@ Examples:
             int headerLineIndex = Array.FindIndex(lines, line => expectedColumns.All(column => line.Contains(column)));
             string headerLine = lines[headerLineIndex];
             //table ends after empty line
-            int lastLineIndex = Array.FindIndex(lines, headerLineIndex + 1, line => line.Length == 0) - 1;
+            int lastLineIndex = Array.FindIndex(lines, headerLineIndex + 1, line => (line.Length == 0 || line.Contains("[Debug]"))) - 1;
             var columnIndexes = expectedColumns.Select(column => headerLine.IndexOf(column)).ToArray();
 
             var parsedTable = new List<List<string>>();


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/commit/48f5e8392ebbdd3d2f3c239854055277e68e0c57 added recently setting encoding to UTF8 if output is redirected to New3Command.cs. Since this code is dead, I'm moving it to dotnet-new3 before any interaction with Console starts.

### Checks:
- [ ] Added unit tests - NA
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - NA