### PR TITLE
fixed criteria for last table line in parsing tabular output in tests

### DIFF
--- a/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
@@ -787,8 +787,10 @@ Examples:
 
             int headerLineIndex = Array.FindIndex(lines, line => expectedColumns.All(column => line.Contains(column)));
             string headerLine = lines[headerLineIndex];
-            //table ends after empty line
-            int lastLineIndex = Array.FindIndex(lines, headerLineIndex + 1, line => line.Length == 0) - 1;
+            //table ends before empty line
+            //or before first [Debug] entry
+            //table is written in single call, so there can be no [Debug] entry in the middle
+            int lastLineIndex = Array.FindIndex(lines, headerLineIndex + 1, line => (line.Length == 0 || line.Contains("[Debug]"))) - 1;
             var columnIndexes = expectedColumns.Select(column => headerLine.IndexOf(column)).ToArray();
 
             var parsedTable = new List<List<string>>();


### PR DESCRIPTION
### Problem
Some search tests randomly fail when table output is put in the middle of debug output as they fail to determine where the table ends, and consider debug output as the table row.

### Solution
Fixed criteria of first line after the table

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)