### PR TITLE
Fix reading from output filestream since it can be slow and hurt perf

### DIFF
--- a/src/Microsoft.TemplateEngine.Core/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Core/PublicAPI.Shipped.txt
@@ -476,18 +476,18 @@ override Microsoft.TemplateEngine.Core.TokenConfig.GetHashCode() -> int
 ~Microsoft.TemplateEngine.Core.Util.Processor.Run(System.IO.Stream source, System.IO.Stream target) -> bool
 ~Microsoft.TemplateEngine.Core.Util.Processor.Run(System.IO.Stream source, System.IO.Stream target, int bufferSize) -> bool
 ~Microsoft.TemplateEngine.Core.Util.Processor.Run(System.IO.Stream source, System.IO.Stream target, int bufferSize, int flushThreshold) -> bool
-~Microsoft.TemplateEngine.Core.Util.ProcessorState.Config.get -> Microsoft.TemplateEngine.Core.Contracts.IEngineConfig
-~Microsoft.TemplateEngine.Core.Util.ProcessorState.CurrentBuffer.get -> byte[]
-~Microsoft.TemplateEngine.Core.Util.ProcessorState.Encoding.get -> System.Text.Encoding
-~Microsoft.TemplateEngine.Core.Util.ProcessorState.EncodingConfig.get -> Microsoft.TemplateEngine.Core.Contracts.IEncodingConfig
-~Microsoft.TemplateEngine.Core.Util.ProcessorState.Inject(System.IO.Stream staged) -> void
-~Microsoft.TemplateEngine.Core.Util.ProcessorState.ProcessorState(System.IO.Stream source, System.IO.Stream target, int bufferSize, int flushThreshold, Microsoft.TemplateEngine.Core.Contracts.IEngineConfig config, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider> operationProviders) -> void
-~Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie match) -> void
-~Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie match, bool consume) -> void
-~Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBackWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie match) -> void
-~Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardThrough(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition) -> void
-~Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition) -> void
-~Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.Config.get -> Microsoft.TemplateEngine.Core.Contracts.IEngineConfig!
+Microsoft.TemplateEngine.Core.Util.ProcessorState.CurrentBuffer.get -> byte[]!
+Microsoft.TemplateEngine.Core.Util.ProcessorState.Encoding.get -> System.Text.Encoding!
+Microsoft.TemplateEngine.Core.Util.ProcessorState.EncodingConfig.get -> Microsoft.TemplateEngine.Core.Contracts.IEncodingConfig!
+Microsoft.TemplateEngine.Core.Util.ProcessorState.Inject(System.IO.Stream! staged) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.ProcessorState(System.IO.Stream! source, System.IO.Stream! target, int bufferSize, int flushThreshold, Microsoft.TemplateEngine.Core.Contracts.IEngineConfig! config, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider!>! operationProviders) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, bool consume) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBackWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardThrough(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
 ~Microsoft.TemplateEngine.Core.Util.Token.Token(byte[] token, int index, int start = 0, int end = -1) -> void
 ~Microsoft.TemplateEngine.Core.Util.Token.Value.get -> byte[]
 ~Microsoft.TemplateEngine.Core.Util.TokenTrie.AddToken(byte[] literalToken) -> int

--- a/src/Microsoft.TemplateEngine.Core/Util/ProcessorState.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/ProcessorState.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;


### PR DESCRIPTION
### Problem
During VisualStudio profile session it was discovered that output .csproj file is read from... And reported as internal VS bug... https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1433562/

### Solution
Write everything and read from MemoryStream, at the end dump it into targetStream.

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)