### PR TITLE
fixes dotnet/templating#4097 removes extra period in the error message

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
@@ -365,7 +365,7 @@ namespace Microsoft.TemplateEngine.Edge {
         
         /// <summary>
         ///   Looks up a localized string similar to Failed to create template.
-        ///Details: {0}..
+        ///Details: {0}.
         /// </summary>
         internal static string TemplateCreator_TemplateCreationResult_Error_CreationFailed {
             get {

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -223,7 +223,7 @@ Details: {1}.</value>
   </data>
   <data name="TemplateCreator_TemplateCreationResult_Error_CreationFailed" xml:space="preserve">
     <value>Failed to create template.
-Details: {0}.</value>
+Details: {0}</value>
   </data>
   <data name="TemplateCreator_TemplateCreationResult_Error_DestructiveChanges" xml:space="preserve">
     <value>Destructive changes detected.</value>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -175,8 +175,8 @@ Podrobnosti: {1}.</target>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">Nepovedlo se vytvořit šablonu. 
+Details: {0}</source>
+        <target state="needs-review-translation">Nepovedlo se vytvořit šablonu. 
 Podrobnosti: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -175,8 +175,8 @@ Details: {1}.</target>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">Fehler beim Erstellen der Vorlage.
+Details: {0}</source>
+        <target state="needs-review-translation">Fehler beim Erstellen der Vorlage.
 Details: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -175,8 +175,8 @@ Detalles: {1}.</target>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">No se pudo crear la plantilla.
+Details: {0}</source>
+        <target state="needs-review-translation">No se pudo crear la plantilla.
 Detalles: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -175,8 +175,8 @@ Détails : {1}.</target>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">Échec de la création du modèle.
+Details: {0}</source>
+        <target state="needs-review-translation">Échec de la création du modèle.
 Détails : {0}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -175,8 +175,8 @@ Dettagli: {1}.</target>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">Non è stato possibile creare il modello.
+Details: {0}</source>
+        <target state="needs-review-translation">Non è stato possibile creare il modello.
 Dettagli: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -175,8 +175,8 @@ Details: {1}.</source>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">テンプレートを作成できませんでした。
+Details: {0}</source>
+        <target state="needs-review-translation">テンプレートを作成できませんでした。
 詳細: {0}。</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -175,8 +175,8 @@ Details: {1}.</source>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">템플릿을 만들지 못했습니다.
+Details: {0}</source>
+        <target state="needs-review-translation">템플릿을 만들지 못했습니다.
 세부 정보: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -175,8 +175,8 @@ Szczegóły: {1}.</target>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">Nie można utworzyć szablonu.
+Details: {0}</source>
+        <target state="needs-review-translation">Nie można utworzyć szablonu.
 Szczegóły: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -175,8 +175,8 @@ Detalhes: {1}.</target>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">Falha ao criar o modelo.
+Details: {0}</source>
+        <target state="needs-review-translation">Falha ao criar o modelo.
 Detalhes: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -175,8 +175,8 @@ Details: {1}.</source>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">Не удалось создать шаблон.
+Details: {0}</source>
+        <target state="needs-review-translation">Не удалось создать шаблон.
 Сведения: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -175,8 +175,8 @@ Ayrıntılar: {1}.</target>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">Şablon oluşturulamadı.
+Details: {0}</source>
+        <target state="needs-review-translation">Şablon oluşturulamadı.
 Ayrıntılar: {0}.</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -175,8 +175,8 @@ Details: {1}.</source>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">未能创建模板。
+Details: {0}</source>
+        <target state="needs-review-translation">未能创建模板。
 详细信息: {0}。</target>
         <note />
       </trans-unit>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -175,8 +175,8 @@ Details: {1}.</source>
       </trans-unit>
       <trans-unit id="TemplateCreator_TemplateCreationResult_Error_CreationFailed">
         <source>Failed to create template.
-Details: {0}.</source>
-        <target state="translated">無法建立範本。
+Details: {0}</source>
+        <target state="needs-review-translation">無法建立範本。
 詳細資料: {0}。</target>
         <note />
       </trans-unit>


### PR DESCRIPTION
### Problem
fixes #4097

### Solution
Removed extra period. Exception should already end with period.

This PR should be cherry picked to 6.0.2xx

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)