### PR TITLE
fixes dotnet/templating#4130 remove BOM from test gitattributes file

### DIFF
--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/.gitattributes
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/.gitattributes
@@ -1,4 +1,4 @@
-﻿#if (A)
+#if (A)
 # comment foo
 foo
 #endif


### PR DESCRIPTION
### Problem
fixes #4130 

### Solution
remove BOM from gitattributes file

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)