### PR TITLE
fixes dotnet/templating#4109 renames .NET Core to .NET

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -707,7 +707,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Template Instantiation Commands for .NET Core CLI.
+        ///   Looks up a localized string similar to Template Instantiation Commands for .NET CLI.
         /// </summary>
         internal static string CommandDescription {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -136,7 +136,7 @@
     <value>Change</value>
   </data>
   <data name="CommandDescription" xml:space="preserve">
-    <value>Template Instantiation Commands for .NET Core CLI</value>
+    <value>Template Instantiation Commands for .NET CLI</value>
   </data>
   <data name="ConfiguredValue" xml:space="preserve">
     <value>Configured Value: {0}</value>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -372,8 +372,8 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">Příkazy pro vytvoření instancí šablon pro .NET Core CLI.</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">Příkazy pro vytvoření instancí šablon pro .NET Core CLI.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -372,8 +372,8 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">Vorlageninstanziierungsbefehle für .NET Core-CLI</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">Vorlageninstanziierungsbefehle für .NET Core-CLI</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -372,8 +372,8 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">Comandos de creación de instancias de plantilla para CLI de .NET Core</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">Comandos de creación de instancias de plantilla para CLI de .NET Core</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -372,8 +372,8 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">Commandes d’instanciation du modèle pour CLI .NET Core</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">Commandes d’instanciation du modèle pour CLI .NET Core</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -372,8 +372,8 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">Comandi di creazione di istanze dei modelli per interfaccia della riga di comando di .NET Core</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">Comandi di creazione di istanze dei modelli per interfaccia della riga di comando di .NET Core</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -372,8 +372,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">.NET Core CLI のテンプレート インスタンス化 コマンド</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">.NET Core CLI のテンプレート インスタンス化 コマンド</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -372,8 +372,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">.NET Core CLI용 템플릿 인스턴스화 명령</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">.NET Core CLI용 템플릿 인스턴스화 명령</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -372,8 +372,8 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">Polecenia tworzenia wystąpień szablonów w przypadku interfejsu wiersza polecenia platformy .NET Core</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">Polecenia tworzenia wystąpień szablonów w przypadku interfejsu wiersza polecenia platformy .NET Core</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -372,8 +372,8 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">Comandos de Instanciação de Modelo para CLI do .NET Core</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">Comandos de Instanciação de Modelo para CLI do .NET Core</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -372,8 +372,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">Команды создания экземпляра шаблона для .NET Core CLI</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">Команды создания экземпляра шаблона для .NET Core CLI</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -372,8 +372,8 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">.NET Core CLI için Şablon Örneği Oluşturma Komutları</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">.NET Core CLI için Şablon Örneği Oluşturma Komutları</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -372,8 +372,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">.NET Core CLI 的模板实例化命令</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">.NET Core CLI 的模板实例化命令</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -372,8 +372,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="CommandDescription">
-        <source>Template Instantiation Commands for .NET Core CLI</source>
-        <target state="translated">.NET Core CLI 的範本具現化命令</target>
+        <source>Template Instantiation Commands for .NET CLI</source>
+        <target state="needs-review-translation">.NET Core CLI 的範本具現化命令</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandFailed">

--- a/src/dotnet-new3/dotnet-new3.csproj
+++ b/src/dotnet-new3/dotnet-new3.csproj
@@ -1,6 +1,6 @@
 <Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Template Instantiation Commands for .NET Core CLI.</Description>
+    <Description>Template Instantiation Commands for .NET CLI.</Description>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Gitignore/.gitignore
@@ -57,7 +57,7 @@ dlldata.c
 # Benchmark Results
 BenchmarkDotNet.Artifacts/
 
-# .NET Core
+# .NET
 project.lock.json
 project.fragment.lock.json
 artifacts/

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/GlobalJson/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/GlobalJson/.template.config/localize/templatestrings.en.json
@@ -1,8 +1,8 @@
 {
   "author": "Microsoft",
   "name": "global.json file",
-  "description": "A file for selecting the .NET Core SDK version.",
-  "symbols/SdkVersion/description": "The version of the .NET Core SDK to use.",
+  "description": "A file for selecting the .NET SDK version.",
+  "symbols/SdkVersion/description": "The version of the .NET SDK to use.",
   "symbols/SdkVersion/displayName": "SDK version",
   "symbols/dotnet-cli-version/displayName": "dotnet CLI version",
   "symbols/RollForward/description": "The roll-forward policy to use when selecting an SDK version.",

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/GlobalJson/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/GlobalJson/.template.config/template.json
@@ -6,7 +6,7 @@
   ],
   "name": "global.json file",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A file for selecting the .NET Core SDK version.",
+  "description": "A file for selecting the .NET SDK version.",
   "tags": {
     "type": "item"
   },
@@ -29,7 +29,7 @@
     "SdkVersion": {
       "type": "parameter",
       "datatype": "string",
-      "description": "The version of the .NET Core SDK to use.",
+      "description": "The version of the .NET SDK to use.",
       "displayName": "SDK version"
     },
     "dotnet-cli-version": {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-CSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-CSharp/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "Class Library",
-  "description": "A project for creating a class library that targets .NET Standard or .NET Core",
+  "description": "A project for creating a class library that targets .NET or .NET Standard",
   "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
   "symbols/TargetFrameworkOverride/displayName": "Target framework override",
   "symbols/Framework/description": "The target framework for the project.",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   ],
   "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project for creating a class library that targets .NET Standard or .NET Core",
+  "description": "A project for creating a class library that targets .NET or .NET Standard",
   "groupIdentity": "Microsoft.Common.Library",
   "precedence": "8000",
   "identity": "Microsoft.Common.Library.CSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-FSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-FSharp/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "Class Library",
-  "description": "A project for creating a class library that targets .NET Standard or .NET Core",
+  "description": "A project for creating a class library that targets .NET or .NET Standard",
   "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
   "symbols/TargetFrameworkOverride/displayName": "Target framework override",
   "symbols/Framework/description": "The target framework for the project.",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-FSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   ],
   "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project for creating a class library that targets .NET Standard or .NET Core",
+  "description": "A project for creating a class library that targets .NET or .NET Standard",
   "groupIdentity": "Microsoft.Common.Library",
   "precedence": "8000",
   "identity": "Microsoft.Common.Library.FSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "Class Library",
-  "description": "A project for creating a class library that targets .NET Standard or .NET Core",
+  "description": "A project for creating a class library that targets .NET or .NET Standard",
   "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
   "symbols/TargetFrameworkOverride/displayName": "Target framework override",
   "symbols/Framework/description": "The target framework for the project.",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -7,7 +7,7 @@
   ],
   "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project for creating a class library that targets .NET Standard or .NET Core",
+  "description": "A project for creating a class library that targets .NET or .NET Standard",
   "groupIdentity": "Microsoft.Common.Library",
   "precedence": "8000",
   "identity": "Microsoft.Common.Library.VisualBasic.7.0",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "Console App",
-  "description": "A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project for creating a command-line application that can run on .NET on Windows, Linux and macOS",
   "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
   "symbols/TargetFrameworkOverride/displayName": "Target framework override",
   "symbols/Framework/description": "The target framework for the project.",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   ],
   "name": "Console App",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project for creating a command-line application that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Common.Console",
   "precedence": "8000",
   "identity": "Microsoft.Common.Console.CSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-FSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-FSharp/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "Console App",
-  "description": "A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project for creating a command-line application that can run on .NET on Windows, Linux and macOS",
   "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
   "symbols/TargetFrameworkOverride/displayName": "Target framework override",
   "symbols/Framework/description": "The target framework for the project.",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-FSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   ],
   "name": "Console App",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project for creating a command-line application that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Common.Console",
   "precedence": "8000",
   "identity": "Microsoft.Common.Console.FSharp.7.0",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-VisualBasic/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-VisualBasic/.template.config/localize/templatestrings.en.json
@@ -1,7 +1,7 @@
 {
   "author": "Microsoft",
   "name": "Console App",
-  "description": "A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project for creating a command-line application that can run on .NET on Windows, Linux and macOS",
   "symbols/TargetFrameworkOverride/description": "Overrides the target framework",
   "symbols/TargetFrameworkOverride/displayName": "Target framework override",
   "symbols/Framework/description": "The target framework for the project.",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-VisualBasic/.template.config/template.json
@@ -7,7 +7,7 @@
   ],
   "name": "Console App",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project for creating a command-line application that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Common.Console",
   "precedence": "8000",
   "identity": "Microsoft.Common.Console.VisualBasic.7.0",

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/InvalidHostData/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/InvalidHostData/.template.config/template.json
@@ -28,7 +28,7 @@
     "SdkVersion": {
       "type": "parameter",
       "datatype": "string",
-      "description": "The version of the .NET Core SDK to use.",
+      "description": "The version of the .NET SDK to use.",
       "displayName": "SDK version"
     },
     "dotnet-cli-version": {

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_Classlib.approved.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_Classlib.approved.txt
@@ -1,6 +1,6 @@
 ﻿Class Library (C#)
 Author: Microsoft
-Description: A project for creating a class library that targets .NET Standard or .NET Core
+Description: A project for creating a class library that targets .NET or .NET Standard
 Options:                                                                             
   -f|--framework  The target framework for the project.                              
                       net7.0            - Target net7.0                              

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_Console.approved.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_Console.approved.txt
@@ -1,6 +1,6 @@
 ﻿Console App (C#)
 Author: Microsoft
-Description: A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS
+Description: A project for creating a command-line application that can run on .NET on Windows, Linux and macOS
 Options:                                                                             
   -f|--framework  The target framework for the project.                              
                       net7.0           - Target net7.0                               

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnChoice.approved.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnChoice.approved.txt
@@ -1,6 +1,6 @@
 ﻿Console App (C#)
 Author: Microsoft
-Description: A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS
+Description: A project for creating a command-line application that can run on .NET on Windows, Linux and macOS
 Options:                                                                            
   --langVersion  Sets the LangVersion property in the created project file          
                  text - Optional                                                    

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnLanguage.approved.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnLanguage.approved.txt
@@ -1,6 +1,6 @@
 ﻿Console App (F#)
 Author: Microsoft
-Description: A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS
+Description: A project for creating a command-line application that can run on .NET on Windows, Linux and macOS
 Options:                                                                             
   -f|--framework  The target framework for the project.                              
                       net7.0           - Target net7.0                               

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnNonChoiceParam.approved.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnNonChoiceParam.approved.txt
@@ -1,6 +1,6 @@
 ﻿Console App (C#)
 Author: Microsoft
-Description: A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS
+Description: A project for creating a command-line application that can run on .NET on Windows, Linux and macOS
 Options:                                                                             
   -f|--framework  The target framework for the project.                              
                       net7.0           - Target net7.0                               


### PR DESCRIPTION
### Problem
partially fixes #4109

### Solution
renames .NET Core to .NET

The PR to be done to 6.0.2xx too (cherry-pick won't be possible) 

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)