### PR TITLE
fixes dotnet/templating#4099  ordering of search results based on download count

### DIFF
--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCoordinatorTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/TemplateSearchCoordinatorTests.cs
@@ -410,6 +410,22 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             }
         }
 
+        [Theory]
+        [InlineData(12489, 3198, 1)]
+        [InlineData(3198, 12489, -1)]
+        [InlineData(124, 3198, -1)]
+        [InlineData(3198, 124, 1)]
+        [InlineData(0, 0, 0)]
+        [InlineData(-10, 0, 0)]
+        [InlineData(987, 0, 1)]
+        [InlineData(0, 10, -1)]
+        [InlineData(987, 1, 0)]
+        [InlineData(123, 345, 0)]
+        public void TestCompare(long x, long y, int expectedOutcome)
+        {
+            Assert.Equal(expectedOutcome, CliTemplateSearchCoordinator.SearchResultTableRow.TotalDownloadsComparer.Compare(x, y));
+        }
+
 #pragma warning disable CS0618 // Type or member is obsolete
         private static string SetupDiscoveryMetadata(string fileLocation, bool includehostData = false)
 


### PR DESCRIPTION
### Problem
#4099

### Solution
Ordering of search results now based on download count (descending) and then by name.
Note: for ordering displayed download count (estimated to thousands) is used (not actual).

This means for: A with 1001 downloads and B with 1999 downloads will be displayed as
```
Z    10k
A     1k
B     1k
C    <1k
```

This fix should be included to 6.0.2xx.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)