### PR TITLE
instantiate command and help option: error handling for invalid options

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Commands/Extensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/Extensions.cs
@@ -51,5 +51,28 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             }
             return commandResult?.Command?.Name ?? string.Empty;
         }
+
+        /// <summary>
+        /// Checks if <paramref name="parseResult"/> contains an error for <paramref name="option"/>.
+        /// </summary>
+        internal static bool HasErrorFor(this ParseResult parseResult, Option option)
+        {
+            if (!parseResult.Errors.Any())
+            {
+                return false;
+            }
+
+            if (parseResult.Errors.Any(e => e.SymbolResult?.Symbol == option))
+            {
+                return true;
+            }
+
+            if (parseResult.Errors.Any(e => e.SymbolResult?.Parent?.Symbol == option))
+            {
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.Help.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.Help.cs
@@ -69,6 +69,13 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                     templatePackageManager,
                     templateGroup);
 
+            if (!matchingTemplates.Any())
+            {
+                //output is handled in HandleNoTemplateFoundResult
+                HandleNoTemplateFoundResult(instantiateCommandArgs, environmentSettings, templatePackageManager, templateGroup, Reporter.Output);
+                return;
+            }
+
             if (!VerifyMatchingTemplates(
                 environmentSettings,
                 context.Output,
@@ -128,6 +135,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             out IEnumerable<TemplateCommand>? filteredTemplates)
         {
             filteredTemplates = matchingTemplates;
+
             //if more than one language, this is an error - handle it
             IEnumerable<string?> languages = matchingTemplates.Select(c => c.Template.GetLanguage()).Distinct();
             if (languages.Count() > 1)
@@ -409,7 +417,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             //except the choice parameter, where we merge possible values
             foreach (TemplateCommand command in templates)
             {
-                foreach (CliTemplateParameter currentParam in command.Template.CliParameters)
+                foreach (CliTemplateParameter currentParam in command.Template.CliParameters.Values)
                 {
                     if (currentParam.IsHidden && !currentParam.AlwaysShow)
                     {

--- a/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.NoMatchHandling.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.NoMatchHandling.cs
@@ -1,0 +1,213 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Edge.Settings;
+
+namespace Microsoft.TemplateEngine.Cli.Commands
+{
+    internal partial class InstantiateCommand : BaseCommand<InstantiateCommandArgs>
+    {
+        internal static List<InvalidTemplateOptionResult> GetInvalidOptions(IEnumerable<TemplateResult> templates)
+        {
+            //we need to process errors only for templates that match on language, type or baseline
+            IEnumerable<TemplateResult> templatesToAnalyze = templates.Where(template => template.IsTemplateMatch);
+
+            List<InvalidTemplateOptionResult> invalidOptionsList = new List<InvalidTemplateOptionResult>();
+
+            //collect the options with invalid names (unmatched tokens)
+            IEnumerable<InvalidTemplateOptionResult> unmatchedOptions = templatesToAnalyze.SelectMany(
+                template => template.InvalidTemplateOptions
+                    .Where(i => i.ErrorKind == InvalidTemplateOptionResult.Kind.InvalidName)).Distinct();
+
+            foreach (InvalidTemplateOptionResult option in unmatchedOptions)
+            {
+                if (templatesToAnalyze.All(
+                    template =>
+                        template.InvalidTemplateOptions.Any(x => x.Equals(option))))
+                {
+                    invalidOptionsList.Add(option);
+                }
+            }
+
+            //collect the options with invalid values (includes default and default if no option value failures)
+            IEnumerable<InvalidTemplateOptionResult> optionsWithInvalidValues = templatesToAnalyze.SelectMany(
+                template => template.InvalidTemplateOptions
+                        .Where(i => i.ErrorKind == InvalidTemplateOptionResult.Kind.InvalidValue)).Distinct();
+
+            foreach (InvalidTemplateOptionResult option in optionsWithInvalidValues)
+            {
+                if (templatesToAnalyze.All(
+                    template =>
+                        template.InvalidTemplateOptions.Any(x => x.Equals(option))
+                        //skip templates where option is not available
+                        || template.InvalidTemplateOptions.Any(x => x.ErrorKind == InvalidTemplateOptionResult.Kind.InvalidName && x.InputFormat == option.InputFormat)))
+                {
+                    if (option.IsChoice)
+                    {
+                        option.CorrectErrorMessageForChoice(templatesToAnalyze);
+                    }
+                    invalidOptionsList.Add(option);
+                }
+            }
+
+            return invalidOptionsList;
+        }
+
+        internal List<TemplateResult> CollectTemplateMatchInfo(InstantiateCommandArgs args, IEngineEnvironmentSettings environmentSettings, TemplatePackageManager templatePackageManager, TemplateGroup templateGroup)
+        {
+            List<TemplateResult> matchInfos = new List<TemplateResult>();
+            foreach (CliTemplateInfo template in templateGroup.Templates)
+            {
+                TemplateCommand command = new TemplateCommand(this, environmentSettings, templatePackageManager, templateGroup, template);
+                Parser parser = ParserFactory.CreateParser(command);
+                ParseResult parseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
+                matchInfos.Add(TemplateResult.FromParseResult(command, parseResult));
+            }
+            return matchInfos;
+        }
+
+        /// <summary>
+        /// Provides the error string to use for the invalid parameters collection.
+        /// </summary>
+        /// <param name="invalidParameterList">the invalid parameters collection to prepare output for.</param>
+        /// <param name="templates">the templates to use to get more information about parameters. Optional - if not provided the possible value for the parameters won't be included to the output.</param>
+        /// <returns>the error string for the output.</returns>
+        private static string InvalidOptionsListToString(IEnumerable<InvalidTemplateOptionResult> invalidParameterList, IEnumerable<TemplateResult>? templates = null)
+        {
+            if (!invalidParameterList.Any())
+            {
+                return string.Empty;
+            }
+            if (templates != null)
+            {
+                //we need to check only the templates matching on base criterias
+                templates = templates.Where(template => template.IsTemplateMatch);
+            }
+
+            StringBuilder invalidParamsErrorText = new StringBuilder(LocalizableStrings.InvalidCommandOptions);
+            foreach (InvalidTemplateOptionResult invalidParam in invalidParameterList)
+            {
+                invalidParamsErrorText.AppendLine();
+                if (invalidParam.ErrorKind == InvalidTemplateOptionResult.Kind.InvalidName)
+                {
+                    invalidParamsErrorText.AppendLine(invalidParam.InputFormat);
+                    invalidParamsErrorText.Indent(1).AppendFormat(LocalizableStrings.InvalidParameterNameDetail, invalidParam.InputFormat);
+                }
+                else if (invalidParam.ErrorKind == InvalidTemplateOptionResult.Kind.InvalidValue)
+                {
+                    invalidParamsErrorText.AppendLine(invalidParam.InputFormat + ' ' + invalidParam.SpecifiedValue);
+                    if (string.IsNullOrWhiteSpace(invalidParam.ErrorMessage))
+                    {
+                        invalidParamsErrorText.Indent(1).AppendFormat(LocalizableStrings.InvalidParameterDetail, invalidParam.InputFormat, invalidParam.SpecifiedValue);
+                    }
+                    else
+                    {
+                        invalidParamsErrorText.Append(invalidParam.ErrorMessage?.IndentLines(1));
+                    }
+                }
+                else
+                {
+                    invalidParamsErrorText.AppendLine(invalidParam.InputFormat + ' ' + invalidParam.SpecifiedValue);
+                    invalidParamsErrorText.Indent(1).AppendFormat(LocalizableStrings.InvalidParameterDefault, invalidParam.InputFormat, invalidParam.SpecifiedValue);
+                }
+            }
+            return invalidParamsErrorText.ToString();
+        }
+
+        private NewCommandStatus HandleNoTemplateFoundResult(
+            InstantiateCommandArgs args,
+            IEngineEnvironmentSettings environmentSettings,
+            TemplatePackageManager templatePackageManager,
+            TemplateGroup templateGroup,
+            Reporter reporter)
+        {
+            List<TemplateResult> matchInfos = CollectTemplateMatchInfo(args, environmentSettings, templatePackageManager, templateGroup);
+            //process language, type and baseline errors
+            if (!matchInfos.Any(mi => mi.IsTemplateMatch))
+            {
+                HandleNoMatchOnTemplateBaseOptions(matchInfos, args, templateGroup);
+                return NewCommandStatus.NotFound;
+            }
+
+            List<InvalidTemplateOptionResult> invalidOptionsList = GetInvalidOptions(matchInfos);
+            if (invalidOptionsList.Any())
+            {
+                reporter.WriteLine(InvalidOptionsListToString(invalidOptionsList, matchInfos).Bold().Red());
+            }
+            else
+            {
+                var tokens = args.ParseResult.Tokens.Select(t => t.Value);
+                reporter.WriteLine(string.Format(LocalizableStrings.NoTemplatesMatchingInputParameters, string.Join(" ", tokens)).Bold().Red());
+            }
+            reporter.WriteLine();
+            //TODO: if we were not able to match the errors, print all the errors template by template.
+
+            if (templateGroup.ShortNames.Any())
+            {
+                reporter.WriteLine(LocalizableStrings.InvalidParameterTemplateHint);
+                reporter.WriteCommand(CommandExamples.HelpCommandExample(args.CommandName, templateGroup.ShortNames[0]));
+            }
+
+            return NewCommandStatus.InvalidParamValues;
+        }
+
+        private void HandleNoMatchOnTemplateBaseOptions(IEnumerable<TemplateResult> matchInfos, InstantiateCommandArgs args, TemplateGroup templateGroup)
+        {
+            Option<string> languageOption = SharedOptionsFactory.CreateLanguageOption();
+            Option<string> typeOption = SharedOptionsFactory.CreateTypeOption();
+            Option<string> baselineOption = SharedOptionsFactory.CreateBaselineOption();
+
+            Command reparseCommand = new Command("reparse-only")
+            {
+                languageOption,
+                typeOption,
+                baselineOption,
+                new Argument("rem-args")
+                {
+                    Arity = new ArgumentArity(0, 999)
+                }
+            };
+
+            ParseResult result = ParserFactory.CreateParser(reparseCommand).Parse(args.RemainingArguments ?? Array.Empty<string>());
+            string baseInputParameters = $"'{args.ShortName}'";
+            foreach (var option in new[] { languageOption, typeOption, baselineOption })
+            {
+                if (result.FindResultFor(option) is { } optionResult)
+                {
+                    baseInputParameters = baseInputParameters + $", {optionResult.Token?.Value}='{optionResult.GetValueOrDefault<string>()}'";
+                }
+            }
+
+            Reporter.Error.WriteLine(string.Format(LocalizableStrings.NoTemplatesMatchingInputParameters, baseInputParameters).Bold().Red());
+            foreach (var option in new[]
+                {
+                    new { Option = languageOption, Condition = matchInfos.All(mi => !mi.IsLanguageMatch) },
+                    new { Option = typeOption, Condition = matchInfos.All(mi => !mi.IsTypeMatch) },
+                    new { Option = baselineOption, Condition = matchInfos.All(mi => !mi.IsBaselineMatch) },
+                })
+            {
+                if (option.Condition && result.FindResultFor(option.Option) is { } optionResult)
+                {
+                    string availableLanguagesStr = string.Join(", ", templateGroup.Languages.Select(l => $"'{l}'").OrderBy(l => l, StringComparer.OrdinalIgnoreCase));
+                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplateOptions_Error_AllowedValuesForOptionList, optionResult.Token?.Value, availableLanguagesStr));
+                }
+            }
+
+            Reporter.Error.WriteLine();
+
+            Reporter.Error.WriteLine(LocalizableStrings.ListTemplatesCommand);
+            Reporter.Error.WriteCommand(CommandExamples.ListCommandExample(args.CommandName));
+
+            Reporter.Error.WriteLine(LocalizableStrings.SearchTemplatesCommand);
+            Reporter.Error.WriteCommand(CommandExamples.SearchCommandExample(args.CommandName, args.ShortName));
+            Reporter.Error.WriteLine();
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.cs
@@ -198,17 +198,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 return HandleAmbuguousResult();
             }
 
-            Reporter.Error.WriteLine(
-                string.Format(LocalizableStrings.NoTemplatesMatchingInputParameters, args.ShortName).Bold().Red());
-            Reporter.Error.WriteLine();
-
-            Reporter.Error.WriteLine(LocalizableStrings.ListTemplatesCommand);
-            Reporter.Error.WriteCommand(CommandExamples.ListCommandExample(args.CommandName));
-
-            Reporter.Error.WriteLine(LocalizableStrings.SearchTemplatesCommand);
-            Reporter.Error.WriteCommand(CommandExamples.SearchCommandExample(args.CommandName, args.ShortName));
-            Reporter.Error.WriteLine();
-            return NewCommandStatus.NotFound;
+            return HandleNoTemplateFoundResult(args, environmentSettings, templatePackageManager, templateGroup, Reporter.Error);
         }
 
         private NewCommandStatus HandleAmbuguousResult() => throw new NotImplementedException();

--- a/src/Microsoft.TemplateEngine.Cli/Commands/TemplateArgs.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/TemplateArgs.cs
@@ -109,8 +109,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 return null;
             }
 
-            var parameter = Template.CliParameters.FirstOrDefault(p => p.Name.Equals(parameterName, StringComparison.OrdinalIgnoreCase));
-            if (parameter == null)
+            if (!Template.CliParameters.TryGetValue(parameterName, out CliTemplateParameter? parameter))
             {
                 throw new InvalidOperationException($"Parameter {parameterName} is not defined for {Template.Identity}.");
             }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/TemplateCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/TemplateCommand.cs
@@ -216,7 +216,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         private void AddTemplateOptionsToCommand(CliTemplateInfo templateInfo)
         {
             HashSet<string> initiallyTakenAliases = GetReservedAliases();
-            IEnumerable<CliTemplateParameter> parameters = templateInfo.CliParameters;
+            IEnumerable<CliTemplateParameter> parameters = templateInfo.CliParameters.Values;
             //TODO: handle errors
             var parametersWithAliasAssignments = AliasAssignmentCoordinator.AssignAliasesForParameter(parameters, initiallyTakenAliases);
 

--- a/src/Microsoft.TemplateEngine.Cli/Commands/TemplateOptionResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/TemplateOptionResult.cs
@@ -1,0 +1,238 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.CommandLine.Parsing;
+using System.Text;
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.Cli.Commands
+{
+    /// <summary>
+    /// The class represents the information about the template option used when executing the command.
+    /// </summary>
+    internal class TemplateOptionResult
+    {
+        internal TemplateOptionResult(
+          TemplateOption? templateOption,
+          string inputFormat,
+          string? specifiedValue)
+        {
+            TemplateOption = templateOption;
+            InputFormat = inputFormat;
+            SpecifiedValue = specifiedValue;
+        }
+
+        /// <summary>
+        /// the alias used in CLI for parameter.
+        /// </summary>
+        internal string InputFormat { get; }
+
+        /// <summary>
+        /// The value specified for the parameter in CLI.
+        /// </summary>
+        internal string? SpecifiedValue { get; }
+
+        internal TemplateOption? TemplateOption { get; }
+
+        internal static TemplateOptionResult? FromParseResult(TemplateOption option, ParseResult parseResult)
+        {
+            OptionResult? optionResult = parseResult.FindResultFor(option.Option);
+
+            if (optionResult == null)
+            {
+                //option is not specified
+                return null;
+            }
+
+            return new TemplateOptionResult(
+                    option,
+                    optionResult.Token?.Value ?? string.Empty,
+                    optionResult.GetValueOrDefault<string>());
+        }
+    }
+
+    /// <summary>
+    /// The class represents the information about the invalid template option used when executing the command.
+    /// </summary>
+    internal class InvalidTemplateOptionResult : TemplateOptionResult, IEquatable<InvalidTemplateOptionResult>
+    {
+        internal InvalidTemplateOptionResult(
+            TemplateOption? templateOption,
+            Kind kind,
+            string inputFormat,
+            string? specifiedValue,
+            string? errorMessage) : base(templateOption, inputFormat, specifiedValue)
+        {
+            ErrorKind = kind;
+            ErrorMessage = errorMessage;
+        }
+
+        /// <summary>
+        /// Defines the possible reason for the parameter to be invalid.
+        /// </summary>
+        internal enum Kind
+        {
+            /// <summary>
+            /// The name is invalid.
+            /// </summary>
+            InvalidName,
+
+            /// <summary>
+            /// The value is invalid.
+            /// </summary>
+            InvalidValue,
+        }
+
+        /// <summary>
+        /// The reason why the parameter is invalid.
+        /// </summary>
+        internal Kind ErrorKind { get; }
+
+        internal string? ErrorMessage { get; private set; }
+
+        internal bool IsChoice => TemplateOption?.TemplateParameter is ChoiceTemplateParameter;
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is InvalidTemplateOptionResult info)
+            {
+                if (InputFormat != info.InputFormat || info.ErrorKind != ErrorKind)
+                {
+                    return false;
+                }
+
+                if (TemplateOption == null && info.TemplateOption == null)
+                {
+                    return true;
+                }
+
+                if (TemplateOption == null || info.TemplateOption == null)
+                {
+                    return false;
+                }
+                return TemplateOption.TemplateParameter.Name.Equals(info.TemplateOption?.TemplateParameter.Name, StringComparison.OrdinalIgnoreCase);
+            }
+            return base.Equals(obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return new { a = TemplateOption?.TemplateParameter.Name?.ToLowerInvariant(), b = ErrorKind, c = InputFormat }.GetHashCode();
+        }
+
+        public bool Equals(InvalidTemplateOptionResult? other)
+        {
+            return this.Equals(other as object);
+        }
+
+        internal static new InvalidTemplateOptionResult FromParseResult(TemplateOption option, ParseResult parseResult)
+        {
+            if (!parseResult.HasErrorFor(option.Option))
+            {
+                throw new ArgumentException($"{nameof(option)} does not have an error in {nameof(parseResult)}");
+            }
+
+            OptionResult? optionResult = parseResult.FindResultFor(option.Option);
+            if (optionResult == null)
+            {
+                //option is not specified
+                throw new ArgumentException($"{nameof(option)}  is not used in {nameof(parseResult)}");
+            }
+
+            string? optionValue = null;
+            if (optionResult.Tokens.Any())
+            {
+                optionValue = string.Join(", ", optionResult.Tokens.Select(t => t.Value));
+            }
+
+            string? errorMessage = null;
+            if (!string.IsNullOrWhiteSpace(optionResult.ErrorMessage))
+            {
+                errorMessage = optionResult.ErrorMessage;
+            }
+            else
+            {
+                foreach (var result in optionResult.Children)
+                {
+                    if (string.IsNullOrWhiteSpace(result.ErrorMessage))
+                    {
+                        continue;
+                    }
+                    errorMessage = result.ErrorMessage;
+                    break;
+                }
+            }
+
+            return new InvalidTemplateOptionResult(
+                    option,
+                    Kind.InvalidValue,
+                    optionResult.Token?.Value ?? string.Empty,
+                    optionValue,
+                    errorMessage);
+        }
+
+        /// <summary>
+        /// Corrects the error message for choice parameter. It should include possible choice values from other templates in the group (passed via <paramref name="templates"/>).
+        /// </summary>
+        /// <param name="templates"></param>
+        internal void CorrectErrorMessageForChoice(IEnumerable<TemplateResult> templates)
+        {
+            if (TemplateOption is null)
+            {
+                throw new NotSupportedException($"Method is not invokable when {nameof(TemplateOption)} is null");
+            }
+
+            StringBuilder error = new StringBuilder();
+            error.AppendFormat(LocalizableStrings.InvalidParameterDetail, InputFormat, SpecifiedValue);
+            ErrorMessage = AppendAllowedValues(error, GetValidValuesForChoiceParameter(templates, TemplateOption.TemplateParameter)).ToString();
+        }
+
+        /// <summary>
+        /// Gets the list of valid choices for <paramref name="parameter"/>.
+        /// </summary>
+        /// <returns>the dictionary of valid choices and descriptions.</returns>
+        private static IDictionary<string, ParameterChoice> GetValidValuesForChoiceParameter(
+            IEnumerable<TemplateResult> templates,
+            CliTemplateParameter parameter)
+        {
+            Dictionary<string, ParameterChoice> validChoices = new Dictionary<string, ParameterChoice>();
+            foreach (CliTemplateInfo template in templates.Select(template => template.TemplateInfo))
+            {
+                if (template.CliParameters.TryGetValue(parameter.Name, out CliTemplateParameter? param))
+                {
+                    if (param is ChoiceTemplateParameter choiceParam)
+                    {
+                        foreach (var choice in choiceParam.Choices)
+                        {
+                            validChoices[choice.Key] = choice.Value;
+                        }
+                    }
+                }
+            }
+            return validChoices;
+        }
+
+        private static StringBuilder AppendAllowedValues(StringBuilder text, IDictionary<string, ParameterChoice> possibleValues)
+        {
+            if (!possibleValues.Any())
+            {
+                return text;
+            }
+
+            text.Append(' ').Append(LocalizableStrings.PossibleValuesHeader);
+            int longestChoiceLength = possibleValues.Keys.Max(x => x.Length);
+            foreach (KeyValuePair<string, ParameterChoice> choiceInfo in possibleValues.OrderBy(x => x.Key, StringComparer.Ordinal))
+            {
+                text.AppendLine();
+                text.Indent(1).Append(choiceInfo.Key.PadRight(longestChoiceLength));
+                if (!string.IsNullOrWhiteSpace(choiceInfo.Value.Description))
+                {
+                    text.Indent().Append("- " + choiceInfo.Value.Description);
+                }
+            }
+            return text;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/Commands/TemplateResult.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/TemplateResult.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.CommandLine.Parsing;
+
+namespace Microsoft.TemplateEngine.Cli.Commands
+{
+    /// <summary>
+    /// The class represents validity of certain template in context of the command being executed.
+    /// </summary>
+    internal class TemplateResult
+    {
+        private readonly TemplateCommand _templateCommand;
+        private readonly ParseResult _parseResult;
+        private List<TemplateOptionResult> _parametersInfo = new List<TemplateOptionResult>();
+
+        private TemplateResult(TemplateCommand templateCommand, ParseResult parseResult)
+        {
+            _templateCommand = templateCommand;
+            _parseResult = parseResult;
+        }
+
+        internal bool IsTemplateMatch => IsLanguageMatch && IsTypeMatch && IsBaselineMatch;
+
+        internal bool IsLanguageMatch { get; private set; }
+
+        internal bool IsTypeMatch { get; private set; }
+
+        internal bool IsBaselineMatch { get; private set; }
+
+        internal CliTemplateInfo TemplateInfo => _templateCommand.Template;
+
+        internal IEnumerable<TemplateOptionResult> ValidTemplateOptions => _parametersInfo.Where(i => !(i is InvalidTemplateOptionResult));
+
+        internal IEnumerable<InvalidTemplateOptionResult> InvalidTemplateOptions => _parametersInfo.OfType<InvalidTemplateOptionResult>();
+
+        internal static TemplateResult FromParseResult(TemplateCommand templateCommand, ParseResult parseResult)
+        {
+            TemplateResult result = new TemplateResult(templateCommand, parseResult);
+            result.IsLanguageMatch = templateCommand.LanguageOption == null || !parseResult.HasErrorFor(templateCommand.LanguageOption);
+            result.IsTypeMatch = templateCommand.TypeOption == null || !parseResult.HasErrorFor(templateCommand.TypeOption);
+            result.IsBaselineMatch = templateCommand.BaselineOption == null || !parseResult.HasErrorFor(templateCommand.BaselineOption);
+            foreach (var option in templateCommand.TemplateOptions)
+            {
+                if (parseResult.HasErrorFor(option.Value.Option))
+                {
+                    result._parametersInfo.Add(InvalidTemplateOptionResult.FromParseResult(option.Value, parseResult));
+                }
+                else
+                {
+                    if (TemplateOptionResult.FromParseResult(option.Value, parseResult) is TemplateOptionResult { } res)
+                    {
+                        result._parametersInfo.Add(res);
+                    }
+                }
+            }
+            foreach (var unmatchedToken in parseResult.UnmatchedTokens)
+            {
+                result._parametersInfo.Add(new InvalidTemplateOptionResult(
+                    null,
+                    InvalidTemplateOptionResult.Kind.InvalidName,
+                    inputFormat: unmatchedToken,
+                    specifiedValue: null,
+                    errorMessage: null));
+            }
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1321,6 +1321,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allowed values for &apos;{0}&apos; option are: {1}..
+        /// </summary>
+        internal static string TemplateOptions_Error_AllowedValuesForOptionList {
+            get {
+                return ResourceManager.GetString("TemplateOptions_Error_AllowedValuesForOptionList", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not find the template package containing template &apos;{0}&apos;.
         /// </summary>
         internal static string TemplatePackageCoordinator_Error_PackageForTemplateNotFound {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -681,4 +681,9 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
     <value>Unrecognized command or argument(s): {0}.</value>
     <comment>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</comment>
   </data>
+  <data name="TemplateOptions_Error_AllowedValuesForOptionList" xml:space="preserve">
+    <value>Allowed values for '{0}' option are: {1}.</value>
+    <comment>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</comment>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/ReporterExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/ReporterExtensions.cs
@@ -4,6 +4,8 @@
 #nullable enable
 
 using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.TemplateEngine.Cli
 {
@@ -79,6 +81,49 @@ namespace Microsoft.TemplateEngine.Cli
         internal static string Indent(this string s, int level = 1)
         {
             return new string(' ', IndentSpaceCount * level) + s;
+        }
+
+        /// <summary>
+        /// Indent all lines in the string, use this method to unify indents in the output.
+        /// </summary>
+        /// <param name="s">string to indent.</param>
+        /// <param name="level">indent level.</param>
+        /// <returns></returns>
+        internal static string IndentLines(this string s, int level = 1)
+        {
+            if (!s.Contains('\n'))
+            {
+                return s.Indent(level);
+            }
+            StringBuilder builder = new StringBuilder();
+            using StringReader sr = new StringReader(s);
+            bool firstLine = true;
+            string? line = sr.ReadLine();
+            while (line != null)
+            {
+                if (!firstLine)
+                {
+                    builder.AppendLine();
+                }
+                else
+                {
+                    firstLine = false;
+                }
+                builder.Indent(level).Append(line);
+                line = sr.ReadLine();
+            }
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Indents stringbuilder, use this method to unify indents in the output.
+        /// </summary>
+        /// <param name="s">string to indent.</param>
+        /// <param name="level">indent level.</param>
+        /// <returns></returns>
+        internal static StringBuilder Indent(this StringBuilder s, int level = 1)
+        {
+            return s.Append(' ', IndentSpaceCount * level);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -715,6 +715,12 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <target state="translated">Běžné šablony:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Nepovedlo se najít balíček šablony obsahující šablonu {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -715,6 +715,12 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
         <target state="translated">Allgemeine Vorlagen:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Das Vorlagenpaket mit der Vorlage "{0}" wurde nicht gefunden.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -715,6 +715,12 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
         <target state="translated">Las plantillas comunes son:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">No encontró el paquete de plantillas que contiene la plantilla "{0}"</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -715,6 +715,12 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <target state="translated">Les modèles courants sont les suivants :</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Le package de modèle contenant le modèle « {0} » est introuvable</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -715,6 +715,12 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <target state="translated">Seguono dei modelli comuni:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Non è stato possibile trovare il pacchetto di modelli contenente il modello '{0}'</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -715,6 +715,12 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">一般的なテンプレート:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">テンプレート '{0}' を含むテンプレートパッケージが見つかりませんでした</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -715,6 +715,12 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">일반적인 템플릿은 다음과 같습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">'{0}' 템플릿이 포함된 ‘템플릿 패키지를 찾을 수 없습니다.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -715,6 +715,12 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
         <target state="translated">Typowymi szablonami są:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Nie można znaleźć pakietu szablonów zawierającego szablon "{0}"</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -715,6 +715,12 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <target state="translated">Os modelos comuns são:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Não foi possível localizar o pacote de modelo contendo o modelo '{0}'</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -715,6 +715,12 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">Общие шаблоны:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Не удалось найти пакет шаблона, содержащий шаблон "{0}"</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -715,6 +715,12 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <target state="translated">Ortak şablonlar şunlardır:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">'{0}' şablonunu içeren şablon paketi bulunamadı</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -715,6 +715,12 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">常用模板包括:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">找不到包含模板“{0}”的模板包</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -715,6 +715,12 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">常見範本包括:</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplateOptions_Error_AllowedValuesForOptionList">
+        <source>Allowed values for '{0}' option are: {1}.</source>
+        <target state="new">Allowed values for '{0}' option are: {1}.</target>
+        <note>0} - option name (as --language)
+{1} - comma separated, escaped in quotes list of allowed values</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">找不到包含範本 '{0}' 的範本套件</target>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.NoMatchHandling.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.NoMatchHandling.cs
@@ -1,0 +1,193 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.CommandLine;
+using FakeItEasy;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Cli.Commands;
+using Microsoft.TemplateEngine.Edge;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.Mocks;
+using Microsoft.TemplateEngine.TestHelper;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
+{
+    public partial class InstantiateTests
+    {
+        private static readonly string NewLine = Environment.NewLine;
+
+        public static IEnumerable<object[]> GetInvalidParametersTestData()
+        {
+            yield return new object[]
+            {
+                "foo --framework netcoreapp3.0",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithChoiceParameter("framework", "netcoreapp2.1", "netcoreapp3.1"),
+                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithChoiceParameter("framework", "net5.0"),
+                },
+                new string[][]
+                {
+                    new string[] { "value", "framework", "--framework", "netcoreapp3.0", $"'netcoreapp3.0' is not a valid value for --framework. The possible values are:{NewLine}   net5.0       {NewLine}   netcoreapp2.1{NewLine}   netcoreapp3.1" }
+                }
+            };
+
+            yield return new object[]
+            {
+                "foo --framework net",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithChoiceParameter("framework", "netcoreapp2.1", "netcoreapp3.1"),
+                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithChoiceParameter("framework", "net5.0"),
+                },
+                new string[][]
+                {
+                    new string[] { "value", "framework", "--framework", "net", $"'net' is not a valid value for --framework. The possible values are:{NewLine}   net5.0       {NewLine}   netcoreapp2.1{NewLine}   netcoreapp3.1" }
+                }
+            };
+
+            yield return new object[]
+            {
+                "foo --framework net",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithChoiceParameter("framework", "netcoreapp2.1"),
+                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithChoiceParameter("framework", "net5.0"),
+                    new MockTemplateInfo("foo", identity: "foo.3", groupIdentity: "foo.group").WithChoiceParameter("framework", "netcoreapp3.1"),
+                },
+                new string[][]
+                {
+                    new string[] { "value", "framework", "--framework", "net", $"'net' is not a valid value for --framework. The possible values are:{NewLine}   net5.0       {NewLine}   netcoreapp2.1{NewLine}   netcoreapp3.1" }
+                }
+            };
+
+            yield return new object[]
+            {
+                "foo --framework net --fake fake --OtherChoice fake",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithChoiceParameter("framework", "netcoreapp2.1", "netcoreapp3.1").WithChoiceParameter("OtherChoice", "val1", "val2"),
+                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group").WithChoiceParameter("framework", "net5.0").WithChoiceParameter("OtherChoice", "val1", "val2"),
+                },
+                new string?[][]
+                {
+                    new string?[] { "value", "framework", "--framework", "net", $"'net' is not a valid value for --framework. The possible values are:{NewLine}   net5.0       {NewLine}   netcoreapp2.1{NewLine}   netcoreapp3.1" },
+                    new string?[] { "name", null, "--fake", null },
+                    new string?[] { "name", null, "fake", null },
+                    new string?[] { "value", "OtherChoice", "--OtherChoice", "fake", $"'fake' is not a valid value for --OtherChoice. The possible values are:{NewLine}   val1{NewLine}   val2" }
+                }
+            };
+            yield return new object[]
+            {
+                "foo --int fake",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+                        .WithParameter("int", paramType: "integer")
+                },
+                new string[][]
+                {
+                    new string[] { "value", "int", "--int", "fake", "Cannot parse argument 'fake' for option '--int' as expected type Int64." },
+                }
+            };
+            yield return new object[]
+            {
+                "foo --int",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+                        .WithParameter("int", paramType: "integer", defaultIfNoOptionValue: "fake")
+                },
+                new string?[][]
+                {
+                    new string?[] { "value", "int", "--int", null, "Cannot parse default if option without value 'fake' for option '--int' as expected type Int64." },
+                }
+            };
+            //TODO: does not work, see https://github.com/dotnet/command-line-api/issues/1474
+            //yield return new object[]
+            //{
+            //    "foo",
+            //    new MockTemplateInfo[]
+            //    {
+            //        new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+            //            .WithParameter("int", paramType: "integer", defaultValue: "fake")
+            //    },
+            //    new string[][]
+            //    {
+            //        new string[] { "value", "int", "--int", "fake", "expected-error" },
+            //    }
+            //};
+
+            yield return new object[]
+            {
+                "foo --langVersion",
+                new MockTemplateInfo[]
+                {
+                    new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group").WithParameter("langVersion"),
+                    new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "foo.group")
+                },
+                new string?[][]
+                {
+                    new string?[] { "value", "langVersion", "--langVersion", null, "Required argument missing for option: '--langVersion'." }
+                }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetInvalidParametersTestData))]
+        // invalid params:
+        // [0] name / value - Kind
+        // [1] canonical
+        // [2] input format
+        // [3] param value
+        // [4] error message
+        internal void CanEvaluateInvalidParameters(string command, MockTemplateInfo[] templates, string?[][] expectedInvalidParams)
+        {
+            TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
+                CliTemplateInfo.FromTemplateInfo(templates, A.Fake<IHostSpecificDataLoader>()))
+                .Single();
+
+            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+            TemplatePackageManager templatePackageManager = A.Fake<TemplatePackageManager>();
+
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", host, new TelemetryLogger(null, false), new NewCommandCallbacks());
+            InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
+            var parseResult = instantiateCommand.Parse($" new {command}");
+            var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
+            var templateCommands = instantiateCommand.GetTemplateCommand(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            Assert.Empty(templateCommands);
+
+            var templateMatchInfos = instantiateCommand.CollectTemplateMatchInfo(args, settings, templatePackageManager, templateGroup);
+            var invalidOptions = InstantiateCommand.GetInvalidOptions(templateMatchInfos);
+            Assert.Equal(expectedInvalidParams.Length, invalidOptions.Count);
+
+            foreach (var invalidParam in expectedInvalidParams)
+            {
+                InvalidTemplateOptionResult.Kind expectedErrorKind = invalidParam[0] == "name"
+                    ? InvalidTemplateOptionResult.Kind.InvalidName
+                    : InvalidTemplateOptionResult.Kind.InvalidValue;
+
+                string? expectedCanonicalName = invalidParam[1];
+                string expectedInputFormat = invalidParam[2] ?? throw new Exception("Input Format cannot be null");
+                string? expectedSpecifiedValue = invalidParam[3];
+                string? expectedErrorMessage = null;
+                if (invalidParam.Length == 5)
+                {
+                    expectedErrorMessage = invalidParam[4];
+                }
+
+                var actualParam = invalidOptions.Single(param => param.InputFormat == expectedInputFormat);
+
+                Assert.Equal(expectedErrorKind, actualParam.ErrorKind);
+                Assert.Equal(expectedCanonicalName, actualParam.TemplateOption?.TemplateParameter.Name);
+                Assert.Equal(expectedInputFormat, actualParam.InputFormat);
+                Assert.Equal(expectedSpecifiedValue, actualParam.SpecifiedValue);
+                Assert.Equal(expectedErrorMessage, actualParam.ErrorMessage);
+            }
+        }
+    }
+}

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CannotShowHelpForTemplate_MatchOnNonChoiceParamWithoutValue.approved.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CannotShowHelpForTemplate_MatchOnNonChoiceParamWithoutValue.approved.txt
@@ -1,3 +1,6 @@
 ﻿Error: Invalid option(s):
 --langVersion 
-   '' is not a valid value for --langVersion.
+   Required argument missing for option: '--langVersion'.
+
+For more information, run:
+   dotnet new3 console -h

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWithUnknownLanguage.approved.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWithUnknownLanguage.approved.txt
@@ -1,4 +1,5 @@
-﻿No templates found matching: 'console', language='D#'.
+﻿No templates found matching: 'console', --language='D#'.
+Allowed values for '--language' option are: 'C#', 'F#', 'VB'.
 
 To list installed templates, run:
    dotnet new3 --list

--- a/test/dotnet-new3.UnitTests/DotnetNewHelp.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewHelp.Approval.cs
@@ -250,9 +250,7 @@ namespace Dotnet_new3.IntegrationTests
             Approvals.Verify(commandResult.StdOut);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "Help is not implemented yet")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CannotShowHelpForTemplate_MatchOnChoiceWithoutValue()
         {
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -262,16 +260,12 @@ namespace Dotnet_new3.IntegrationTests
                 .WithWorkingDirectory(workingDirectory)
                 .Execute();
 
-            commandResult
-                .Should().Fail()
-                .And.NotHaveStdOut();
-
-            Approvals.Verify(commandResult.StdErr);
+            //help command cannot fail, therefore the output is written to stdout
+            commandResult.Should().Pass().And.NotHaveStdErr();
+            Approvals.Verify(commandResult.StdOut);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "Help is not implemented yet")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CannotShowHelpForTemplate_MatchOnUnexistingParam()
         {
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -281,11 +275,9 @@ namespace Dotnet_new3.IntegrationTests
                 .WithWorkingDirectory(workingDirectory)
                 .Execute();
 
-            commandResult
-                .Should().Fail()
-                .And.NotHaveStdOut();
-
-            Approvals.Verify(commandResult.StdErr);
+            //help command cannot fail, therefore the output is written to stdout
+            commandResult.Should().Pass().And.NotHaveStdErr();
+            Approvals.Verify(commandResult.StdOut);
         }
 
         [Fact]
@@ -298,11 +290,8 @@ namespace Dotnet_new3.IntegrationTests
                     .WithWorkingDirectory(workingDirectory)
                     .Execute();
 
-            commandResult
-                    .Should().Pass()
-                    .And.NotHaveStdErr()
-                    .And.NotHaveStdOutContaining("Usage: new3 [options]");
-
+            //help command cannot fail, therefore the output is written to stdout
+            commandResult.Should().Pass().And.NotHaveStdErr().And.NotHaveStdOutContaining("Usage: new3 [options]");
             Approvals.Verify(commandResult.StdOut);
         }
 
@@ -324,9 +313,7 @@ namespace Dotnet_new3.IntegrationTests
             Approvals.Verify(commandResult.StdOut);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "Help is not implemented yet")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CannotShowHelpForTemplate_MatchOnNonChoiceParamWithoutValue()
         {
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -336,11 +323,9 @@ namespace Dotnet_new3.IntegrationTests
                 .WithWorkingDirectory(workingDirectory)
                 .Execute();
 
-            commandResult
-                .Should().Fail()
-                .And.NotHaveStdOut();
-
-            Approvals.Verify(commandResult.StdErr);
+            //help command cannot fail, therefore the output is written to stdout
+            commandResult.Should().Pass().And.NotHaveStdErr();
+            Approvals.Verify(commandResult.StdOut);
         }
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.Approval.cs
@@ -30,9 +30,7 @@ namespace Dotnet_new3.IntegrationTests
             Approvals.Verify(commandResult.StdErr);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "instantiation error handling is not complete yet")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CannotInstantiateTemplateWithUnknownLanguage()
         {
             var commandResult = new DotnetNewCommand(_log, "console", "--language", "D#")
@@ -88,9 +86,7 @@ namespace Dotnet_new3.IntegrationTests
             Approvals.Verify(commandResult.StdErr);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "instantiation error handling is not complete yet")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CannotInstantiateTemplate_WhenParameterIsInvalid()
         {
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -108,9 +104,7 @@ namespace Dotnet_new3.IntegrationTests
             Approvals.Verify(commandResult.StdErr);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "instantiation error handling is not complete yet")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CannotInstantiateTemplate_WhenChoiceParameterValueIsInvalid()
         {
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -128,9 +122,7 @@ namespace Dotnet_new3.IntegrationTests
             Approvals.Verify(commandResult.StdErr);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "instantiation error handling is not complete yet")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CannotInstantiateTemplate_WhenChoiceParameterValueIsNotComplete()
         {
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -148,9 +140,7 @@ namespace Dotnet_new3.IntegrationTests
             Approvals.Verify(commandResult.StdErr);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "instantiation error handling is not complete yet")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CannotInstantiateTemplate_OnMultipleParameterErrors()
         {
             string workingDirectory = TestUtils.CreateTemporaryFolder();


### PR DESCRIPTION
### Problem
Part of https://github.com/dotnet/templating/issues/3809:  error handing for invalid template options

### Solution
Implements error handling for invalid template options.
Mostly previous implementation code with some adaptations for new parsing

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)