### PR TITLE
added list of post action IDs defined in template.json to `ITemplateInfo`

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/ITemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ITemplateInfo.cs
@@ -120,5 +120,10 @@ namespace Microsoft.TemplateEngine.Abstractions
         /// Gets the list of short names defined for the template.
         /// </summary>
         IReadOnlyList<string> ShortNameList { get; }
+
+        /// <summary>
+        /// Gets the list of post actions IDs defined in the template.
+        /// </summary>
+        IReadOnlyList<Guid> PostActions { get;  }
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Microsoft.TemplateEngine.Abstractions.ITemplateInfo.PostActions.get -> System.Collections.Generic.IReadOnlyList<System.Guid>!

--- a/src/Microsoft.TemplateEngine.Edge/FilterableTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/FilterableTemplateInfo.cs
@@ -56,7 +56,9 @@ namespace Microsoft.TemplateEngine.Edge
 
         public DateTime? ConfigTimestampUtc { get; set; }
 
-        public IReadOnlyDictionary<string, string> TagsCollection => throw new NotImplementedException();
+        public IReadOnlyDictionary<string, string> TagsCollection { get; private set; }
+
+        public IReadOnlyList<Guid> PostActions { get; private set; }
 
         public static FilterableTemplateInfo FromITemplateInfo(ITemplateInfo source)
         {
@@ -82,7 +84,9 @@ namespace Microsoft.TemplateEngine.Edge
                 ThirdPartyNotices = source.ThirdPartyNotices,
                 BaselineInfo = source.BaselineInfo,
                 HasScriptRunningPostActions = source.HasScriptRunningPostActions,
-                ShortNameList = source.ShortNameList
+                ShortNameList = source.ShortNameList,
+                TagsCollection = source.TagsCollection,
+                PostActions = source.PostActions
             };
 
             return filterableTemplate;

--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿
+﻿~Microsoft.TemplateEngine.Edge.FilterableTemplateInfo.PostActions.get -> System.Collections.Generic.IReadOnlyList<System.Guid>

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
@@ -92,6 +92,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             ThirdPartyNotices = template.ThirdPartyNotices;
             BaselineInfo = template.BaselineInfo;
             ShortNameList = template.ShortNameList;
+            PostActions = template.PostActions;
 
             LocaleConfigPlace = localizationInfo?.ConfigPlace;
 
@@ -245,6 +246,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         bool ITemplateInfo.HasScriptRunningPostActions { get; set; }
 
         public JObject? HostData { get; private set; }
+
+        [JsonProperty]
+        public IReadOnlyList<Guid> PostActions { get; private set; } = Array.Empty<Guid>();
 
         public static TemplateInfo FromJObject(JObject entry)
         {

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReader.cs
@@ -91,7 +91,19 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 }
 
                 info.HostData = entry.Get<JObject>(nameof(info.HostData));
-
+                JArray? postActionsArray = entry.Get<JArray>(nameof(info.PostActions));
+                if (postActionsArray != null)
+                {
+                    List<Guid> postActions = new List<Guid>();
+                    foreach (JToken item in postActionsArray)
+                    {
+                        if (Guid.TryParse(item.ToString(), out Guid id))
+                        {
+                            postActions.Add(id);
+                        }
+                    }
+                    info.PostActions = postActions;
+                }
                 return info;
             }
         }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectTemplate.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,14 +16,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
     {
         private readonly SimpleConfigModel _config;
         private readonly IGenerator _generator;
-        private readonly IFile _localeConfigFile;
-        private readonly IFile _hostConfigFile;
+        private readonly IFile? _localeConfigFile;
+        private readonly IFile? _hostConfigFile;
 
         internal RunnableProjectTemplate(
             IGenerator generator,
             SimpleConfigModel config,
-            IFile localeConfigFile,
-            IFile hostConfigFile)
+            IFile? localeConfigFile,
+            IFile? hostConfigFile)
         {
             _config = config;
             _generator = generator;
@@ -35,17 +37,17 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         Guid ITemplateInfo.GeneratorId => _generator.Id;
 
-        string ITemplateInfo.Author => _config.Author;
+        string? ITemplateInfo.Author => _config.Author;
 
-        string ITemplateInfo.Description => _config.Description;
+        string? ITemplateInfo.Description => _config.Description;
 
         IReadOnlyList<string> ITemplateInfo.Classifications => _config.Classifications;
 
-        string ITemplateInfo.DefaultName => _config.DefaultName;
+        string? ITemplateInfo.DefaultName => _config.DefaultName;
 
         IGenerator ITemplate.Generator => _generator;
 
-        string ITemplateInfo.GroupIdentity => _config.GroupIdentity;
+        string? ITemplateInfo.GroupIdentity => _config.GroupIdentity;
 
         int ITemplateInfo.Precedence => _config.Precedence;
 
@@ -79,7 +81,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 }
                 foreach (ITemplateParameter parameter in ((ITemplateInfo)this).Parameters.Where(p => p.DataType != null && p.DataType.Equals("choice", StringComparison.OrdinalIgnoreCase)))
                 {
-                    tags[parameter.Name] = new CacheTag(parameter.DisplayName, parameter.Description, parameter.Choices, parameter.DefaultValue);
+                    IReadOnlyDictionary<string, ParameterChoice> choices = parameter.Choices ?? new Dictionary<string, ParameterChoice>();
+                    tags[parameter.Name] = new CacheTag(parameter.DisplayName, parameter.Description, choices, parameter.DefaultValue);
                 }
                 return tags;
             }
@@ -124,23 +127,25 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         string ITemplateInfo.ConfigPlace => _config.SourceFile.FullPath;
 
-        IFileSystemInfo ITemplate.LocaleConfiguration => _localeConfigFile;
+        IFileSystemInfo? ITemplate.LocaleConfiguration => _localeConfigFile;
 
-        string ITemplateInfo.LocaleConfigPlace => _localeConfigFile?.FullPath;
+        string? ITemplateInfo.LocaleConfigPlace => _localeConfigFile?.FullPath;
 
         //read in simple template model instead
         bool ITemplate.IsNameAgreementWithFolderPreferred => _config.PreferNameDirectory;
 
-        string ITemplateInfo.HostConfigPlace => _hostConfigFile?.FullPath;
+        string? ITemplateInfo.HostConfigPlace => _hostConfigFile?.FullPath;
 
         //read in simple template model instead
-        string ITemplateInfo.ThirdPartyNotices => _config.ThirdPartyNotices;
+        string? ITemplateInfo.ThirdPartyNotices => _config.ThirdPartyNotices;
 
         IReadOnlyDictionary<string, IBaselineInfo> ITemplateInfo.BaselineInfo => _config.BaselineInfo;
 
         IReadOnlyDictionary<string, string> ITemplateInfo.TagsCollection => _config.Tags;
 
         bool ITemplateInfo.HasScriptRunningPostActions { get; set; }
+
+        IReadOnlyList<Guid> ITemplateInfo.PostActions => _config.PostActionModels.Select(pam => pam.ActionId).ToArray();
 
         internal IRunnableProjectConfig Config => _config;
     }

--- a/src/Microsoft.TemplateSearch.Common/Abstractions/TemplateSearchData.cs
+++ b/src/Microsoft.TemplateSearch.Common/Abstractions/TemplateSearchData.cs
@@ -93,6 +93,8 @@ namespace Microsoft.TemplateSearch.Common
 
         [Obsolete]
         bool ITemplateInfo.HasScriptRunningPostActions { get => TemplateInfo.HasScriptRunningPostActions; set => throw new NotImplementedException(); }
+
+        IReadOnlyList<Guid> ITemplateInfo.PostActions => TemplateInfo.PostActions;
         #endregion
 
         private ITemplateInfo TemplateInfo { get; }

--- a/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/BlobStorageTemplateInfo.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/BlobStorageTemplateInfo.cs
@@ -50,6 +50,7 @@ namespace Microsoft.TemplateSearch.Common
             ThirdPartyNotices = templateInfo.ThirdPartyNotices;
             TagsCollection = templateInfo.TagsCollection ?? new Dictionary<string, string>();
             BaselineInfo = templateInfo.BaselineInfo ?? new Dictionary<string, IBaselineInfo>();
+            PostActions = templateInfo.PostActions;
         }
 
         [JsonConstructor]
@@ -146,6 +147,9 @@ namespace Microsoft.TemplateSearch.Common
         [JsonProperty]
         public IReadOnlyDictionary<string, string> TagsCollection { get; private set; } = new Dictionary<string, string>();
 
+        [JsonProperty]
+        public IReadOnlyList<Guid> PostActions { get; private set; } = Array.Empty<Guid>();
+
         public static BlobStorageTemplateInfo FromJObject(JObject entry)
         {
             string identity = entry.ToString(nameof(Identity))
@@ -188,6 +192,20 @@ namespace Microsoft.TemplateSearch.Common
                     baselineInfo.Add(item.Name, baseline);
                 }
                 info.BaselineInfo = baselineInfo;
+            }
+
+            JArray? postActionsArray = entry.Get<JArray>(nameof(info.PostActions));
+            if (postActionsArray != null)
+            {
+                List<Guid> postActions = new List<Guid>();
+                foreach (JToken item in postActionsArray)
+                {
+                    if (Guid.TryParse(item.ToString(), out Guid id))
+                    {
+                        postActions.Add(id);
+                    }
+                }
+                info.PostActions = postActions;
             }
 
             //read parameters

--- a/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplateSearchData.Json.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplateSearchData.Json.cs
@@ -183,6 +183,17 @@ namespace Microsoft.TemplateSearch.Common
                     serializer.Serialize(writer, value.TemplateInfo.BaselineInfo);
                 }
 
+                if (value.TemplateInfo.PostActions.Any())
+                {
+                    writer.WritePropertyName(nameof(ITemplateInfo.PostActions));
+                    writer.WriteStartArray();
+                    foreach (Guid guid in value.TemplateInfo.PostActions)
+                    {
+                        writer.WriteValue(guid.ToString());
+                    }
+                    writer.WriteEndArray();
+                }
+
                 if (value.AdditionalData.Any())
                 {
                     foreach (var item in value.AdditionalData)
@@ -195,7 +206,6 @@ namespace Microsoft.TemplateSearch.Common
                 writer.WriteEndObject();
             }
         }
-
         #endregion
     }
 }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyBlobTemplateInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyBlobTemplateInfo.cs
@@ -25,6 +25,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Results
             //new properties - not written to json
             Parameters = templateInfo.Parameters;
             TagsCollection = templateInfo.TagsCollection;
+            PostActions = templateInfo.PostActions;
 
             //compatibility for old way to manage parameters
             if (templateInfo.Tags.Any())
@@ -167,6 +168,9 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Results
 
         [JsonProperty]
         public IReadOnlyDictionary<string, ICacheParameter> CacheParameters { get; private set; } = new Dictionary<string, ICacheParameter>();
+
+        [JsonIgnore]
+        public IReadOnlyList<Guid> PostActions { get; private set; }
 
         // ShortName should get deserialized when it exists, for backwards compat.
         // But moving forward, ShortNameList should be the definitive source.

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/TemplateCacheTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/TemplateCacheTests.cs
@@ -14,12 +14,20 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.TestHelper;
 using Xunit;
 
 namespace Microsoft.TemplateEngine.Edge.UnitTests
 {
-    public class TemplateCacheTests
+    public class TemplateCacheTests : IClassFixture<EnvironmentSettingsHelper>
     {
+        private EnvironmentSettingsHelper _environmentSettingsHelper;
+
+        public TemplateCacheTests(EnvironmentSettingsHelper environmentSettingsHelper)
+        {
+            _environmentSettingsHelper = environmentSettingsHelper;
+        }
+    
         [Theory]
         [InlineData("en-US", "en")]
         [InlineData("zh-CN", "zh-Hans")]
@@ -73,6 +81,36 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             {
                 CultureInfo.CurrentUICulture = persistedCulture;
             }
+        }
+
+        [Fact]
+        public void CanHandlePostActions()
+        {
+            IEngineEnvironmentSettings environmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            SettingsFilePaths paths = new SettingsFilePaths(environmentSettings);
+
+            Guid postAction1 = Guid.NewGuid();
+            Guid postAction2 = Guid.NewGuid();
+
+            ITemplate template = A.Fake<ITemplate>();
+            A.CallTo(() => template.Identity).Returns("testIdentity");
+            A.CallTo(() => template.Name).Returns("testName");
+            A.CallTo(() => template.ShortNameList).Returns(new[] { "testShort" });
+            A.CallTo(() => template.MountPointUri).Returns("testMount");
+            A.CallTo(() => template.ConfigPlace).Returns(".template.config/template.json");
+            A.CallTo(() => template.PostActions).Returns(new[] { postAction1, postAction2 });
+            IMountPoint mountPoint = A.Fake<IMountPoint>();
+            A.CallTo(() => mountPoint.MountPointUri).Returns("testMount");
+
+            ScanResult result = new ScanResult(mountPoint, new[] { template }, Array.Empty<ILocalizationLocator>(), Array.Empty<(string AssemblyPath, Type InterfaceType, IIdentifiedComponent Instance)>());
+            TemplateCache templateCache = new TemplateCache(new[] { result }, new Dictionary<string, DateTime>(), NullLogger.Instance);
+
+            environmentSettings.Host.FileSystem.WriteObject(paths.TemplateCacheFile, templateCache);
+            var readCache = new TemplateCache(environmentSettings.Host.FileSystem.ReadObject(paths.TemplateCacheFile), NullLogger.Instance);
+
+            Assert.Single(readCache.TemplateInfo);
+            var readTemplate = readCache.TemplateInfo[0];
+            Assert.Equal(new[] { postAction1, postAction2 }, readTemplate.PostActions);
         }
 
     }

--- a/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
@@ -22,6 +22,8 @@ namespace Microsoft.TemplateEngine.Mocks
 
         private string[] _shortNameList = Array.Empty<string>();
 
+        private Guid[] _postActions = Array.Empty<Guid>();
+
         private Dictionary<string, string> _tags = new Dictionary<string, string>();
 
         private Dictionary<string, string[]> _choiceParameters = new Dictionary<string, string[]>();
@@ -152,6 +154,8 @@ namespace Microsoft.TemplateEngine.Mocks
 
         public IReadOnlyDictionary<string, string> TagsCollection => _tags;
 
+        public IReadOnlyList<Guid> PostActions => _postActions;
+
         public MockTemplateInfo WithParameters(params string[] parameters)
         {
             if (_parameters.Length == 0)
@@ -205,6 +209,19 @@ namespace Microsoft.TemplateEngine.Mocks
             else
             {
                 _classifications = _classifications.Concat(classifications).ToArray();
+            }
+            return this;
+        }
+
+        public MockTemplateInfo WithPostActions(params Guid[] postActions)
+        {
+            if (_postActions.Length == 0)
+            {
+                _postActions = postActions;
+            }
+            else
+            {
+                _postActions = _postActions.Concat(postActions).ToArray();
             }
             return this;
         }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ScanTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ScanTests.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.IO;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.TestHelper;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
+{
+    public class ScanTests : IClassFixture<EnvironmentSettingsHelper>
+    {
+        private EnvironmentSettingsHelper _environmentSettingsHelper;
+
+        public ScanTests(EnvironmentSettingsHelper environmentSettingsHelper)
+        {
+            _environmentSettingsHelper = environmentSettingsHelper;
+        }
+
+        [Fact]
+        public void CanReadPostActions()
+        {
+            var jsonToBe = new
+            {
+                name = "TestTemplate",
+                identity = "id",
+                shortName = "test",
+                postActions = new[]
+                {
+                    new
+                    {
+                        actionId = Guid.NewGuid(),
+                    },
+                    new
+                    {
+                        actionId = Guid.NewGuid(),
+                    },
+                }
+            };
+            IEngineEnvironmentSettings environmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            string sourceBasePath = environmentSettings.GetNewVirtualizedPath();
+
+            string templateConfigDir = Path.Combine(sourceBasePath, RunnableProjectGenerator.TemplateConfigDirectoryName);
+            string filePath = Path.Combine(templateConfigDir, RunnableProjectGenerator.TemplateConfigFileName);
+            environmentSettings.Host.FileSystem.CreateDirectory(templateConfigDir);
+            environmentSettings.Host.FileSystem.WriteAllText(filePath, JsonConvert.SerializeObject(jsonToBe));
+
+            IMountPoint mountPoint = environmentSettings.MountPath(sourceBasePath);
+            RunnableProjectGenerator generator = new RunnableProjectGenerator();
+            var templates = generator.GetTemplatesAndLangpacksFromDir(mountPoint, out _);
+
+            Assert.Single(templates);
+            var template = templates[0];
+            Assert.Equal(new[] { jsonToBe.postActions[0].actionId, jsonToBe.postActions[1].actionId }, template.PostActions);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.TestHelper/AssemblyComponentCatalog.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/AssemblyComponentCatalog.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TemplateEngine.TestHelper
     public class AssemblyComponentCatalog : IReadOnlyList<(Type, IIdentifiedComponent)>
     {
         private readonly IReadOnlyList<Assembly> _assemblies;
-        private IReadOnlyList<(Type, IIdentifiedComponent)> _lookup;
+        private IReadOnlyList<(Type, IIdentifiedComponent)>? _lookup;
 
         public AssemblyComponentCatalog(IReadOnlyList<Assembly> assemblies)
         {
@@ -24,8 +24,7 @@ namespace Microsoft.TemplateEngine.TestHelper
         {
             get
             {
-                EnsureLoaded();
-                return _lookup.Count;
+                return EnsureLookupLoaded().Count;
             }
         }
 
@@ -33,24 +32,22 @@ namespace Microsoft.TemplateEngine.TestHelper
         {
             get
             {
-                EnsureLoaded();
-                return _lookup[index];
+                return EnsureLookupLoaded()[index];
             }
         }
 
         public IEnumerator<(Type, IIdentifiedComponent)> GetEnumerator()
         {
-            EnsureLoaded();
-            return _lookup.GetEnumerator();
+            return EnsureLookupLoaded().GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        private void EnsureLoaded()
+        private IReadOnlyList<(Type, IIdentifiedComponent)> EnsureLookupLoaded()
         {
             if (_lookup != null)
             {
-                return;
+                return _lookup;
             }
 
             var builder = new List<(Type, IIdentifiedComponent)>();
@@ -78,7 +75,7 @@ namespace Microsoft.TemplateEngine.TestHelper
                 }
             }
 
-            _lookup = builder.ToList();
+            return builder.ToList();
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/test/Microsoft.TemplateEngine.TestHelper/FileSystemHelpers.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/FileSystemHelpers.cs
@@ -4,17 +4,30 @@
 using System;
 using System.IO;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Mount;
 
 namespace Microsoft.TemplateEngine.TestHelper
 {
     public static class FileSystemHelpers
     {
-        public static string GetNewVirtualizedPath(IEngineEnvironmentSettings environment)
+        public static string GetNewVirtualizedPath(this IEngineEnvironmentSettings environmentSettings)
         {
             string basePath = Path.Combine(Directory.GetCurrentDirectory(), "sandbox", Guid.NewGuid().ToString()) + Path.DirectorySeparatorChar;
-            environment.Host.VirtualizeDirectory(basePath);
+            environmentSettings.Host.VirtualizeDirectory(basePath);
 
             return basePath;
+        }
+
+        public static IMountPoint MountPath (this IEngineEnvironmentSettings environmentSettings, string path)
+        {
+            foreach (var factory in environmentSettings.Components.OfType<IMountPointFactory>())
+            {
+                if (factory.TryMount(environmentSettings, null, path, out IMountPoint? mountPoint))
+                {
+                    return mountPoint;
+                }
+            }
+            throw new Exception($"Failed to mount path {path}.");
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks Condition="'$(PackSpecific)' != 'true'">$(NETStandardTargetFramework);$(NETFullTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETStandardTargetFramework)</TargetFrameworks>
+    <Nullable>enable</Nullable>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 

--- a/test/Microsoft.TemplateEngine.TestHelper/MonitoredFileSystem.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/MonitoredFileSystem.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/test/Microsoft.TemplateEngine.TestHelper/TestHost.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/TestHost.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;

--- a/test/Microsoft.TemplateSearch.Common.UnitTests/TemplateSearchCacheReaderTests.cs
+++ b/test/Microsoft.TemplateSearch.Common.UnitTests/TemplateSearchCacheReaderTests.cs
@@ -116,12 +116,16 @@ namespace Microsoft.TemplateSearch.Common.UnitTests
         [Fact]
         public void CanReadSearchMetadata_V2_E2E()
         {
+            Guid postAction1 = Guid.NewGuid();
+            Guid postAction2 = Guid.NewGuid();
+
             ITemplateInfo mockTemplate = new MockTemplateInfo("shortName", "Full Name", "test.identity", "test.group.identity", 100, "test author")
                 .WithClassifications("test", "asset")
                 .WithDescription("my test description")
                 .WithTag("language", "CSharp")
                 .WithParameters("param1", "param2")
-                .WithChoiceParameter("choice", "var1", "var2", "var3");
+                .WithChoiceParameter("choice", "var1", "var2", "var3")
+                .WithPostActions(postAction1, postAction2);
 
             TemplateSearchData template = new TemplateSearchData(mockTemplate);
 
@@ -161,6 +165,9 @@ namespace Microsoft.TemplateSearch.Common.UnitTests
             Assert.Single(templateToTest.Parameters.Where(p => p.DataType == "choice"));
             Assert.Equal(3, templateToTest.Parameters.Single(p => p.DataType == "choice").Choices?.Count);
             Assert.True(templateToTest.Parameters.Single(p => p.DataType == "choice").Choices?.ContainsKey("var1"));
+
+            Assert.Equal(2, ((ITemplateInfo)templateToTest).PostActions.Count);
+            Assert.Equal(new[] { postAction1, postAction2 }, ((ITemplateInfo)templateToTest).PostActions);
         }
     }
 }


### PR DESCRIPTION
### Problem
`--allow-scripts` option handling in CLI needs a lot of workarounds to evaluate whether run script post action is defined in template.json.

### Solution
Added list of defined post actions in template.json.
The list might have duplicates if several post actions of same type is defined.

Why not the whole post action model? Decided to keep data to minimum not to affect performance / cache size.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)