### PR TITLE
[system-command-line] error handling for ambiguous results on template instantiation

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/AnsiConsole.cs
+++ b/src/Microsoft.TemplateEngine.Cli/AnsiConsole.cs
@@ -1,13 +1,15 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace Microsoft.TemplateEngine.Cli
 {
     internal class AnsiConsole
     {
         private int _boldRecursion;
 
-        private AnsiConsole(TextWriter writer)
+        internal AnsiConsole(TextWriter writer)
         {
             Writer = writer;
 

--- a/src/Microsoft.TemplateEngine.Cli/CliTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CliTemplateInfo.cs
@@ -138,7 +138,7 @@ namespace Microsoft.TemplateEngine.Cli
         }
 
         /// <summary>
-        /// Gets the  template package which contain the template.
+        /// Gets the template package which contains the template.
         /// </summary>
         /// <remarks>
         /// The method might throw exceptions if <see cref="TemplatePackageManager.GetTemplatePackageAsync(ITemplateInfo, CancellationToken)"/> call throws.

--- a/src/Microsoft.TemplateEngine.Cli/CliTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CliTemplateInfo.cs
@@ -4,6 +4,8 @@
 #nullable enable
 
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
+using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli
@@ -119,6 +121,33 @@ namespace Microsoft.TemplateEngine.Cli
             }
 
             return templateInfos.Select(templateInfo => new CliTemplateInfo(templateInfo, hostSpecificDataLoader.ReadHostSpecificTemplateData(templateInfo)));
+        }
+
+        /// <summary>
+        /// Gets the <b>managed</b> template package which contain the template, <see langword="null"/> otherwise.
+        /// </summary>
+        /// <remarks>
+        /// The method might throw exceptions if <see cref="TemplatePackageManager.GetTemplatePackageAsync(ITemplateInfo, CancellationToken)"/> call throws.
+        /// </remarks>
+        internal async Task<IManagedTemplatePackage?> GetManagedTemplatePackageAsync(
+            TemplatePackageManager templatePackageManager,
+            CancellationToken cancellationToken)
+        {
+            ITemplatePackage templatePackage = await GetTemplatePackageAsync(templatePackageManager, cancellationToken).ConfigureAwait(false);
+            return templatePackage as IManagedTemplatePackage;
+        }
+
+        /// <summary>
+        /// Gets the  template package which contain the template.
+        /// </summary>
+        /// <remarks>
+        /// The method might throw exceptions if <see cref="TemplatePackageManager.GetTemplatePackageAsync(ITemplateInfo, CancellationToken)"/> call throws.
+        /// </remarks>
+        internal Task<ITemplatePackage> GetTemplatePackageAsync(
+            TemplatePackageManager templatePackageManager,
+            CancellationToken cancellationToken)
+        {
+            return templatePackageManager.GetTemplatePackageAsync(this, cancellationToken);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.Help.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.Help.cs
@@ -78,8 +78,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             if (!VerifyMatchingTemplates(
                 environmentSettings,
-                context.Output,
                 matchingTemplates,
+                Reporter.Output,
                 out IEnumerable<TemplateCommand>? templatesToShow))
             {
                 //error
@@ -129,8 +129,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         internal static bool VerifyMatchingTemplates(
             IEngineEnvironmentSettings environmentSettings,
-            TextWriter writer,
             IEnumerable<TemplateCommand> matchingTemplates,
+            Reporter reporter,
             [NotNullWhen(true)]
             out IEnumerable<TemplateCommand>? filteredTemplates)
         {
@@ -153,7 +153,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                         HandleAmbiguousLanguage(
                             environmentSettings,
                             matchingTemplates.Select(c => c.Template),
-                            writer);
+                            reporter);
 
                         filteredTemplates = null;
                         return false;
@@ -164,7 +164,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                     HandleAmbiguousLanguage(
                         environmentSettings,
                         matchingTemplates.Select(c => c.Template),
-                        writer);
+                        reporter);
 
                     filteredTemplates = null;
                     return false;
@@ -178,7 +178,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 HandleAmbiguousType(
                     environmentSettings,
                     matchingTemplates.Select(c => c.Template),
-                    writer);
+                    reporter);
                 filteredTemplates = null;
                 return false;
             }
@@ -369,38 +369,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 context.Output.WriteLine(Indent + string.Join(" ", parts));
             }
             context.Output.WriteLine();
-        }
-
-        private static NewCommandStatus HandleAmbiguousLanguage(
-            IEngineEnvironmentSettings environmentSettings,
-            IEnumerable<CliTemplateInfo> templates,
-            TextWriter writer)
-        {
-            writer.WriteLine(HelpStrings.TableHeader_AmbiguousTemplatesList);
-            TemplateGroupDisplay.DisplayTemplateList(
-                environmentSettings,
-                templates,
-                new TabularOutputSettings(environmentSettings.Environment),
-                writer: writer);
-            writer.WriteLine(HelpStrings.Hint_AmbiguousLanguage);
-            return NewCommandStatus.NotFound;
-        }
-
-        private static NewCommandStatus HandleAmbiguousType(
-            IEngineEnvironmentSettings environmentSettings,
-            IEnumerable<CliTemplateInfo> templates,
-            TextWriter writer)
-        {
-            writer.WriteLine(HelpStrings.TableHeader_AmbiguousTemplatesList);
-            TemplateGroupDisplay.DisplayTemplateList(
-                environmentSettings,
-                templates,
-                new TabularOutputSettings(
-                    environmentSettings.Environment,
-                    columnsToDisplay: new[] { TabularOutputSettings.ColumnNames.Type }),
-                writer: writer);
-            writer.WriteLine(HelpStrings.Hint_AmbiguousType);
-            return NewCommandStatus.NotFound;
         }
 
         /// <summary>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.Help.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.Help.cs
@@ -56,7 +56,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             }
             if (selectedTemplateGroups.Take(2).Count() > 1)
             {
-                HandleAmbiguousTemplateGroup(instantiateCommandArgs);
+                HandleAmbiguousTemplateGroup(environmentSettings, templatePackageManager, selectedTemplateGroups, Reporter.Output);
                 return;
             }
 

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -410,7 +410,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Uninstall the templates or the packages to keep only one template from the list..
+        ///   Looks up a localized string similar to Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run..
         /// </summary>
         internal static string AmbiguousTemplatesMultiplePackagesHint {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -493,7 +493,7 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
     <value>Unable to resolve the template, the following installed templates are conflicting:</value>
   </data>
   <data name="AmbiguousTemplatesMultiplePackagesHint" xml:space="preserve">
-    <value>Uninstall the templates or the packages to keep only one template from the list.</value>
+    <value>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</value>
   </data>
   <data name="AmbiguousTemplatesSamePackageHint" xml:space="preserve">
     <value>The package {0} is not correct, uninstall it and report the issue to the package author.</value>

--- a/src/Microsoft.TemplateEngine.Cli/TabularOutput/TemplateGroupDisplay.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TabularOutput/TemplateGroupDisplay.cs
@@ -29,16 +29,15 @@ namespace Microsoft.TemplateEngine.Cli.TabularOutput
             IEngineEnvironmentSettings engineEnvironmentSettings,
             IEnumerable<TemplateGroup> templateGroups,
             TabularOutputSettings helpFormatterSettings,
-            string? selectedLanguage = null,
-            bool useErrorOutput = false,
-            TextWriter? writer = null)
+            Reporter reporter,
+            string? selectedLanguage = null)
         {
             IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay = GetTemplateGroupsForListDisplay(
                 templateGroups,
                 selectedLanguage,
                 engineEnvironmentSettings.GetDefaultLanguage(),
                 engineEnvironmentSettings.Environment);
-            DisplayTemplateList(groupsForDisplay, helpFormatterSettings, useErrorOutput, writer: writer);
+            DisplayTemplateList(groupsForDisplay, helpFormatterSettings, reporter);
         }
 
         /// <summary>
@@ -57,16 +56,15 @@ namespace Microsoft.TemplateEngine.Cli.TabularOutput
             IEngineEnvironmentSettings engineEnvironmentSettings,
             IEnumerable<ITemplateInfo> templates,
             TabularOutputSettings helpFormatterSettings,
-            string? selectedLanguage = null,
-            bool useErrorOutput = false,
-            TextWriter? writer = null)
+            Reporter reporter,
+            string? selectedLanguage = null)
         {
             IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay = GetTemplateGroupsForListDisplay(
                 templates,
                 selectedLanguage,
                 engineEnvironmentSettings.GetDefaultLanguage(),
                 engineEnvironmentSettings.Environment);
-            DisplayTemplateList(groupsForDisplay, helpFormatterSettings, useErrorOutput, writer: writer);
+            DisplayTemplateList(groupsForDisplay, helpFormatterSettings, reporter);
         }
 
         /// <summary>
@@ -154,8 +152,7 @@ namespace Microsoft.TemplateEngine.Cli.TabularOutput
         private static void DisplayTemplateList(
             IReadOnlyCollection<TemplateGroupTableRow> groupsForDisplay,
             TabularOutputSettings tabularOutputSettings,
-            bool useErrorOutput = false,
-            TextWriter? writer = null)
+            Reporter reporter)
         {
             TabularOutput<TemplateGroupTableRow> formatter =
                 TabularOutput
@@ -169,13 +166,6 @@ namespace Microsoft.TemplateEngine.Cli.TabularOutput
                     .DefineColumn(t => t.Author, LocalizableStrings.ColumnNameAuthor, TabularOutputSettings.ColumnNames.Tags, defaultColumn: false, shrinkIfNeeded: true, minWidth: 10)
                     .DefineColumn(t => t.Classifications, out object tagsColumn, LocalizableStrings.ColumnNameTags, TabularOutputSettings.ColumnNames.Author, defaultColumn: true)
                     .OrderBy(nameColumn, StringComparer.OrdinalIgnoreCase);
-
-            if (writer != null)
-            {
-                writer.WriteLine(formatter.Layout());
-                return;
-            }
-            Reporter reporter = useErrorOutput ? Reporter.Error : Reporter.Output;
             reporter.WriteLine(formatter.Layout());
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/TemplateGroup.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateGroup.cs
@@ -134,9 +134,9 @@ namespace Microsoft.TemplateEngine.Cli
         }
 
         /// <summary>
-        /// Returns the description of template group
-        /// Template group description is the name of highest precedence template in the group.
-        /// If multiple templates have the maximum precedence, the description of first one is returned.
+        /// Returns the description of template group.
+        /// Template group description is the description of the template in the group with the highest precedence.
+        /// If multiple templates have the maximum precedence, the description of the first one is returned.
         /// </summary>
         internal string Description
         {

--- a/src/Microsoft.TemplateEngine.Cli/TemplateListCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateListCoordinator.cs
@@ -65,6 +65,7 @@ namespace Microsoft.TemplateEngine.Cli
                     _engineEnvironmentSettings,
                     resolutionResult.TemplateGroupsWithMatchingTemplateInfoAndParameters,
                     settings,
+                    reporter: Reporter.Output,
                     selectedLanguage: args.Language);
                 return NewCommandStatus.Success;
             }
@@ -127,7 +128,8 @@ namespace Microsoft.TemplateEngine.Cli
             TemplateGroupDisplay.DisplayTemplateList(
                 _engineEnvironmentSettings,
                 curatedTemplates,
-                new TabularOutputSettings(_engineEnvironmentSettings.Environment));
+                new TabularOutputSettings(_engineEnvironmentSettings.Environment),
+                reporter: Reporter.Output);
 
             Reporter.Output.WriteLine(LocalizableStrings.TemplateInformationCoordinator_DotnetNew_ExampleHeader);
             Reporter.Output.WriteCommand(CommandExamples.InstantiateTemplateExample(args.CommandName, "console"));

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -539,7 +539,11 @@ namespace Microsoft.TemplateEngine.Cli
                         string.Format(
                             LocalizableStrings.TemplatePackageCoordinator_lnstall_Info_Success,
                             result.TemplatePackage.DisplayName));
-                    TemplateGroupDisplay.DisplayTemplateList(_engineEnvironmentSettings, templates, new TabularOutputSettings(_engineEnvironmentSettings.Environment));
+                    TemplateGroupDisplay.DisplayTemplateList(
+                        _engineEnvironmentSettings,
+                        templates,
+                        new TabularOutputSettings(_engineEnvironmentSettings.Environment),
+                        reporter: Reporter.Output);
                 }
                 else
                 {

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -207,8 +207,8 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">Odinstalujte šablony nebo balíčky, aby z daného seznamu zůstala pouze jedna šablona.</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">Odinstalujte šablony nebo balíčky, aby z daného seznamu zůstala pouze jedna šablona.</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -207,8 +207,8 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">Deinstallieren Sie die Vorlagen oder Pakete, um nur eine Vorlage aus der Liste zu behalten.</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">Deinstallieren Sie die Vorlagen oder Pakete, um nur eine Vorlage aus der Liste zu behalten.</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -207,8 +207,8 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">Desinstale las plantillas o los paquetes para conservar solo una plantilla de la lista.</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">Desinstale las plantillas o los paquetes para conservar solo una plantilla de la lista.</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -207,8 +207,8 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">Désinstallez les modèles ou les packages pour ne conserver qu’un seul modèle dans la liste.</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">Désinstallez les modèles ou les packages pour ne conserver qu’un seul modèle dans la liste.</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -207,8 +207,8 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">Disinstallare i modelli o i pacchetti per mantenere un solo modello dall'elenco.</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">Disinstallare i modelli o i pacchetti per mantenere un solo modello dall'elenco.</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -207,8 +207,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">テンプレートまたはパッケージをアンインストールして、一覧から1つのテンプレートのみを保持します。</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">テンプレートまたはパッケージをアンインストールして、一覧から1つのテンプレートのみを保持します。</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -207,8 +207,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">목록에서 하나의 템플릿만 유지하려면 템플릿 또는 패키지를 제거합니다.</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">목록에서 하나의 템플릿만 유지하려면 템플릿 또는 패키지를 제거합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -207,8 +207,8 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">Odinstaluj szablony lub pakiety, aby zachować tylko jeden szablon z listy.</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">Odinstaluj szablony lub pakiety, aby zachować tylko jeden szablon z listy.</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -207,8 +207,8 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">Desinstale os modelos ou os pacotes para manter somente um modelo da lista.</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">Desinstale os modelos ou os pacotes para manter somente um modelo da lista.</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -207,8 +207,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">Удалите шаблоны или пакеты, чтобы оставить только один шаблон из списка.</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">Удалите шаблоны или пакеты, чтобы оставить только один шаблон из списка.</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -207,8 +207,8 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">Şablonları veya paketleri kaldırarak listede yalnızca bir şablon tutun.</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">Şablonları veya paketleri kaldırarak listede yalnızca bir şablon tutun.</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -207,8 +207,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">卸载模板或程序包以仅保留列表中的一个模板。</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">卸载模板或程序包以仅保留列表中的一个模板。</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -207,8 +207,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesMultiplePackagesHint">
-        <source>Uninstall the templates or the packages to keep only one template from the list.</source>
-        <target state="translated">解除安裝範本或套件，只保留清單中的一個範本。</target>
+        <source>Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.</source>
+        <target state="needs-review-translation">解除安裝範本或套件，只保留清單中的一個範本。</target>
         <note />
       </trans-unit>
       <trans-unit id="AmbiguousTemplatesSamePackageHint">

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/HelpTests.Resolution.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/HelpTests.Resolution.cs
@@ -46,7 +46,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(1, matchingTemplates.Count());
             StringWriter output = new StringWriter();
-            Assert.True(InstantiateCommand.VerifyMatchingTemplates(settings, output, matchingTemplates, out _));
+            Reporter reporter = new Reporter(new AnsiConsole(output));
+            Assert.True(InstantiateCommand.VerifyMatchingTemplates(settings, matchingTemplates, reporter, out _));
             Assert.Empty(output.ToString());
         }
 
@@ -72,7 +73,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(3, matchingTemplates.Count());
             StringWriter output = new StringWriter();
-            Assert.False(InstantiateCommand.VerifyMatchingTemplates(settings, output, matchingTemplates, out _));
+            Reporter reporter = new Reporter(new AnsiConsole(output));
+            Assert.False(InstantiateCommand.VerifyMatchingTemplates(settings, matchingTemplates, reporter, out _));
             return Verifier.Verify(output.ToString(), _verifySettings.Settings);
         }
 
@@ -98,7 +100,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(2, matchingTemplates.Count());
             StringWriter output = new StringWriter();
-            Assert.True(InstantiateCommand.VerifyMatchingTemplates(settings, output, matchingTemplates, out IEnumerable<TemplateCommand>? filtered));
+            Reporter reporter = new Reporter(new AnsiConsole(output));
+            Assert.True(InstantiateCommand.VerifyMatchingTemplates(settings, matchingTemplates, reporter, out IEnumerable<TemplateCommand>? filtered));
             Assert.Equal(1, filtered?.Count());
             Assert.Equal("Console.App.L1", filtered?.Single().Template.Identity);
             Assert.Empty(output.ToString());
@@ -125,7 +128,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(1, matchingTemplates.Count());
             StringWriter output = new StringWriter();
-            Assert.True(InstantiateCommand.VerifyMatchingTemplates(settings, output, matchingTemplates, out IEnumerable<TemplateCommand>? filtered));
+            Reporter reporter = new Reporter(new AnsiConsole(output));
+            Assert.True(InstantiateCommand.VerifyMatchingTemplates(settings, matchingTemplates, reporter, out IEnumerable<TemplateCommand>? filtered));
             Assert.Equal(1, filtered?.Count());
             Assert.Equal("Console.App.L2", filtered?.Single().Template.Identity);
             Assert.Empty(output.ToString());
@@ -150,7 +154,8 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(3, matchingTemplates.Count());
             StringWriter output = new StringWriter();
-            Assert.True(InstantiateCommand.VerifyMatchingTemplates(settings, output, matchingTemplates, out IEnumerable<TemplateCommand>? filtered));
+            Reporter reporter = new Reporter(new AnsiConsole(output));
+            Assert.True(InstantiateCommand.VerifyMatchingTemplates(settings, matchingTemplates, reporter, out IEnumerable<TemplateCommand>? filtered));
             Assert.Equal(3, filtered?.Count());
             Assert.Empty(output.ToString());
         }

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateResolution/SameShortName/BasicFSharp/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateResolution/SameShortName/BasicFSharp/.template.config/template.json
@@ -1,0 +1,15 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "Basic FSharp",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.Group1",
+  "precedence": "100",
+  "identity": "TestAssets.DifferentLanguagesGroup.BasicFSharp",
+  "shortName": "basic",
+  "sourceName": "bar",
+  "tags": {
+    "language": "F#",
+    "type": "item"
+  }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateResolution/SameShortName/BasicVB/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateResolution/SameShortName/BasicVB/.template.config/template.json
@@ -1,0 +1,15 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "Basic VB",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.Group2",
+  "precedence": "100",
+  "identity": "TestAssets.DifferentLanguagesGroup.BasicVB",
+  "shortName": "basic",
+  "sourceName": "bar",
+  "tags": {
+    "language": "VB",
+    "type": "item"
+  }
+}

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenAmbiguousShortNameChoice.approved.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenAmbiguousShortNameChoice.approved.txt
@@ -1,0 +1,7 @@
+﻿Unable to resolve the template, the following installed templates are conflicting:
+Identity           Template Name  Short Name  Language  Author      Package
+%delimiter%
+TestAssets.Group1  Basic FSharp   basic       F#        Test Asset  BasicFSharp
+TestAssets.Group2  Basic VB       basic       VB        Test Asset  BasicVB    
+
+Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenPrecedenceIsSame.approved.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenPrecedenceIsSame.approved.txt
@@ -4,4 +4,4 @@ Identity                                       Template Name   Short Name  Langu
 TestAssets.SamePrecedenceGroup.BasicTemplate1  Basic Template  basic       C#        100         Test Asset  
 TestAssets.SamePrecedenceGroup.BasicTemplate2  Basic Template  basic       C#        100         Test Asset  
 
-Uninstall the templates or the packages to keep only one template from the list.
+Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.

--- a/test/dotnet-new3.UnitTests/DotnetNewHelp.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewHelp.Approval.cs
@@ -209,13 +209,12 @@ namespace Dotnet_new3.IntegrationTests
                 .WithWorkingDirectory(workingDirectory)
                 .Execute();
 
+            //help command cannot fail, therefore the output is written to stdout
             commandResult.Should().Pass().And.NotHaveStdErr();
             Approvals.Verify(commandResult.StdOut);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "TODO: does not fail now, check if can fail")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CannotShowHelpForTemplate_WhenAmbiguousLanguageChoice()
         {
             string workingDirectory = TestUtils.CreateTemporaryFolder();
@@ -227,9 +226,9 @@ namespace Dotnet_new3.IntegrationTests
                 .WithWorkingDirectory(workingDirectory)
                 .Execute();
 
-            commandResult.Should().Fail().And.NotHaveStdOut();
-
-            Approvals.Verify(commandResult.StdErr);
+            //help command cannot fail, therefore the output is written to stdout
+            commandResult.Should().Pass().And.NotHaveStdErr();
+            Approvals.Verify(commandResult.StdOut);
         }
 
         [Fact]

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.Approval.cs
@@ -46,9 +46,7 @@ namespace Dotnet_new3.IntegrationTests
             Approvals.Verify(commandResult.StdErr);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "instantiation error handling is not complete yet")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CannotInstantiateTemplate_WhenAmbiguousLanguageChoice()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
@@ -189,9 +187,7 @@ namespace Dotnet_new3.IntegrationTests
             Approvals.Verify(commandResult.StdErr);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "instantiation error handling is not complete yet")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CannotInstantiateTemplate_WhenPrecedenceIsSame()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/3809:
- error handling for ambiguous template group 
- error handling for ambiguous template

### Solution
Ported implementation from old parser, no major differences from previous UX.
Only improvement: now in case of ambiguous template group hint for uninstalling the package is shown.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)