### PR TITLE
[system-command-line] implements --allow-scripts option for templates that have run script post action

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Commands/TemplateCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/TemplateCommand.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Installer;
 using Microsoft.TemplateEngine.Cli.Extensions;
+using Microsoft.TemplateEngine.Cli.PostActionProcessors;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Utils;
 
@@ -103,6 +104,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                     Description = SymbolStrings.TemplateCommand_Option_AllowScripts,
                     Arity = new ArgumentArity(1, 1)
                 };
+                AllowScriptsOption.SetDefaultValue(AllowRunScripts.Prompt);
                 this.AddOption(AllowScriptsOption);
             }
 
@@ -176,8 +178,10 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             }
         }
 
-        //TODO: implement this
-        private bool HasRunScriptPostActionDefined(CliTemplateInfo template) => false;
+        private bool HasRunScriptPostActionDefined(CliTemplateInfo template)
+        {
+            return template.PostActions.Contains(ProcessStartPostActionProcessor.ActionProcessorId);
+        }
 
         private HashSet<string> GetReservedAliases()
         {

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowAllowScriptsOption.approved.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowAllowScriptsOption.approved.txt
@@ -1,0 +1,16 @@
+﻿TestAssets.PostActions.RunScript.Basic
+Author: Test Asset
+
+Usage:
+  new3 TestAssets.PostActions.RunScript.Basic [options] [template options]
+
+Options:
+  -n, --name <name>                The name for the output being created. If no name is specified, the name of the output directory is used.
+  -o, --output <output>            Location to place the generated output.
+  --dry-run                        Displays a summary of what would happen if the given command line were run if it would result in a template creation.
+  --force                          Forces content to be generated even if it would change existing files.
+  --no-update-check                Disables checking for the template package updates when instantiating a template.
+  --allow-scripts <No|Prompt|Yes>  Specifies if post action scripts should run. [default: Prompt]
+
+Template options:
+   (No options)

--- a/test/dotnet-new3.UnitTests/DotnetNewHelp.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewHelp.Approval.cs
@@ -327,5 +327,23 @@ namespace Dotnet_new3.IntegrationTests
             commandResult.Should().Pass().And.NotHaveStdErr();
             Approvals.Verify(commandResult.StdOut);
         }
+
+        [Fact]
+        public void CanShowAllowScriptsOption()
+        {
+            string templateLocation = "PostActions/RunScript/Basic";
+            string templateName = "TestAssets.PostActions.RunScript.Basic";
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+            Helpers.InstallTestTemplate(templateLocation, _log, workingDirectory, home);
+
+            var commandResult = new DotnetNewCommand(_log, templateName, "--help")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute();
+
+            commandResult.Should().Pass().And.NotHaveStdErr();
+            Approvals.Verify(commandResult.StdOut);
+        }
     }
 }

--- a/test/dotnet-new3.UnitTests/PostActionTests.cs
+++ b/test/dotnet-new3.UnitTests/PostActionTests.cs
@@ -181,9 +181,7 @@ namespace Dotnet_new3.IntegrationTests
                   .And.HaveStdOutContaining("TemplateApplication.Tests");
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "This test is failing due to --allow-scripts option is not implemented yet.")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void RunScript_Basic()
         {
             string templateLocation = "PostActions/RunScript/Basic";
@@ -216,9 +214,7 @@ namespace Dotnet_new3.IntegrationTests
             }
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "This test is failing due to --allow-scripts option is not implemented yet.")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void RunScript_DoNotRedirect()
         {
             string templateLocation = "PostActions/RunScript/DoNotRedirect";
@@ -243,9 +239,7 @@ namespace Dotnet_new3.IntegrationTests
                 .And.NotHaveStdOutContaining("Manual instructions: Run 'setup.sh'");
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "This test is failing due to --allow-scripts option is not implemented yet.")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void RunScript_Redirect()
         {
             string templateLocation = "PostActions/RunScript/Redirect";
@@ -270,9 +264,7 @@ namespace Dotnet_new3.IntegrationTests
                 .And.NotHaveStdOutContaining("Manual instructions: Run 'setup.sh'");
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "This test is failing due to --allow-scripts option is not implemented yet.")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void RunScript_RedirectOnError()
         {
             string templateLocation = "PostActions/RunScript/RedirectOnError";
@@ -515,6 +507,34 @@ Action would have been taken automatically:
                 .And.HaveStdErrContaining($"The post action 210d431b-a78b-4d2f-b762-4ed3e3ea9027 is not supported.")
                 .And.HaveStdErrContaining($"Description: This is not defined post action.")
                 .And.HaveStdErrContaining($"Manual instructions: Run setup.cmd script manually.");
+        }
+
+        [Fact]
+        public void RunScript_DoNotExecuteWhenScriptsAreNotAllowed()
+        {
+            string templateLocation = "PostActions/RunScript/Basic";
+            string templateName = "TestAssets.PostActions.RunScript.Basic";
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+            Helpers.InstallTestTemplate(templateLocation, _log, workingDirectory, home);
+
+            var commandResult = new DotnetNewCommand(_log, templateName, "--allow-scripts", "no")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute();
+
+            commandResult
+                .Should()
+                .Fail()
+                .And.HaveStdErrContaining("Execution of 'Run script' post action is not allowed.");
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                commandResult.Should().HaveStdErrContaining("Manual instructions: Run 'setup.cmd'");
+            }
+            else
+            {
+                commandResult.Should().HaveStdErrContaining("Manual instructions: Run 'setup.sh'");
+            }
         }
     }
 }


### PR DESCRIPTION
### Problem

#3809: implement --allow-scripts option if the template has run-script post action

### Solution
Implement option based on cache information added in https://github.com/dotnet/templating/pull/4221

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)