### PR TITLE
[system-command-line] instantiate command error handling improvements

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/CliTemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CliTemplateInfo.cs
@@ -90,7 +90,8 @@ namespace Microsoft.TemplateEngine.Cli
                     {
                         if (parameters.ContainsKey(parameter.Name))
                         {
-                            //TODO:
+                            //runnable projects generator ensures the symbols are unique, so no error handling here.
+                            //in case there is a duplicate, the logic is broken.
                             throw new Exception($"Template {Identity} defines {parameter.Name} twice.");
                         }
                         if (parameter.IsChoice())

--- a/src/Microsoft.TemplateEngine.Cli/Commands/AliasAssignmentCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/AliasAssignmentCoordinator.cs
@@ -25,7 +25,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 if (parameter.Name.Contains(':'))
                 {
                     // Colon is reserved, template param names cannot have any.
-                    errors.Add($"Parameter name '{parameter.Name}' contains colon, which is forbidden.");
+                    errors.Add(string.Format(LocalizableStrings.AliasAssignmentCoordinator_Error_NameShouldNotHaveColon, parameter.Name));
                     result.Add((parameter, aliases, errors));
                     continue;
                 }
@@ -64,7 +64,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 {
                     // short name starting point was explicitly specified
                     string fullShortNameOverride = "-" + shortNameOverride;
-                    if (!isAliasTaken(shortNameOverride))
+                    if (!isAliasTaken(fullShortNameOverride))
                     {
                         aliases.Add(fullShortNameOverride);
                         takenAliases.Add(fullShortNameOverride);
@@ -79,7 +79,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                         takenAliases.Add(qualifiedShortNameOverride);
                         continue;
                     }
-                    errors.Add($"Failed to assign short option name from {parameter.Name}, tried: '{fullShortNameOverride}'; '{qualifiedShortNameOverride}.'");
+                    errors.Add(string.Format(LocalizableStrings.AliasAssignmentCoordinator_Error_ShortAlias, parameter.Name, fullShortNameOverride, qualifiedShortNameOverride));
                 }
             }
         }
@@ -123,7 +123,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                     takenAliases.Add(optionName);
                     continue;
                 }
-                errors.Add($"Failed to assign long option name from {parameter.Name}, tried: '--{longName}'; '--param:{longName}.'");
+                errors.Add(string.Format(LocalizableStrings.AliasAssignmentCoordinator_Error_LongAlias, parameter.Name, $"--{longName}", $"--param:{longName}"));
             }
         }
 
@@ -154,7 +154,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 aliases.Add(qualifiedShortName);
                 return;
             }
-            errors.Add($"Failed to assign short option name from {parameter.Name}, tried: '{shortName}'; '{qualifiedShortName}.'");
+            errors.Add(string.Format(LocalizableStrings.AliasAssignmentCoordinator_Error_ShortAlias, parameter.Name, shortName, qualifiedShortName));
         }
 
         private static string GetFreeShortName(Func<string, bool> isAliasTaken, string name, string prefix = "")

--- a/src/Microsoft.TemplateEngine.Cli/Commands/Exceptions/InvalidTemplateParametersException.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/Exceptions/InvalidTemplateParametersException.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Text;
+
+namespace Microsoft.TemplateEngine.Cli.Commands.Exceptions
+{
+    internal class InvalidTemplateParametersException : Exception
+    {
+        private string? _message;
+
+        public InvalidTemplateParametersException(CliTemplateInfo template, IReadOnlyDictionary<CliTemplateParameter, IReadOnlyList<string>> parameterErrors)
+        {
+            ParameterErrors = parameterErrors;
+            Template = template;
+        }
+
+        public override string Message
+        {
+            get
+            {
+                if (_message == null)
+                {
+                    StringBuilder stringBuilder = new StringBuilder();
+                    stringBuilder.Append(string.Format(LocalizableStrings.Exception_InvalidTemplateParameters_MessageHeader, Template.Identity, Template.ShortNameList[0]));
+
+                    foreach (var error in ParameterErrors)
+                    {
+                        stringBuilder.AppendLine().Append(error.Key.Name.Indent(1));
+                        foreach (var message in error.Value)
+                        {
+                            stringBuilder.AppendLine().Append(message.Indent(2));
+                        }
+                    }
+                    _message = stringBuilder.ToString();
+                }
+                return _message;
+            }
+        }
+
+        public CliTemplateInfo Template { get; }
+
+        internal IReadOnlyDictionary<CliTemplateParameter, IReadOnlyList<string>> ParameterErrors { get; }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.NoMatchHandling.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/InstantiateCommand.NoMatchHandling.cs
@@ -65,10 +65,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             List<TemplateResult> matchInfos = new List<TemplateResult>();
             foreach (CliTemplateInfo template in templateGroup.Templates)
             {
-                TemplateCommand command = new TemplateCommand(this, environmentSettings, templatePackageManager, templateGroup, template);
-                Parser parser = ParserFactory.CreateParser(command);
-                ParseResult parseResult = parser.Parse(args.RemainingArguments ?? Array.Empty<string>());
-                matchInfos.Add(TemplateResult.FromParseResult(command, parseResult));
+                if (ReparseForTemplate(args, environmentSettings, templatePackageManager, templateGroup, template)
+                    is (TemplateCommand command, ParseResult parseResult))
+                {
+                    matchInfos.Add(TemplateResult.FromParseResult(command, parseResult));
+                }
             }
             return matchInfos;
         }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/TemplateCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/TemplateCommand.cs
@@ -5,10 +5,9 @@
 
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.CommandLine.Parsing;
-using System.Globalization;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Installer;
+using Microsoft.TemplateEngine.Cli.Commands.Exceptions;
 using Microsoft.TemplateEngine.Cli.Extensions;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Utils;
@@ -25,6 +24,10 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         private readonly CliTemplateInfo _template;
         private Dictionary<string, TemplateOption> _templateSpecificOptions = new Dictionary<string, TemplateOption>();
 
+        /// <summary>
+        /// Create command for instantiation of specific template.
+        /// </summary>
+        /// <exception cref="InvalidTemplateParametersException">when <paramref name="template"/> has invalid template parameters.</exception>
         public TemplateCommand(
             InstantiateCommand instantiateCommand,
             IEngineEnvironmentSettings environmentSettings,
@@ -216,11 +219,17 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         private void AddTemplateOptionsToCommand(CliTemplateInfo templateInfo)
         {
             HashSet<string> initiallyTakenAliases = GetReservedAliases();
-            IEnumerable<CliTemplateParameter> parameters = templateInfo.CliParameters.Values;
-            //TODO: handle errors
-            var parametersWithAliasAssignments = AliasAssignmentCoordinator.AssignAliasesForParameter(parameters, initiallyTakenAliases);
 
-            foreach ((CliTemplateParameter parameter, IReadOnlyList<string> aliases, IReadOnlyList<string> errors) in parametersWithAliasAssignments)
+            var parametersWithAliasAssignments = AliasAssignmentCoordinator.AssignAliasesForParameter(templateInfo.CliParameters.Values, initiallyTakenAliases);
+            if (parametersWithAliasAssignments.Any(p => p.Errors.Any()))
+            {
+                IReadOnlyDictionary<CliTemplateParameter, IReadOnlyList<string>> errors = parametersWithAliasAssignments
+                    .Where(p => p.Errors.Any())
+                    .ToDictionary(p => p.Parameter, p => p.Errors);
+                throw new InvalidTemplateParametersException(templateInfo, errors);
+            }
+
+            foreach ((CliTemplateParameter parameter, IReadOnlyList<string> aliases, IReadOnlyList<string> _) in parametersWithAliasAssignments)
             {
                 TemplateOption option = new TemplateOption(parameter, aliases);
                 this.AddOption(option.Option);

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -210,6 +210,33 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to assign long option alias for parameter &apos;{0}&apos;, tried: &apos;{1}&apos;; &apos;{2}&apos;..
+        /// </summary>
+        internal static string AliasAssignmentCoordinator_Error_LongAlias {
+            get {
+                return ResourceManager.GetString("AliasAssignmentCoordinator_Error_LongAlias", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameter name &apos;{0}&apos; contains colon, which is forbidden..
+        /// </summary>
+        internal static string AliasAssignmentCoordinator_Error_NameShouldNotHaveColon {
+            get {
+                return ResourceManager.GetString("AliasAssignmentCoordinator_Error_NameShouldNotHaveColon", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to assign short option alias for parameter &apos;{0}&apos;, tried: &apos;{1}&apos;; &apos;{2}&apos;..
+        /// </summary>
+        internal static string AliasAssignmentCoordinator_Error_ShortAlias {
+            get {
+                return ResourceManager.GetString("AliasAssignmentCoordinator_Error_ShortAlias", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Alias &apos;{0}&apos; is a template short name, and therefore cannot be aliased..
         /// </summary>
         internal static string AliasCannotBeShortName {
@@ -794,6 +821,15 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string DisplaysHelp {
             get {
                 return ResourceManager.GetString("DisplaysHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Template {0} ({1}) is malformed. The following template parameters are invalid:.
+        /// </summary>
+        internal static string Exception_InvalidTemplateParameters_MessageHeader {
+            get {
+                return ResourceManager.GetString("Exception_InvalidTemplateParameters_MessageHeader", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -686,4 +686,23 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
     <comment>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</comment>
   </data>
+  <data name="AliasAssignmentCoordinator_Error_LongAlias" xml:space="preserve">
+    <value>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</value>
+    <comment>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</comment>
+  </data>
+  <data name="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon" xml:space="preserve">
+    <value>Parameter name '{0}' contains colon, which is forbidden.</value>
+    <comment>{0} is parameter name, has no whitespaces.</comment>
+  </data>
+  <data name="AliasAssignmentCoordinator_Error_ShortAlias" xml:space="preserve">
+    <value>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</value>
+    <comment>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</comment>
+  </data>
+  <data name="Exception_InvalidTemplateParameters_MessageHeader" xml:space="preserve">
+    <value>Template {0} ({1}) is malformed. The following template parameters are invalid:</value>
+    <comment>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</comment>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -92,6 +92,23 @@
         <target state="translated">Přidávání typu odkazu {0} se nepodporuje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">Alias {0} je krátký název šablony, proto se pro něj nedá alias vytvořit.</target>
@@ -422,6 +439,12 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <source>Displays help for this command.</source>
         <target state="translated">Zobrazí nápovědu k tomuto příkazu.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -92,6 +92,23 @@
         <target state="translated">Das Hinzufügen des Verweistyps {0} wird nicht unterstützt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">Der Alias "{0}" ist ein Kurzname für die Vorlage und kann daher nicht als Alias verwendet werden.</target>
@@ -422,6 +439,12 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
         <source>Displays help for this command.</source>
         <target state="translated">Zeigt die Hilfe für diesen Befehl an.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -92,6 +92,23 @@
         <target state="translated">No se puede agregar el tipo de referencia {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">El alias "{0}" es un nombre corto de plantilla y, por lo tanto, no puede tener alias.</target>
@@ -422,6 +439,12 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
         <source>Displays help for this command.</source>
         <target state="translated">Muestra ayuda para este comando.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -92,6 +92,23 @@
         <target state="translated">L'ajout du type de référence {0} n'est pas pris en charge.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">L’alias « {0} » est un nom court du modèle et ne peut donc pas être associé à un alias.</target>
@@ -422,6 +439,12 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <source>Displays help for this command.</source>
         <target state="translated">Affiche l’aide pour cette commande.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -92,6 +92,23 @@ aggiunto    : {0}
         <target state="translated">L'aggiunta del tipo riferimento {0} non è supportata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">L'alias '{0}' è un nome breve del modello e pertanto non può essere associato a un alias.</target>
@@ -422,6 +439,12 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <source>Displays help for this command.</source>
         <target state="translated">Visualizza la guida per questo comando.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -92,6 +92,23 @@
         <target state="translated">参照型 {0} の追加はサポートされていません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">エイリアス ' {0} ' はテンプレートの短い名前であるため、襟リアスにすることはできません。</target>
@@ -422,6 +439,12 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <source>Displays help for this command.</source>
         <target state="translated">このコマンドのヘルプを表示します。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -92,6 +92,23 @@
         <target state="translated">참조 형식 {0} 추가는 지원되지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">별칭 '{0}'은(는) 템플릿 축약 이름이므로 별칭을 지정할 수 없습니다.</target>
@@ -422,6 +439,12 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <source>Displays help for this command.</source>
         <target state="translated">이 명령에 대한 도움말을 표시합니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -92,6 +92,23 @@
         <target state="translated">Dodawanie odwołania typu {0} nie jest obsługiwane.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">Alias "{0}" jest nazwą skróconą szablonu i dlatego nie może być aliasowana.</target>
@@ -422,6 +439,12 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
         <source>Displays help for this command.</source>
         <target state="translated">Wyświetla pomoc dotyczącą tego polecenia.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -92,6 +92,23 @@
         <target state="translated">Não há suporte para adicionar o tipo de referência {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">O alias '{0}' é um nome curto do modelo e, portanto, não pode receber um alias.</target>
@@ -422,6 +439,12 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <source>Displays help for this command.</source>
         <target state="translated">Exibe a ajuda para este comando.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -92,6 +92,23 @@
         <target state="translated">Добавление ссылки типа {0} не поддерживается.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">Псевдоним "{0}" является коротким именем шаблона и поэтому не может быть псевдонимом.</target>
@@ -422,6 +439,12 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <source>Displays help for this command.</source>
         <target state="translated">Отображает справку по этой команде.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -92,6 +92,23 @@
         <target state="translated">{0} başvuru türünün eklenmesi desteklenmiyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">'{0}' diğer adı bir şablon kısa adıdır ve bu nedenle diğer ad alamaz.</target>
@@ -422,6 +439,12 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <source>Displays help for this command.</source>
         <target state="translated">Bu komutla ilgili yardımı görüntüler.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -92,6 +92,23 @@
         <target state="translated">不支持添加引用类型 {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">别名“{0}”是一个模板简短名称，因此不能作为别名。</target>
@@ -422,6 +439,12 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <source>Displays help for this command.</source>
         <target state="translated">显示此命令的帮助。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -92,6 +92,23 @@
         <target state="translated">不支援要新增的專案類型 {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_LongAlias">
+        <source>Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign long option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_NameShouldNotHaveColon">
+        <source>Parameter name '{0}' contains colon, which is forbidden.</source>
+        <target state="new">Parameter name '{0}' contains colon, which is forbidden.</target>
+        <note>{0} is parameter name, has no whitespaces.</note>
+      </trans-unit>
+      <trans-unit id="AliasAssignmentCoordinator_Error_ShortAlias">
+        <source>Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</source>
+        <target state="new">Failed to assign short option alias for parameter '{0}', tried: '{1}'; '{2}'.</target>
+        <note>{0} is parameter name, {1} and {2} are attempted option aliases for the parameter.
+{0}, {1}, {2} should have no whitespaces.</note>
+      </trans-unit>
       <trans-unit id="AliasCannotBeShortName">
         <source>Alias '{0}' is a template short name, and therefore cannot be aliased.</source>
         <target state="translated">別名 '{0}' 是範本簡短名稱，因此無法別名化。</target>
@@ -422,6 +439,12 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <source>Displays help for this command.</source>
         <target state="translated">顯示此命令的協助。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Exception_InvalidTemplateParameters_MessageHeader">
+        <source>Template {0} ({1}) is malformed. The following template parameters are invalid:</source>
+        <target state="new">Template {0} ({1}) is malformed. The following template parameters are invalid:</target>
+        <note>{0} is template identity, {1} is template short name.
+The header is followed by the list of parameters and their errors (might be several for one parameter).</note>
       </trans-unit>
       <trans-unit id="ExtraArgsCommandAfterExpansion">
         <source>After expanding the extra args files, the command is:

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TemplateCommandTests.CannotCreateCommandForInvalidParameter.verified.txt
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TemplateCommandTests.CannotCreateCommandForInvalidParameter.verified.txt
@@ -1,0 +1,6 @@
+﻿Template foo.1 (foo) is malformed. The following template parameters are invalid:
+   have:colon
+      Parameter name 'have:colon' contains colon, which is forbidden.
+   n2
+      Failed to assign long option alias for parameter 'n2', tried: '--name'; '--param:name'.
+      Failed to assign short option alias for parameter 'n2', tried: '-n'; '-p:n'.

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/HelpTests.Resolution.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/HelpTests.Resolution.cs
@@ -43,7 +43,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($" new console2");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(1, matchingTemplates.Count());
             StringWriter output = new StringWriter();
             Reporter reporter = new Reporter(new AnsiConsole(output));
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($" new console");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(3, matchingTemplates.Count());
             StringWriter output = new StringWriter();
             Reporter reporter = new Reporter(new AnsiConsole(output));
@@ -97,7 +97,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($" new console");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(2, matchingTemplates.Count());
             StringWriter output = new StringWriter();
             Reporter reporter = new Reporter(new AnsiConsole(output));
@@ -125,7 +125,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($"new console --language L2");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(1, matchingTemplates.Count());
             StringWriter output = new StringWriter();
             Reporter reporter = new Reporter(new AnsiConsole(output));
@@ -151,7 +151,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($"new console");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(3, matchingTemplates.Count());
             StringWriter output = new StringWriter();
             Reporter reporter = new Reporter(new AnsiConsole(output));
@@ -179,7 +179,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($"new console --language L2");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(0, matchingTemplates.Count());
         }
 
@@ -203,7 +203,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($"new console --type item");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(0, matchingTemplates.Count());
         }
 
@@ -226,7 +226,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($"new console --baseline core");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(0, matchingTemplates.Count());
         }
 
@@ -250,7 +250,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($"new console --language L2 --type item --baseline core");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(0, matchingTemplates.Count());
         }
 
@@ -280,7 +280,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($"new console --language L2 --type item");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(0, matchingTemplates.Count());
         }
 
@@ -318,7 +318,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($"new console --langVersion ver");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(1, matchingTemplates.Count());
         }
 
@@ -356,7 +356,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($"new console --framework netcoreapp1.0");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(1, matchingTemplates.Count());
 
         }
@@ -395,7 +395,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
             InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
             var parseResult = instantiateCommand.Parse($"new console --do-not-exist");
             var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
-            var matchingTemplates = InstantiateCommand.GetMatchingTemplates(instantiateCommand, args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
+            var matchingTemplates = instantiateCommand.GetMatchingTemplates(args, settings, A.Fake<TemplatePackageManager>(), templateGroup);
             Assert.Equal(0, matchingTemplates.Count());
         }
     }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/TemplateCommandTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/TemplateCommandTests.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.CommandLine;
+using FakeItEasy;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Cli.Commands;
+using Microsoft.TemplateEngine.Cli.Commands.Exceptions;
+using Microsoft.TemplateEngine.Edge;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.Mocks;
+using Microsoft.TemplateEngine.TestHelper;
+using VerifyXunit;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
+{
+    [UsesVerify]
+    public class TemplateCommandTests : IClassFixture<VerifyFixture>
+    {   
+        private readonly VerifyFixture _verifySettings;
+
+        public TemplateCommandTests(VerifyFixture verifySettings)
+        {
+            _verifySettings = verifySettings;
+        }
+
+        [Fact]
+        public Task CannotCreateCommandForInvalidParameter()
+        {
+            var template = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "foo.group")
+                .WithParameters("have:colon", "n1", "n2");
+
+            var paramSymbolInfo = new Dictionary<string, string>()
+            {
+                { "longName", "name" },
+                { "shortName", "n" }
+            };
+            var symbolInfo = new Dictionary<string, IReadOnlyDictionary<string, string>>
+            {
+                { "n1", paramSymbolInfo },
+                { "n2", paramSymbolInfo }
+            };
+
+            var hostDataLoader = A.Fake<IHostSpecificDataLoader>();
+            A.CallTo(() => hostDataLoader.ReadHostSpecificTemplateData(template)).Returns(new HostSpecificTemplateData(symbolInfo));
+
+            TemplateGroup templateGroup = TemplateGroup.FromTemplateList(
+                CliTemplateInfo.FromTemplateInfo(new[] { template }, hostDataLoader))
+                .Single();
+
+            ITemplateEngineHost host = TestHost.GetVirtualHost();
+            IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+            TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
+
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", host, new TelemetryLogger(null, false), new NewCommandCallbacks());
+            InstantiateCommand instantiateCommand = InstantiateCommand.FromNewCommand(myCommand);
+            var parseResult = instantiateCommand.Parse($" new foo");
+            var args = new InstantiateCommandArgs(instantiateCommand, parseResult);
+
+            try
+            {
+                _ = new TemplateCommand(instantiateCommand, settings, packageManager, templateGroup, templateGroup.Templates.Single());
+            }
+            catch (InvalidTemplateParametersException e)
+            {
+                Assert.Equal(2, e.ParameterErrors.Count);
+                Assert.Equal(templateGroup.Templates.Single(), e.Template);
+
+                return Verifier.Verify(e.Message, _verifySettings.Settings);
+            }
+
+            Assert.True(false, "should not land here");
+            return Task.FromResult(1);
+            
+        }
+
+    }
+}


### PR DESCRIPTION
### Problem
#3809 
error handling for alias assignment
invalid template logic (duplicate parameters etc)

### Solution
Implemented error handling for alias assignment.

For possible errors in template grouping: they cannot happen as parameter uniqueness etc is validated when template.json is read. So kept exceptions as is without extra handlinsg.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)