### PR TITLE
Enable building project template package for alpha builds

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/TemplateResolution/CliFilters.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateResolution/CliFilters.cs
@@ -331,8 +331,8 @@ namespace Microsoft.TemplateEngine.Cli.TemplateResolution
                             LocalizableStrings.TemplateResolver_Warning_FailedToReparseTemplate,
                             $"{template.Identity} ({shortname})"));
                     Reporter.Verbose.WriteLine(string.Format(LocalizableStrings.Generic_Details, ex.ToString()));
+                    return new[] { new ParameterMatchInfo("%GENERIC-ERROR%", null, MatchKind.Mismatch, ParameterMatchInfo.MismatchKind.InvalidValue, null) };
                 }
-                return Array.Empty<MatchInfo>();
             };
         }
     }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/Microsoft.DotNet.Common.ProjectTemplates.7.0.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/Microsoft.DotNet.Common.ProjectTemplates.7.0.csproj
@@ -10,6 +10,7 @@
         <!-- .NET 6 template package is shipped with the preview / RC since .NET 6 is not released yet -->
         <!-- if the package should be shipped for servicing, set <IsPackable> to true for explicit version here -->
         <IsPackable>false</IsPackable>
+        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'alpha'">true</IsPackable>
         <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'preview'">true</IsPackable>
         <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rc'">true</IsPackable>
         <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtm'">true</IsPackable>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/Microsoft.DotNet.Common.ProjectTemplates.7.0.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/Microsoft.DotNet.Common.ProjectTemplates.7.0.csproj
@@ -7,13 +7,7 @@
         <OutputPath>$(TemplatesDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
         <UsingToolTemplateLocalizer>true</UsingToolTemplateLocalizer>
-        <!-- .NET 6 template package is shipped with the preview / RC since .NET 6 is not released yet -->
-        <!-- if the package should be shipped for servicing, set <IsPackable> to true for explicit version here -->
-        <IsPackable>false</IsPackable>
-        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'alpha'">true</IsPackable>
-        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'preview'">true</IsPackable>
-        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rc'">true</IsPackable>
-        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtm'">true</IsPackable>
+        <IsPackable>true</IsPackable>
         <NoWarn>2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ProjectTemplates.7.0</PackageId>

--- a/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
@@ -437,7 +437,6 @@ Examples:
 
             commandResult.Should()
                 .ExitWith(0)
-                .And.NotHaveStdErr()
                 .And.HaveStdOutContaining("Searching for the templates...")
                 .And.HaveStdOutContaining("Matches from template source: NuGet.org")
                 .And.HaveStdOutContaining("These templates matched your input: 'con', --framework")
@@ -458,7 +457,6 @@ Examples:
 
             commandResult.Should()
                 .ExitWith(0)
-                .And.NotHaveStdErr()
                 .And.HaveStdOutContaining("Searching for the templates...")
                 .And.HaveStdOutContaining("Matches from template source: NuGet.org")
                 .And.HaveStdOutContaining("These templates matched your input: 'con', -f")
@@ -479,7 +477,6 @@ Examples:
 
             commandResult.Should()
                 .ExitWith(0)
-                .And.NotHaveStdErr()
                 .And.HaveStdOutContaining("Searching for the templates...")
                 .And.HaveStdOutContaining("Matches from template source: NuGet.org")
                 .And.HaveStdOutContaining("These templates matched your input: -f")
@@ -504,7 +501,6 @@ Examples:
 
             commandResult.Should()
                 .ExitWith(0)
-                .And.NotHaveStdErr()
                 .And.HaveStdOutContaining("Searching for the templates...")
                 .And.HaveStdOutContaining("Matches from template source: NuGet.org")
                 .And.HaveStdOutContaining("These templates matched your input: 'con', --langVersion")
@@ -526,7 +522,6 @@ Examples:
 
             commandResult.Should()
                 .ExitWith(0)
-                .And.NotHaveStdErr()
                 .And.HaveStdOutContaining("Searching for the templates...")
                 .And.HaveStdOutContaining("Matches from template source: NuGet.org")
                 .And.HaveStdOutContaining("These templates matched your input: --langVersion")
@@ -551,7 +546,6 @@ Examples:
 
             commandResult.Should()
                 .ExitWith(0)
-                .And.NotHaveStdErr()
                 .And.HaveStdOutContaining("Searching for the templates...")
                 .And.HaveStdOutContaining("Matches from template source: NuGet.org")
                 .And.HaveStdOutContaining("These templates matched your input: 'con', --langVersion")
@@ -573,7 +567,6 @@ Examples:
 
             commandResult.Should()
                 .ExitWith(0)
-                .And.NotHaveStdErr()
                 .And.HaveStdOutContaining("Searching for the templates...")
                 .And.HaveStdOutContaining("Matches from template source: NuGet.org")
                 .And.HaveStdOutContaining("These templates matched your input: --langVersion")
@@ -598,7 +591,6 @@ Examples:
 
             commandResult.Should()
                 .ExitWith(0)
-                .And.NotHaveStdErr()
                 .And.HaveStdOutContaining("Searching for the templates...")
                 .And.HaveStdOutContaining("Matches from template source: NuGet.org")
                 .And.HaveStdOutContaining("These templates matched your input: 'con', -f='netcoreapp3.1'")
@@ -620,7 +612,6 @@ Examples:
 
             commandResult.Should()
                 .ExitWith(0)
-                .And.NotHaveStdErr()
                 .And.HaveStdOutContaining("Searching for the templates...")
                 .And.HaveStdOutContaining("Matches from template source: NuGet.org")
                 .And.HaveStdOutContaining("These templates matched your input: -f='net5.0'")


### PR DESCRIPTION
We need the .NET 7.0 project templates to be produced so we can include them in the .NET 7 SDK: dotnet/installer#12946.

I'm not sure why they were disabled in the first place, so maybe there's a different or better way we should be doing this.