### PR TITLE
[release/6.0.2xx] downgraded System.CommandLine to 2.0.0-beta1.21473.1 to match SDK version

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -23,7 +23,7 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>3a25a7f1cc446b60678ed25c9d829420d6321eba</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta1.21525.1">
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta1.21473.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>09a24a79ef01a0c70655919ee3c59bb54a8574df</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,7 @@
     <SystemIOCompressionPackageVersion>4.3.0</SystemIOCompressionPackageVersion>
     <SystemRuntimeLoaderPackageVersion>4.3.0</SystemRuntimeLoaderPackageVersion>
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
-    <SystemCommandLinePackageVersion>2.0.0-beta1.21525.1</SystemCommandLinePackageVersion>
+    <SystemCommandLinePackageVersion>2.0.0-beta1.21473.1</SystemCommandLinePackageVersion>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
     <NuGetCredentialsPackageVersion>6.0.0-preview.3.179</NuGetCredentialsPackageVersion>
     <NuGetConfigurationPackageVersion>6.0.0-preview.3.179</NuGetConfigurationPackageVersion>

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer/Commands/Export/ExportCommand.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer/Commands/Export/ExportCommand.cs
@@ -19,7 +19,6 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Commands.Export
             exportCommand.AddArgument(new Argument("template-path")
             {
                 Arity = ArgumentArity.OneOrMore,
-                ValueType = typeof(string),
                 Description = LocalizableStrings.command_export_help_templatePath_description,
             });
             exportCommand.AddOption(new Option("-r")


### PR DESCRIPTION
SDK decided to go with 2.0.0-beta1.21473.1 for 6.0.2xx, and templating should match this version.

See: https://github.com/dotnet/sdk/pull/23380