### PR TITLE
incremented precedence for project templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -9,7 +9,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET or .NET Standard",
   "groupIdentity": "Microsoft.Common.Library",
-  "precedence": "8000",
+  "precedence": "9000",
   "identity": "Microsoft.Common.Library.CSharp.7.0",
   "shortName": "classlib",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-FSharp/.template.config/template.json
@@ -9,7 +9,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET or .NET Standard",
   "groupIdentity": "Microsoft.Common.Library",
-  "precedence": "8000",
+  "precedence": "9000",
   "identity": "Microsoft.Common.Library.FSharp.7.0",
   "shortName": "classlib",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ClassLibrary-VisualBasic/.template.config/template.json
@@ -9,7 +9,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a class library that targets .NET or .NET Standard",
   "groupIdentity": "Microsoft.Common.Library",
-  "precedence": "8000",
+  "precedence": "9000",
   "identity": "Microsoft.Common.Library.VisualBasic.7.0",
   "shortName": "classlib",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -9,7 +9,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a command-line application that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Common.Console",
-  "precedence": "8000",
+  "precedence": "9000",
   "identity": "Microsoft.Common.Console.CSharp.7.0",
   "shortName": "console",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-FSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-FSharp/.template.config/template.json
@@ -9,7 +9,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a command-line application that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Common.Console",
-  "precedence": "8000",
+  "precedence": "9000",
   "identity": "Microsoft.Common.Console.FSharp.7.0",
   "shortName": "console",
   "tags": {

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-VisualBasic/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-VisualBasic/.template.config/template.json
@@ -9,7 +9,7 @@
   "generatorVersions": "[1.0.0.0-*)",
   "description": "A project for creating a command-line application that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Common.Console",
-  "precedence": "8000",
+  "precedence": "9000",
   "identity": "Microsoft.Common.Console.VisualBasic.7.0",
   "shortName": "console",
   "tags": {


### PR DESCRIPTION
https://github.com/dotnet/templating/pull/4295 to release/7.0.1xx-preview1

### Issue: 

https://github.com/dotnet/templating/issues/4296

### Description:
https://github.com/dotnet/templating/issues/4296 discovered that that templates from  .NET 6 SDK and .NET 7 SDK conflicts due to unchanged precedence. PR increases the precedence for .NET 7 templates.

### Customer impact: 
unable to use console / classlib templates when both .NET 6 SDK and .NET 7 SDK is installed.

### Regression: 
yes

### Risk: 
Low. Tested manually and with automation tests.