### PR TITLE
fixes dotnet/templating#4301 intermittent error message on installing he package with version from multiple NuGet feeds

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
@@ -333,6 +333,11 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                 }
                 return (source, foundPackages);
             }
+            catch (TaskCanceledException)
+            {
+                //do nothing
+                //GetPackageMetadataAsync may cancel the task in case package is found in another feed.
+            }
             catch (Exception ex)
             {
                 _nugetLogger.LogError(string.Format(LocalizableStrings.NuGetApiPackageManager_Error_FailedToReadPackage, source.Source));


### PR DESCRIPTION
### Problem
fixes dotnet/templating#4301

### Solution
do not log `TaskCancelledException` as the error

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)

This PR needs to be included to 6.0.3xx 