### PR TITLE
fixed CanShowConfigWithDebugShowConfig test

### DIFF
--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewDebugOptions.CanShowConfigWithDebugShowConfig.approved.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewDebugOptions.CanShowConfigWithDebugShowConfig.approved.txt
@@ -1,13 +1,13 @@
 ﻿Current configuration:
  
 Mount Point Factories                 Type                                                                        Assembly                                                                                            
-------------------------------------  --------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------------
+%delimiter%
 94e92610-cf4c-4f6d-aeb6-9e42dde1899d  Microsoft.TemplateEngine.Edge.Mount.Archive.ZipFileMountPointFactory        Microsoft.TemplateEngine.Edge, Version=<version>, Culture=neutral, PublicKeyToken=<token>
 8c19221b-dea3-4250-86fe-2d4e189a11d2  Microsoft.TemplateEngine.Edge.Mount.FileSystem.FileSystemMountPointFactory  Microsoft.TemplateEngine.Edge, Version=<version>, Culture=neutral, PublicKeyToken=<token>
 
 
 Generators                            Type                                                                             Assembly                                                                                                                     
-------------------------------------  -------------------------------------------------------------------------------  -----------------------------------------------------------------------------------------------------------------------------
+%delimiter%
 0c434df7-e2cb-4dee-b216-d7c58c8eb4b3  Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator  Microsoft.TemplateEngine.Orchestrator.RunnableProjects, Version=<version>, Culture=neutral, PublicKeyToken=<token>
 
 
@@ -15,7 +15,7 @@ The 'dotnet-new3 new3' command creates a .NET project based on a template.
 
 Common templates are:
 Template Name  Short Name  Language    Tags          
--------------  ----------  ----------  --------------
+%delimiter%
 Class Library  classlib    [C#],F#,VB  Common/Library
 Console App    console     [C#],F#,VB  Common/Console
 

--- a/test/dotnet-new3.UnitTests/DotnetNewDebugOptions.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewDebugOptions.cs
@@ -83,6 +83,8 @@ namespace Dotnet_new3.IntegrationTests
             {
                 //remove versions
                 var finalOutput = Regex.Replace(output, "Version=[A-Za-z0-9\\.]+", "Version=<version>");
+                //removes the delimiter line as we don't know the length of last columns containing paths above
+                finalOutput = Regex.Replace(finalOutput, "---[ -]*", "%delimiter%");
                 //remove tokens
                 finalOutput = Regex.Replace(finalOutput, "PublicKeyToken=[A-Za-z0-9]+", "PublicKeyToken=<token>");
                 return finalOutput;


### PR DESCRIPTION
### Problem
`CanShowConfigWithDebugShowConfig` is not working in internal pipeline. 
Reason: different table content causing the different number of dashes in table header delimiter

### Solution
excluded table header delimiter from approval