### PR TITLE
fixed error message in case specified '--type' is invalid

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.NoMatchHandling.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.NoMatchHandling.cs
@@ -192,15 +192,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             Reporter.Error.WriteLine(string.Format(LocalizableStrings.NoTemplatesMatchingInputParameters, baseInputParameters).Bold().Red());
             foreach (var option in new[]
                 {
-                    new { Option = languageOption, Condition = matchInfos.All(mi => !mi.IsLanguageMatch) },
-                    new { Option = typeOption, Condition = matchInfos.All(mi => !mi.IsTypeMatch) },
-                    new { Option = baselineOption, Condition = matchInfos.All(mi => !mi.IsBaselineMatch) },
+                    new { Option = languageOption, Condition = matchInfos.All(mi => !mi.IsLanguageMatch), AllowedValues = templateGroup.Languages },
+                    new { Option = typeOption, Condition = matchInfos.All(mi => !mi.IsTypeMatch), AllowedValues = templateGroup.Types },
+                    new { Option = baselineOption, Condition = matchInfos.All(mi => !mi.IsBaselineMatch), AllowedValues = (IReadOnlyList<string?>)templateGroup.Baselines },
                 })
             {
                 if (option.Condition && result.FindResultFor(option.Option) is { } optionResult)
                 {
-                    string availableLanguagesStr = string.Join(", ", templateGroup.Languages.Select(l => $"'{l}'").OrderBy(l => l, StringComparer.OrdinalIgnoreCase));
-                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplateOptions_Error_AllowedValuesForOptionList, optionResult.Token.Value, availableLanguagesStr));
+                    string allowedValues = string.Join(", ", option.AllowedValues.Select(l => $"'{l}'").OrderBy(l => l, StringComparer.OrdinalIgnoreCase));
+                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplateOptions_Error_AllowedValuesForOptionList, optionResult.Token.Value, allowedValues));
                 }
             }
 

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWithUnknownType.approved.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWithUnknownType.approved.txt
@@ -1,0 +1,7 @@
+﻿No templates found matching: 'console', --type='item'.
+Allowed values for '--type' option are: 'project'.
+
+To list installed templates, run:
+   dotnet-new3 new3 list
+To search for the templates on NuGet.org, run:
+   dotnet-new3 new3 search console

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.Approval.cs
@@ -47,6 +47,22 @@ namespace Dotnet_new3.IntegrationTests
         }
 
         [Fact]
+        public void CannotInstantiateTemplateWithUnknownType()
+        {
+            var commandResult = new DotnetNewCommand(_log, "console", "--type", "item")
+                .WithCustomHive(_fixture.HomeDirectory)
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute();
+
+            commandResult
+                .Should()
+                .Fail()
+                .And.NotHaveStdOut();
+
+            Approvals.Verify(commandResult.StdErr);
+        }
+
+        [Fact]
         public void CannotInstantiateTemplate_WhenAmbiguousLanguageChoice()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");


### PR DESCRIPTION
### Problem
Error message on invalid `--type` suggests allowed values from `--language`.

### Solution
Fixed error message

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)