### PR TITLE
Fix localize task error reporting

### DIFF
--- a/src/Microsoft.TemplateEngine.Tasks/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Tasks/LocalizableStrings.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.TemplateEngine.Tasks {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to export localization files for &apos;template.json&apos; file under the path &apos;{0}&apos;: {1}..
+        /// </summary>
+        internal static string Command_Localize_Log_ExportTaskFailed {
+            get {
+                return ResourceManager.GetString("Command_Localize_Log_ExportTaskFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;LocalizeTemplates&apos; stopped processing the following file, because the operation was cancelled: {0}.
         /// </summary>
         internal static string Command_Localize_Log_FileProcessingCancelled {

--- a/src/Microsoft.TemplateEngine.Tasks/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Tasks/LocalizableStrings.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Command_Localize_Log_ExportTaskFailed" xml:space="preserve">
+    <value>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</value>
+    <comment>Do not localize: 'template.json'</comment>
+  </data>
   <data name="Command_Localize_Log_FileProcessingCancelled" xml:space="preserve">
     <value>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</value>
     <comment>Do not localize: 'LocalizeTemplates'.

--- a/src/Microsoft.TemplateEngine.Tasks/Tasks/LocalizeTemplates.cs
+++ b/src/Microsoft.TemplateEngine.Tasks/Tasks/LocalizeTemplates.cs
@@ -99,7 +99,14 @@ namespace Microsoft.TemplateEngine.Tasks
                     ExportResult result = pathTaskPair.Task.Result;
                     if (!result.Succeeded)
                     {
-                        Log.LogError("", "", "", result.TemplateJsonPath, 0, 0, 0, 0, result.ErrorMessage);
+                        if (!string.IsNullOrWhiteSpace(result.ErrorMessage))
+                        {
+                            Log.LogError(LocalizableStrings.Command_Localize_Log_ExportTaskFailed, result.TemplateJsonPath, result.ErrorMessage);
+                        }
+                        else if (result.InnerException != null)
+                        {
+                            Log.LogErrorFromException(result.InnerException, showStackTrace: true, showDetail: true, result.TemplateJsonPath);
+                        }
                     }
                     failed |= !result.Succeeded;
                 }

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Tasks/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+        <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
+        <note>Do not localize: 'template.json'</note>
+      </trans-unit>
       <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
         <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>

--- a/test/Microsoft.TemplateEngine.Tasks.IntegrationTests/LocalizeTemplateTests.cs
+++ b/test/Microsoft.TemplateEngine.Tasks.IntegrationTests/LocalizeTemplateTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.TemplateEngine.Tasks.IntegrationTests
                 .Should()
                 .Fail()
                 .And.HaveStdOutContaining("Build FAILED.")
-                .And.HaveStdOutContaining("error : Each child of '//postActions' should have a unique id");
+                .And.HaveStdOutContaining("Each child of '//postActions' should have a unique id");
 
             string locFolder = Path.Combine(tmpDir, "content/TemplateWithSourceName/.template.config/localize");
 


### PR DESCRIPTION
### Problem
Localize template tasks: when export task fails and no error message is set, the logging error fails with null ref exception.

### Solution
added check for null before logging the error
added logging of inner exception
