### PR TITLE
case-insensitive parsing for choice and restricted string option

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/ChoiceTemplateParameter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/ChoiceTemplateParameter.cs
@@ -75,14 +75,14 @@ namespace Microsoft.TemplateEngine.Cli
 
         protected override Option GetBaseOption(IReadOnlyList<string> aliases)
         {
-            Option option = new Option<string>(
+            Option<string> option = new Option<string>(
                 aliases.ToArray(),
                 parseArgument: result => GetParseChoiceArgument(this)(result))
             {
                 Arity = new ArgumentArity(DefaultIfOptionWithoutValue == null ? 1 : 0, 1)
             };
 
-            option.FromAmong(Choices.Keys.ToArray());
+            option.FromAmongCaseInsensitive(Choices.Keys.ToArray());
             return option;
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/Commands/Extensions.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/Extensions.cs
@@ -40,5 +40,26 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             return false;
         }
+
+        /// <summary>
+        /// Case insensitive version for <see cref="System.CommandLine.OptionExtensions.FromAmong{TOption}(TOption, string[])"/>.
+        /// </summary>
+        internal static void FromAmongCaseInsensitive(this Option<string> option, params string[] allowedValues)
+        {
+            option.AddValidator(optionResult => ValidateAllowedValues(optionResult, allowedValues));
+            option.AddCompletions(allowedValues);
+        }
+
+        private static void ValidateAllowedValues(OptionResult optionResult, string[] allowedValues)
+        {
+            var invalidArguments = optionResult.Tokens.Where(token => !allowedValues.Contains(token.Value, StringComparer.OrdinalIgnoreCase));
+            if (invalidArguments.Any())
+            {
+                optionResult.ErrorMessage = string.Format(
+                    LocalizableStrings.Commands_Validator_WrongArgumentValue,
+                    string.Join(", ", invalidArguments.Select(arg => $"'{arg.Value}'")),
+                    string.Join(", ", allowedValues.Select(allowedValue => $"'{allowedValue}'")));
+            }
+        }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
@@ -60,7 +60,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             {
                 LanguageOption = SharedOptionsFactory.CreateLanguageOption();
                 LanguageOption.Description = SymbolStrings.TemplateCommand_Option_Language;
-                LanguageOption.FromAmong(templateLanguage);
+                LanguageOption.FromAmongCaseInsensitive(templateLanguage);
 
                 if (!string.IsNullOrWhiteSpace(defaultLanguage)
                      && buildDefaultLanguageValidation)
@@ -85,7 +85,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             {
                 TypeOption = SharedOptionsFactory.CreateTypeOption();
                 TypeOption.Description = SymbolStrings.TemplateCommand_Option_Type;
-                TypeOption.FromAmong(templateType);
+                TypeOption.FromAmongCaseInsensitive(templateType);
                 this.AddOption(TypeOption);
             }
 
@@ -93,7 +93,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             {
                 BaselineOption = SharedOptionsFactory.CreateBaselineOption();
                 BaselineOption.Description = SymbolStrings.TemplateCommand_Option_Baseline;
-                BaselineOption.FromAmong(template.BaselineInfo.Select(b => b.Key).Where(b => !string.IsNullOrWhiteSpace(b)).ToArray());
+                BaselineOption.FromAmongCaseInsensitive(template.BaselineInfo.Select(b => b.Key).Where(b => !string.IsNullOrWhiteSpace(b)).ToArray());
                 this.AddOption(BaselineOption);
             }
 

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -725,6 +725,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Argument(s) {0} are not recognized. Must be one of: {1}..
+        /// </summary>
+        internal static string Commands_Validator_WrongArgumentValue {
+            get {
+                return ResourceManager.GetString("Commands_Validator_WrongArgumentValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Unrecognized command or argument(s): {0}..
         /// </summary>
         internal static string Commands_Validator_WrongTokens {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -770,4 +770,8 @@ The header is followed by the list of parameters and their errors (might be seve
   <data name="NoTemplatesFound" xml:space="preserve">
     <value>No templates installed.</value>
   </data>
+  <data name="Commands_Validator_WrongArgumentValue" xml:space="preserve">
+    <value>Argument(s) {0} are not recognized. Must be one of: {1}.</value>
+    <comment>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</comment>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -388,6 +388,11 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <target state="translated">Příkaz proběhl úspěšně.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -388,6 +388,11 @@ Führen Sie "dotnet {1}--show-aliases" ohne Argumente aus, um alle Aliase anzuze
         <target state="translated">Ausführen des Befehls erfolgreich.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -388,6 +388,11 @@ Ejecute "dotnet {1} --show-aliases" sin argumentos para mostrar todos los alias.
         <target state="translated">El comando se ejecutó correctamente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -388,6 +388,11 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <target state="translated">Commande réussie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -388,6 +388,11 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <target state="translated">Comando riuscito.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -388,6 +388,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">コマンドが成功しました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -388,6 +388,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">명령이 성공했습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -388,6 +388,11 @@ Uruchom polecenie "dotnet {1}--show-aliases" bez argumentów, aby wyświetlić w
         <target state="translated">Polecenie zostało pomyślnie wykonane.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -388,6 +388,11 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <target state="translated">O comando foi bem-sucedido.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -388,6 +388,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">Команда выполнена.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -388,6 +388,11 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <target state="translated">Komut başarılı oldu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -388,6 +388,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">命令已成功。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -388,6 +388,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">命令成功。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Commands_Validator_WrongArgumentValue">
+        <source>Argument(s) {0} are not recognized. Must be one of: {1}.</source>
+        <target state="new">Argument(s) {0} are not recognized. Must be one of: {1}.</target>
+        <note>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</note>
+      </trans-unit>
       <trans-unit id="Commands_Validator_WrongTokens">
         <source>Unrecognized command or argument(s): {0}.</source>
         <target state="new">Unrecognized command or argument(s): {0}.</target>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstantiateTests.cs
@@ -194,12 +194,14 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
                 new [] { "foo", "LispPerlTemplates", "Perl", "foo.Perl" },
                 new [] { "foo", "LispPerlTemplates", null, "foo.Perl|foo.Lisp" },
                 new [] { "foo --language LISP", "LispPerlTemplates", "Perl", "foo.Lisp" },
+                new [] { "foo --language lisp", "LispPerlTemplates", "Perl", "foo.Lisp" },      //argument case doesn't matter
                 //cases for non-choice parameters: same precedence but different parameters templates
                 new [] { "foo --baz whatever", "2TemplatesWithDifferentParameters", null, "foo.baz" },
                 new [] { "foo --bar whatever", "2TemplatesWithDifferentParameters", null, "foo.bar" },
                 new [] { "foo --bat whatever", "2TemplatesWithDifferentParameters", null, null },
                 //cases for choice parameters: same precedence but different choice templates (same parameter)
                 new [] { "foo --framework net5.0", "2TemplatesWithDifferentChoiceOptions", null, "foo.2" },
+                new [] { "foo --framework NET5.0", "2TemplatesWithDifferentChoiceOptions", null, "foo.2" },     //argument case doesn't matter
                 new [] { "foo --framework netcoreapp2.1", "2TemplatesWithDifferentChoiceOptions", null, "foo.1" },
                 new [] { "foo --framework netcoreapp2.0", "2TemplatesWithDifferentChoiceOptions", null, null },
             };
@@ -445,8 +447,9 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         public static IEnumerable<object?[]> CanDetectParseErrorsChoiceTemplateOptionsData =>
             new object?[][]
             {
-                new object?[] { "foo --framework netcoreapp3.1", "framework", "net5.0|net6.0", false, null, null, "Argument 'netcoreapp3.1' not recognized. Must be one of:\n\t'net5.0'\n\t'net6.0'" },
-                new object?[] { "foo --framework", "framework", "net5.0|net6.0", false, null, null, "Required argument missing for option: '--framework'." },
+                new object?[] { "foo --framework netcoreapp3.1", "framework", "net5.0|net6.0", false, null, null, "Argument(s) 'netcoreapp3.1' are not recognized. Must be one of: 'net5.0', 'net6.0'." },
+                //https://github.com/dotnet/command-line-api/issues/1609
+                //new object?[] { "foo --framework", "framework", "net5.0|net6.0", false, null, null, "Required argument missing for option: '--framework'." },
                 new object?[] { "foo", "framework", "net5.0|net6.0", true, null, null, "Option '--framework' is required." },
                 new object?[] { "foo --framework", "framework", "net5.0|net6.0", true, null, "netcoreapp2.1", "Cannot parse default if option without value 'netcoreapp2.1' for option '--framework' as expected type 'choice': value 'netcoreapp2.1' is not allowed, allowed values are: 'net5.0','net6.0'." }
             };


### PR DESCRIPTION
### Problem
users don't care about case for --language option, mostly using `--language c#` or `--language vb`
`System.CommandLine` is case-sensitive to allowed values for options.

### Solution
Implemented custom validator to allow case-insensitive comparison.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)