### PR TITLE
do not fail on single provider failure when getting the templates

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
@@ -392,6 +392,16 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to retrieve template packages from provider &apos;{0}&apos;.
+        ///Details: {1}.
+        /// </summary>
+        internal static string TemplatePackageManager_Error_FailedToGetTemplatePackages {
+            get {
+                return ResourceManager.GetString("TemplatePackageManager_Error_FailedToGetTemplatePackages", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to scan {0}.
         ///Details: {1}.
         /// </summary>

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -235,7 +235,7 @@ Details: {0}</value>
   <data name="TemplatePackageManager_Error_FailedToGetTemplatePackages" xml:space="preserve">
     <value>Failed to retrieve template packages from provider '{0}'.
 Details: {1}</value>
-    <comment>{0} - provider name (not localized), last line should not end with a period - period is already included to message</comment>
+    <comment>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</comment>
   </data>
   <data name="TemplatePackageManager_Error_FailedToScan" xml:space="preserve">
     <value>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -232,6 +232,11 @@ Details: {0}</value>
     <value>Failed to load host data in {0} at {1}.</value>
     <comment>{0} - path to template location, {1} relative path inside template location.</comment>
   </data>
+  <data name="TemplatePackageManager_Error_FailedToGetTemplatePackages" xml:space="preserve">
+    <value>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</value>
+    <comment>{0} - provider name (not localized), last line should not end with a period - period is already included to message</comment>
+  </data>
   <data name="TemplatePackageManager_Error_FailedToScan" xml:space="preserve">
     <value>Failed to scan {0}.
 Details: {1}</value>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -190,6 +190,13 @@ Podrobnosti: {0}.</target>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -195,7 +195,7 @@ Podrobnosti: {0}.</target>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -195,7 +195,7 @@ Details: {0}.</target>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -190,6 +190,13 @@ Details: {0}.</target>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -195,7 +195,7 @@ Detalles: {0}.</target>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -190,6 +190,13 @@ Detalles: {0}.</target>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -195,7 +195,7 @@ Détails : {0}.</target>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -190,6 +190,13 @@ Détails : {0}.</target>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -190,6 +190,13 @@ Dettagli: {0}.</target>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -195,7 +195,7 @@ Dettagli: {0}.</target>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -195,7 +195,7 @@ Details: {0}</source>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -190,6 +190,13 @@ Details: {0}</source>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -195,7 +195,7 @@ Details: {0}</source>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -190,6 +190,13 @@ Details: {0}</source>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -195,7 +195,7 @@ Szczegóły: {0}.</target>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -190,6 +190,13 @@ Szczegóły: {0}.</target>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -195,7 +195,7 @@ Detalhes: {0}.</target>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -190,6 +190,13 @@ Detalhes: {0}.</target>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -195,7 +195,7 @@ Details: {0}</source>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -190,6 +190,13 @@ Details: {0}</source>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -195,7 +195,7 @@ Ayrıntılar: {0}.</target>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -190,6 +190,13 @@ Ayrıntılar: {0}.</target>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -195,7 +195,7 @@ Details: {0}</source>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -190,6 +190,13 @@ Details: {0}</source>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -195,7 +195,7 @@ Details: {0}</source>
 Details: {1}</source>
         <target state="new">Failed to retrieve template packages from provider '{0}'.
 Details: {1}</target>
-        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+        <note>{0} - provider name (not localized). Last line should not end with a period - period is already included in {1}.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -190,6 +190,13 @@ Details: {0}</source>
         <target state="new">Failed to load host data in {0} at {1}.</target>
         <note>{0} - path to template location, {1} relative path inside template location.</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToGetTemplatePackages">
+        <source>Failed to retrieve template packages from provider '{0}'.
+Details: {1}</source>
+        <target state="new">Failed to retrieve template packages from provider '{0}'.
+Details: {1}</target>
+        <note>{0} - provider name (not localized), last line should not end with a period - period is already included to message</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageManager_Error_FailedToScan">
         <source>Failed to scan {0}.
 Details: {1}</source>


### PR DESCRIPTION
### Problem
https://github.com/dotnet/sdk/pull/23677
`GivenNewCommandItDisplaysCompletions` now fails due to optional workload provider fails in test environment.

### Solution
Failure of single provider should not impact other work - log an error and skip faulter provider and continue.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)