### PR TITLE
allow to control diff/no-diff mode via variable for search-pipeline

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -58,7 +58,7 @@ steps:
 
 - bash: >
     $(Build.SourcesDirectory)/.dotnet/dotnet $(Build.SourcesDirectory)/artifacts/bin/Microsoft.TemplateSearch.TemplateDiscovery/Debug/net6.0/Microsoft.TemplateSearch.TemplateDiscovery.dll
-    --basePath $(System.DefaultWorkingDirectory)/NugetDownloadDirectory --allowPreviewPacks -v --test --latestVersionToTest $(RepoSdkVersion)
+    --basePath $(System.DefaultWorkingDirectory)/NugetDownloadDirectory --allowPreviewPacks -v --test --latestVersionToTest $(RepoSdkVersion) --diff $(EnableDiffMode)
   displayName: Run Cache Updater
 
 - task: CopyFiles@2


### PR DESCRIPTION
There are some cases when we need to make a clean scan for template packages - made it possible via build variable.