### PR TITLE
Fix Search CI

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -24,11 +24,6 @@ steps:
 
 - script: '$(Build.SourcesDirectory)/build.sh'
 
-- bash: |
-    SdkVersion=$(dotnet msbuild $(Build.SourcesDirectory)/eng/Versions.props -verbosity:diagnostic | grep "VSRedistCommonNetCoreToolsetx64PackageVersion = " | xargs | cut -d' ' -f 3)
-    echo "##vso[task.setvariable variable=RepoSdkVersion;]$SdkVersion"
-  displayName: 'Determine SDK version'
-
 - task: UseDotNet@2
   displayName: 'Use .NET 3.1'
   inputs:
@@ -50,12 +45,18 @@ steps:
     version: 5.0.300
     installationPath: $(Build.SourcesDirectory)/.dotnet
 
+- bash: |
+    SdkVersion=$(dotnet msbuild $(Build.SourcesDirectory)/eng/Versions.props -verbosity:diagnostic | grep "VSRedistCommonNetCoreToolsetx64PackageVersion = " | xargs | cut -d' ' -f 3)
+    echo "##vso[task.setvariable variable=RepoSdkVersion;]$SdkVersion"
+  displayName: 'Determine SDK version'
+  failOnStderr: true
+
 - bash: >
     curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
     -Version $(RepoSdkVersion)
     -InstallDir $(Build.SourcesDirectory)/.dotnet
     -SkipNonVersionedFiles
-  displayName: Install .NET 6.0
+  displayName: Install .NET version used by reposity
 
 - bash: >
     $(Build.SourcesDirectory)/.dotnet/dotnet $(Build.SourcesDirectory)/artifacts/bin/Microsoft.TemplateSearch.TemplateDiscovery/Debug/net6.0/Microsoft.TemplateSearch.TemplateDiscovery.dll

--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -75,10 +75,13 @@ steps:
   artifact: outputs
   displayName: Publish Artifacts
 
-- bash: az config set extension.use_dynamic_install=yes_without_prompt
-  displayName: Disable Azure CLI prompts
-
 - ${{ if eq(parameters.publishToBlob, true) }}:
+  - bash: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+    displayName: Install Azure CLI
+
+  - bash: az config set extension.use_dynamic_install=yes_without_prompt
+    displayName: Disable Azure CLI prompts
+
   - bash: >
       az storage azcopy blob upload 
       -c $(CacheFileStorageContainer)


### PR DESCRIPTION
There were 2 problems, with recent change of CI to "more safe":
  * one, that one doesn't have `dotnet` installed hence we failed to evaluate value of MSBuild property, now we execute that step after we install `dotnet` tool...
  * second problem was that this CI also didn't have `az` tool installed, hence added that step too...