### PR TITLE
[release/6.0.1xx] build Microsoft.DotNet.Common.ProjectTemplates.6.0 in servicing for source-build

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/Microsoft.DotNet.Common.ProjectTemplates.6.0.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/Microsoft.DotNet.Common.ProjectTemplates.6.0.csproj
@@ -6,12 +6,7 @@
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
         <OutputPath>$(TemplatesDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
-        <!-- .NET 6 template package is shipped with the preview / RC since .NET 6 is not released yet -->
-        <!-- if the package should be shipped for servicing, set <IsPackable> to true for explicit version here -->
-        <IsPackable>false</IsPackable>
-        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'preview'">true</IsPackable>
-        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rc'">true</IsPackable>
-        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtm'">true</IsPackable>
+        <IsPackable>true</IsPackable>
         <NoWarn>2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ProjectTemplates.6.0</PackageId>


### PR DESCRIPTION
### Problem
fixes dotnet/templating#4337

### Description
Enabled publishing for `Microsoft.DotNet.Common.ProjectTemplates.6.0` during servicing, as it is needed to eliminate over-engineering in source-build.
Previously it was decided not to publish template packages to NuGet.org for servicing releases, unless there is a need to, to minimize amount of versions having no update except version, however requirement of publishing from source-build side was missed. 
This change reenables publishing.

### Customer impact
No impact to customers, engineering change only.
After this change `Microsoft.DotNet.Common.ProjectTemplates.6.0` will be published also to NuGet.org for each servicing release (https://www.nuget.org/packages/Microsoft.DotNet.Common.ProjectTemplates.6.0), even when there is no change.

### Regression
no

### Risk
minimum, engineering change only. 
