### PR TITLE
[release/6.0.2xx] build Microsoft.DotNet.Common.ProjectTemplates.6.0 in servicing for source-build

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/Microsoft.DotNet.Common.ProjectTemplates.6.0.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/Microsoft.DotNet.Common.ProjectTemplates.6.0.csproj
@@ -6,12 +6,7 @@
         <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
         <OutputPath>$(TemplatesDir)</OutputPath>
         <EnableDefaultItems>False</EnableDefaultItems>
-        <!-- .NET 6 template package is shipped with the preview / RC since .NET 6 is not released yet -->
-        <!-- if the package should be shipped for servicing, set <IsPackable> to true for explicit version here -->
-        <IsPackable>false</IsPackable>
-        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'preview'">true</IsPackable>
-        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rc'">true</IsPackable>
-        <IsPackable Condition="'$(PreReleaseVersionLabel)' == 'rtm'">true</IsPackable>
+        <IsPackable>true</IsPackable>
         <NoWarn>2008;NU5105</NoWarn>
         <NoPackageAnalysis>true</NoPackageAnalysis>
         <PackageId>Microsoft.DotNet.Common.ProjectTemplates.6.0</PackageId>


### PR DESCRIPTION
### Problem
fixes dotnet/templating#4337 

See https://github.com/dotnet/templating/pull/4361