### PR TITLE
do not fail in case template cache cannot be saved, log warning and continue

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
@@ -410,5 +410,15 @@ namespace Microsoft.TemplateEngine.Edge {
                 return ResourceManager.GetString("TemplatePackageManager_Error_FailedToScan", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to store template cache, details: {0}
+        ///Template cache will be recreated on the next run..
+        /// </summary>
+        internal static string TemplatePackageManager_Error_FailedToStoreCache {
+            get {
+                return ResourceManager.GetString("TemplatePackageManager_Error_FailedToStoreCache", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -242,4 +242,9 @@ Details: {1}</value>
 Details: {1}</value>
     <comment>last line should not end with a period, period is a part of the format entry</comment>
   </data>
+  <data name="TemplatePackageManager_Error_FailedToStoreCache" xml:space="preserve">
+    <value>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</value>
+    <comment>{0} should not end with period - period is a part of the format entry.</comment>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
@@ -336,7 +336,16 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                 scanResult?.Dispose();
             }
             _userTemplateCache = cache;
-            _environmentSettings.Host.FileSystem.WriteObject(_paths.TemplateCacheFile, cache);
+
+            try
+            {
+                _environmentSettings.Host.FileSystem.WriteObject(_paths.TemplateCacheFile, cache);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(LocalizableStrings.TemplatePackageManager_Error_FailedToStoreCache, ex.Message);
+                _logger.LogDebug($"Stack trace: {ex.StackTrace}");
+            }
 
             return cache;
         }

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
 Podrobnosti: {1}</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
 Details: {1}.</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
 Detalles: {1}</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
 Détails : {1}</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
 Dettagli: {1}</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
 詳細: {1}</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
 세부 정보: {1}</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
 Szczegóły: {1}</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
 Detalhes: {1}</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
 Подробности: {1}</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
 Ayrıntılar: {1}</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
  详细信息: {1}</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -204,6 +204,13 @@ Details: {1}</source>
 詳細資料: {1}</target>
         <note>last line should not end with a period, period is a part of the format entry</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageManager_Error_FailedToStoreCache">
+        <source>Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</source>
+        <target state="new">Failed to store template cache, details: {0}
+Template cache will be recreated on the next run.</target>
+        <note>{0} should not end with period - period is a part of the format entry.</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION

### Problem
https://github.com/dotnet/installer/pull/13192#issuecomment-1035691082

### Solution
we removed mutex allowing only single run at the time while working on new parser.
as discovered during unit testing, sometimes the template cache cannot be stored due to concurrency. 
in case template cache cannot be stored, operation should not be cancelled. Template cache may be recreated on next operation.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)