### PR TITLE
template discovery: stop retrieving information about packages after 4000 hits.

### DIFF
--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
@@ -81,6 +81,11 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
                     //try to get all remaining packages
                     skip = 3000;
                     pageSize = totalPackCount - 3000;
+                    if (pageSize > 1000)
+                    {
+                        pageSize = 1000;
+                        Console.WriteLine($"Warning: {totalPackCount} packages were found, but only first 4000 packages can be retrieved. Other packages will be skipped.");
+                    }
                 }
                 string queryString = string.Format(_searchUriFormat, skip, pageSize);
 


### PR DESCRIPTION
### Problem
search cache pipeline is failing

### Solution
It is possible to get only first 4000 hits from NuGet search. 
Solution is to skip other packages for now. 
We should aim to deprecate "template" query soon, or find another way to search for the packages.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)