### PR TITLE
Search cache fix

### DIFF
--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
@@ -81,10 +81,12 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
                     //try to get all remaining packages
                     skip = 3000;
                     pageSize = totalPackCount - 3000;
+
+                    //pageSize limit is 1000
+                    //therefore max amount of packages that can be retrieved is 4000.
                     if (pageSize > 1000)
                     {
                         pageSize = 1000;
-                        Console.WriteLine($"Warning: {totalPackCount} packages were found, but only first 4000 packages can be retrieved. Other packages will be skipped.");
                     }
                 }
                 string queryString = string.Format(_searchUriFormat, skip, pageSize);
@@ -108,8 +110,13 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
                                 yield return sourceInfo;
                             }
                         }
-                        if (totalPackCount == packCount)
+                        //4000 is NuGet limit, stop after 4000 is processed.
+                        if (totalPackCount == packCount || totalPackCount > 4000 && packCount == 4000)
                         {
+                            if (totalPackCount > 4000)
+                            {
+                                Console.WriteLine($"Warning: {totalPackCount} packages were found, but only first 4000 packages can be retrieved. Other packages will be skipped.");
+                            }
                             done = true;
                         }
                         else if (skip > 3000 || skip >= totalPackCount)


### PR DESCRIPTION
https://github.com/dotnet/templating/pull/4399, part 2.

There was additional check if all packages were processed, adapted it as well.