### PR TITLE
increased timeout for Windows CI job to 90 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,7 @@ stages:
       helixRepo: dotnet/templating
       jobs:
       - job: Windows_NT
+        timeoutInMinutes: 90
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             vmImage: windows-2019


### PR DESCRIPTION
### Problem
Windows job sometimes is cancelled by timeout.

### Solution
increased timeout for Windows CI job to 90 minutes
didn't touch Ubuntu / OSX for now - they seems not to run more than 60 minutes.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)