### PR TITLE
[release/6.0.1xx] updated Microsoft.CodeAnalysis.NetAnalyzers to 6.0.0

### DIFF
--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -6,7 +6,7 @@
     <EnableAnalyzers Condition="'$(DotNetBuildFromSource)' == 'true'">false</EnableAnalyzers>
   </PropertyGroup>
   <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0-preview3.21153.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333" PrivateAssets="all" />
     <PackageReference Condition="'$(EnablePublicApiAnalyzer)' == 'true'" Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.2" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />

--- a/eng/AnalyzersForTests.props
+++ b/eng/AnalyzersForTests.props
@@ -6,7 +6,7 @@
     <EnableAnalyzers Condition="'$(DotNetBuildFromSource)' == 'true'">false</EnableAnalyzers>
   </PropertyGroup>
   <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0-preview3.21153.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
updated `Microsoft.CodeAnalysis.NetAnalyzers` version to 6.0.0.

### Problem 
Branch was using old version of analyzer and this caused the error when building against new version of runtime. 

### Customer Impact
engineering only change.

### Risk
engineering only change.

### Testing
automated tests