### PR TITLE
[release/6.0.2xx] forces System.Net.Http 4.3.4 in all sub dependencies

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -34,6 +34,11 @@
     <PackageReference Include="Wcwidth.Sources" ExcludeAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
+  <!-- forces the version in sub dependencies -->
+  <ItemGroup>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Compile Update="LocalizableStrings.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -10,4 +10,10 @@
     <PackageReference Update="xunit.abstractions" Version="2.0.3" />
     <PackageReference Update="Newtonsoft.Json.Schema" Version="3.0.13" />
   </ItemGroup>
+
+  <!-- forces the version in sub dependencies -->
+  <!-- xunit.assert has this dependency, so applying to all test projects-->
+  <ItemGroup>
+    <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
https://github.com/dotnet/templating/pull/4274 to release/6.0.2xx