### PR TITLE
execute OneLocBuild also for main branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,13 @@ stages:
         LclSource: lclFilesfromPackage
         LclPackageId: 'LCL-JUNO-PROD-TEMPLATING'
         condition: eq(variables['Build.SourceBranch'], format('{0}{1}', 'refs/heads/', variables['OneLocBuildBranch'] ))
+    - template: /eng/common/templates/job/onelocbuild.yml
+      parameters:
+        MirrorRepo: templating
+        MirrorBranch: main
+        LclSource: lclFilesfromPackage
+        LclPackageId: 'LCL-JUNO-PROD-TMPLTNGMAIN'
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true


### PR DESCRIPTION
Adapted pipeline to execute OneLocBuild also for main branch.

Main is not specified via variables as it would be run always in parallel with current release branch specified via variables.
