### PR TITLE
do not install packages which are already installed either from the SDK or an optional workload.

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Commands/Example.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/Example.cs
@@ -59,6 +59,10 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 _commandParts.AddRange(args.Select(a => a.Any(char.IsWhiteSpace) ? $"'{a}'" : a));
                 return this;
             }
+            if (option.Arity.MinimumNumberOfValues == 0)
+            {
+                return this;
+            }
 
             _commandParts.Add(CommandLineUtils.FormatArgumentUsage(option));
             return this;

--- a/src/Microsoft.TemplateEngine.Cli/Commands/SharedOptionsFactory.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/SharedOptionsFactory.cs
@@ -28,6 +28,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             };
         }
 
+        internal static Option<bool> CreateForceOption()
+        {
+            return new(new[] { "--force" })
+            {
+                Arity = new ArgumentArity(0, 1),
+                Description = SymbolStrings.TemplateCommand_Option_Force,
+            };
+        }
+
         internal static Option<string> CreateAuthorOption()
         {
             return new(new[] { "--author" })
@@ -137,6 +146,12 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         internal static Option<T> AsHidden<T>(this Option<T> o)
         {
             o.IsHidden = true;
+            return o;
+        }
+
+        internal static Option<T> WithDescription<T>(this Option<T> o, string description)
+        {
+            o.Description = description;
             return o;
         }
 

--- a/src/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.Designer.cs
@@ -325,6 +325,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Allows to install the template package even if the same package is already available from different sources..
+        /// </summary>
+        internal static string Option_Install_Force {
+            get {
+                return ResourceManager.GetString("Option_Install_Force", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Allows the command to stop and wait for user input or action (for example to complete authentication)..
         /// </summary>
         internal static string Option_Interactive {

--- a/src/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.Designer.cs
@@ -325,7 +325,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allows to install the template package even if the same package is already available from different sources..
+        ///   Looks up a localized string similar to Allows installing template packages from the specified sources even if they would override a template package from another source..
         /// </summary>
         internal static string Option_Install_Force {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.resx
@@ -207,6 +207,9 @@ If command is specified without the argument, it lists all the template packages
   <data name="Option_Debug_VirtualSettings" xml:space="preserve">
     <value>If specified, the settings will be not preserved on file system.</value>
   </data>
+  <data name="Option_Install_Force" xml:space="preserve">
+    <value>Allows to install the template package even if the same package is already available from different sources.</value>
+  </data>
   <data name="Option_Interactive" xml:space="preserve">
     <value>Allows the command to stop and wait for user input or action (for example to complete authentication).</value>
   </data>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/SymbolStrings.resx
@@ -208,7 +208,7 @@ If command is specified without the argument, it lists all the template packages
     <value>If specified, the settings will be not preserved on file system.</value>
   </data>
   <data name="Option_Install_Force" xml:space="preserve">
-    <value>Allows to install the template package even if the same package is already available from different sources.</value>
+    <value>Allows installing template packages from the specified sources even if they would override a template package from another source.</value>
   </data>
   <data name="Option_Interactive" xml:space="preserve">
     <value>Allows the command to stop and wait for user input or action (for example to complete authentication).</value>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/install/BaseInstallCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/install/BaseInstallCommand.cs
@@ -23,6 +23,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             this.AddArgument(NameArgument);
             this.AddOption(InteractiveOption);
             this.AddOption(AddSourceOption);
+            this.AddOption(ForceOption);
         }
 
         internal static Argument<string[]> NameArgument { get; } = new("package")
@@ -34,6 +35,8 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         internal virtual Option<bool> InteractiveOption { get; } = SharedOptionsFactory.CreateInteractiveOption();
 
         internal virtual Option<string[]> AddSourceOption { get; } = SharedOptionsFactory.CreateAddSourceOption();
+
+        internal virtual Option<bool> ForceOption { get; } = SharedOptionsFactory.CreateForceOption().WithDescription(SymbolStrings.Option_Install_Force);
 
         protected NewCommand ParentCommand { get; }
 

--- a/src/Microsoft.TemplateEngine.Cli/Commands/install/InstallCommandArgs.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/install/InstallCommandArgs.cs
@@ -25,6 +25,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             Interactive = parseResult.GetValueForOption(installCommand.InteractiveOption);
             AdditionalSources = parseResult.GetValueForOption(installCommand.AddSourceOption);
+            Force = parseResult.GetValueForOption(installCommand.ForceOption);
         }
 
         public IReadOnlyList<string> TemplatePackages { get; }
@@ -32,5 +33,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         public bool Interactive { get; }
 
         public IReadOnlyList<string>? AdditionalSources { get; }
+
+        public bool Force { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.cs.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.cs.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.de.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.de.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.es.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.es.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.fr.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.fr.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.it.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.it.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ja.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ja.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ko.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ko.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pl.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pl.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pt-BR.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.pt-BR.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ru.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.ru.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.tr.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.tr.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hans.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hans.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hant.xlf
@@ -153,6 +153,11 @@ If command is specified without the argument, it lists all the template packages
         <target state="new">If specified, the settings will be not preserved on file system.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Option_Install_Force">
+        <source>Allows to install the template package even if the same package is already available from different sources.</source>
+        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Option_Interactive">
         <source>Allows the command to stop and wait for user input or action (for example to complete authentication).</source>
         <target state="new">Allows the command to stop and wait for user input or action (for example to complete authentication).</target>

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/SymbolStrings.zh-Hant.xlf
@@ -154,8 +154,8 @@ If command is specified without the argument, it lists all the template packages
         <note />
       </trans-unit>
       <trans-unit id="Option_Install_Force">
-        <source>Allows to install the template package even if the same package is already available from different sources.</source>
-        <target state="new">Allows to install the template package even if the same package is already available from different sources.</target>
+        <source>Allows installing template packages from the specified sources even if they would override a template package from another source.</source>
+        <target state="new">Allows installing template packages from the specified sources even if they would override a template package from another source.</target>
         <note />
       </trans-unit>
       <trans-unit id="Option_Interactive">

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1537,11 +1537,38 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Installing the template packages will override the available template packages..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Install_Info_OverrideNotice {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Install_Info_OverrideNotice", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following template packages are already available:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Install_Info_PackageIsAvailable {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Install_Info_PackageIsAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The following template packages will be installed:.
         /// </summary>
         internal static string TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled {
             get {
                 return ResourceManager.GetString("TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To install these template packages anyway, apply &apos;{0}&apos; option:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_Install_Info_UseForceToOverride {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_Install_Info_UseForceToOverride", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1537,7 +1537,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Installing the template packages will override the available template packages..
+        ///   Looks up a localized string similar to Installing the template package(s) will override the available template package(s)..
         /// </summary>
         internal static string TemplatePackageCoordinator_Install_Info_OverrideNotice {
             get {
@@ -1546,7 +1546,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The following template packages are already available:.
+        ///   Looks up a localized string similar to The following template package(s) are already available:.
         /// </summary>
         internal static string TemplatePackageCoordinator_Install_Info_PackageIsAvailable {
             get {
@@ -1564,7 +1564,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To install these template packages anyway, apply &apos;{0}&apos; option:.
+        ///   Looks up a localized string similar to To install the template package(s) anyway, apply &apos;{0}&apos; option:.
         /// </summary>
         internal static string TemplatePackageCoordinator_Install_Info_UseForceToOverride {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -775,14 +775,14 @@ The header is followed by the list of parameters and their errors (might be seve
     <comment>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</comment>
   </data>
   <data name="TemplatePackageCoordinator_Install_Info_OverrideNotice" xml:space="preserve">
-    <value>Installing the template packages will override the available template packages.</value>
+    <value>Installing the template package(s) will override the available template package(s).</value>
   </data>
   <data name="TemplatePackageCoordinator_Install_Info_PackageIsAvailable" xml:space="preserve">
-    <value>The following template packages are already available:</value>
+    <value>The following template package(s) are already available:</value>
     <comment>Followed by list of packages that are available</comment>
   </data>
   <data name="TemplatePackageCoordinator_Install_Info_UseForceToOverride" xml:space="preserve">
-    <value>To install these template packages anyway, apply '{0}' option:</value>
+    <value>To install the template package(s) anyway, apply '{0}' option:</value>
     <comment>{0} is option to use (--force). Followed by command to use to install the packages.</comment>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -774,4 +774,15 @@ The header is followed by the list of parameters and their errors (might be seve
     <value>Argument(s) {0} are not recognized. Must be one of: {1}.</value>
     <comment>{0} - comma-separated quoted list of argument value(s) given by user, {1} - comma-separated quoted list of allowed values.</comment>
   </data>
+  <data name="TemplatePackageCoordinator_Install_Info_OverrideNotice" xml:space="preserve">
+    <value>Installing the template packages will override the available template packages.</value>
+  </data>
+  <data name="TemplatePackageCoordinator_Install_Info_PackageIsAvailable" xml:space="preserve">
+    <value>The following template packages are already available:</value>
+    <comment>Followed by list of packages that are available</comment>
+  </data>
+  <data name="TemplatePackageCoordinator_Install_Info_UseForceToOverride" xml:space="preserve">
+    <value>To install these template packages anyway, apply '{0}' option:</value>
+    <comment>{0} is option to use (--force). Followed by command to use to install the packages.</comment>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/NuGetUtils.cs
+++ b/src/Microsoft.TemplateEngine.Cli/NuGetUtils.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.TemplateEngine.Abstractions;
+using NuGet.Packaging;
+
+namespace Microsoft.TemplateEngine.Cli
+{
+    internal static class NuGetUtils
+    {
+        /// <summary>
+        /// Gets ID and version of NuGet package.
+        /// </summary>
+        /// <param name="engineEnvironmentSettings">environment settings.</param>
+        /// <param name="packageLocation">file path to NuGet package.</param>
+        /// <returns>ID and version of NuGet package; or default in case path is not a valid NuGet package.</returns>
+        internal static (string Id, string Version) GetNuGetPackageInfo(IEngineEnvironmentSettings engineEnvironmentSettings, string packageLocation)
+        {
+            if (!engineEnvironmentSettings.Host.FileSystem.FileExists(packageLocation))
+            {
+                //packageLocation is not a file
+                return default;
+            }
+
+            try
+            {
+                using Stream inputStream = engineEnvironmentSettings.Host.FileSystem.OpenRead(packageLocation);
+                using PackageArchiveReader reader = new PackageArchiveReader(inputStream);
+
+                NuspecReader nuspec = reader.NuspecReader;
+
+                return new(nuspec.GetId(), nuspec.GetVersion().ToNormalizedString());
+            }
+            catch (Exception)
+            {
+                return default;
+            }
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -320,12 +320,12 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 Reporter reporter = args.Force ? Reporter.Output : Reporter.Error;
 
+                reporter.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Install_Info_OverrideNotice);
                 reporter.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Install_Info_PackageIsAvailable);
                 foreach (var request in invalidTemplatePackages)
                 {
                     reporter.WriteLine($"{request.PackageInfo.Id}::{request.PackageInfo.Version}".Indent());
                 }
-                reporter.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Install_Info_OverrideNotice);
                 reporter.WriteLine();
 
                 if (!args.Force)

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Příkaz se pokouší nainstalovat balíček šablony {0} dvakrát, zkontrolujte argumenty a zkuste to znovu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">Nainstalují se tyto balíčky šablon:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Der Befehl versucht, das Vorlagenpaket "{0}" zweimal zu installieren, überprüfen Sie die Argumente, und versuchen Sie es noch mal.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">Die folgenden Vorlagenpakete werden installiert:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">El comando está intentando instalar el paquete de plantillas "{0}" dos veces, compruebe los argumentos y vuelva a intentarlo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">Se instalarán los siguientes paquetes de plantillas:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">La commande tente d’installer deux fois le package de modèles « {0} ». Vérifiez les arguments et réessayez.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">Les packages de modèles suivants seront installés :</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Il comando sta tentando di installare il pacchetto di modelli '{0}' due volte, controllare gli argomenti e riprovare.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">Verranno installati i pacchetti di modelli seguenti:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">コマンドがテンプレート パッケージ '{0}' を2回インストールしようとしています。引数を確認して、もう一度やり直してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">次のパッケージがインストールされます:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">명령이 '{0}' 템플릿 패키지를 두 번 설치하려고 시도하고 있습니다. 인수를 확인하고 재시도하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">다음 템플릿 패키지가 설치됩니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Polecenie próbuje zainstalować pakiet szablonów "{0}" dwa razy. Sprawdź argumenty i ponów próbę.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">Zostaną zainstalowane następujące pakiety szablonów:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">O comando está tentando instalar o pacote de modelos '{0}' duas vezes, verifique os argumentos e tente novamente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">Os seguintes pacotes de modelo serão instalados:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Команда пытается установить пакет шаблона "{0}" дважды. Проверьте аргументы и повторите попытку.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">Планируется установка следующих пакетов шаблонов:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Komut, '{0}' şablon paketini iki kere yüklemeye çalışıyor. Bağımsız değişkenleri kontrol edin ve yeniden deneyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">Şu şablon paketleri yüklenecek:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">该命令正在尝试安装模板包“{0}”两次，请检查参数，然后重试。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">将安装以下模板包:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -857,10 +857,25 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">命令正在嘗試安裝範本套件 '{0}' 兩次，請檢查引數並重試。</target>
         <note />
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
+        <source>Installing the template packages will override the available template packages.</source>
+        <target state="new">Installing the template packages will override the available template packages.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
+        <source>The following template packages are already available:</source>
+        <target state="new">The following template packages are already available:</target>
+        <note>Followed by list of packages that are available</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
         <source>The following template packages will be installed:</source>
         <target state="translated">將安裝下列範本套件:</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
+        <source>To install these template packages anyway, apply '{0}' option:</source>
+        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">
         <source>Failed to uninstall {0}, reason: {1}.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -858,13 +858,13 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_OverrideNotice">
-        <source>Installing the template packages will override the available template packages.</source>
-        <target state="new">Installing the template packages will override the available template packages.</target>
+        <source>Installing the template package(s) will override the available template package(s).</source>
+        <target state="new">Installing the template package(s) will override the available template package(s).</target>
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackageIsAvailable">
-        <source>The following template packages are already available:</source>
-        <target state="new">The following template packages are already available:</target>
+        <source>The following template package(s) are already available:</source>
+        <target state="new">The following template package(s) are already available:</target>
         <note>Followed by list of packages that are available</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled">
@@ -873,8 +873,8 @@ The header is followed by the list of parameters and their errors (might be seve
         <note />
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Install_Info_UseForceToOverride">
-        <source>To install these template packages anyway, apply '{0}' option:</source>
-        <target state="new">To install these template packages anyway, apply '{0}' option:</target>
+        <source>To install the template package(s) anyway, apply '{0}' option:</source>
+        <target state="new">To install the template package(s) anyway, apply '{0}' option:</target>
         <note>{0} is option to use (--force). Followed by command to use to install the packages.</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Uninstall_Error_GenericError">

--- a/src/dotnet-new3/BuiltInTemplatePackagesProvider.cs
+++ b/src/dotnet-new3/BuiltInTemplatePackagesProvider.cs
@@ -74,7 +74,13 @@ namespace Dotnet_new3
                     {
                         string expandedPath = Environment.ExpandEnvironmentVariables(sourceLocation).Replace('\\', Path.DirectorySeparatorChar);
                         IEnumerable<string> expandedPaths = InstallRequestPathResolution.ExpandMaskedPath(expandedPath, _settings);
-                        templatePackages.AddRange(expandedPaths.Select(path => new TemplatePackage(this, path, _settings.Host.FileSystem.GetLastWriteTimeUtc(path))));
+                        foreach (string path in expandedPaths)
+                        {
+                            if (_settings.Host.FileSystem.FileExists(path) || _settings.Host.FileSystem.DirectoryExists(path))
+                            {
+                                templatePackages.Add(new TemplatePackage(this, path, _settings.Host.FileSystem.GetLastWriteTimeUtc(path)));
+                            }
+                        }
                     }
                 }
 

--- a/src/dotnet-new3/defaultinstall.template.list
+++ b/src/dotnet-new3/defaultinstall.template.list
@@ -1,1 +1,0 @@
-%DN3%\template_feed\

--- a/src/dotnet-new3/defaultinstall.template.list.debug
+++ b/src/dotnet-new3/defaultinstall.template.list.debug
@@ -1,2 +1,2 @@
 %DN3%\artifacts\packages\Debug\Shipping\*.ProjectTemplates.*.nupkg
-%DN3%\artifacts\packages\Debug\Shipping\*.ItemTemplates.nupkg
+%DN3%\artifacts\packages\Debug\Shipping\*.ItemTemplates.*.nupkg

--- a/src/dotnet-new3/defaultinstall.template.list.debug
+++ b/src/dotnet-new3/defaultinstall.template.list.debug
@@ -1,0 +1,2 @@
+%DN3%\artifacts\packages\Debug\Shipping\*.ProjectTemplates.*.nupkg
+%DN3%\artifacts\packages\Debug\Shipping\*.ItemTemplates.nupkg

--- a/src/dotnet-new3/defaultinstall.template.list.release
+++ b/src/dotnet-new3/defaultinstall.template.list.release
@@ -1,2 +1,2 @@
 %DN3%\artifacts\packages\Release\Shipping\*.ProjectTemplates.*.nupkg
-%DN3%\artifacts\packages\Release\Shipping\*.ItemTemplates.nupkg
+%DN3%\artifacts\packages\Release\Shipping\*.ItemTemplates.*.nupkg

--- a/src/dotnet-new3/defaultinstall.template.list.release
+++ b/src/dotnet-new3/defaultinstall.template.list.release
@@ -1,0 +1,2 @@
+%DN3%\artifacts\packages\Release\Shipping\*.ProjectTemplates.*.nupkg
+%DN3%\artifacts\packages\Release\Shipping\*.ItemTemplates.nupkg

--- a/src/dotnet-new3/dotnet-new3.csproj
+++ b/src/dotnet-new3/dotnet-new3.csproj
@@ -7,8 +7,21 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <Content Include="defaultinstall.template.list.debug">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <Link>defaultinstall.template.list</Link>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Configuration)' != 'Debug'">
+    <Content Include="defaultinstall.template.list.release">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <Link>defaultinstall.template.list</Link>
+    </Content>
+  </ItemGroup>
+
   <ItemGroup>
-    <None Update="**\*.list" CopyToOutputDirectory="Always" />
     <None Update="dotnet-new3.sh" CopyToOutputDirectory="Always" />
     <None Update="dotnet-new3.cmd" CopyToOutputDirectory="Always" />
   </ItemGroup>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.Install_GetAllSuggestions.verified.txt
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.Install_GetAllSuggestions.verified.txt
@@ -11,7 +11,7 @@
     Kind: Keyword,
     SortText: --force,
     InsertText: --force,
-    Detail: Allows to install the template package even if the same package is already available from different sources.
+    Detail: Allows installing template packages from the specified sources even if they would override a template package from another source.
   },
   {
     Label: --interactive,

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.Install_GetAllSuggestions.verified.txt
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.Install_GetAllSuggestions.verified.txt
@@ -7,6 +7,13 @@
     Detail: Specifies a NuGet source to use during install.
   },
   {
+    Label: --force,
+    Kind: Keyword,
+    SortText: --force,
+    InsertText: --force,
+    Detail: Allows to install the template package even if the same package is already available from different sources.
+  },
+  {
     Label: --interactive,
     Kind: Keyword,
     SortText: --interactive,

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstallTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/InstallTests.cs
@@ -95,6 +95,27 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         }
 
         [Fact]
+        public void Install_CanParseForceOption()
+        {
+            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(includeTestTemplates: false));
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host, _ => new TelemetryLogger(null, false), new NewCommandCallbacks());
+
+            var parseResult = myCommand.Parse($"new install source --force");
+            InstallCommandArgs args = new InstallCommandArgs((InstallCommand)parseResult.CommandResult.Command, parseResult);
+
+            Assert.True(args.Force);
+            Assert.Single(args.TemplatePackages);
+            Assert.Contains("source", args.TemplatePackages);
+
+            parseResult = myCommand.Parse($"new install source");
+            args = new InstallCommandArgs((InstallCommand)parseResult.CommandResult.Command, parseResult);
+
+            Assert.False(args.Force);
+            Assert.Single(args.TemplatePackages);
+            Assert.Contains("source", args.TemplatePackages);
+        }
+
+        [Fact]
         public void Install_CanParseMultipleArgs()
         {
             ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: BuiltInTemplatePackagesProviderFactory.GetComponents(includeTestTemplates: false));

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelp_Install_common.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelp_Install_common.verified.txt
@@ -11,5 +11,5 @@ Arguments:
 Options:
   --interactive                                Allows the command to stop and wait for user input or action (for example to complete authentication).
   --add-source, --nuget-source <nuget-source>  Specifies a NuGet source to use during install.
-  --force                                      Allows to install the template package even if the same package is already available from different sources.
+  --force                                      Allows installing template packages from the specified sources even if they would override a template package from another source.
   -?, -h, --help                               Show help and usage information

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelp_Install_common.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelp_Install_common.verified.txt
@@ -11,4 +11,5 @@ Arguments:
 Options:
   --interactive                                Allows the command to stop and wait for user input or action (for example to complete authentication).
   --add-source, --nuget-source <nuget-source>  Specifies a NuGet source to use during install.
+  --force                                      Allows to install the template package even if the same package is already available from different sources.
   -?, -h, --help                               Show help and usage information

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CanInstallPackageAvailableFromBuiltInsWithForce.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CanInstallPackageAvailableFromBuiltInsWithForce.verified.txt
@@ -1,0 +1,17 @@
+﻿The following template packages will be installed:
+   Microsoft.DotNet.Common.ItemTemplates::%VERSION%
+
+The following template packages are already available:
+   Microsoft.DotNet.Common.ItemTemplates::%VERSION%
+Installing the template packages will override the available template packages.
+
+Success: Microsoft.DotNet.Common.ItemTemplates::6.0.100 installed the following templates:
+Template Name                    Short Name     Language  Tags    
+-------------------------------  -------------  --------  --------
+dotnet gitignore file            gitignore                Config  
+Dotnet local tool manifest file  tool-manifest            Config  
+EditorConfig file                editorconfig             Config  
+global.json file                 globaljson               Config  
+NuGet Config                     nugetconfig              Config  
+Solution File                    sln                      Solution
+Web Config                       webconfig                Config  

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CanInstallPackageAvailableFromBuiltInsWithForce.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CanInstallPackageAvailableFromBuiltInsWithForce.verified.txt
@@ -1,9 +1,9 @@
 ﻿The following template packages will be installed:
    Microsoft.DotNet.Common.ItemTemplates::%VERSION%
 
-The following template packages are already available:
+Installing the template package(s) will override the available template package(s).
+The following template package(s) are already available:
    Microsoft.DotNet.Common.ItemTemplates::%VERSION%
-Installing the template packages will override the available template packages.
 
 Success: Microsoft.DotNet.Common.ItemTemplates::6.0.100 installed the following templates:
 Template Name                    Short Name     Language  Tags    

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallMultiplePackageAvailableFromBuiltIns.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallMultiplePackageAvailableFromBuiltIns.verified.txt
@@ -1,0 +1,6 @@
+﻿The following template packages are already available:
+   Microsoft.DotNet.Common.ItemTemplates::%VERSION%
+Installing the template packages will override the available template packages.
+
+To install these template packages anyway, apply '--force' option:
+   dotnet-new3 new3 install Microsoft.DotNet.Common.ItemTemplates::6.0.100 Microsoft.DotNet.Web.ItemTemplates::5.0.0 --force

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallMultiplePackageAvailableFromBuiltIns.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallMultiplePackageAvailableFromBuiltIns.verified.txt
@@ -1,6 +1,6 @@
-﻿The following template packages are already available:
+﻿Installing the template package(s) will override the available template package(s).
+The following template package(s) are already available:
    Microsoft.DotNet.Common.ItemTemplates::%VERSION%
-Installing the template packages will override the available template packages.
 
-To install these template packages anyway, apply '--force' option:
+To install the template package(s) anyway, apply '--force' option:
    dotnet-new3 new3 install Microsoft.DotNet.Common.ItemTemplates::6.0.100 Microsoft.DotNet.Web.ItemTemplates::5.0.0 --force

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallPackageAvailableFromBuiltIns.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallPackageAvailableFromBuiltIns.verified.txt
@@ -1,6 +1,6 @@
-﻿The following template packages are already available:
+﻿Installing the template package(s) will override the available template package(s).
+The following template package(s) are already available:
    Microsoft.DotNet.Common.ItemTemplates::%VERSION%
-Installing the template packages will override the available template packages.
 
-To install these template packages anyway, apply '--force' option:
+To install the template package(s) anyway, apply '--force' option:
    dotnet-new3 new3 install Microsoft.DotNet.Common.ItemTemplates::6.0.100 --force

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallPackageAvailableFromBuiltIns.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallPackageAvailableFromBuiltIns.verified.txt
@@ -1,0 +1,6 @@
+﻿The following template packages are already available:
+   Microsoft.DotNet.Common.ItemTemplates::%VERSION%
+Installing the template packages will override the available template packages.
+
+To install these template packages anyway, apply '--force' option:
+   dotnet-new3 new3 install Microsoft.DotNet.Common.ItemTemplates::6.0.100 --force

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.Approval.cs
@@ -1,0 +1,71 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.TemplateEngine.TestHelper;
+using VerifyXunit;
+using Xunit;
+
+namespace Dotnet_new3.IntegrationTests
+{
+    [UsesVerify]
+    public partial class DotnetNewInstallTests
+    {
+        [Fact]
+        public Task CannotInstallPackageAvailableFromBuiltIns()
+        {
+            var commandResult = new DotnetNewCommand(_log, "install", "Microsoft.DotNet.Common.ItemTemplates::6.0.100")
+                .WithCustomHive()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute();
+
+            commandResult
+                .Should()
+                .Fail();
+
+            return Verifier.Verify(commandResult.StdErr, _verifySettings)
+                .AddScrubber(output =>
+                {
+                    output.ScrubByRegex("   Microsoft\\.DotNet\\.Common\\.ItemTemplates::[A-Za-z0-9.-]+", "   Microsoft.DotNet.Common.ItemTemplates::%VERSION%");
+                });
+        }
+
+        [Fact]
+        public Task CanInstallPackageAvailableFromBuiltInsWithForce()
+        {
+            var commandResult = new DotnetNewCommand(_log, "install", "Microsoft.DotNet.Common.ItemTemplates::6.0.100", "--force")
+                .WithCustomHive()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute();
+
+            commandResult
+                .Should()
+                .Pass();
+
+            return Verifier.Verify(commandResult.StdOut, _verifySettings)
+                .AddScrubber(output =>
+                {
+                    output.ScrubByRegex("   Microsoft.DotNet.Common.ItemTemplates::[A-Za-z0-9.-]+", "   Microsoft.DotNet.Common.ItemTemplates::%VERSION%");
+                });
+        }
+
+        [Fact]
+        public Task CannotInstallMultiplePackageAvailableFromBuiltIns()
+        {
+            var commandResult = new DotnetNewCommand(_log, "install", "Microsoft.DotNet.Common.ItemTemplates::6.0.100", "Microsoft.DotNet.Web.ItemTemplates::5.0.0")
+                .WithCustomHive()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute();
+
+            commandResult
+                .Should()
+                .Fail();
+
+            return Verifier.Verify(commandResult.StdErr, _verifySettings)
+                .AddScrubber(output =>
+                {
+                    output.ScrubByRegex("   Microsoft\\.DotNet\\.Common\\.ItemTemplates::[A-Za-z0-9.-]+", "   Microsoft.DotNet.Common.ItemTemplates::%VERSION%");
+                });
+        }
+    }
+}

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -5,19 +5,22 @@ using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.TemplateEngine.TestHelper;
+using VerifyTests;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Dotnet_new3.IntegrationTests
 {
-    public class DotnetNewInstallTests : IClassFixture<DiagnosticFixture>
+    public partial class DotnetNewInstallTests : IClassFixture<DiagnosticFixture>, IClassFixture<VerifySettingsFixture>
     {
+        private readonly VerifySettings _verifySettings;
         private readonly ITestOutputHelper _log;
         private readonly IMessageSink _messageSink;
 
-        public DotnetNewInstallTests(DiagnosticFixture diagnosisFixture, ITestOutputHelper log)
+        public DotnetNewInstallTests(DiagnosticFixture diagnosisFixture, VerifySettingsFixture verifySettings, ITestOutputHelper log)
         {
+            _verifySettings = verifySettings.Settings;
             _log = log;
             _messageSink = diagnosisFixture.DiagnosticSink;
         }

--- a/test/dotnet-new3.UnitTests/dotnet-new3.IntegrationTests.csproj
+++ b/test/dotnet-new3.UnitTests/dotnet-new3.IntegrationTests.csproj
@@ -55,4 +55,8 @@ namespace Dotnet_new3.IntegrationTests
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <Exec Command="dotnet pack $(SolutionDir)template_feed\Microsoft.DotNet.Common.ProjectTemplates.7.0" />
+    <Exec Command="dotnet pack $(SolutionDir)template_feed\Microsoft.DotNet.Common.ItemTemplates" />
+  </Target>
 </Project>


### PR DESCRIPTION
### Problem
1st task of https://github.com/dotnet/templating/issues/4298

### Solution
`dotnet new install` by default does not install templates which are already installed either from the SDK or an optional workload. To override users need to use additional option (`--force`).

### Checks:
- [x] Added unit tests and integration tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)