### PR TITLE
do not error out on failed update check of template from local nuget

### DIFF
--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetApiPackageManagerTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetApiPackageManagerTests.cs
@@ -122,12 +122,24 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         }
 
         [Fact]
-        public async Task GetLatestVersion_UnknownPackage()
+        public async Task GetLatestVersion_UnknownPackage_GromLocalNuget()
         {
             IEngineEnvironmentSettings engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
 
             NuGetApiPackageManager packageManager = new NuGetApiPackageManager(engineEnvironmentSettings);
-            var exception = await Assert.ThrowsAsync<PackageNotFoundException>(() => packageManager.GetLatestVersionAsync("Microsoft.DotNet.NotCommon.ProjectTemplates.5.0", "5.0.0")).ConfigureAwait(false);
+            (string latestVersion, bool isLatestVersion) = await packageManager.GetLatestVersionAsync("Microsoft.DotNet.NotCommon.ProjectTemplates.5.0", "5.0.0").ConfigureAwait(false);
+
+            latestVersion.Should().Be("5.0.0");
+            isLatestVersion.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task GetLatestVersion_UnknownPackage_FromPackageRepository()
+        {
+            IEngineEnvironmentSettings engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+
+            NuGetApiPackageManager packageManager = new NuGetApiPackageManager(engineEnvironmentSettings);
+            var exception = await Assert.ThrowsAsync<PackageNotFoundException>(() => packageManager.GetLatestVersionAsync("Microsoft.DotNet.NotCommon.ProjectTemplates.5.0", "5.0.0", "someExternalPackagesRepository")).ConfigureAwait(false);
 
             exception.PackageIdentifier.Should().Be("Microsoft.DotNet.NotCommon.ProjectTemplates.5.0");
             exception.Message.Should().NotBeNullOrEmpty();


### PR DESCRIPTION

### Problem
#4489 
`dotnet new <template>` attempts to check for update. If the template was installed from local nuget, that is not available in any referenced package repository (e.g. because this is the testing phase of creating a new nuget before pushing to repository) an error message is displayed about inability to update the nuget. This might be confusing and missleading. So continuing to check for updates (even for local nugets), but not outputing errors for local nugets

### Solution
`dotnet new <template>` still attempts to check for updates (even for local nugets), But it does not output a package update error for local nugets

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)