### PR TITLE
Add a notice if newer version is available from built-in provider on template instantiation

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
@@ -154,27 +154,34 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         internal async Task<NewCommandStatus> InvokeAsync(ParseResult parseResult, ITelemetryLogger telemetryLogger, CancellationToken cancellationToken)
         {
             TemplateCommandArgs args = new TemplateCommandArgs(this, _instantiateCommand, parseResult);
-
             TemplateInvoker invoker = new TemplateInvoker(_environmentSettings, telemetryLogger, () => Console.ReadLine() ?? string.Empty, _instantiateCommand.Callbacks);
-            if (!args.NoUpdateCheck)
-            {
-                TemplatePackageCoordinator packageCoordinator = new TemplatePackageCoordinator(telemetryLogger, _environmentSettings, _templatePackageManager);
-                Task<CheckUpdateResult?> checkForUpdateTask = packageCoordinator.CheckUpdateForTemplate(args.Template, cancellationToken);
-                Task<NewCommandStatus> instantiateTask = invoker.InvokeTemplateAsync(args, cancellationToken);
-                await Task.WhenAll(checkForUpdateTask, instantiateTask).ConfigureAwait(false);
+            TemplatePackageCoordinator packageCoordinator = new TemplatePackageCoordinator(telemetryLogger, _environmentSettings, _templatePackageManager);
 
-                if (checkForUpdateTask?.Result != null)
-                {
-                    // print if there is update for this template
-                    packageCoordinator.DisplayUpdateCheckResult(checkForUpdateTask.Result, args);
-                }
-                // return creation result
-                return instantiateTask.Result;
-            }
-            else
+            Task<NewCommandStatus> instantiateTask = invoker.InvokeTemplateAsync(args, cancellationToken);
+            Task<(string Id, string Version)> builtInPackageCheck = packageCoordinator.ValidateBuiltInPackageAvailabilityAsync(args.Template, cancellationToken);
+            Task<CheckUpdateResult?> checkForUpdateTask = packageCoordinator.CheckUpdateForTemplate(args, cancellationToken);
+
+            Task[] tasksToWait = new Task[] { instantiateTask, builtInPackageCheck, checkForUpdateTask };
+
+            await Task.WhenAll(tasksToWait).ConfigureAwait(false);
+            Reporter.Output.WriteLine();
+
+            if (checkForUpdateTask.Result != null)
             {
-                return await invoker.InvokeTemplateAsync(args, cancellationToken).ConfigureAwait(false);
+                // print if there is update for the template package containing the template
+                packageCoordinator.DisplayUpdateCheckResult(checkForUpdateTask.Result, args);
             }
+
+            if (builtInPackageCheck.Result != default)
+            {
+                // print if there is same or newer built-in package
+                packageCoordinator.DisplayBuiltInPackagesCheckResult(
+                    builtInPackageCheck.Result.Id,
+                    builtInPackageCheck.Result.Version,
+                    args);
+            }
+
+            return instantiateTask.Result;
         }
 
         private bool HasRunScriptPostActionDefined(CliTemplateInfo template)

--- a/src/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
@@ -158,7 +158,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             TemplatePackageCoordinator packageCoordinator = new TemplatePackageCoordinator(telemetryLogger, _environmentSettings, _templatePackageManager);
 
             Task<NewCommandStatus> instantiateTask = invoker.InvokeTemplateAsync(args, cancellationToken);
-            Task<(string Id, string Version)> builtInPackageCheck = packageCoordinator.ValidateBuiltInPackageAvailabilityAsync(args.Template, cancellationToken);
+            Task<(string Id, string Version, string Provider)> builtInPackageCheck = packageCoordinator.ValidateBuiltInPackageAvailabilityAsync(args.Template, cancellationToken);
             Task<CheckUpdateResult?> checkForUpdateTask = packageCoordinator.CheckUpdateForTemplate(args, cancellationToken);
 
             Task[] tasksToWait = new Task[] { instantiateTask, builtInPackageCheck, checkForUpdateTask };
@@ -178,6 +178,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 packageCoordinator.DisplayBuiltInPackagesCheckResult(
                     builtInPackageCheck.Result.Id,
                     builtInPackageCheck.Result.Version,
+                    builtInPackageCheck.Result.Provider,
                     args);
             }
 

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1483,6 +1483,24 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An update for template package &apos;{0}&apos; is available from built-in provider..
+        /// </summary>
+        internal static string TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To use built-in template package, uninstall manually installed template package using:.
+        /// </summary>
+        internal static string TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage {
+            get {
+                return ResourceManager.GetString("TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not find the template package containing template &apos;{0}&apos;.
         /// </summary>
         internal static string TemplatePackageCoordinator_Error_PackageForTemplateNotFound {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -1483,7 +1483,7 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An update for template package &apos;{0}&apos; is available from built-in provider..
+        ///   Looks up a localized string similar to An update for template package &apos;{0}&apos; is available in the &apos;{1}&apos; provider..
         /// </summary>
         internal static string TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -785,4 +785,12 @@ The header is followed by the list of parameters and their errors (might be seve
     <value>To install the template package(s) anyway, apply '{0}' option:</value>
     <comment>{0} is option to use (--force). Followed by command to use to install the packages.</comment>
   </data>
+  <data name="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable" xml:space="preserve">
+    <value>An update for template package '{0}' is available from built-in provider.</value>
+    <comment>{0} - id and version of template package</comment>
+  </data>
+  <data name="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage" xml:space="preserve">
+    <value>To use built-in template package, uninstall manually installed template package using:</value>
+    <comment>followed by command to uninstall package</comment>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -786,8 +786,8 @@ The header is followed by the list of parameters and their errors (might be seve
     <comment>{0} is option to use (--force). Followed by command to use to install the packages.</comment>
   </data>
   <data name="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable" xml:space="preserve">
-    <value>An update for template package '{0}' is available from built-in provider.</value>
-    <comment>{0} - id and version of template package</comment>
+    <value>An update for template package '{0}' is available in the '{1}' provider.</value>
+    <comment>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</comment>
   </data>
   <data name="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage" xml:space="preserve">
     <value>To use built-in template package, uninstall manually installed template package using:</value>

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -12,6 +12,7 @@ using Microsoft.TemplateEngine.Cli.TabularOutput;
 using Microsoft.TemplateEngine.Edge.Settings;
 using Microsoft.TemplateEngine.Utils;
 using NuGet.Credentials;
+using NuGet.Versioning;
 
 namespace Microsoft.TemplateEngine.Cli
 {
@@ -35,24 +36,29 @@ namespace Microsoft.TemplateEngine.Cli
         }
 
         /// <summary>
-        /// Checks if there is an update for the package containing the <paramref name="template"/>.
+        /// Checks if there is an update for the package containing the template to execute.
         /// </summary>
-        /// <param name="template">template to check the update for.</param>
+        /// <param name="args">template command arguments.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>Task for checking the update or null when check for update is not possible.</returns>
-        internal async Task<CheckUpdateResult?> CheckUpdateForTemplate(ITemplateInfo template, CancellationToken cancellationToken = default)
+        internal async Task<CheckUpdateResult?> CheckUpdateForTemplate(TemplateCommandArgs args, CancellationToken cancellationToken = default)
         {
-            _ = template ?? throw new ArgumentNullException(nameof(template));
             cancellationToken.ThrowIfCancellationRequested();
+
+            //if update check is disabled - do nothing
+            if (args.NoUpdateCheck)
+            {
+                return null;
+            }
 
             ITemplatePackage templatePackage;
             try
             {
-                templatePackage = await _templatePackageManager.GetTemplatePackageAsync(template, cancellationToken).ConfigureAwait(false);
+                templatePackage = await _templatePackageManager.GetTemplatePackageAsync(args.Template, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception)
             {
-                Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Error_PackageForTemplateNotFound, template.Identity));
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Error_PackageForTemplateNotFound, args.Template.Identity));
                 return null;
             }
 
@@ -63,6 +69,52 @@ namespace Microsoft.TemplateEngine.Cli
             }
             InitializeNuGetCredentialService(interactive: false);
             return (await managedTemplatePackage.ManagedProvider.GetLatestVersionsAsync(new[] { managedTemplatePackage }, cancellationToken).ConfigureAwait(false)).Single();
+        }
+
+        internal async Task<(string, string)> ValidateBuiltInPackageAvailabilityAsync(ITemplateInfo template, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ITemplatePackage templatePackage;
+            try
+            {
+                templatePackage = await _templatePackageManager.GetTemplatePackageAsync(template, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Error_PackageForTemplateNotFound, template.Identity));
+                return default;
+            }
+
+            if (!(templatePackage is IManagedTemplatePackage managedTemplatePackage))
+            {
+                //update is not supported - built-in or optional workload source
+                return default;
+            }
+
+            IReadOnlyList<ITemplatePackage> templatePackages = await _templatePackageManager.GetTemplatePackagesAsync(force: false, cancellationToken).ConfigureAwait(false);
+            IEnumerable<(string Id, string Version)> unmanagedTemplatePackages = templatePackages
+                .Where(tp => tp is not IManagedTemplatePackage)
+                .Select(tp => NuGetUtils.GetNuGetPackageInfo(_engineEnvironmentSettings, tp.MountPointUri))
+                .Where(i => i != default);
+
+            var matchingTemplatePackage = unmanagedTemplatePackages.FirstOrDefault(package => string.Equals(managedTemplatePackage.Identifier, package.Id, StringComparison.OrdinalIgnoreCase));
+            if (matchingTemplatePackage == default)
+            {
+                return default;
+            }
+
+            NuGetVersion managedPackageVersion;
+            NuGetVersion unmanagedPackageVersion;
+
+            if (NuGetVersion.TryParse(managedTemplatePackage.Version, out managedPackageVersion) && NuGetVersion.TryParse(matchingTemplatePackage.Version, out unmanagedPackageVersion))
+            {
+                if (unmanagedPackageVersion >= managedPackageVersion)
+                {
+                    return matchingTemplatePackage;
+                }
+            }
+            return default;
         }
 
         internal void DisplayUpdateCheckResult(CheckUpdateResult versionCheckResult, ICommandArgs args)
@@ -82,12 +134,28 @@ namespace Microsoft.TemplateEngine.Cli
                             .For<NewCommand>(args.ParseResult)
                             .WithSubcommand<InstallCommand>()
                             .WithArgument(InstallCommand.NameArgument, $"{versionCheckResult.TemplatePackage.Identifier}::{versionCheckResult.LatestVersion}"));
+                    Reporter.Output.WriteLine();
                 }
             }
             else
             {
                 HandleUpdateCheckErrors(versionCheckResult, ignoreLocalPackageNotFound: true);
+                Reporter.Error.WriteLine();
             }
+        }
+
+        internal void DisplayBuiltInPackagesCheckResult(string packageId, string version, ICommandArgs args)
+        {
+            Reporter.Output.WriteLine(
+                string.Format(
+                    LocalizableStrings.TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable,
+                    $"{packageId}::{version}"));
+            Reporter.Output.WriteLine(LocalizableStrings.TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage);
+            Reporter.Output.WriteCommand(
+                Example
+                 .For<NewCommand>(args.ParseResult)
+                 .WithSubcommand<UninstallCommand>()
+                 .WithArgument(UninstallCommand.NameArgument, packageId));
         }
 
         /// <summary>

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -71,7 +71,9 @@ namespace Microsoft.TemplateEngine.Cli
             return (await managedTemplatePackage.ManagedProvider.GetLatestVersionsAsync(new[] { managedTemplatePackage }, cancellationToken).ConfigureAwait(false)).Single();
         }
 
-        internal async Task<(string, string)> ValidateBuiltInPackageAvailabilityAsync(ITemplateInfo template, CancellationToken cancellationToken)
+        internal async Task<(string Id, string Version, string Provider)> ValidateBuiltInPackageAvailabilityAsync(
+            ITemplateInfo template,
+            CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -93,10 +95,16 @@ namespace Microsoft.TemplateEngine.Cli
             }
 
             IReadOnlyList<ITemplatePackage> templatePackages = await _templatePackageManager.GetTemplatePackagesAsync(force: false, cancellationToken).ConfigureAwait(false);
-            IEnumerable<(string Id, string Version)> unmanagedTemplatePackages = templatePackages
+
+            IEnumerable<(string Id, string Version, string Provider)> unmanagedTemplatePackages = templatePackages
                 .Where(tp => tp is not IManagedTemplatePackage)
-                .Select(tp => NuGetUtils.GetNuGetPackageInfo(_engineEnvironmentSettings, tp.MountPointUri))
-                .Where(i => i != default);
+                .Select(tp => new
+                            {
+                                Info = NuGetUtils.GetNuGetPackageInfo(_engineEnvironmentSettings, tp.MountPointUri),
+                                Package = tp
+                            })
+                .Where(i => i.Info != default)
+                .Select(i => (i.Info.Id, i.Info.Version, i.Package.Provider.Factory.DisplayName));
 
             var matchingTemplatePackage = unmanagedTemplatePackages.FirstOrDefault(package => string.Equals(managedTemplatePackage.Identifier, package.Id, StringComparison.OrdinalIgnoreCase));
             if (matchingTemplatePackage == default)
@@ -144,12 +152,13 @@ namespace Microsoft.TemplateEngine.Cli
             }
         }
 
-        internal void DisplayBuiltInPackagesCheckResult(string packageId, string version, ICommandArgs args)
+        internal void DisplayBuiltInPackagesCheckResult(string packageId, string version, string provider, ICommandArgs args)
         {
             Reporter.Output.WriteLine(
                 string.Format(
                     LocalizableStrings.TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable,
-                    $"{packageId}::{version}"));
+                    $"{packageId}::{version}",
+                    provider));
             Reporter.Output.WriteLine(LocalizableStrings.TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage);
             Reporter.Output.WriteCommand(
                 Example

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Nepovedlo se najít balíček šablony obsahující šablonu {0}.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Das Vorlagenpaket mit der Vorlage "{0}" wurde nicht gefunden.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">No encontró el paquete de plantillas que contiene la plantilla "{0}"</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Le package de modèle contenant le modèle « {0} » est introuvable</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Non è stato possibile trovare il pacchetto di modelli contenente il modello '{0}'</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">テンプレート '{0}' を含むテンプレートパッケージが見つかりませんでした</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">'{0}' 템플릿이 포함된 ‘템플릿 패키지를 찾을 수 없습니다.</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Nie można znaleźć pakietu szablonów zawierającego szablon "{0}"</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Não foi possível localizar o pacote de modelo contendo o modelo '{0}'</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">Не удалось найти пакет шаблона, содержащий шаблон "{0}"</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">'{0}' şablonunu içeren şablon paketi bulunamadı</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">找不到包含模板“{0}”的模板包</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -828,9 +828,9 @@ The header is followed by the list of parameters and their errors (might be seve
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
-        <source>An update for template package '{0}' is available from built-in provider.</source>
-        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
-        <note>{0} - id and version of template package</note>
+        <source>An update for template package '{0}' is available in the '{1}' provider.</source>
+        <target state="new">An update for template package '{0}' is available in the '{1}' provider.</target>
+        <note>{0} - id and version of template package, {1} - provider name (.NET SDK, Optional workloads, etc)</note>
       </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
         <source>To use built-in template package, uninstall manually installed template package using:</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -827,6 +827,16 @@ The header is followed by the list of parameters and their errors (might be seve
         <note>0} - option name (as --language)
 {1} - comma separated, escaped in quotes list of allowed values</note>
       </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_BuiltInPackageAvailable">
+        <source>An update for template package '{0}' is available from built-in provider.</source>
+        <target state="new">An update for template package '{0}' is available from built-in provider.</target>
+        <note>{0} - id and version of template package</note>
+      </trans-unit>
+      <trans-unit id="TemplatePackageCoordinator_BuiltInCheck_Info_UninstallPackage">
+        <source>To use built-in template package, uninstall manually installed template package using:</source>
+        <target state="new">To use built-in template package, uninstall manually installed template package using:</target>
+        <note>followed by command to uninstall package</note>
+      </trans-unit>
       <trans-unit id="TemplatePackageCoordinator_Error_PackageForTemplateNotFound">
         <source>Could not find the template package containing template '{0}'</source>
         <target state="translated">找不到包含範本 '{0}' 的範本套件</target>

--- a/src/dotnet-new3/BuiltInTemplatePackagesProvider.cs
+++ b/src/dotnet-new3/BuiltInTemplatePackagesProvider.cs
@@ -15,7 +15,7 @@ namespace Dotnet_new3
     {
         public static readonly Guid FactoryId = new Guid("{3227D09D-C1EA-48F1-A33B-1F132BFD9F06}");
 
-        public string DisplayName => "new3 BuiltIn";
+        public string DisplayName => "new3 built-in";
 
         public Guid Id => FactoryId;
 

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CanShowWarningIfPackageIsAvailableFromBuiltInSources.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CanShowWarningIfPackageIsAvailableFromBuiltInSources.verified.txt
@@ -1,0 +1,9 @@
+﻿The template "dotnet gitignore file" was created successfully.
+
+An update for template package 'Microsoft.DotNet.Common.ItemTemplates::6.0.100' is available.
+To update the package use:
+   dotnet-new3 new3 install Microsoft.DotNet.Common.ItemTemplates::6.0.201
+
+An update for template package 'Microsoft.DotNet.Common.ItemTemplates::%VERSION%' is available from built-in provider.
+To use built-in template package, uninstall manually installed template package using:
+   dotnet-new3 new3 uninstall Microsoft.DotNet.Common.ItemTemplates

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CanShowWarningIfPackageIsAvailableFromBuiltInSources.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CanShowWarningIfPackageIsAvailableFromBuiltInSources.verified.txt
@@ -4,6 +4,6 @@ An update for template package 'Microsoft.DotNet.Common.ItemTemplates::6.0.100' 
 To update the package use:
    dotnet-new3 new3 install Microsoft.DotNet.Common.ItemTemplates::6.0.201
 
-An update for template package 'Microsoft.DotNet.Common.ItemTemplates::%VERSION%' is available from built-in provider.
+An update for template package 'Microsoft.DotNet.Common.ItemTemplates::%VERSION%' is available in the 'new3 built-in' provider.
 To use built-in template package, uninstall manually installed template package using:
    dotnet-new3 new3 uninstall Microsoft.DotNet.Common.ItemTemplates

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.Approval.cs
@@ -308,6 +308,34 @@ namespace Dotnet_new3.IntegrationTests
         }
 
         [Fact]
+        public Task CanShowWarningIfPackageIsAvailableFromBuiltInSources()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
+            new DotnetNewCommand(_log, "install", "Microsoft.DotNet.Common.ItemTemplates::6.0.100", "--force")
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should().Pass();
+
+            var commandResult = new DotnetNewCommand(_log, "gitignore")
+                  .WithCustomHive(home)
+                  .WithWorkingDirectory(workingDirectory)
+                  .Execute();
+
+            commandResult
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr();
+
+            return Verifier.Verify(commandResult.StdOut, _verifySettings)
+            .AddScrubber(output =>
+            {
+                output.ScrubByRegex("'Microsoft\\.DotNet\\.Common\\.ItemTemplates::[A-Za-z0-9.-]+' is available from built-in provider", "'Microsoft.DotNet.Common.ItemTemplates::%VERSION%' is available from built-in provider");
+            });
+        }
+        
+        [Fact]
         public Task CanShowError_OnTemplatesWithSameShortName()
         {
             string home = TestUtils.CreateTemporaryFolder("Home");

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.Approval.cs
@@ -331,7 +331,7 @@ namespace Dotnet_new3.IntegrationTests
             return Verifier.Verify(commandResult.StdOut, _verifySettings)
             .AddScrubber(output =>
             {
-                output.ScrubByRegex("'Microsoft\\.DotNet\\.Common\\.ItemTemplates::[A-Za-z0-9.-]+' is available from built-in provider", "'Microsoft.DotNet.Common.ItemTemplates::%VERSION%' is available from built-in provider");
+                output.ScrubByRegex("'Microsoft\\.DotNet\\.Common\\.ItemTemplates::[A-Za-z0-9.-]+' is available in", "'Microsoft.DotNet.Common.ItemTemplates::%VERSION%' is available in");
             });
         }
         


### PR DESCRIPTION
### Problem
2nd task of https://github.com/dotnet/templating/issues/4298

### Solution
On template instantiation, added a check if the template package of template being instantiated is available from built in provider.
If it is available, and the version is same or newer, the message is shown suggesting to uninstall manually installed package.
Check is not performed for unmanaged template packages (i.e. packages already coming from built-in providers).

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)