### PR TITLE
introduced `--use-program-main` option for `console` template to disable top-level program

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/dotnetcli.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/dotnetcli.host.json
@@ -16,6 +16,10 @@
     "langVersion": {
       "longName": "langVersion",
       "shortName": ""
+    },
+    "UseProgramMain": {
+      "longName": "use-program-main",
+      "shortName": ""
     }
   },
   "usageExamples": [

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/ide.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/ide.host.json
@@ -6,5 +6,11 @@
       "add": [],
       "remove": [ "Common" ]
     }
+  ],
+  "symbolInfo": [
+    {
+      "id": "UseProgramMain",
+      "isVisible": "true"
+    }
   ]
 }

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.cs.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.cs.json
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "Verze jazyka",
   "symbols/skipRestore/description": "Pokud se tato možnost zadá, přeskočí automatické obnovení projektu při vytvoření.",
   "symbols/skipRestore/displayName": "Přeskočit obnovení",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "Obnoví balíčky NuGet vyžadované tímto projektem.",
   "postActions/restore/manualInstructions/default/text": "Spustit dotnet restore",
   "postActions/open-file/description": "Otevře Program.cs v editoru."

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.de.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.de.json
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "Sprachversion",
   "symbols/skipRestore/description": "Wenn angegeben, wird die automatische Wiederherstellung des Projekts beim Erstellen übersprungen.",
   "symbols/skipRestore/displayName": "Wiederherstellung überspringen",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "Stellt die NuGet-Pakete wieder her, die für dieses Projekt erforderlich sind.",
   "postActions/restore/manualInstructions/default/text": "„dotnet restore“ ausführen",
   "postActions/open-file/description": "Öffnet „Program.cs“ im Editor"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.en.json
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "Language version",
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "symbols/skipRestore/displayName": "Skip restore",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "Restore NuGet packages required by this project.",
   "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
   "postActions/open-file/description": "Opens Program.cs in the editor"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.es.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.es.json
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "Versión de lenguaje",
   "symbols/skipRestore/description": "Si se especifica, se omite la restauración automática del proyecto durante la creación.",
   "symbols/skipRestore/displayName": "Omitir restauración",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "Restaure los paquetes NuGet necesarios para este proyecto.",
   "postActions/restore/manualInstructions/default/text": "Ejecutar \"dotnet restore\"",
   "postActions/open-file/description": "Abre Program.cs en el editor"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.fr.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.fr.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Application console",
   "description": "Projet de création d'une application en ligne de commande pouvant s'exécuter sur .NET sur Windows, Linux et macOS",
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "Version du langage",
   "symbols/skipRestore/description": "S’il est spécifié, ignore la restauration automatique du projet lors de la création.",
   "symbols/skipRestore/displayName": "Ignorer la restauration",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "Restaurez les packages NuGet requis par ce projet.",
   "postActions/restore/manualInstructions/default/text": "Exécuter « dotnet restore »",
   "postActions/open-file/description": "Ouvre Program.cs dans l’éditeur"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.it.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.it.json
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "Versione del linguaggio",
   "symbols/skipRestore/description": "Se specificato, ignora il ripristino automatico del progetto durante la creazione.",
   "symbols/skipRestore/displayName": "Salta ripristino",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "Ripristina i pacchetti NuGet richiesti da questo progetto.",
   "postActions/restore/manualInstructions/default/text": "Esegui 'dotnet restore'",
   "postActions/open-file/description": "Apre Program.cs nell'editor"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.ja.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.ja.json
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "言語バージョン",
   "symbols/skipRestore/description": "指定した場合、作成時にプロジェクトの自動復元がスキップされます。",
   "symbols/skipRestore/displayName": "復元のスキップ",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "このプロジェクトに必要な NuGet パッケージを復元します。",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' を実行する",
   "postActions/open-file/description": "エディターで Program.cs を開きます"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.ko.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.ko.json
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "언어 버전",
   "symbols/skipRestore/description": "지정된 경우, 프로젝트 생성 시 자동 복원을 건너뜁니다.",
   "symbols/skipRestore/displayName": "복원 건너뛰기",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "이 프로젝트에 필요한 NuGet 패키지를 복원합니다.",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' 실행",
   "postActions/open-file/description": "편집기에서 Program.cs를 엽니다"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.pl.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.pl.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplikacja konsoli",
   "description": "Projekt służący do tworzenia aplikacji wiersza polecenia, która może działać na platformie .NET w systemach Windows, Linux i macOS",
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "Wersja języka",
   "symbols/skipRestore/description": "Jeśli ta opcja jest określona, pomija automatyczne przywracanie projektu podczas tworzenia.",
   "symbols/skipRestore/displayName": "Pomiń przywracanie",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "Przywróć pakiety NuGet wymagane przez ten projekt.",
   "postActions/restore/manualInstructions/default/text": "Uruchom polecenie \"dotnet restore\"",
   "postActions/open-file/description": "Otwiera plik Program.cs w edytorze"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.pt-BR.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.pt-BR.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Aplicativo do Console",
   "description": "Um projeto para criar um aplicativo de linha de comando que pode ser executado no .NET no Windows, Linux e macOS",
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "Versão do idioma",
   "symbols/skipRestore/description": "Se especificado, ignora a restauração automática do projeto sendo criado.",
   "symbols/skipRestore/displayName": "Ignorar restauração",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "Restaura os pacotes do NuGet exigidos por este projeto.",
   "postActions/restore/manualInstructions/default/text": "Executar 'dotnet restore'",
   "postActions/open-file/description": "Abrir Program.cs no editor"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.ru.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.ru.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "author": "Microsoft",
   "name": "Консольное приложение",
   "description": "Проект для создания приложения командной строки, которое может выполняться в среде .NET в Windows, Linux и macOS",
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "Версия языка",
   "symbols/skipRestore/description": "Если установлено, автоматическое восстановление проекта при создании пропускается.",
   "symbols/skipRestore/displayName": "Пропустить восстановление",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "Восстановление пакетов NuGet, необходимых для этого проекта.",
   "postActions/restore/manualInstructions/default/text": "Выполнить команду \"dotnet restore\"",
   "postActions/open-file/description": "Открывает файл Program.cs в редакторе"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.tr.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.tr.json
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "Dil sürümü",
   "symbols/skipRestore/description": "Belirtilmişse, oluşturulmakta olan projenin otomatik geri yüklenmesini atlar.",
   "symbols/skipRestore/displayName": "Geri yüklemeyi atla",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "Bu projenin gerektirdiği NuGet paketlerini geri yükleyin.",
   "postActions/restore/manualInstructions/default/text": "'dotnet restore' çalıştır",
   "postActions/open-file/description": "Düzenleyicide Program.cs dosyasını açar"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.zh-Hans.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.zh-Hans.json
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "语言版本",
   "symbols/skipRestore/description": "如果指定，则在创建时跳过项目的自动还原。",
   "symbols/skipRestore/displayName": "跳过还原",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "还原此项目所需的 NuGet 包。",
   "postActions/restore/manualInstructions/default/text": "运行 \"dotnet restore\"",
   "postActions/open-file/description": "在编辑器中打开 Program.cs"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.zh-Hant.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.zh-Hant.json
@@ -12,6 +12,8 @@
   "symbols/langVersion/displayName": "語言版本",
   "symbols/skipRestore/description": "若指定，會在建立時跳過專案的自動還原。",
   "symbols/skipRestore/displayName": "略過還原",
+  "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
   "postActions/restore/description": "還原此專案所需的 NuGet 套件。",
   "postActions/restore/manualInstructions/default/text": "執行 'dotnet restore'",
   "postActions/open-file/description": "在編輯器中開啟 Program.cs"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -61,6 +61,13 @@
       "defaultValue": "false",
       "displayName": "Skip restore"
     },
+    "UseProgramMain": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+      "displayName": "Do not use top-level statements"
+    },
     "csharp10orLater": {
       "type": "generated",
       "generator": "regexMatch",
@@ -98,7 +105,11 @@
     },
     "csharpFeature_TopLevelProgram": {
       "type": "computed",
-      "value": "csharp9orLater == \"true\""
+      "value": "(csharp9orLater == \"true\" && UseProgramMain != \"true\")"
+    },
+    "csharpFeature_FileScopedNamespaces": {
+      "type": "computed",
+      "value": "csharp10orLater == \"true\""
     }
   },
   "primaryOutputs": [

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/Program.cs
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/Program.cs
@@ -8,6 +8,16 @@ using System;
 #if (csharpFeature_TopLevelProgram)
 Console.WriteLine("Hello, World!");
 #else
+#if (csharpFeature_FileScopedNamespaces)
+namespace Company.ConsoleApplication1;
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine("Hello, World!");
+    }
+}
+#else
 namespace Company.ConsoleApplication1
 {
     class Program
@@ -18,4 +28,5 @@ namespace Company.ConsoleApplication1
         }
     }
 }
+#endif
 #endif

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.TemplateCommand_GetAllSuggestions.verified.txt
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/TabCompletionTests.TemplateCommand_GetAllSuggestions.verified.txt
@@ -89,6 +89,17 @@ Default: false
     Detail: Specifies the template type to instantiate.
   },
   {
+    Label: --use-program-main,
+    Kind: Keyword,
+    SortText: --use-program-main,
+    InsertText: --use-program-main,
+    Detail:
+Whether to generate an explicit Program class and Main method instead of top-level statements.
+Type: bool
+Default: false
+
+  },
+  {
     Label: -?,
     Kind: Keyword,
     SortText: -?,

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnChoice.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnChoice.verified.txt
@@ -24,6 +24,9 @@ Template options:
   --no-restore                 If specified, skips the automatic restore of the project on create.
                                Type: bool
                                Default: false
+  --use-program-main           Whether to generate an explicit Program class and Main method instead of top-level statements.
+                               Type: bool
+                               Default: false
 
 To see help for other template languages (F#, VB), use --language option:
    dotnet-new3 new3 console -h --language F#

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnNonChoiceParam.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MatchOnNonChoiceParam.verified.txt
@@ -26,6 +26,9 @@ Template options:
   --no-restore                                   If specified, skips the automatic restore of the project on create.
                                                  Type: bool
                                                  Default: false
+  --use-program-main                             Whether to generate an explicit Program class and Main method instead of top-level statements.
+                                                 Type: bool
+                                                 Default: false
 
 To see help for other template languages (F#, VB), use --language option:
    dotnet-new3 new3 console -h --language F#

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_console.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_console.verified.txt
@@ -26,6 +26,9 @@ Template options:
   --no-restore                                   If specified, skips the automatic restore of the project on create.
                                                  Type: bool
                                                  Default: false
+  --use-program-main                             Whether to generate an explicit Program class and Main method instead of top-level statements.
+                                                 Type: bool
+                                                 Default: false
 
 To see help for other template languages (F#, VB), use --language option:
    dotnet-new3 new3 console -h --language F#


### PR DESCRIPTION
### Problem
Top-level program console template is not in favor for some users.
Related to: 
https://github.com/dotnet/templating/issues/3985
https://github.com/dotnet/templating/issues/3654
https://github.com/dotnet/sdk/issues/23029

### Solution
introduced `--use-program-main` option for `console` template to disable top-level program

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)