### PR TITLE
Fix regression in installing nugets specified by wildcards

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -202,12 +202,7 @@ namespace Microsoft.TemplateEngine.Cli
             {
                 string[] splitByColons = installArg.Split(new[] { "::" }, StringSplitOptions.RemoveEmptyEntries);
                 string identifier = splitByColons[0];
-                string? version = null;
-                //'*' is placeholder for the latest version
-                if (splitByColons.Length > 1 && splitByColons[1] != "*")
-                {
-                    version = splitByColons[1];
-                }
+                string? version = splitByColons.Length > 1 ? splitByColons[1] : null;
                 foreach (string expandedIdentifier in InstallRequestPathResolution.ExpandMaskedPath(identifier, _engineEnvironmentSettings))
                 {
                     installRequests.Add(new InstallRequest(expandedIdentifier, version, details: details));

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstaller.cs
@@ -14,7 +14,6 @@ using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Installer;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 using NuGet.Packaging;
-using NuGet.Versioning;
 
 namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 {
@@ -81,7 +80,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                 //check if identifier is a valid package ID
                 bool validPackageId = PackageIdValidator.IsValidPackageId(installationRequest.PackageIdentifier);
                 //check if version is specified it is correct version
-                bool hasValidVersion = string.IsNullOrWhiteSpace(installationRequest.Version) || NuGetVersion.TryParse(installationRequest.Version, out _);
+                bool hasValidVersion = NuGetVersionHelper.IsSupportedVersionString(installationRequest.Version);
                 if (!validPackageId)
                 {
                     _logger.LogDebug($"{installationRequest.PackageIdentifier} is not a valid NuGet package ID.");

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetVersionHelper.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetVersionHelper.cs
@@ -1,0 +1,73 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NuGet.Versioning;
+
+namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
+{
+    internal static class NuGetVersionHelper
+    {
+        public static string GetVersionPatternWithoutWildcard(string? versionString)
+        {
+            if (IsSpecificVersionString(versionString) || string.IsNullOrEmpty(versionString))
+            {
+                return versionString ?? string.Empty;
+            }
+
+            return versionString!.Substring(0, versionString.Length - 1);
+        }
+
+        public static bool IsSupportedVersionString(string? versionString)
+        {
+            return
+                IsFloatingVersionString(versionString) && IsSupportedFloatingVersion(versionString)
+                ||
+                NuGetVersion.TryParse(versionString, out _);
+        }
+
+        public static bool IsSpecificVersionString(string? versionString)
+        {
+            return !IsFloatingVersionString(versionString);
+        }
+
+        public static bool IsFloatingVersionString(string? versionString)
+        {
+            return
+                string.IsNullOrEmpty(versionString) ||
+                versionString.Last() == '*' && versionString.Count(c => c == '*') == 1;
+        }
+
+        public static bool VersionMatches(NuGetVersion version, string? versionPatternWithoutWildcard)
+        {
+            return
+                string.IsNullOrEmpty(versionPatternWithoutWildcard) ||
+                version.ToString().StartsWith(versionPatternWithoutWildcard, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsSupportedFloatingVersion(string? versionString)
+        {
+            if (string.IsNullOrEmpty(versionString))
+            {
+                return true;
+            }
+
+            int trailingCharsToRemove = 1;
+            if (versionString!.Length > 1 && versionString[versionString.Length - 2] == '.')
+            {
+                trailingCharsToRemove++;
+            }
+
+            string parseableVersionString = versionString.Substring(0, versionString.Length - trailingCharsToRemove);
+
+            return
+                string.IsNullOrEmpty(parseableVersionString) ||
+                NuGetVersion.TryParse(parseableVersionString, out _);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetVersionHelperTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetVersionHelperTests.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Microsoft.TemplateEngine.Edge.Installers.NuGet;
+using NuGet.Versioning;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Edge.UnitTests
+{
+    public class NuGetVersionHelperTests
+    {
+        [Theory]
+        [InlineData(null, true)]
+        [InlineData("", true)]
+        [InlineData("*", true)]
+        [InlineData("1.*", true)]
+        [InlineData("55.66.77.*", true)]
+        [InlineData("55.66.77*", true)]
+        [InlineData("123.456.789.012", true)]
+        [InlineData("1.2", true)]
+        [InlineData("1.*.1", false)]
+        [InlineData("1.*.*", false)]
+        [InlineData("*.1", false)]
+        [InlineData("a.b", false)]
+        [InlineData("a.b.*", false)]
+        public void IsSupportedVersionStringTest(string versionString, bool isSupported)
+        {
+            Assert.Equal(isSupported, NuGetVersionHelper.IsSupportedVersionString(versionString));
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("*", "")]
+        [InlineData("1.*", "1.")]
+        [InlineData("55.66.77.*", "55.66.77.")]
+        [InlineData("55.66.77*", "55.66.77")]
+        [InlineData("123.456.789.012", "123.456.789.012")]
+        [InlineData("1.2", "1.2")]
+        public void GetVersionPatternWithoutWildcardTest(string versionString, string patternWithoutWildcard)
+        {
+            Assert.Equal(patternWithoutWildcard, NuGetVersionHelper.GetVersionPatternWithoutWildcard(versionString));
+        }
+
+        [Theory]
+        [InlineData(null, true)]
+        [InlineData("", true)]
+        [InlineData("*", true)]
+        [InlineData("1.*", true)]
+        [InlineData("55.66.77.*", true)]
+        [InlineData("55.66.77*", true)]
+        [InlineData("123.456.789.012", false)]
+        [InlineData("1.2", false)]
+        public void IsFloatingVersionStringTest(string versionString, bool isFloatingVersion)
+        {
+            Assert.Equal(isFloatingVersion, NuGetVersionHelper.IsFloatingVersionString(versionString));
+        }
+
+        [Theory]
+        [InlineData("1.2.3.4", null, true)]
+        [InlineData("1.2.3.4", "", true)]
+        [InlineData("1.2.3.4", "1", true)]
+        [InlineData("1.2.3.4", "1.2.", true)]
+        [InlineData("1.2.3.4", "1.2.3.4.", false)]
+        [InlineData("1.2.3.4", "2.2", false)]
+        public void VersionMatchesTest(string versionString, string patternWithoutWildcard, bool iaMatch)
+        {
+            NuGetVersion version = new NuGetVersion(versionString);
+            Assert.Equal(iaMatch, NuGetVersionHelper.VersionMatches(version, patternWithoutWildcard));
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetVersionHelperTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetVersionHelperTests.cs
@@ -31,20 +31,6 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         }
 
         [Theory]
-        [InlineData(null, "")]
-        [InlineData("", "")]
-        [InlineData("*", "")]
-        [InlineData("1.*", "1.")]
-        [InlineData("55.66.77.*", "55.66.77.")]
-        [InlineData("55.66.77*", "55.66.77")]
-        [InlineData("123.456.789.012", "123.456.789.012")]
-        [InlineData("1.2", "1.2")]
-        public void GetVersionPatternWithoutWildcardTest(string versionString, string patternWithoutWildcard)
-        {
-            Assert.Equal(patternWithoutWildcard, NuGetVersionHelper.GetVersionPatternWithoutWildcard(versionString));
-        }
-
-        [Theory]
         [InlineData(null, true)]
         [InlineData("", true)]
         [InlineData("*", true)]
@@ -53,22 +39,23 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         [InlineData("55.66.77*", true)]
         [InlineData("123.456.789.012", false)]
         [InlineData("1.2", false)]
-        public void IsFloatingVersionStringTest(string versionString, bool isFloatingVersion)
+        public void TryParseFloatRangeReturnsExpectedBoolFlag(string versionString, bool isFloatingVersion)
         {
-            Assert.Equal(isFloatingVersion, NuGetVersionHelper.IsFloatingVersionString(versionString));
+            Assert.Equal(isFloatingVersion, NuGetVersionHelper.TryParseFloatRangeEx(versionString, out _));
         }
 
         [Theory]
         [InlineData("1.2.3.4", null, true)]
         [InlineData("1.2.3.4", "", true)]
-        [InlineData("1.2.3.4", "1", true)]
-        [InlineData("1.2.3.4", "1.2.", true)]
-        [InlineData("1.2.3.4", "1.2.3.4.", false)]
-        [InlineData("1.2.3.4", "2.2", false)]
-        public void VersionMatchesTest(string versionString, string patternWithoutWildcard, bool iaMatch)
+        [InlineData("1.2.3.4", "1.2.*", true)]
+        [InlineData("1.2.3.4", "2.2*", false)]
+        [InlineData("1.2.3.4", "1.2.*-*", true)]
+        public void TryParseFloatRangeMatchingTest(string versionString, string pattern, bool isMatch)
         {
             NuGetVersion version = new NuGetVersion(versionString);
-            Assert.Equal(iaMatch, NuGetVersionHelper.VersionMatches(version, patternWithoutWildcard));
+            FloatRange floatRange;
+            Assert.True(NuGetVersionHelper.TryParseFloatRangeEx(pattern, out floatRange));
+            Assert.Equal(isMatch, floatRange.Satisfies(version));
         }
     }
 }


### PR DESCRIPTION
### Problem
#4307 
Wildcards in template nugets to be installed lead to errors (this was supported in 6.x and before)

### Solution
Performing custom enumeration and matching of available versions in repository streams

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)