### PR TITLE
Fix guid replacement casing

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GuidMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GuidMacroConfig.cs
@@ -10,6 +10,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
     internal class GuidMacroConfig : IMacroConfig
     {
         internal const string DefaultFormats = "ndbpxNDPBX";
+        internal const string UpperCaseDenominator = "-uc-";
+        internal const string LowerCaseDenominator = "-lc-";
 
         internal GuidMacroConfig(string variableName, string dataType, string? format, string? defaultFormat)
         {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
@@ -1018,8 +1018,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             {
                 foreach (char format in GuidMacroConfig.DefaultFormats)
                 {
-                    string newGuid = char.IsUpper(format) ? map.Key.ToString(format.ToString()).ToUpperInvariant() : map.Key.ToString(format.ToString()).ToLowerInvariant();
-                    macroGeneratedReplacements.Add(new ReplacementTokens(map.Value + "-" + format, newGuid.TokenConfig()));
+                    bool isUpperCase = char.IsUpper(format);
+                    string newGuid = map.Key.ToString(format.ToString());
+                    newGuid = isUpperCase ? newGuid.ToUpperInvariant() : newGuid.ToLowerInvariant();
+                    string replacementKey = map.Value + (isUpperCase ? GuidMacroConfig.UpperCaseDenominator : GuidMacroConfig.LowerCaseDenominator) + format;
+                    macroGeneratedReplacements.Add(new ReplacementTokens(replacementKey, newGuid.TokenConfig()));
                 }
             }
 

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectGeneratorTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectGeneratorTests.cs
@@ -62,30 +62,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 
             IEngineEnvironmentSettings environment = _environmentSettingsHelper.CreateEnvironment();
             string sourceBasePath = FileSystemHelpers.GetNewVirtualizedPath(environment);
-
-            foreach (KeyValuePair<string, string?> fileInfo in templateSourceFiles)
-            {
-                string filePath = Path.Combine(sourceBasePath, fileInfo.Key);
-                string fullPathDir = Path.GetDirectoryName(filePath)!;
-                environment.Host.FileSystem.CreateDirectory(fullPathDir);
-                environment.Host.FileSystem.WriteAllText(filePath, fileInfo.Value ?? string.Empty);
-            }
-
             string targetDir = FileSystemHelpers.GetNewVirtualizedPath(environment);
 
-            //create mount point
-            IMountPoint? sourceMountPoint = null;
-            foreach (var factory in environment.Components.OfType<IMountPointFactory>())
-            {
-                if (factory.TryMount(environment, null, sourceBasePath, out IMountPoint myMountPoint))
-                {
-                    sourceMountPoint = myMountPoint;
-                    break;
-                }
-            }
-            Assert.True(sourceMountPoint != null, "couldn't create source mount point");
-
-            IRunnableProjectConfig runnableConfig = TemplateConfigTestHelpers.ConfigFromSource(environment, sourceMountPoint);
+            TemplateConfigTestHelpers.WriteTemplateSource(environment, sourceBasePath, templateSourceFiles);
+            IMountPoint? sourceMountPoint = TemplateConfigTestHelpers.CreateMountPoint(environment, sourceBasePath);
+            IRunnableProjectConfig runnableConfig = TemplateConfigTestHelpers.ConfigFromSource(environment, sourceMountPoint!);
             RunnableProjectGenerator rpg = new RunnableProjectGenerator();
             IParameterSet parameters = new ParameterSet(runnableConfig);
             IDirectory sourceDir = sourceMountPoint!.DirectoryInfo("/");

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectGeneratorTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectGeneratorTests.cs
@@ -1,0 +1,124 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.TemplateConfigTests;
+using Microsoft.TemplateEngine.TestHelper;
+using Xunit;
+using static Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
+{
+    public class RunnableProjectGeneratorTests : IClassFixture<EnvironmentSettingsHelper>
+    {
+        private EnvironmentSettingsHelper _environmentSettingsHelper;
+
+        public RunnableProjectGeneratorTests(EnvironmentSettingsHelper environmentSettingsHelper)
+        {
+            _environmentSettingsHelper = environmentSettingsHelper;
+        }
+
+        [Fact]
+        public async void CreateAsyncTest_GuidsMacroProcessingCaseSensitivity()
+        {
+            //
+            // Template content preparation
+            //
+
+            Guid inputTestGuid = new Guid("12aa8f4e-a4aa-4ac1-927c-94cb99485ef1");
+            string contentFileNamePrefix = "content - ";
+
+            string guidsConfigFormat = @"
+{{
+  ""guids"": [
+    ""{0}"" 
+  ]
+}}
+";
+            string guidsConfig = string.Format(guidsConfigFormat, inputTestGuid);
+
+            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>();
+            // template.json
+            templateSourceFiles.Add(TemplateConfigTestHelpers.DefaultConfigRelativePath, guidsConfig);
+
+            //content
+            foreach (string guidFormat in GuidMacroConfig.DefaultFormats.Select(c => c.ToString()))
+            {
+                templateSourceFiles.Add(contentFileNamePrefix + guidFormat, inputTestGuid.ToString(guidFormat));
+            }
+
+            //
+            // Dependencies preparation and mounting
+            //
+
+            IEngineEnvironmentSettings environment = _environmentSettingsHelper.CreateEnvironment();
+            string sourceBasePath = FileSystemHelpers.GetNewVirtualizedPath(environment);
+
+            foreach (KeyValuePair<string, string?> fileInfo in templateSourceFiles)
+            {
+                string filePath = Path.Combine(sourceBasePath, fileInfo.Key);
+                string fullPathDir = Path.GetDirectoryName(filePath)!;
+                environment.Host.FileSystem.CreateDirectory(fullPathDir);
+                environment.Host.FileSystem.WriteAllText(filePath, fileInfo.Value ?? string.Empty);
+            }
+
+            string targetDir = FileSystemHelpers.GetNewVirtualizedPath(environment);
+
+            //create mount point
+            IMountPoint? sourceMountPoint = null;
+            foreach (var factory in environment.Components.OfType<IMountPointFactory>())
+            {
+                if (factory.TryMount(environment, null, sourceBasePath, out IMountPoint myMountPoint))
+                {
+                    sourceMountPoint = myMountPoint;
+                    break;
+                }
+            }
+            Assert.True(sourceMountPoint != null, "couldn't create source mount point");
+
+            IRunnableProjectConfig runnableConfig = TemplateConfigTestHelpers.ConfigFromSource(environment, sourceMountPoint);
+            RunnableProjectGenerator rpg = new RunnableProjectGenerator();
+            IParameterSet parameters = new ParameterSet(runnableConfig);
+            IDirectory sourceDir = sourceMountPoint!.DirectoryInfo("/");
+
+            //
+            // Running the actual scenario: template files processing and generating output (including macros processing)
+            //
+
+            await rpg.CreateAsync(environment, runnableConfig, sourceDir, parameters, targetDir, CancellationToken.None);
+
+            //
+            // Veryfying the outputs
+            //
+
+            Guid expectedResultGuid = Guid.Empty;
+            foreach (string guidFormat in GuidMacroConfig.DefaultFormats.Select(c => c.ToString()))
+            {
+                string resultContent = environment.Host.FileSystem.ReadAllText(Path.Combine(targetDir, contentFileNamePrefix + guidFormat));
+                Guid resultGuid;
+                Assert.True(
+                    Guid.TryParseExact(resultContent, guidFormat, out resultGuid),
+                    $"Expected the result conent ({resultContent}) to be parseable by Guid format '{guidFormat}'");
+
+                if (expectedResultGuid == Guid.Empty)
+                {
+                    expectedResultGuid = resultGuid;
+                }
+                else
+                {
+                    Assert.Equal(expectedResultGuid, resultGuid);
+                }
+            }
+            Assert.NotEqual(inputTestGuid, expectedResultGuid);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TemplateConfigTestHelpers.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TemplateConfigTestHelpers.cs
@@ -1,12 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Mocks;
+using Xunit;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.TemplateConfigTests
 {
@@ -15,7 +19,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
         public static readonly Guid FileSystemMountPointFactoryId = new Guid("8C19221B-DEA3-4250-86FE-2D4E189A11D2");
         public static readonly string DefaultConfigRelativePath = ".template.config/template.json";
 
-        public static IFileSystemInfo ConfigFileSystemInfo(IMountPoint mountPoint, string configFile = null)
+        public static IFileSystemInfo ConfigFileSystemInfo(IMountPoint mountPoint, string? configFile = null)
         {
             if (string.IsNullOrEmpty(configFile))
             {
@@ -26,7 +30,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
         }
 
         // Note: this does not deal with configs split into multiple files.
-        internal static IRunnableProjectConfig ConfigFromSource(IEngineEnvironmentSettings environment, IMountPoint mountPoint, string configFile = null)
+        internal static IRunnableProjectConfig ConfigFromSource(IEngineEnvironmentSettings environment, IMountPoint mountPoint, string? configFile = null)
         {
             return new SimpleConfigModel((IFile)ConfigFileSystemInfo(mountPoint, configFile));
         }
@@ -38,6 +42,33 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             runSpec.Exclude = new List<IPathMatcher>() { new FileSourceStateMatcher(FileDispositionStates.Exclude, matcher) };
             runSpec.CopyOnly = new List<IPathMatcher>() { new FileSourceStateMatcher(FileDispositionStates.CopyOnly, matcher) };
             runSpec.Rename = source.Renames ?? new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+
+        internal static void WriteTemplateSource(
+            IEngineEnvironmentSettings environment,
+            string sourceBasePath,
+            IDictionary<string, string?> templateSourceFileNamesWithContent)
+        {
+            foreach (KeyValuePair<string, string?> fileInfo in templateSourceFileNamesWithContent)
+            {
+                string filePath = Path.Combine(sourceBasePath, fileInfo.Key);
+                string fullPathDir = Path.GetDirectoryName(filePath)!;
+                environment.Host.FileSystem.CreateDirectory(fullPathDir);
+                environment.Host.FileSystem.WriteAllText(filePath, fileInfo.Value ?? string.Empty);
+            }
+        }
+
+        internal static IMountPoint? CreateMountPoint(IEngineEnvironmentSettings environment, string sourceBasePath)
+        {
+            foreach (var factory in environment.Components.OfType<IMountPointFactory>())
+            {
+                if (factory.TryMount(environment, null, sourceBasePath, out IMountPoint sourceMountPoint))
+                {
+                    return sourceMountPoint;
+                }
+            }
+            Assert.True(false, "couldn't create source mount point");
+            return null;
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TestTemplateSetup.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/TestTemplateSetup.cs
@@ -59,15 +59,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             {
                 if (_sourceMountPoint == null)
                 {
-                    foreach (var factory in _environmentSettings.Components.OfType<IMountPointFactory>())
-                    {
-                        if (factory.TryMount(_environmentSettings, null, _sourceBaseDir, out IMountPoint myMountPoint))
-                        {
-                            _sourceMountPoint = myMountPoint;
-                            return _sourceMountPoint;
-                        }
-                    }
-                    Assert.True(false, "couldn't create source mount point");
+                    _sourceMountPoint = TemplateConfigTestHelpers.CreateMountPoint(_environmentSettings, _sourceBaseDir);
                 }
 
                 return _sourceMountPoint;
@@ -86,13 +78,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
 
         public void WriteSource()
         {
-            foreach (KeyValuePair<string, string> fileInfo in _sourceFiles)
-            {
-                string filePath = Path.Combine(_sourceBaseDir, fileInfo.Key);
-                string fullPathDir = Path.GetDirectoryName(filePath);
-                _environmentSettings.Host.FileSystem.CreateDirectory(fullPathDir);
-                _environmentSettings.Host.FileSystem.WriteAllText(filePath, fileInfo.Value ?? string.Empty);
-            }
+            TemplateConfigTestHelpers.WriteTemplateSource(_environmentSettings, _sourceBaseDir, _sourceFiles);
         }
 
         public void InstantiateTemplate(string targetBaseDir, IParameterSet parameters = null, IVariableCollection variables = null)


### PR DESCRIPTION
### Problem
Fixes #3130

### Solution
With consideration to possible backward compatibility issues (described in the issue) a new macro parameter tags are being generated and fetched - those are fully distinct regardles of comparison used.

### Checks:
- [ x] Added unit tests
- [ x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)