### PR TITLE
Fix doc code snippet to prevent GH highligh

### DIFF
--- a/docs/Reference-for-template.json.md
+++ b/docs/Reference-for-template.json.md
@@ -64,7 +64,7 @@ Sample template.json snippet:
 ```
 
 Sample template file content:
-```
+```console
 [n]: 98048c9cbf2846baa98e63767ee5e3a8
 [d]: 98048c9c-bf28-46ba-a98e-63767ee5e3a8
 [b]: {98048c9c-bf28-46ba-a98e-63767ee5e3a8}
@@ -89,7 +89,7 @@ Sample template file content:
 ```
 
 Output content after template instantiation:
-```
+```console
 [n]: a6d920ff125841318f5e07df108f5a4a
 [d]: a6d920ff-1258-4131-8f5e-07df108f5a4a
 [b]: {a6d920ff-1258-4131-8f5e-07df108f5a4a}


### PR DESCRIPTION
### Problem
Annoing error highlights in the documentation code snippets:

![image](https://user-images.githubusercontent.com/3809076/161572427-bf5f5cfa-8aea-4f85-be27-3d80222cf52c.png)

### Solution
Adding `console` language specifier to prevent syntax checking

![image](https://user-images.githubusercontent.com/3809076/161572625-cb3bc42a-81a9-49cd-93d0-9fedcecc5b9d.png)

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)