### PR TITLE
removed dependency on `VSRedistCommonNetCoreToolsetx64PackageVersion`

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -51,10 +51,6 @@
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>b8a61266d9a6780cb7eb9c1942695cf813fdef0a</Sha>
     </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.Toolset.x64" Version="">
-      <Uri>https://www.github.com/dotnet/installer</Uri>
-      <Sha />
-    </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.2.0-4.22223.6">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>68ce7949a2ac960994374d387ec3c840523f2a44</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,8 +25,6 @@
     <!-- Maestro-managed Package Versions - Ordered by repo name -->
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
     <SystemCommandLinePackageVersion>2.0.0-beta3.22222.1</SystemCommandLinePackageVersion>
-    <!-- Dependencies from https://github.com/dotnet/installer -->
-    <VSRedistCommonNetCoreToolsetx64PackageVersion>7.0.100-alpha.1.21451.23</VSRedistCommonNetCoreToolsetx64PackageVersion>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
     <NuGetCredentialsPackageVersion>6.2.0-rc.146</NuGetCredentialsPackageVersion>
     <NuGetConfigurationPackageVersion>6.2.0-rc.146</NuGetConfigurationPackageVersion>

--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -45,22 +45,24 @@ steps:
     version: 5.0.300
     installationPath: $(Build.SourcesDirectory)/.dotnet
 
-- bash: |
-    SdkVersion=$(dotnet msbuild $(Build.SourcesDirectory)/eng/Versions.props -verbosity:diagnostic | grep "VSRedistCommonNetCoreToolsetx64PackageVersion = " | xargs | cut -d' ' -f 3)
-    echo "##vso[task.setvariable variable=RepoSdkVersion;]$SdkVersion"
-  displayName: 'Determine SDK version'
-  failOnStderr: true
+- task: UseDotNet@2
+  displayName: 'Use .NET 6.0.100'
+  inputs:
+    packageType: sdk
+    version: 6.0.100
+    installa6ionPath: $(Build.SourcesDirectory)/.dotnet
 
 - bash: >
     curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
-    -Version $(RepoSdkVersion)
+    -Channel 7.0.1xx
+    -Quality daily
     -InstallDir $(Build.SourcesDirectory)/.dotnet
     -SkipNonVersionedFiles
-  displayName: Install .NET version used by reposity
+  displayName: Install latest daily .NET version 
 
 - bash: >
     $(Build.SourcesDirectory)/.dotnet/dotnet $(Build.SourcesDirectory)/artifacts/bin/Microsoft.TemplateSearch.TemplateDiscovery/Debug/net6.0/Microsoft.TemplateSearch.TemplateDiscovery.dll
-    --basePath $(System.DefaultWorkingDirectory)/NugetDownloadDirectory --allowPreviewPacks -v --test --latestVersionToTest $(RepoSdkVersion) --diff $(EnableDiffMode)
+    --basePath $(System.DefaultWorkingDirectory)/NugetDownloadDirectory --allowPreviewPacks -v --test --diff $(EnableDiffMode)
   displayName: Run Cache Updater
 
 - task: CopyFiles@2

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/CommandArgs.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/CommandArgs.cs
@@ -36,8 +36,6 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery
 
         internal IReadOnlyList<SupportedQueries> Queries { get; init; } = new List<SupportedQueries>();
 
-        internal string? LatestSdkToTest { get; init; }
-
         internal bool DiffMode { get; init; }
 
         internal FileInfo? DiffOverrideSearchCacheLocation { get; init; }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/TemplateDiscoveryCommand.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/TemplateDiscoveryCommand.cs
@@ -68,11 +68,6 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery
             Description = $"Path to pre-downloaded packages. If specified, the packages won't be downloaded from NuGet.org.",
         }.ExistingOnly());
 
-        private Option<string> _latestSdkToTestOption = (new Option<string>("--latestVersionToTest")
-        {
-            Description = $"Latest .NET SDK version to be tested.",
-        });
-
         private Option<bool> _diffOption = new Option<bool>("--diff", getDefaultValue: () => true)
         {
             Description = $"The list of packages will be compared with previous run, and if package version is not changed, the package won't be rescanned.",
@@ -102,7 +97,6 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery
             AddOption(_queriesOption);
             AddOption(_packagesPathOption);
             AddOption(_verboseOption);
-            AddOption(_latestSdkToTestOption);
             AddOption(_diffOption);
             AddOption(_diffOverrideCacheOption);
             AddOption(_diffOverrideNonPackagesOption);
@@ -169,7 +163,6 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery
                     Verbose = bindingContext.ParseResult.GetValueForOption(_command._verboseOption),
                     TestEnabled = bindingContext.ParseResult.GetValueForOption(_command._testOption),
                     Queries = bindingContext.ParseResult.GetValueForOption(_command._queriesOption) ?? Array.Empty<SupportedQueries>(),
-                    LatestSdkToTest = bindingContext.ParseResult.GetValueForOption(_command._latestSdkToTestOption),
                     DiffMode = bindingContext.ParseResult.GetValueForOption(_command._diffOption),
                     DiffOverrideSearchCacheLocation = bindingContext.ParseResult.GetValueForOption(_command._diffOverrideCacheOption),
                     DiffOverrideKnownPackagesLocation = bindingContext.ParseResult.GetValueForOption(_command._diffOverrideNonPackagesOption),

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
@@ -49,16 +49,17 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
             CanSearch(workingDirectory, metadataPath);
 
             //latest
-            if (!string.IsNullOrWhiteSpace(config.LatestSdkToTest))
-            {
-                sdkVersion = config.LatestSdkToTest;
-                workingDirectory = TestUtils.CreateTemporaryFolder("latest");
-                UseSdkVersion(workingDirectory, sdkVersion, resolvedVersionPattern: string.Join('.', sdkVersion.Split('.', 3).Take(2)) + '.', rollForward: "latestFeature");
-                Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
-                CanSearch(workingDirectory, legacyMetadataPath);
-                Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
-                CanSearch(workingDirectory, metadataPath);
-            }
+            workingDirectory = TestUtils.CreateTemporaryFolder("latest");
+            //print the version
+            new DotnetCommand(TestOutputLogger.Instance, "--version")
+                .WithWorkingDirectory(workingDirectory)
+                .Execute()
+                .Should()
+                .ExitWith(0);
+            Console.WriteLine($"Running tests on latest .NET for: {legacyMetadataPath}.");
+            CanSearch(workingDirectory, legacyMetadataPath);
+            Console.WriteLine($"Running tests on latest .NET for: {metadataPath}.");
+            CanSearch(workingDirectory, metadataPath);
         }
 
         private static void UseSdkVersion(string workingDirectory, string requestedSdkVersion, string resolvedVersionPattern, string rollForward = "latestMinor", bool allowPrerelease = false)


### PR DESCRIPTION
### Problem
dependency on `VSRedistCommonNetCoreToolsetx64PackageVersion` is not working, moreover causes cycles impacting flow.
See: https://github.com/dotnet/templating/pull/4592


### Solution
- Removed dependency
- Search cache pipeline to install the latest daily from 7.0.1xx channel instead
- Removed checks based on version for latest

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)