### PR TITLE
Honor explicitly requested package identifier during uninstall

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -425,30 +425,15 @@ namespace Microsoft.TemplateEngine.Cli
             NewCommandStatus result = NewCommandStatus.Success;
             IReadOnlyList<IManagedTemplatePackage> templatePackages = await _templatePackageManager.GetManagedTemplatePackagesAsync(false, cancellationToken).ConfigureAwait(false);
 
-            List<Tuple<string, string>> parsedIdentifiers = new List<Tuple<string, string>>();
-            foreach (string requestedPackageIdentifier in commandArgs.TemplatePackages)
-            {
-                // First try to search for installed packages that have identical identifier as requested to be unistalled - this will prevent issues
-                //  during clashes of packages and local path names
-                parsedIdentifiers.AddRange(
-                    InstallRequestPathResolution.ExpandMaskedPath(requestedPackageIdentifier, _engineEnvironmentSettings)
-                    .Select(expandedPackageIdentifier => new Tuple<string, string>(requestedPackageIdentifier, expandedPackageIdentifier))
-                    );
-            }
-
             var packagesToUninstall = new Dictionary<IManagedTemplatePackageProvider, List<IManagedTemplatePackage>>();
-            foreach (Tuple<string, string> templatePackageIdentifier in parsedIdentifiers)
+            List<string> notFoundPackages = new List<string>();
+            foreach (var requestedPackageIdentifier in commandArgs.TemplatePackages)
             {
                 bool templatePackageIdentified = false;
-
+                // First try to search for installed packages that have identical identifier as requested to be unistalled
                 foreach (IManagedTemplatePackage templatePackage in templatePackages)
                 {
-                    if (
-                        // Original or expanded package identifier matches
-                        templatePackage.Identifier.Equals(templatePackageIdentifier.Item1, StringComparison.OrdinalIgnoreCase)
-                        ||
-                        templatePackage.Identifier.Equals(templatePackageIdentifier.Item2, StringComparison.OrdinalIgnoreCase)
-                        )
+                    if (templatePackage.Identifier.Equals(requestedPackageIdentifier, StringComparison.OrdinalIgnoreCase))
                     {
                         templatePackageIdentified = true;
                         if (packagesToUninstall.TryGetValue(templatePackage.ManagedProvider, out List<IManagedTemplatePackage>? packages))
@@ -462,26 +447,53 @@ namespace Microsoft.TemplateEngine.Cli
                     }
                 }
 
-                if (templatePackageIdentified)
+                if (!templatePackageIdentified)
                 {
-                    continue;
-                }
+                    // If not found - try to expand path and search with expanded path for all local packages (folders and nugets)
+                    foreach (string expandedIdentifier in InstallRequestPathResolution.ExpandMaskedPath(requestedPackageIdentifier, _engineEnvironmentSettings))
+                    {
+                        templatePackageIdentified = false;
+                        foreach (IManagedTemplatePackage templatePackage in templatePackages.Where(pm => pm.IsLocalPackage))
+                        {
+                            if (templatePackage.Identifier.Equals(expandedIdentifier, StringComparison.OrdinalIgnoreCase))
+                            {
+                                templatePackageIdentified = true;
+                                if (packagesToUninstall.TryGetValue(templatePackage.ManagedProvider, out List<IManagedTemplatePackage>? packages))
+                                {
+                                    packages.Add(templatePackage);
+                                }
+                                else
+                                {
+                                    packagesToUninstall[templatePackage.ManagedProvider] = new List<IManagedTemplatePackage>() { templatePackage };
+                                }
+                            }
+                        }
 
+                        if (!templatePackageIdentified)
+                        {
+                            notFoundPackages.Add(expandedIdentifier);
+                        }
+                    }
+                }
+            }
+
+            foreach (string notFoundPackage in notFoundPackages)
+            {
                 result = NewCommandStatus.NotFound;
                 Reporter.Error.WriteLine(
                     string.Format(
                         LocalizableStrings.TemplatePackageCoordinator_Error_PackageNotFound,
-                        templatePackageIdentifier.Item2).Bold().Red());
-                if (await IsTemplateShortNameAsync(templatePackageIdentifier.Item2, cancellationToken).ConfigureAwait(false))
+                        notFoundPackage).Bold().Red());
+                if (await IsTemplateShortNameAsync(notFoundPackage, cancellationToken).ConfigureAwait(false))
                 {
-                    var packages = await GetTemplatePackagesByShortNameAsync(templatePackageIdentifier.Item2, cancellationToken).ConfigureAwait(false);
+                    var packages = await GetTemplatePackagesByShortNameAsync(notFoundPackage, cancellationToken).ConfigureAwait(false);
                     var managedPackages = packages.OfType<IManagedTemplatePackage>();
                     if (managedPackages.Any())
                     {
                         Reporter.Error.WriteLine(
                               string.Format(
                                   LocalizableStrings.TemplatePackageCoordinator_Error_TemplateIncludedToPackages,
-                                  templatePackageIdentifier.Item2));
+                                  notFoundPackage));
                         foreach (IManagedTemplatePackage managedPackage in managedPackages)
                         {
                             IEnumerable<ITemplateInfo> templates = await _templatePackageManager.GetTemplatesAsync(managedPackage, cancellationToken).ConfigureAwait(false);
@@ -533,6 +545,7 @@ namespace Microsoft.TemplateEngine.Cli
                 }
                 Reporter.Error.WriteLine();
             }
+
             return (result, packagesToUninstall);
         }
 

--- a/test/dotnet-new3.UnitTests/DotnetNewUninstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUninstall.cs
@@ -170,9 +170,15 @@ namespace Dotnet_new3.IntegrationTests
 
             Assert.True(File.Exists(Path.Combine(home, "packages", "Microsoft.DotNet.Web.ProjectTemplates.5.0.5.0.0.nupkg")));
 
-            new DotnetNewCommand(_log, commandName, "Microsoft.DotNet.Web.ProjectTemplates.5.0")
+            // This tests proper uninstallation of package even if there is a clash with existing folder name
+            //  (this used to fail - see #4613)
+            string packageNameToUnisntall = "Microsoft.DotNet.Web.ProjectTemplates.5.0";
+            string workingDir = TestUtils.CreateTemporaryFolder();
+            Directory.CreateDirectory(Path.Combine(workingDir, packageNameToUnisntall));
+
+            new DotnetNewCommand(_log, commandName, packageNameToUnisntall)
                 .WithCustomHive(home)
-                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .WithWorkingDirectory(workingDir)
                 .Execute()
                 .Should()
                 .ExitWith(0)


### PR DESCRIPTION
### Problem
Fixes #4156
Remote feed packages could not be unistalled when unistall command run from local folder with subfolder of clashing name

### Solution
The package identifier requested to be unistalled is checked first as is only then expanded for wildcards or local folders. If any package found - it's uninstalled and no error is logged

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)