### PR TITLE
--dry-run and destructive changes reporting honors output and target dir

### DIFF
--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotOverwriteFilesWithoutForce.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotOverwriteFilesWithoutForce.verified.txt
@@ -1,5 +1,5 @@
 ﻿Creating this template will make changes to existing files:
-  Overwrite   ./%FILENAME%
-  Overwrite   ./%FILENAME%
+  Overwrite   folderA/%FILENAME%
+  Overwrite   folderA/%FILENAME%
 
 Rerun the command and pass --force to accept and create.

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.DryRunRespectsTargetPathAndOutputDir.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.DryRunRespectsTargetPathAndOutputDir.verified.txt
@@ -1,0 +1,3 @@
+﻿File actions would have been taken:
+  Create: folderF/Custom/Path/%FILENAME%
+  Create: folderF/Custom/Path/%FILENAME%


### PR DESCRIPTION
### Problem
Fixes #4526
Output folder was not reflected in output and error statements of `--dry-run` and destructive changes notification

### Solution
The Output path is prepended to the outputs, records are normalized and adjusted relatively to working directory

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)