### PR TITLE
[release/7.0.1xx-preview4] Workaround official build break issue with Signing Validation

### DIFF
--- a/eng/common/templates/post-build/post-build.yml
+++ b/eng/common/templates/post-build/post-build.yml
@@ -106,7 +106,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Server.Amd64.VS2019
+          demands: ImageOverride -equals Build.Windows.Amd64.VS2022
 
       steps:
         - template: setup-maestro-vars.yml
@@ -143,7 +143,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Server.Amd64.VS2019
+          demands: ImageOverride -equals Build.Windows.Amd64.VS2022
       steps:
         - template: setup-maestro-vars.yml
           parameters:
@@ -203,7 +203,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Server.Amd64.VS2019
+          demands: ImageOverride -equals Build.Windows.Amd64.VS2022
       steps:
         - template: setup-maestro-vars.yml
           parameters:
@@ -261,7 +261,7 @@ stages:
         # If it's not devdiv, it's dnceng
         ${{ else }}:
           name: NetCore1ESPool-Internal
-          demands: ImageOverride -equals Build.Server.Amd64.VS2019
+          demands: ImageOverride -equals Build.Windows.Amd64.VS2022
       steps:
         - template: setup-maestro-vars.yml
           parameters:


### PR DESCRIPTION
The latest SDK requires VS2022 (MSBuild 17.0+), so we need to update the template.
This will make it into arcade once p4 ships.

### Problem
<!-- Add the issue number if exists. Describe the problem otherwise. -->

### Solution
<!-- Describe the solution. -->

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)