### PR TITLE
Remove usage of noncompliant web templates version

### DIFF
--- a/test/dotnet-new3.UnitTests/AllWebProjectsWork.cs
+++ b/test/dotnet-new3.UnitTests/AllWebProjectsWork.cs
@@ -138,7 +138,6 @@ namespace Dotnet_new3.IntegrationTests
                 .And
                 .NotHaveStdErr();
 
-            InstallPackage(TemplatePackagesPaths.MicrosoftDotNetWebProjectTemplates21Path, BaseWorkingDirectory);
             InstallPackage(TemplatePackagesPaths.MicrosoftDotNetWebProjectTemplates31Path, BaseWorkingDirectory);
             InstallPackage(TemplatePackagesPaths.MicrosoftDotNetWebProjectTemplates50Path, BaseWorkingDirectory);
         }

--- a/test/dotnet-new3.UnitTests/Approvals/AllWebProjectsWork.CanShowHelp_Mvc.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/AllWebProjectsWork.CanShowHelp_Mvc.verified.txt
@@ -70,11 +70,10 @@ Template options:
   -rrc, --razor-runtime-compilation                                       Determines if the project is configured to use Razor runtime compilation in Debug builds.
                                                                           Type: bool
                                                                           Default: false
-  -f, --framework <net5.0|netcoreapp2.1|netcoreapp3.1>                    The target framework for the project.
+  -f, --framework <net5.0|netcoreapp3.1>                                  The target framework for the project.
                                                                           Type: choice
                                                                             net5.0         Target net5.0
                                                                             netcoreapp3.1  Target netcoreapp3.1
-                                                                            netcoreapp2.1  Target netcoreapp2.1
                                                                           Default: net5.0
   --no-restore                                                            If specified, skips the automatic restore of the project on create.
                                                                           Type: bool
@@ -88,9 +87,6 @@ Template options:
   --called-api-scopes <called-api-scopes>                                 Scopes to request to call the API from the web app. This option only applies if --auth SingleOrg, --auth MultiOrg or --auth IndividualB2C is specified.
                                                                           Type: string
                                                                           Default: user.read
-  --use-browserlink                                                       Whether or not to include BrowserLink in the project
-                                                                          Type: bool
-                                                                          Default: false
 
 To see help for other template languages (F#), use --language option:
    dotnet-new3 new3 mvc -h --language F#

--- a/test/dotnet-new3.UnitTests/Approvals/AllWebProjectsWork.CanShowHelp_WebAPI.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/AllWebProjectsWork.CanShowHelp_WebAPI.verified.txt
@@ -15,66 +15,65 @@ Options:
   --type <project>        Specifies the template type to instantiate.
 
 Template options:
-  -au, --auth <IndividualB2C|None|SingleOrg|Windows>    The type of authentication to use
-                                                        Type: choice
-                                                          None           No authentication
-                                                          IndividualB2C  Individual authentication with Azure AD B2C
-                                                          SingleOrg      Organizational authentication for a single tenant
-                                                          Windows        Windows authentication
-                                                        Default: None
-  --aad-b2c-instance <aad-b2c-instance>                 The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth).
-                                                        Type: string
-                                                        Default: https://login.microsoftonline.com/tfp/
-  -ssp, --susi-policy-id <susi-policy-id>               The sign-in and sign-up policy ID for this project (use with IndividualB2C auth).
-                                                        Type: string
-  --aad-instance <aad-instance>                         The Azure Active Directory instance to connect to (use with SingleOrg auth).
-                                                        Type: string
-                                                        Default: https://login.microsoftonline.com/
-  --client-id <client-id>                               The Client ID for this project (use with SingleOrg or IndividualB2C auth).
-                                                        Type: string
-                                                        Default: 11111111-1111-1111-11111111111111111
-  --domain <domain>                                     The domain for the directory tenant (use with SingleOrg or IndividualB2C auth).
-                                                        Type: string
-                                                        Default: qualified.domain.name
-  --default-scope <default-scope>                       The API scope the client needs to request to provision an access token. (use with IndividualB2C, SingleOrg).
-                                                        Type: string
-                                                        Default: access_as_user
-  --tenant-id <tenant-id>                               The TenantId ID of the directory to connect to (use with SingleOrg auth).
-                                                        Type: string
-                                                        Default: 22222222-2222-2222-2222-222222222222
-  -r, --org-read-access                                 Whether or not to allow this application read access to the directory (only applies to SingleOrg auth).
-                                                        Type: bool
-                                                        Default: false
-  --exclude-launch-settings                             Whether to exclude launchSettings.json in the generated template.
-                                                        Type: bool
-                                                        Default: false
-  --no-https                                            Whether to turn off HTTPS. This option only applies if Individual, IndividualB2C, SingleOrg, or MultiOrg aren't used for --auth.
-                                                        Type: bool
-                                                        Default: false
-  -uld, --use-local-db                                  Whether to use LocalDB instead of SQLite. This option only applies if --auth Individual or --auth IndividualB2C is specified.
-                                                        Type: bool
-                                                        Default: false
-  -f, --framework <net5.0|netcoreapp2.1|netcoreapp3.1>  The target framework for the project.
-                                                        Type: choice
-                                                          net5.0         Target net5.0
-                                                          netcoreapp3.1  Target netcoreapp3.1
-                                                          netcoreapp2.1  Target netcoreapp2.1
-                                                        Default: net5.0
-  --no-restore                                          If specified, skips the automatic restore of the project on create.
-                                                        Type: bool
-                                                        Default: false
-  --called-api-url <called-api-url>                     URL of the API to call from the web app. This option only applies if --auth SingleOrg or --auth IndividualB2C is specified.
-                                                        Type: string
-                                                        Default: https://graph.microsoft.com/v1.0
-  --calls-graph                                         Specifies if the web app calls Microsoft Graph. This option only applies if --auth SingleOrg is specified.
-                                                        Type: bool
-                                                        Default: false
-  --called-api-scopes <called-api-scopes>               Scopes to request to call the API from the web app. This option only applies if --auth SingleOrg or --auth IndividualB2C is specified.
-                                                        Type: string
-                                                        Default: user.read
-  --no-openapi                                          Disable OpenAPI (Swagger) support
-                                                        Type: bool
-                                                        Default: false
+  -au, --auth <IndividualB2C|None|SingleOrg|Windows>  The type of authentication to use
+                                                      Type: choice
+                                                        None           No authentication
+                                                        IndividualB2C  Individual authentication with Azure AD B2C
+                                                        SingleOrg      Organizational authentication for a single tenant
+                                                        Windows        Windows authentication
+                                                      Default: None
+  --aad-b2c-instance <aad-b2c-instance>               The Azure Active Directory B2C instance to connect to (use with IndividualB2C auth).
+                                                      Type: string
+                                                      Default: https://login.microsoftonline.com/tfp/
+  -ssp, --susi-policy-id <susi-policy-id>             The sign-in and sign-up policy ID for this project (use with IndividualB2C auth).
+                                                      Type: string
+  --aad-instance <aad-instance>                       The Azure Active Directory instance to connect to (use with SingleOrg auth).
+                                                      Type: string
+                                                      Default: https://login.microsoftonline.com/
+  --client-id <client-id>                             The Client ID for this project (use with SingleOrg or IndividualB2C auth).
+                                                      Type: string
+                                                      Default: 11111111-1111-1111-11111111111111111
+  --domain <domain>                                   The domain for the directory tenant (use with SingleOrg or IndividualB2C auth).
+                                                      Type: string
+                                                      Default: qualified.domain.name
+  --default-scope <default-scope>                     The API scope the client needs to request to provision an access token. (use with IndividualB2C, SingleOrg).
+                                                      Type: string
+                                                      Default: access_as_user
+  --tenant-id <tenant-id>                             The TenantId ID of the directory to connect to (use with SingleOrg auth).
+                                                      Type: string
+                                                      Default: 22222222-2222-2222-2222-222222222222
+  -r, --org-read-access                               Whether or not to allow this application read access to the directory (only applies to SingleOrg auth).
+                                                      Type: bool
+                                                      Default: false
+  --exclude-launch-settings                           Whether to exclude launchSettings.json in the generated template.
+                                                      Type: bool
+                                                      Default: false
+  --no-https                                          Whether to turn off HTTPS. This option only applies if Individual, IndividualB2C, SingleOrg, or MultiOrg aren't used for --auth.
+                                                      Type: bool
+                                                      Default: false
+  -uld, --use-local-db                                Whether to use LocalDB instead of SQLite. This option only applies if --auth Individual or --auth IndividualB2C is specified.
+                                                      Type: bool
+                                                      Default: false
+  -f, --framework <net5.0|netcoreapp3.1>              The target framework for the project.
+                                                      Type: choice
+                                                        net5.0         Target net5.0
+                                                        netcoreapp3.1  Target netcoreapp3.1
+                                                      Default: net5.0
+  --no-restore                                        If specified, skips the automatic restore of the project on create.
+                                                      Type: bool
+                                                      Default: false
+  --called-api-url <called-api-url>                   URL of the API to call from the web app. This option only applies if --auth SingleOrg or --auth IndividualB2C is specified.
+                                                      Type: string
+                                                      Default: https://graph.microsoft.com/v1.0
+  --calls-graph                                       Specifies if the web app calls Microsoft Graph. This option only applies if --auth SingleOrg is specified.
+                                                      Type: bool
+                                                      Default: false
+  --called-api-scopes <called-api-scopes>             Scopes to request to call the API from the web app. This option only applies if --auth SingleOrg or --auth IndividualB2C is specified.
+                                                      Type: string
+                                                      Default: user.read
+  --no-openapi                                        Disable OpenAPI (Swagger) support
+                                                      Type: bool
+                                                      Default: false
 
 To see help for other template languages (F#), use --language option:
    dotnet-new3 new3 webapi -h --language F#

--- a/test/dotnet-new3.UnitTests/Approvals/AllWebProjectsWork.CanShowHelp_Webapp_common.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/AllWebProjectsWork.CanShowHelp_Webapp_common.verified.txt
@@ -74,11 +74,10 @@ Template options:
   -rrc, --razor-runtime-compilation                                       Determines if the project is configured to use Razor runtime compilation in Debug builds.
                                                                           Type: bool
                                                                           Default: false
-  -f, --framework <net5.0|netcoreapp2.1|netcoreapp3.1>                    The target framework for the project.
+  -f, --framework <net5.0|netcoreapp3.1>                                  The target framework for the project.
                                                                           Type: choice
                                                                             net5.0         Target net5.0
                                                                             netcoreapp3.1  Target netcoreapp3.1
-                                                                            netcoreapp2.1  Target netcoreapp2.1
                                                                           Default: net5.0
   --called-api-url <called-api-url>                                       URL of the API to call from the web app. This option only applies if --auth SingleOrg, --auth MultiOrg or --auth IndividualB2C is specified.
                                                                           Type: string
@@ -89,6 +88,3 @@ Template options:
   --called-api-scopes <called-api-scopes>                                 Scopes to request to call the API from the web app. This option only applies if --auth SingleOrg, --auth MultiOrg or --auth IndividualB2C is specified.
                                                                           Type: string
                                                                           Default: user.read
-  --use-browserlink                                                       Whether or not to include BrowserLink in the project
-                                                                          Type: bool
-                                                                          Default: false

--- a/test/dotnet-new3.UnitTests/dotnet-new3.IntegrationTests.csproj
+++ b/test/dotnet-new3.UnitTests/dotnet-new3.IntegrationTests.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.2.1" Version="5.0" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.3.1" Version="5.0" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.Common.ProjectTemplates.5.0" Version="5.0" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.DotNet.Web.ProjectTemplates.2.1" Version="2.1.*" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.Web.ProjectTemplates.3.1" Version="3.1.*" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.Web.ProjectTemplates.5.0" Version="5.0.*" GeneratePathProperty="true" />
   </ItemGroup>
@@ -32,7 +31,6 @@ namespace Dotnet_new3.IntegrationTests
       public const string MicrosoftDotNetCommonProjectTemplates21Path = @"$(PkgMicrosoft_DotNet_Common_ProjectTemplates_2_1)"%3B
       public const string MicrosoftDotNetCommonProjectTemplates31Path = @"$(PkgMicrosoft_DotNet_Common_ProjectTemplates_3_1)"%3B
       public const string MicrosoftDotNetCommonProjectTemplates50Path = @"$(PkgMicrosoft_DotNet_Common_ProjectTemplates_5_0)"%3B
-      public const string MicrosoftDotNetWebProjectTemplates21Path = @"$(PkgMicrosoft_DotNet_Web_ProjectTemplates_2_1)"%3B
       public const string MicrosoftDotNetWebProjectTemplates31Path = @"$(PkgMicrosoft_DotNet_Web_ProjectTemplates_3_1)"%3B
       public const string MicrosoftDotNetWebProjectTemplates50Path = @"$(PkgMicrosoft_DotNet_Web_ProjectTemplates_5_0)"%3B
   }


### PR DESCRIPTION
### Problem
Microsoft.Dotnet.Web.ProjectTemplates.2.1 is not compliant

### Solution
Removing usage of that version from our integration tests

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)