### PR TITLE
[release/6.0.1xx] pin System.Security.Cryptography.X509Certificates version 

### DIFF
--- a/eng/AnalyzersForTests.props
+++ b/eng/AnalyzersForTests.props
@@ -6,7 +6,7 @@
     <EnableAnalyzers Condition="'$(DotNetBuildFromSource)' == 'true'">false</EnableAnalyzers>
   </PropertyGroup>
   <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0-preview3.21153.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -35,6 +35,7 @@
   <!-- forces the version in sub dependencies -->
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" /> 
   </ItemGroup>
   
   <ItemGroup>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -15,5 +15,6 @@
   <!-- xunit.assert has this dependency, so applying to all test projects-->
   <ItemGroup>
     <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" /> 
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Problem
`System.Security.Cryptography.X509Certificates` dependency should be updated.

### Solution
Forces `System.Security.Cryptography.X509Certificates version 4.3.0` for test projects and `Microsoft.TemplateEngine.Cli`.