### PR TITLE
[release/6.0.3xx] pin System.Security.Cryptography.X509Certificates version

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
+++ b/src/Microsoft.TemplateEngine.Cli/Microsoft.TemplateEngine.Cli.csproj
@@ -37,6 +37,7 @@
   <!-- forces the version in sub dependencies -->
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" /> 
   </ItemGroup>
   
   <ItemGroup>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -16,5 +16,6 @@
   <!-- xunit.assert has this dependency, so applying to all test projects-->
   <ItemGroup>
     <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" /> 
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Problem
`System.Security.Cryptography.X509Certificates` dependency should be updated.

Solution
Forces `System.Security.Cryptography.X509Certificates` version 4.3.0 for test projects and `Microsoft.TemplateEngine.Cli`