### PR TITLE
Flush log outputs explicitly

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/AnsiConsole.cs
+++ b/src/Microsoft.TemplateEngine.Cli/AnsiConsole.cs
@@ -32,9 +32,10 @@ namespace Microsoft.TemplateEngine.Cli
         {
             Write(message);
             Writer.WriteLine();
+            Writer.Flush();
         }
 
-        internal void Write(string message)
+        private void Write(string message)
         {
             var escapeScan = 0;
             for (; ; )

--- a/src/Microsoft.TemplateEngine.Cli/CliConsoleFormatter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CliConsoleFormatter.cs
@@ -50,6 +50,8 @@ namespace Microsoft.TemplateEngine.Cli
                     CreateDebugMessage(textWriter, logEntry, message!, scopeProvider);
                     break;
             }
+
+            textWriter.Flush();
         }
 
         public void Dispose() => _optionsReloadToken?.Dispose();

--- a/src/Microsoft.TemplateEngine.Cli/Reporter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Reporter.cs
@@ -65,20 +65,5 @@ namespace Microsoft.TemplateEngine.Cli
                 _console?.Writer?.WriteLine();
             }
         }
-
-        internal void Write(string message)
-        {
-            lock (_lock)
-            {
-                if (ShouldPassAnsiCodesThrough)
-                {
-                    _console?.Writer?.Write(message);
-                }
-                else
-                {
-                    _console?.Write(message);
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
### Problem
#4618 - possibly caused by stale log entries

### Solution
Attempt to resolve by explicit flushing of log entries (despite Console TextWriter should be implicitly set to AutoFlush mode by default).

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)