### PR TITLE
show warning when deprecated command is used

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
@@ -183,6 +183,25 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             this.AddOption(command.ColumnsOption);
         }
 
+        protected void PrintDeprecationMessage<TDepr, TNew>(ParseResult parseResult, Option? additionalOption = null) where TDepr : Command where TNew : Command
+        {
+            var newCommandExample = Example.For<TNew>(parseResult);
+            if (additionalOption != null)
+            {
+                newCommandExample.WithOption(additionalOption);
+            }
+
+            Reporter.Output.WriteLine(string.Format(
+             LocalizableStrings.Commands_Warning_DeprecatedCommand,
+             Example.For<TDepr>(parseResult),
+             newCommandExample).Yellow());
+
+            Reporter.Output.WriteLine(LocalizableStrings.Commands_Warning_DeprecatedCommand_Info.Yellow());
+            Reporter.Output.WriteCommand(Example.For<TNew>(parseResult).WithHelpOption().ToString().Yellow());
+            Reporter.Output.WriteLine();
+
+        }
+
         private static async Task HandleGlobalOptionsAsync(TArgs args, IEngineEnvironmentSettings environmentSettings, CancellationToken cancellationToken)
         {
             HandleDebugAttach(args);

--- a/src/Microsoft.TemplateEngine.Cli/Commands/install/LegacyInstallCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/install/LegacyInstallCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using Microsoft.TemplateEngine.Abstractions;
 
@@ -21,5 +22,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         internal override Option<bool> InteractiveOption => ParentCommand.InteractiveOption;
 
         internal override Option<string[]> AddSourceOption => ParentCommand.AddSourceOption;
+
+        protected override Task<NewCommandStatus> ExecuteAsync(InstallCommandArgs args, IEngineEnvironmentSettings environmentSettings, ITelemetryLogger telemetryLogger, InvocationContext context)
+        {
+            PrintDeprecationMessage<LegacyInstallCommand, InstallCommand>(args.ParseResult);
+            return base.ExecuteAsync(args, environmentSettings, telemetryLogger, context);
+        }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/list/LegacyListCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/list/LegacyListCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using Microsoft.TemplateEngine.Abstractions;
 
@@ -30,6 +31,12 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         protected override Option GetFilterOption(FilterOptionDefinition def)
         {
             return ParentCommand.LegacyFilters[def];
+        }
+
+        protected override Task<NewCommandStatus> ExecuteAsync(ListCommandArgs args, IEngineEnvironmentSettings environmentSettings, ITelemetryLogger telemetryLogger, InvocationContext context)
+        {
+            PrintDeprecationMessage<LegacyListCommand, ListCommand>(args.ParseResult);
+            return base.ExecuteAsync(args, environmentSettings, telemetryLogger, context);
         }
 
         private void ValidateParentCommandArguments(CommandResult commandResult)

--- a/src/Microsoft.TemplateEngine.Cli/Commands/search/LegacySearchCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/search/LegacySearchCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using Microsoft.TemplateEngine.Abstractions;
 
@@ -25,6 +26,12 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         protected override Option GetFilterOption(FilterOptionDefinition def)
         {
             return ParentCommand.LegacyFilters[def];
+        }
+
+        protected override Task<NewCommandStatus> ExecuteAsync(SearchCommandArgs args, IEngineEnvironmentSettings environmentSettings, ITelemetryLogger telemetryLogger, InvocationContext context)
+        {
+            PrintDeprecationMessage<LegacySearchCommand, SearchCommand>(args.ParseResult);
+            return base.ExecuteAsync(args, environmentSettings, telemetryLogger, context);
         }
 
         private void ValidateParentCommandArguments(CommandResult commandResult)

--- a/src/Microsoft.TemplateEngine.Cli/Commands/uninstall/LegacyUninstallCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/uninstall/LegacyUninstallCommand.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using Microsoft.TemplateEngine.Abstractions;
 
@@ -19,6 +20,12 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             this.AddAlias("-u");
 
             parentCommand.AddNoLegacyUsageValidators(this);
+        }
+
+        protected override Task<NewCommandStatus> ExecuteAsync(UninstallCommandArgs args, IEngineEnvironmentSettings environmentSettings, ITelemetryLogger telemetryLogger, InvocationContext context)
+        {
+            PrintDeprecationMessage<LegacyUninstallCommand, UninstallCommand>(args.ParseResult);
+            return base.ExecuteAsync(args, environmentSettings, telemetryLogger, context);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/update/LegacyUpdateApplyCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/update/LegacyUpdateApplyCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using Microsoft.TemplateEngine.Abstractions;
 
@@ -23,5 +24,11 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         internal override Option<bool> InteractiveOption => ParentCommand.InteractiveOption;
 
         internal override Option<string[]> AddSourceOption => ParentCommand.AddSourceOption;
+
+        protected override Task<NewCommandStatus> ExecuteAsync(UpdateCommandArgs args, IEngineEnvironmentSettings environmentSettings, ITelemetryLogger telemetryLogger, InvocationContext context)
+        {
+            PrintDeprecationMessage<LegacyUpdateApplyCommand, UpdateCommand>(args.ParseResult);
+            return base.ExecuteAsync(args, environmentSettings, telemetryLogger, context);
+        }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/update/LegacyUpdateCheckCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/update/LegacyUpdateCheckCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using Microsoft.TemplateEngine.Abstractions;
 
@@ -23,5 +24,12 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         internal override Option<bool> InteractiveOption => ParentCommand.InteractiveOption;
 
         internal override Option<string[]> AddSourceOption => ParentCommand.AddSourceOption;
+
+        protected override Task<NewCommandStatus> ExecuteAsync(UpdateCommandArgs args, IEngineEnvironmentSettings environmentSettings, ITelemetryLogger telemetryLogger, InvocationContext context)
+        {
+            PrintDeprecationMessage<LegacyUpdateCheckCommand, UpdateCommand>(args.ParseResult, additionalOption: UpdateCommand.CheckOnlyOption);
+
+            return base.ExecuteAsync(args, environmentSettings, telemetryLogger, context);
+        }
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/Commands/update/UpdateCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/update/UpdateCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             this.AddOption(CheckOnlyOption);
         }
 
-        internal Option<bool> CheckOnlyOption { get; } = new(new[] { "--check-only", "--dry-run" })
+        internal static Option<bool> CheckOnlyOption { get; } = new(new[] { "--check-only", "--dry-run" })
         {
             Description = SymbolStrings.Command_Update_Option_CheckOnly
         };

--- a/src/Microsoft.TemplateEngine.Cli/Commands/update/UpdateCommandArgs.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/update/UpdateCommandArgs.cs
@@ -11,7 +11,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         {
             if (command is UpdateCommand updateCommand)
             {
-                CheckOnly = parseResult.GetValueForOption(updateCommand.CheckOnlyOption);
+                CheckOnly = parseResult.GetValueForOption(UpdateCommand.CheckOnlyOption);
             }
             else if (command is LegacyUpdateCheckCommand)
             {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -743,6 +743,24 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Warning: use of &apos;{0}&apos; is deprecated. Use &apos;{1}&apos; instead..
+        /// </summary>
+        internal static string Commands_Warning_DeprecatedCommand {
+            get {
+                return ResourceManager.GetString("Commands_Warning_DeprecatedCommand", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to For more information, run: .
+        /// </summary>
+        internal static string Commands_Warning_DeprecatedCommand_Info {
+            get {
+                return ResourceManager.GetString("Commands_Warning_DeprecatedCommand_Info", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Command succeeded..
         /// </summary>
         internal static string CommandSucceeded {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -793,4 +793,12 @@ The header is followed by the list of parameters and their errors (might be seve
     <value>To use built-in template package, uninstall manually installed template package using:</value>
     <comment>followed by command to uninstall package</comment>
   </data>
+  <data name="Commands_Warning_DeprecatedCommand" xml:space="preserve">
+    <value>Warning: use of '{0}' is deprecated. Use '{1}' instead.</value>
+    <comment>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</comment>
+  </data>
+  <data name="Commands_Warning_DeprecatedCommand_Info" xml:space="preserve">
+    <value>For more information, run: </value>
+    <comment>followed by command example (at new line, without quotes)</comment>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -398,6 +398,16 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <target state="translated">Nerozpoznaný příkaz nebo argument(y): {0}.</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">Nakonfigurovaná hodnota: {0}</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -398,6 +398,16 @@ Führen Sie \"dotnet {1}--show-aliases\" ohne Argumente aus, um alle Aliase anzu
         <target state="translated">Befehl oder Argument(e) nicht erkannt:{0}.</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">Konfigurierter Wert: {0}</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -398,6 +398,16 @@ Ejecute \"dotnet {1} --show-aliases\" sin argumentos para mostrar todos los alia
         <target state="translated">No se reconoce el comando o el argumento: {0}.</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">Valor configurado: {0}</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -398,6 +398,16 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <target state="translated">Commande ou argument non reconnu : {0}</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">Valeur configurée : {0}</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -398,6 +398,16 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <target state="translated">Il comando o l'argomento {0} non è stato riconosciuto.</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">Valore configurato: {0}</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -398,6 +398,16 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">認識されないコマンドまたは引数: {0}。</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">構成された値: {0}</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -398,6 +398,16 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">인식할 수 없는 명령 또는 인수: {0}.</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">구성된 값:{0}</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -398,6 +398,16 @@ Uruchom polecenie \"dotnet {1}--show-aliases\" bez argumentów, aby wyświetlić
         <target state="translated">Nierozpoznane polecenie lub argument: {0}</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">Skonfigurowana wartość: {0}</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -398,6 +398,16 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <target state="translated">Comando ou argumento(s) não reconhecido(s): {0}.</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">Valor Configurado: {0}</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -398,6 +398,16 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">Команда или аргументы не распознаны: {0}.</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">Настроено значение: {0}</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -398,6 +398,16 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <target state="translated">Tanınmayan komut veya bağımsız değişken: {0}</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">Yapılandırılan Değer: {0}</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -398,6 +398,16 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">未识别命令或参数: {0}。</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">配置的值: {0}</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -398,6 +398,16 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">無法辨識的命令或引數 {0}。</target>
         <note>{0} - wrong token or comma-separated tokens (if multiple). Each token is enclosed with single quotes: 'token'.</note>
       </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand">
+        <source>Warning: use of '{0}' is deprecated. Use '{1}' instead.</source>
+        <target state="new">Warning: use of '{0}' is deprecated. Use '{1}' instead.</target>
+        <note>{0} - deprecated command ('dotnet new --install'); {1} - new command ('dotnet new install).</note>
+      </trans-unit>
+      <trans-unit id="Commands_Warning_DeprecatedCommand_Info">
+        <source>For more information, run: </source>
+        <target state="new">For more information, run: </target>
+        <note>followed by command example (at new line, without quotes)</note>
+      </trans-unit>
       <trans-unit id="ConfiguredValue">
         <source>Configured Value: {0}</source>
         <target state="translated">設定值: {0}</target>

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CanShowDeprecationMessage_WhenLegacyCommandIsUsed_common.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CanShowDeprecationMessage_WhenLegacyCommandIsUsed_common.verified.txt
@@ -1,0 +1,15 @@
+﻿Warning: use of 'dotnet-new3 new3 --install' is deprecated. Use 'dotnet-new3 new3 install' instead.
+For more information, run: 
+   dotnet-new3 new3 install -h
+
+The following template packages will be installed:
+   Microsoft.DotNet.Web.ItemTemplates::5.0.0
+
+Success: Microsoft.DotNet.Web.ItemTemplates::5.0.0 installed the following templates:
+Template Name         Short Name      Language  Tags       
+--------------------  --------------  --------  -----------
+MVC ViewImports       viewimports     [C#]      Web/ASP.NET
+MVC ViewStart         viewstart       [C#]      Web/ASP.NET
+Protocol Buffer File  proto                     Web/gRPC   
+Razor Component       razorcomponent  [C#]      Web/ASP.NET
+Razor Page            page            [C#]      Web/ASP.NET

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.DoNotShowDeprecationMessage_WhenNewCommandIsUsed.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.DoNotShowDeprecationMessage_WhenNewCommandIsUsed.verified.txt
@@ -1,0 +1,11 @@
+﻿The following template packages will be installed:
+   Microsoft.DotNet.Web.ItemTemplates::5.0.0
+
+Success: Microsoft.DotNet.Web.ItemTemplates::5.0.0 installed the following templates:
+Template Name         Short Name      Language  Tags       
+--------------------  --------------  --------  -----------
+MVC ViewImports       viewimports     [C#]      Web/ASP.NET
+MVC ViewStart         viewstart       [C#]      Web/ASP.NET
+Protocol Buffer File  proto                     Web/gRPC   
+Razor Component       razorcomponent  [C#]      Web/ASP.NET
+Razor Page            page            [C#]      Web/ASP.NET

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewList.CanShowDeprecationMessage_WhenLegacyCommandIsUsed_common.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewList.CanShowDeprecationMessage_WhenLegacyCommandIsUsed_common.verified.txt
@@ -1,0 +1,17 @@
+﻿Warning: use of 'dotnet-new3 new3 --list' is deprecated. Use 'dotnet-new3 new3 list' instead.
+For more information, run: 
+   dotnet-new3 new3 list -h
+
+These templates matched your input: 
+
+Template Name                    Short Name     Language    Tags          
+-------------------------------  -------------  ----------  --------------
+Class Library                    classlib       [C#],F#,VB  Common/Library
+Console App                      console        [C#],F#,VB  Common/Console
+dotnet gitignore file            gitignore                  Config        
+Dotnet local tool manifest file  tool-manifest              Config        
+EditorConfig file                editorconfig               Config        
+global.json file                 globaljson                 Config        
+NuGet Config                     nugetconfig                Config        
+Solution File                    sln                        Solution      
+Web Config                       webconfig                  Config        

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewList.DoNotShowDeprecationMessage_WhenNewCommandIsUsed.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewList.DoNotShowDeprecationMessage_WhenNewCommandIsUsed.verified.txt
@@ -1,0 +1,13 @@
+﻿These templates matched your input: 
+
+Template Name                    Short Name     Language    Tags          
+-------------------------------  -------------  ----------  --------------
+Class Library                    classlib       [C#],F#,VB  Common/Library
+Console App                      console        [C#],F#,VB  Common/Console
+dotnet gitignore file            gitignore                  Config        
+Dotnet local tool manifest file  tool-manifest              Config        
+EditorConfig file                editorconfig               Config        
+global.json file                 globaljson                 Config        
+NuGet Config                     nugetconfig                Config        
+Solution File                    sln                        Solution      
+Web Config                       webconfig                  Config        

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.Approval.cs
@@ -67,5 +67,39 @@ namespace Dotnet_new3.IntegrationTests
                     output.ScrubByRegex("   Microsoft\\.DotNet\\.Common\\.ItemTemplates::[A-Za-z0-9.-]+", "   Microsoft.DotNet.Common.ItemTemplates::%VERSION%");
                 });
         }
+
+        [Theory]
+        [InlineData("-i")]
+        [InlineData("--install")]
+        public Task CanShowDeprecationMessage_WhenLegacyCommandIsUsed(string commandName)
+        {
+            var commandResult = new DotnetNewCommand(_log, commandName, "Microsoft.DotNet.Web.ItemTemplates::5.0.0")
+                .WithCustomHive()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute();
+
+            commandResult
+                .Should()
+                .Pass();
+
+            return Verifier.Verify(commandResult.StdOut, _verifySettings)
+                .UseTextForParameters("common")
+                .DisableRequireUniquePrefix();
+        }
+
+        [Fact]
+        public Task DoNotShowDeprecationMessage_WhenNewCommandIsUsed()
+        {
+            var commandResult = new DotnetNewCommand(_log, "install", "Microsoft.DotNet.Web.ItemTemplates::5.0.0")
+                .WithCustomHive()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute();
+
+            commandResult
+                .Should()
+                .Pass();
+
+            return Verifier.Verify(commandResult.StdOut, _verifySettings);
+        }
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewList.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewList.Approval.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.NET.TestFramework.Assertions;
+using Microsoft.TemplateEngine.TestHelper;
+using VerifyXunit;
+using Xunit;
+
+namespace Dotnet_new3.IntegrationTests
+{
+    public partial class DotnetNewList
+    {
+        [Theory]
+        [InlineData("-l")]
+        [InlineData("--list")]
+        public Task CanShowDeprecationMessage_WhenLegacyCommandIsUsed(string commandName)
+        {
+            var commandResult = new DotnetNewCommand(_log, commandName)
+                .WithCustomHive()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute();
+
+            commandResult
+                .Should()
+                .Pass();
+
+            return Verifier.Verify(commandResult.StdOut, _verifySettings)
+                .UseTextForParameters("common")
+                .DisableRequireUniquePrefix();
+        }
+
+        [Fact]
+        public Task DoNotShowDeprecationMessage_WhenNewCommandIsUsed()
+        {
+            var commandResult = new DotnetNewCommand(_log, "list")
+                .WithCustomHive()
+                .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
+                .Execute();
+
+            commandResult
+                .Should()
+                .Pass();
+
+            return Verifier.Verify(commandResult.StdOut, _verifySettings);
+        }
+    }
+}

--- a/test/dotnet-new3.UnitTests/DotnetNewList.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewList.cs
@@ -3,20 +3,25 @@
 
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.TemplateEngine.TestHelper;
+using VerifyTests;
+using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Dotnet_new3.IntegrationTests
 {
-    public class DotnetNewList : IClassFixture<SharedHomeDirectory>
+    [UsesVerify]
+    public partial class DotnetNewList : IClassFixture<SharedHomeDirectory>, IClassFixture<VerifySettingsFixture>
     {
+        private readonly VerifySettings _verifySettings;
         private readonly SharedHomeDirectory _sharedHome;
         private readonly ITestOutputHelper _log;
 
-        public DotnetNewList(SharedHomeDirectory sharedHome, ITestOutputHelper log)
+        public DotnetNewList(SharedHomeDirectory sharedHome, VerifySettingsFixture verifySettings, ITestOutputHelper log)
         {
             _sharedHome = sharedHome;
             _log = log;
+            _verifySettings = verifySettings.Settings;
         }
 
         [Theory]

--- a/test/dotnet-new3.UnitTests/DotnetNewUpdateApply.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUpdateApply.cs
@@ -95,7 +95,42 @@ namespace Dotnet_new3.IntegrationTests
                 .ExitWith(0)
                 .And
                 .NotHaveStdErr()
-                .And.HaveStdOut("All template packages are up-to-date.");
+                .And.HaveStdOutContaining("All template packages are up-to-date.");
+        }
+
+        [Fact]
+        public void CanShowDeprecationMessage_WhenLegacyCommandIsUsed()
+        {
+            const string deprecationMessage =
+@"Warning: use of 'dotnet-new3 new3 --update-apply' is deprecated. Use 'dotnet-new3 new3 update' instead.
+For more information, run: 
+   dotnet-new3 new3 update -h";
+
+            var home = TestUtils.CreateTemporaryFolder("Home");
+            var commandResult = new DotnetNewCommand(_log, "--update-apply")
+                .WithCustomHive(home)
+                .Execute();
+
+            commandResult.Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr();
+
+            Assert.StartsWith(deprecationMessage, commandResult.StdOut);
+        }
+
+        [Fact]
+        public void DoNotShowDeprecationMessage_WhenNewCommandIsUsed()
+        {
+            var home = TestUtils.CreateTemporaryFolder("Home");
+            var commandResult = new DotnetNewCommand(_log, "update")
+                .WithCustomHive(home)
+                .Execute();
+
+            commandResult.Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr()
+                .And.NotHaveStdOutContaining("Warning")
+                .And.NotHaveStdOutContaining("deprecated");
         }
     }
 }


### PR DESCRIPTION
### Problem
fixes https://github.com/dotnet/templating/issues/4260

### Solution
Prints the error when deprecated syntax is used.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)