### PR TITLE
Add some check and retry for diagnosing flaky tests

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
@@ -104,6 +104,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
             if (template.GeneratorId == RunnableProjectGeneratorId && HostConfigPlace != null)
             {
+                logger.LogDebug($"Start loading host config {HostConfigPlace}");
                 try
                 {
                     using (var sr = new StreamReader(template.TemplateSourceRoot.FileInfo(HostConfigPlace).OpenRead()))
@@ -120,6 +121,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                         template.MountPointUri,
                         template.HostConfigPlace);
                 }
+                logger.LogDebug($"End loading host config {HostConfigPlace}");
             }
         }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
@@ -521,6 +521,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
             if (errorMessages.Any())
             {
+                _logger.LogDebug($"Localization file {localeFile?.GetDisplayPath()} is not compatible with base configuration {_sourceFile?.GetDisplayPath()}");
                 StringBuilder stringBuilder = new StringBuilder();
                 stringBuilder.AppendLine(string.Format(LocalizableStrings.RunnableProjectGenerator_Warning_LocFileSkipped, localeFile?.GetDisplayPath(), _sourceFile?.GetDisplayPath()));
                 foreach (string errorMessage in errorMessages)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -163,9 +163,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
             foreach (IFile file in folder.EnumerateFiles(TemplateConfigFileName, SearchOption.AllDirectories))
             {
+                logger.LogDebug($"Found {TemplateConfigFileName} at {file.GetDisplayPath()}.");
                 try
                 {
                     IFile? hostConfigFile = FindBestHostTemplateConfigFile(source.EnvironmentSettings, file);
+                    logger.LogDebug($"Found *{HostTemplateFileConfigBaseName} at {hostConfigFile?.GetDisplayPath()}.");
 
                     // issue here: we need to pass locale as parameter
                     // consider passing current locale file here if exists

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/LocalizationTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/LocalizationTests.cs
@@ -425,11 +425,12 @@ false,
             var localizationModel = LocalizationModelDeserializer.Deserialize(localizationFile);
             Assert.False(templateConfig.VerifyLocalizationModel(localizationModel, localizationFile));
 
-            Assert.Single(loggedMessages);
+            var warningMessages = loggedMessages.Where(log => log.Item1 == LogLevel.Warning);
+            Assert.Single(warningMessages);
             Assert.Contains(
                 string.Format(LocalizableStrings.Authoring_InvalidManualInstructionLocalizationIndex, "extra", "pa0"),
-                loggedMessages.Single().Item2);
-            Assert.Contains(localizationFilename, loggedMessages.Single().Item2);
+                warningMessages.Single().Item2);
+            Assert.Contains(localizationFilename, warningMessages.Single().Item2);
         }
 
         [Fact]
@@ -470,11 +471,12 @@ false,
             var localizationModel = LocalizationModelDeserializer.Deserialize(mountPoint.FileInfo(localizationFile));
             Assert.False(templateConfig.VerifyLocalizationModel(localizationModel));
 
-            Assert.Single(loggedMessages);
+            var warningMessages = loggedMessages.Where(log => log.Item1 == LogLevel.Warning);
+            Assert.Single(warningMessages);
 
             Assert.Contains(
                string.Format(LocalizableStrings.Authoring_InvalidPostActionLocalizationIndex, "pa1"),
-               loggedMessages.Single().Item2);
+               warningMessages.Single().Item2);
         }
 
         #endregion

--- a/test/Microsoft.TemplateEngine.TestHelper/TestUtils.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/TestUtils.cs
@@ -151,46 +151,6 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
             return ((file1byte - file2byte) == 0);
         }
 
-        public static void EnsureTestAssetsAvailable(string[] paths, ITestOutputHelper log)
-        {
-            if (paths == null)
-            {
-                return;
-            }
-
-            List<Exception> exceptions = new List<Exception>();
-            foreach (string path in paths)
-            {
-                if (!File.Exists(path))
-                {
-                    // Check file existence
-                    exceptions.Add(new FileNotFoundException($"File {path} doesn't exist or can not be found."));
-                }
-                else
-                {
-                    // Check if file can be read
-                    try
-                    {
-                        using (FileStream fs = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read))
-                        using (StreamReader sr = new StreamReader(fs))
-                        {
-                            var content = sr.ReadToEnd();
-                            log.WriteLine($"The content of file {path} is:");
-                            log.WriteLine(content);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        exceptions.Add(ex);
-                    }
-                }
-            }
-            if (exceptions.Count > 0)
-            {
-                throw new AggregateException("Test assets are not available.", exceptions);
-            }
-        }
-
         public static async Task<T> AttemptSearch<T, E>(int count, TimeSpan interval, Func<Task<T>> execute) where E : Exception
         {
             T? result = default;
@@ -209,10 +169,9 @@ $@"<?xml version=""1.0"" encoding=""utf-8""?>
                         throw ex;
                     }
 
-                    if (ex is AggregateException)
+                    if (ex is AggregateException agEx)
                     {
-                        var agEx = ex as AggregateException;
-                        if (!agEx!.InnerExceptions.Any(e => e is E))
+                        if (!agEx.InnerExceptions.Any(e => e is E))
                         {
                             throw ex;
                         }

--- a/test/Microsoft.TemplateSearch.Common.UnitTests/Microsoft.TemplateSearch.Common.UnitTests.csproj
+++ b/test/Microsoft.TemplateSearch.Common.UnitTests/Microsoft.TemplateSearch.Common.UnitTests.csproj
@@ -16,10 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="NuGetTemplateSearchInfoWithInvalidData.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/test/Microsoft.TemplateSearch.Common.UnitTests/TemplateSearchCacheReaderTests.cs
+++ b/test/Microsoft.TemplateSearch.Common.UnitTests/TemplateSearchCacheReaderTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.TemplateSearch.Common.UnitTests
                 A.Fake<ITemplateSearchProviderFactory>(),
                 environmentSettings,
                 new Dictionary<string, Func<object, object>>());
-            await sourceFileProvider.GetSearchFileAsync(default).ConfigureAwait(false);
+            await AttemptGetSearchFileAsync(3, 10, sourceFileProvider);
             string content = environmentSettings.Host.FileSystem.ReadAllText(Path.Combine(environmentSettings.Paths.HostVersionSettingsDir, "nugetTemplateSearchInfo.json"));
             var jObj = JObject.Parse(content);
             Assert.NotNull(TemplateSearchCache.FromJObject(jObj, environmentSettings.Host.Logger, null));
@@ -107,7 +107,7 @@ namespace Microsoft.TemplateSearch.Common.UnitTests
                 environmentSettings,
                 new Dictionary<string, Func<object, object>>(),
                 new[] { "https://go.microsoft.com/fwlink/?linkid=2087906&clcid=0x409" });  //v1 search cache
-            await sourceFileProvider.GetSearchFileAsync(default).ConfigureAwait(false);
+            await AttemptGetSearchFileAsync(3, 10, sourceFileProvider);
             string content = environmentSettings.Host.FileSystem.ReadAllText(Path.Combine(environmentSettings.Paths.HostVersionSettingsDir, "nugetTemplateSearchInfo.json"));
             var jObj = JObject.Parse(content);
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -170,6 +170,31 @@ namespace Microsoft.TemplateSearch.Common.UnitTests
 
             Assert.Equal(2, ((ITemplateInfo)templateToTest).PostActions.Count);
             Assert.Equal(new[] { postAction1, postAction2 }, ((ITemplateInfo)templateToTest).PostActions);
+        }
+
+        private async Task<string> AttemptGetSearchFileAsync(int count, int intervalInSeconds, NuGetMetadataSearchProvider searchProvider)
+        {
+            string location = string.Empty;
+            int attempt = 0;
+            while (attempt < count)
+            {
+                try
+                {
+                    location = await searchProvider.GetSearchFileAsync(default).ConfigureAwait(false);
+                    break;
+                }
+                catch (AggregateException ex)
+                {
+                    if (!ex.InnerExceptions.Any(e => e is HttpRequestException) || attempt + 1 == count)
+                    {
+                        throw ex;
+                    }
+                }
+                Thread.Sleep(intervalInSeconds * 1000);
+                attempt++;
+            }
+
+            return location;
         }
     }
 }

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -618,6 +618,7 @@ namespace Dotnet_new3.IntegrationTests
             var assets = new string[] { Path.Combine(invalidTemplatePath, "template.json") };
             TestUtils.EnsureTestAssetsAvailable(assets, _log);
             new DotnetNewCommand(_log, "-i", invalidTemplatePath)
+                .WithDebug()
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()
@@ -641,6 +642,7 @@ namespace Dotnet_new3.IntegrationTests
             var assets = new string[] { Path.Combine(invalidTemplatePath, ".template.config/dotnetcli.host.json") };
             TestUtils.EnsureTestAssetsAvailable(assets, _log);
             new DotnetNewCommand(_log, "-i", invalidTemplatePath)
+                .WithDebug()
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
                 .Execute()

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -615,7 +615,6 @@ namespace Dotnet_new3.IntegrationTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             string invalidTemplatePath = TestUtils.GetTestTemplateLocation("Invalid/MissingMandatoryConfig");
-            var assets = new string[] { Path.Combine(invalidTemplatePath, "template.json") };
             new DotnetNewCommand(_log, "-i", invalidTemplatePath)
                 .WithDebug()
                 .WithCustomHive(home)
@@ -638,7 +637,6 @@ namespace Dotnet_new3.IntegrationTests
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
             string invalidTemplatePath = TestUtils.GetTestTemplateLocation("Invalid/InvalidHostData");
-            var assets = new string[] { Path.Combine(invalidTemplatePath, ".template.config/dotnetcli.host.json") };
             new DotnetNewCommand(_log, "-i", invalidTemplatePath)
                 .WithDebug()
                 .WithCustomHive(home)

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -615,6 +615,8 @@ namespace Dotnet_new3.IntegrationTests
         {
             var home = TestUtils.CreateTemporaryFolder("Home");
             string invalidTemplatePath = TestUtils.GetTestTemplateLocation("Invalid/MissingMandatoryConfig");
+            var assets = new string[] { Path.Combine(invalidTemplatePath, "template.json") };
+            TestUtils.EnsureTestAssetsAvailable(assets, _log);
             new DotnetNewCommand(_log, "-i", invalidTemplatePath)
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())
@@ -636,6 +638,8 @@ namespace Dotnet_new3.IntegrationTests
         {
             string home = TestUtils.CreateTemporaryFolder("Home");
             string invalidTemplatePath = TestUtils.GetTestTemplateLocation("Invalid/InvalidHostData");
+            var assets = new string[] { Path.Combine(invalidTemplatePath, ".template.config/dotnetcli.host.json") };
+            TestUtils.EnsureTestAssetsAvailable(assets, _log);
             new DotnetNewCommand(_log, "-i", invalidTemplatePath)
                 .WithCustomHive(home)
                 .WithWorkingDirectory(TestUtils.CreateTemporaryFolder())

--- a/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstall.cs
@@ -616,7 +616,6 @@ namespace Dotnet_new3.IntegrationTests
             var home = TestUtils.CreateTemporaryFolder("Home");
             string invalidTemplatePath = TestUtils.GetTestTemplateLocation("Invalid/MissingMandatoryConfig");
             var assets = new string[] { Path.Combine(invalidTemplatePath, "template.json") };
-            TestUtils.EnsureTestAssetsAvailable(assets, _log);
             new DotnetNewCommand(_log, "-i", invalidTemplatePath)
                 .WithDebug()
                 .WithCustomHive(home)
@@ -640,7 +639,6 @@ namespace Dotnet_new3.IntegrationTests
             string home = TestUtils.CreateTemporaryFolder("Home");
             string invalidTemplatePath = TestUtils.GetTestTemplateLocation("Invalid/InvalidHostData");
             var assets = new string[] { Path.Combine(invalidTemplatePath, ".template.config/dotnetcli.host.json") };
-            TestUtils.EnsureTestAssetsAvailable(assets, _log);
             new DotnetNewCommand(_log, "-i", invalidTemplatePath)
                 .WithDebug()
                 .WithCustomHive(home)

--- a/test/dotnet-new3.UnitTests/DotnetNewLocaleTests.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewLocaleTests.cs
@@ -97,6 +97,7 @@ namespace Dotnet_new3.IntegrationTests
             var assets = new string[] { Path.Combine(testTemplateLocation, ".template.config/localize/templatestrings.de-DE.json") };
             TestUtils.EnsureTestAssetsAvailable(assets, _log);
             new DotnetNewCommand(_log, "-i", testTemplateLocation)
+                .WithDebug()
                 .WithCustomHive(home)
                 .WithWorkingDirectory(workingDir)
                 .Execute()
@@ -136,6 +137,7 @@ namespace Dotnet_new3.IntegrationTests
   };
 
             var commandResult = new DotnetNewCommand(_log, "-i", testTemplateLocation)
+                .WithDebug()
                 .WithCustomHive(home)
                 .WithWorkingDirectory(workingDir)
                 .Execute();

--- a/test/dotnet-new3.UnitTests/DotnetNewLocaleTests.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewLocaleTests.cs
@@ -94,6 +94,8 @@ namespace Dotnet_new3.IntegrationTests
             var home = TestUtils.CreateTemporaryFolder("Home");
             var workingDir = TestUtils.CreateTemporaryFolder("Home");
             var testTemplateLocation = TestUtils.GetTestTemplateLocation("Invalid/Localization/InvalidFormat");
+            var assets = new string[] { Path.Combine(testTemplateLocation, ".template.config/localize/templatestrings.de-DE.json") };
+            TestUtils.EnsureTestAssetsAvailable(assets, _log);
             new DotnetNewCommand(_log, "-i", testTemplateLocation)
                 .WithCustomHive(home)
                 .WithWorkingDirectory(workingDir)
@@ -113,6 +115,13 @@ namespace Dotnet_new3.IntegrationTests
             var home = TestUtils.CreateTemporaryFolder("Home");
             var workingDir = TestUtils.CreateTemporaryFolder("Home");
             var testTemplateLocation = TestUtils.GetTestTemplateLocation("Invalid/Localization/ValidationFailure");
+            var assets = new string[]
+            {
+                Path.Combine(testTemplateLocation, ".template.config/template.json"),
+                Path.Combine(testTemplateLocation, ".template.config/localize/templatestrings.de-DE.json"),
+                Path.Combine(testTemplateLocation, ".template.config/localize/templatestrings.tr.json")
+            };
+            TestUtils.EnsureTestAssetsAvailable(assets, _log);
 
             var expectedErrors = new[]
             {

--- a/test/dotnet-new3.UnitTests/DotnetNewLocaleTests.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewLocaleTests.cs
@@ -94,7 +94,6 @@ namespace Dotnet_new3.IntegrationTests
             var home = TestUtils.CreateTemporaryFolder("Home");
             var workingDir = TestUtils.CreateTemporaryFolder("Home");
             var testTemplateLocation = TestUtils.GetTestTemplateLocation("Invalid/Localization/InvalidFormat");
-            var assets = new string[] { Path.Combine(testTemplateLocation, ".template.config/localize/templatestrings.de-DE.json") };
             new DotnetNewCommand(_log, "-i", testTemplateLocation)
                 .WithDebug()
                 .WithCustomHive(home)
@@ -115,12 +114,6 @@ namespace Dotnet_new3.IntegrationTests
             var home = TestUtils.CreateTemporaryFolder("Home");
             var workingDir = TestUtils.CreateTemporaryFolder("Home");
             var testTemplateLocation = TestUtils.GetTestTemplateLocation("Invalid/Localization/ValidationFailure");
-            var assets = new string[]
-            {
-                Path.Combine(testTemplateLocation, ".template.config/template.json"),
-                Path.Combine(testTemplateLocation, ".template.config/localize/templatestrings.de-DE.json"),
-                Path.Combine(testTemplateLocation, ".template.config/localize/templatestrings.tr.json")
-            };
 
             var expectedErrors = new[]
             {

--- a/test/dotnet-new3.UnitTests/DotnetNewLocaleTests.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewLocaleTests.cs
@@ -95,7 +95,6 @@ namespace Dotnet_new3.IntegrationTests
             var workingDir = TestUtils.CreateTemporaryFolder("Home");
             var testTemplateLocation = TestUtils.GetTestTemplateLocation("Invalid/Localization/InvalidFormat");
             var assets = new string[] { Path.Combine(testTemplateLocation, ".template.config/localize/templatestrings.de-DE.json") };
-            TestUtils.EnsureTestAssetsAvailable(assets, _log);
             new DotnetNewCommand(_log, "-i", testTemplateLocation)
                 .WithDebug()
                 .WithCustomHive(home)
@@ -122,7 +121,6 @@ namespace Dotnet_new3.IntegrationTests
                 Path.Combine(testTemplateLocation, ".template.config/localize/templatestrings.de-DE.json"),
                 Path.Combine(testTemplateLocation, ".template.config/localize/templatestrings.tr.json")
             };
-            TestUtils.EnsureTestAssetsAvailable(assets, _log);
 
             var expectedErrors = new[]
             {


### PR DESCRIPTION
### Problem
#4618 - some flaky tests in CI

### Solution
Add some check and log to help on diagnostic.
For network related issue, make it retry some times.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)