### PR TITLE
fix #4650 - adding validation for multichoice symbols

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/ChoiceTemplateParameter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/ChoiceTemplateParameter.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.CommandLine;
 using System.CommandLine.Help;
 using System.CommandLine.Parsing;
@@ -163,7 +165,7 @@ namespace Microsoft.TemplateEngine.Cli
 
         private static bool TryConvertValueToChoice(string value, ChoiceTemplateParameter parameter, out string parsedValue, out string error)
         {
-            return TryConvertValueToChoice(value.Tokenize(), parameter, out parsedValue, out error);
+            return TryConvertValueToChoice(value.TokenizeMultiValueParameter(), parameter, out parsedValue, out error);
         }
 
         private static bool TryConvertValueToChoice(IEnumerable<string> values, ChoiceTemplateParameter parameter, out string parsedValue, out string error)
@@ -181,7 +183,7 @@ namespace Microsoft.TemplateEngine.Cli
                 parsedValues.Add(value);
             }
 
-            parsedValue = string.Join("|", parsedValues);
+            parsedValue = string.Join(MultiValueParameter.MultiValueSeparator, parsedValues);
             return true;
         }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Choice parameter {0} is invalid. It allows multiple values (&apos;AllowMultipleValues=true&apos;), while some of the configured choices contain separator characters. Invalid choices: {1}.
+        ///   Looks up a localized string similar to Choice parameter {0} is invalid. It allows multiple values (&apos;AllowMultipleValues=true&apos;), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}.
         /// </summary>
         internal static string Authoring_InvalidMultichoiceSymbol {
             get {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Choice parameter {0} is invalid. It allows multiple values (&apos;AllowMultipleValues=true&apos;), while some of the configured choices contain separator characters. Invalid choices: {1}.
+        /// </summary>
+        internal static string Authoring_InvalidMultichoiceSymbol {
+            get {
+                return ResourceManager.GetString("Authoring_InvalidMultichoiceSymbol", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Post action(s) with id(s) &apos;{0}&apos; specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file..
         /// </summary>
         internal static string Authoring_InvalidPostActionLocalizationIndex {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
@@ -125,6 +125,10 @@
     <comment>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</comment>
   </data>
+  <data name="Authoring_InvalidMultichoiceSymbol" xml:space="preserve">
+    <value>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</value>
+    <comment>{0} is the offending symbol name, {1} is a csv list of offending choice values</comment>
+  </data>
   <data name="Authoring_InvalidPostActionLocalizationIndex" xml:space="preserve">
     <value>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</value>
     <comment>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".</comment>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
@@ -126,8 +126,8 @@
 {1} is a single-word identifier string. Such as "myPostAction".</comment>
   </data>
   <data name="Authoring_InvalidMultichoiceSymbol" xml:space="preserve">
-    <value>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</value>
-    <comment>{0} is the offending symbol name, {1} is a csv list of offending choice values</comment>
+    <value>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</value>
+    <comment>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</comment>
   </data>
   <data name="Authoring_InvalidPostActionLocalizationIndex" xml:space="preserve">
     <value>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</value>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
@@ -1018,8 +1018,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     string.Format(
                         LocalizableStrings.Authoring_InvalidMultichoiceSymbol,
                         p.DisplayName,
+                        string.Join(", ", MultiValueParameter.MultiValueSeparators.Select(c => $"'{c}'")),
                         string.Join(
-                            ",",
+                            ", ",
                             p.Choices.Where(c => !c.Key.IsValidMultiValueParameterValue())
                                 .Select(c => $"{{{c.Key}}}"))))
             );

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -329,7 +329,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             {
                 if (param.AllowMultipleValues)
                 {
-                    List<string?> val = literal.Tokenize().Select(t => ResolveChoice(environmentSettings, t, param)).Where(r => !string.IsNullOrEmpty(r)).ToList();
+                    List<string> val =
+                        literal
+                            .TokenizeMultiValueParameter()
+                            .Select(t => ResolveChoice(environmentSettings, t, param))
+                            .Where(r => !string.IsNullOrEmpty(r))
+                            .Select(r => r!)
+                            .ToList();
                     if (val.Count <= 1)
                     {
                         return val.Count == 0 ? string.Empty : val[0];

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">Akce publikování s ID {0} určené v souboru lokalizace v souboru template.json neexistují. Odeberte lokalizované řetězce ze souboru lokalizace.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">Die in der Lokalisierungsdatei angegebenen POST-Aktionen mit den IDs „{0}“ sind in der Datei „template.json“ nicht vorhanden. Entfernen Sie die lokalisierten Zeichenfolgen aus der Lokalisierungsdatei.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">Las acciones \"post\" con Id. \"{0}\" especificadas en el archivo de localización no existen en el archivo template.json. Quite las cadenas localizadas del archivo de localización.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">Les actions de publication ayant l’ID «{0}» spécifié dans le fichier de localisation n’existent pas dans le fichier template.json. Supprimez les chaînes localisées du fichier de localisation.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">Le azioni di pubblicazione con id '{0}' specificate nel file di localizzazione non esistono nel file template.json. Rimuovere le stringhe localizzate dal file di localizzazione.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">ローカライズ ファイルに指定された ID '{0}' の事後アクションが template.json ファイルに存在しません。ローカライズされた文字列をローカライズ ファイルから削除してください。</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">지역화 파일에 지정된 id ‘{0}’이(가) 있는 게시 작업이 template.json 파일에 없습니다. 현지화 파일에서 현지화된 문자열을 제거합니다.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">Akcje publikowania z identyfikatorami „{0}” określone w pliku lokalizacji nie istnieją w pliku template.json. Usuń zlokalizowane ciągi z pliku lokalizacji.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">A(s) ação(ões) posterior(es) com a(s) id(s) '{0}' especificada(s) no arquivo de localização não existe(m) no arquivo template.json. Remova as cadeia de caracteres localizadas do arquivo de localização.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">Операции POST с идентификатором \"{0}\", указанные в файле локализации, не существуют в файле template.json. Удалите локализованные строки из файла локализации.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">Yerelleştirme dosyasında belirtilen ‘{0}’ kimliklerine sahip gönderme eylemleri template.json dosyasında yok. Yerelleştirilmiş dizeleri yerelleştirme dosyasından kaldırın.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">本地化文件中指定的 id 为“{0}”的发布操作在 template.json 文件中不存在。请从本地化文件中删除本地化的字符串。</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
@@ -13,6 +13,11 @@
         <note>{0} is a list of single-word identifier strings separated by comma. Such as "myManualInstruction, someUserPickedText, instruction3".
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
+      <trans-unit id="Authoring_InvalidMultichoiceSymbol">
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
+        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+      </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>
         <target state="translated">當地語系化檔案中指定識別碼為 '{0}' 的張貼動作不存在於 template.json 檔案中。請從當地語系化檔案中移除當地語系化字串。</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
@@ -14,9 +14,9 @@
 {1} is a single-word identifier string. Such as "myPostAction".</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidMultichoiceSymbol">
-        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</source>
-        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {1}</target>
-        <note>{0} is the offending symbol name, {1} is a csv list of offending choice values</note>
+        <source>Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</source>
+        <target state="new">Choice parameter {0} is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ({1}). Invalid choices: {2}</target>
+        <note>{0} is the offending symbol name, {1} is a set of separator characters, {2} is a csv list of offending choice values</note>
       </trans-unit>
       <trans-unit id="Authoring_InvalidPostActionLocalizationIndex">
         <source>Post action(s) with id(s) '{0}' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.</source>

--- a/src/Microsoft.TemplateEngine.Utils/MultiValueParameter.cs
+++ b/src/Microsoft.TemplateEngine.Utils/MultiValueParameter.cs
@@ -29,11 +29,14 @@ namespace Microsoft.TemplateEngine.Utils
         }
 
         /// <summary>
+        /// Set of characters that can be used for separating multi valued parameters (currently applicable only to choices).
+        /// </summary>
+        public static char[] MultiValueSeparators { get; } = new[] { MultiValueSeparator, ',' };
+
+        /// <summary>
         /// The actual atomic values specified for the parameter.
         /// </summary>
         public IReadOnlyList<string> Values { get; private init; }
-
-        internal static char[] MultiValueSeparators { get; } = new[] { MultiValueSeparator, ',' };
 
         /// <inheritdoc/>
         public override string ToString() => string.Join(MultiValueSeparator.ToString(), Values);

--- a/src/Microsoft.TemplateEngine.Utils/MultiValueParameter.cs
+++ b/src/Microsoft.TemplateEngine.Utils/MultiValueParameter.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -12,6 +14,11 @@ namespace Microsoft.TemplateEngine.Utils
     /// </summary>
     public class MultiValueParameter
     {
+        /// <summary>
+        /// Separator of multi valued parameters (currently applicable only to choices).
+        /// </summary>
+        public const char MultiValueSeparator = '|';
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MultiValueParameter"/> class.
         /// </summary>
@@ -26,6 +33,9 @@ namespace Microsoft.TemplateEngine.Utils
         /// </summary>
         public IReadOnlyList<string> Values { get; private init; }
 
-        public override string ToString() => string.Join("|", Values);
+        internal static char[] MultiValueSeparators { get; } = new[] { MultiValueSeparator, ',' };
+
+        /// <inheritdoc/>
+        public override string ToString() => string.Join(MultiValueSeparator.ToString(), Values);
     }
 }

--- a/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
@@ -1,12 +1,14 @@
-﻿Microsoft.TemplateEngine.Utils.MultiValueParameter
+﻿const Microsoft.TemplateEngine.Utils.MultiValueParameter.MultiValueSeparator = '|' -> char
+Microsoft.TemplateEngine.Utils.MultiValueParameter
+Microsoft.TemplateEngine.Utils.MultiValueParameter.MultiValueParameter(System.Collections.Generic.IReadOnlyList<string!>! values) -> void
+Microsoft.TemplateEngine.Utils.MultiValueParameter.Values.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateEngine.Utils.TemplateParameter.AllowMultipleValues.get -> bool
 Microsoft.TemplateEngine.Utils.TemplateParameter.EnableQuotelessLiterals.get -> bool
 Microsoft.TemplateEngine.Utils.TemplateParameter.TemplateParameter(string! name, string! type, string! datatype, Microsoft.TemplateEngine.Abstractions.TemplateParameterPriority priority = Microsoft.TemplateEngine.Abstractions.TemplateParameterPriority.Required, bool isName = false, string? defaultValue = null, string? defaultIfOptionWithoutValue = null, string? description = null, string? displayName = null, bool allowMultipleValues = false, bool enableQuotelessLiterals = false, System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Abstractions.ParameterChoice!>? choices = null) -> void
-static Microsoft.TemplateEngine.Utils.TemplateParameterExtensions.Tokenize(this string! literal) -> System.Collections.Generic.IReadOnlyList<string!>!
+override Microsoft.TemplateEngine.Utils.MultiValueParameter.ToString() -> string!
+static Microsoft.TemplateEngine.Utils.TemplateParameterExtensions.IsValidMultiValueParameterValue(this string! value) -> bool
+static Microsoft.TemplateEngine.Utils.TemplateParameterExtensions.TokenizeMultiValueParameter(this string! literal) -> System.Collections.Generic.IReadOnlyList<string!>!
 static Microsoft.TemplateEngine.Utils.WellKnownSearchFilters.AuthorFilter(string? author) -> System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo?>!
 static Microsoft.TemplateEngine.Utils.WellKnownSearchFilters.BaselineFilter(string? baselineName) -> System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo?>!
 static Microsoft.TemplateEngine.Utils.WellKnownSearchFilters.ClassificationFilter(string? classification) -> System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo?>!
 static Microsoft.TemplateEngine.Utils.WellKnownSearchFilters.LanguageFilter(string? language) -> System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo?>!
-~Microsoft.TemplateEngine.Utils.MultiValueParameter.MultiValueParameter(System.Collections.Generic.IReadOnlyList<string> values) -> void
-~Microsoft.TemplateEngine.Utils.MultiValueParameter.Values.get -> System.Collections.Generic.IReadOnlyList<string>
-~override Microsoft.TemplateEngine.Utils.MultiValueParameter.ToString() -> string

--- a/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
@@ -6,6 +6,7 @@ Microsoft.TemplateEngine.Utils.TemplateParameter.AllowMultipleValues.get -> bool
 Microsoft.TemplateEngine.Utils.TemplateParameter.EnableQuotelessLiterals.get -> bool
 Microsoft.TemplateEngine.Utils.TemplateParameter.TemplateParameter(string! name, string! type, string! datatype, Microsoft.TemplateEngine.Abstractions.TemplateParameterPriority priority = Microsoft.TemplateEngine.Abstractions.TemplateParameterPriority.Required, bool isName = false, string? defaultValue = null, string? defaultIfOptionWithoutValue = null, string? description = null, string? displayName = null, bool allowMultipleValues = false, bool enableQuotelessLiterals = false, System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Abstractions.ParameterChoice!>? choices = null) -> void
 override Microsoft.TemplateEngine.Utils.MultiValueParameter.ToString() -> string!
+static Microsoft.TemplateEngine.Utils.MultiValueParameter.MultiValueSeparators.get -> char[]!
 static Microsoft.TemplateEngine.Utils.TemplateParameterExtensions.IsValidMultiValueParameterValue(this string! value) -> bool
 static Microsoft.TemplateEngine.Utils.TemplateParameterExtensions.TokenizeMultiValueParameter(this string! literal) -> System.Collections.Generic.IReadOnlyList<string!>!
 static Microsoft.TemplateEngine.Utils.WellKnownSearchFilters.AuthorFilter(string? author) -> System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo?>!

--- a/src/Microsoft.TemplateEngine.Utils/TemplateParameterExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Utils/TemplateParameterExtensions.cs
@@ -10,25 +10,39 @@ using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Utils
 {
+    /// <summary>
+    /// Extensions helper methods for work with <see cref="ITemplateParameter"/>.
+    /// </summary>
     public static class TemplateParameterExtensions
     {
-        private const char[]? _whitespaceSeparators = null;
-        private static readonly char[] _multiValueSeparators = new[] { '|', ',' };
-
+        /// <summary>
+        /// Indicates whether the input parameter is of a choice type.
+        /// </summary>
+        /// <param name="parameter">Parameter to be inspected.</param>
+        /// <returns>True if given parameter is of a choice type, false otherwise.</returns>
         public static bool IsChoice(this ITemplateParameter parameter)
         {
             return parameter.DataType?.Equals("choice", StringComparison.OrdinalIgnoreCase) ?? false;
         }
 
-        public static IReadOnlyList<string> Tokenize(this string literal)
+        /// <summary>
+        /// Splits a string value representing a multi valued parameter (currently applicable only to choices) into atomic tokens.
+        /// </summary>
+        /// <param name="literal">A string representing multi valued parameter.</param>
+        /// <returns>List of atomic string tokens.</returns>
+        public static IReadOnlyList<string> TokenizeMultiValueParameter(this string literal)
         {
-            string[] tokens = literal.Split(_multiValueSeparators, StringSplitOptions.RemoveEmptyEntries);
-            if (tokens.Length == 1)
-            {
-                tokens = literal.Split(_whitespaceSeparators, StringSplitOptions.RemoveEmptyEntries);
-            }
+            return literal.Split(MultiValueParameter.MultiValueSeparators, StringSplitOptions.RemoveEmptyEntries);
+        }
 
-            return tokens.Select(t => t.Trim()).ToList();
+        /// <summary>
+        /// Check a multi valued parameter value (currently applicable only to choices), whether it doesn't contain any disallowed (separator) characters.
+        /// </summary>
+        /// <param name="value">Parameter value to be checked.</param>
+        /// <returns>True if given value doesn't contain any disallowed characters, false otherwise.</returns>
+        public static bool IsValidMultiValueParameterValue(this string value)
+        {
+            return value.IndexOfAny(MultiValueParameter.MultiValueSeparators) == -1;
         }
     }
 

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectConfigTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectConfigTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
                 Assert.Single(loggedMessages.Where(l => l.Item1 >= LogLevel.Warning));
                 string errorMessage = loggedMessages.First(l => l.Item1 >= LogLevel.Warning).Item2;
                 Assert.Contains(
-                    "Choice parameter  is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {First|Choice}",
+                    "Choice parameter  is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters ('|', ','). Invalid choices: {First|Choice}",
                     errorMessage);
             }
         }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectConfigTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectConfigTests.cs
@@ -1,0 +1,156 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using FakeItEasy;
+using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.SymbolModel;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.TemplateConfigTests;
+using Microsoft.TemplateEngine.TestHelper;
+using Microsoft.TemplateEngine.Utils;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using static Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
+{
+    public class RunnableProjectConfigTests : IClassFixture<EnvironmentSettingsHelper>
+    {
+        private readonly EnvironmentSettingsHelper _environmentSettingsHelper;
+
+        public RunnableProjectConfigTests(EnvironmentSettingsHelper environmentSettingsHelper)
+        {
+            _environmentSettingsHelper = environmentSettingsHelper;
+        }
+
+        private const string InvalidMultiChoiceDefinition = @"
+{
+    ""type"": ""parameter"",
+    ""description"": ""sample switch"",
+    ""datatype"": ""choice"",
+    ""allowMultipleValues"": true,
+    ""choices"": [
+    {
+        ""choice"": ""First|Choice"",
+        ""description"": ""First Sample Choice""
+
+    },
+    {
+        ""choice"": ""SecondChoice"",
+        ""description"": ""Second Sample Choice""
+    },
+    {
+        ""choice"": ""ThirdChoice"",
+        ""description"": ""Third Sample Choice""
+
+    }
+    ],
+    ""defaultValue "": ""ThirdChoice ""
+}
+";
+
+        private const string ValidChoiceDefinition = @"
+{
+    ""type"": ""parameter"",
+    ""description"": ""sample switch"",
+    ""datatype"": ""choice"",
+    ""allowMultipleValues"": true,
+    ""choices"": [
+    {
+        ""choice"": ""FirstChoice"",
+        ""description"": ""First Sample Choice""
+
+    },
+    {
+        ""choice"": ""SecondChoice"",
+        ""description"": ""Second Sample Choice""
+    },
+    {
+        ""choice"": ""ThirdChoice"",
+        ""description"": ""Third Sample Choice""
+
+    }
+    ],
+    ""defaultValue "": ""ThirdChoice ""
+}
+";
+
+        [Theory]
+        [InlineData(ValidChoiceDefinition, false, true)]
+        [InlineData(InvalidMultiChoiceDefinition, false, true)]
+        [InlineData(ValidChoiceDefinition, true, true)]
+        [InlineData(InvalidMultiChoiceDefinition, true, false)]
+        public void PerformTemplateValidation_ChoiceValuesValidation(string paramDefintion, bool isMultichoice, bool expectedToBeValid)
+        {
+            //
+            // Template content preparation
+            //
+
+            Guid inputTestGuid = new Guid("12aa8f4e-a4aa-4ac1-927c-94cb99485ef1");
+            string contentFileNamePrefix = "content - ";
+            JObject choiceParam = JObject.Parse(paramDefintion);
+            choiceParam["AllowMultipleValues"] = isMultichoice;
+            SimpleConfigModel config = new SimpleConfigModel()
+            {
+                Identity = "test",
+                Name = "name",
+                ShortNameList = new [] { "shortName" },
+                Symbols = new Dictionary<string, ISymbolModel>()
+                {
+                    { "ParamA", new ParameterSymbol(choiceParam, null) }
+                }
+            };
+
+            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>();
+            // template.json
+            templateSourceFiles.Add(TemplateConfigTestHelpers.DefaultConfigRelativePath, config.ToJObject().ToString());
+
+            //content
+            foreach (string guidFormat in GuidMacroConfig.DefaultFormats.Select(c => c.ToString()))
+            {
+                templateSourceFiles.Add(contentFileNamePrefix + guidFormat, inputTestGuid.ToString(guidFormat));
+            }
+
+            //
+            // Dependencies preparation and mounting
+            //
+
+            List<(LogLevel, string)> loggedMessages = new List<(LogLevel, string)>();
+            InMemoryLoggerProvider loggerProvider = new InMemoryLoggerProvider(loggedMessages);
+            IEngineEnvironmentSettings environment = _environmentSettingsHelper.CreateEnvironment(addLoggerProviders: new [] { loggerProvider });
+            string sourceBasePath = FileSystemHelpers.GetNewVirtualizedPath(environment);
+            string targetDir = FileSystemHelpers.GetNewVirtualizedPath(environment);
+            RunnableProjectGenerator rpg = new RunnableProjectGenerator();
+
+            TemplateConfigTestHelpers.WriteTemplateSource(environment, sourceBasePath, templateSourceFiles);
+            IMountPoint? sourceMountPoint = TemplateConfigTestHelpers.CreateMountPoint(environment, sourceBasePath);
+            RunnableProjectConfig runnableConfig = new RunnableProjectConfig(environment, rpg, config, sourceMountPoint.FileInfo(TemplateConfigTestHelpers.DefaultConfigRelativePath));
+
+            if (expectedToBeValid)
+            {
+                runnableConfig.PerformTemplateValidation();
+                Assert.Empty(loggedMessages.Where(l => l.Item1 >= LogLevel.Warning));
+            }
+            else
+            {
+                var exc = Assert.Throws<TemplateValidationException>(runnableConfig.PerformTemplateValidation);
+                Assert.Contains("The template configuration ", exc.Message);
+                Assert.Contains(" is not valid.", exc.Message);
+                Assert.Single(loggedMessages.Where(l => l.Item1 >= LogLevel.Warning));
+                string errorMessage = loggedMessages.First(l => l.Item1 >= LogLevel.Warning).Item2;
+                Assert.Contains(
+                    "Choice parameter  is invalid. It allows multiple values ('AllowMultipleValues=true'), while some of the configured choices contain separator characters. Invalid choices: {First|Choice}",
+                    errorMessage);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Problem
#4650 
Choice symbols with multiple values allowed parse some strings (default values, choice value sent over API etc.) and split them on `|` or `,` chars - hence if those chars would be present in the actual choice values, results would be broken.

### Solution
Adding template validation step, that validates choice symbols marked as allowing multiple values. Those choice symbols cannot have any choices that would contain the magic split chars

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)