### PR TITLE
[feature/constraints] fixed reading of args

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
@@ -6,7 +6,7 @@ Microsoft.TemplateEngine.Edge.TemplateConstraintManager.ConstraintInitialization
 Microsoft.TemplateEngine.Edge.TemplateConstraintManager.ConstraintInitializationException.ConstraintInitializationException(string! type, System.Exception? innerException = null) -> void
 Microsoft.TemplateEngine.Edge.TemplateConstraintManager.ConstraintInitializationException.Type.get -> string!
 Microsoft.TemplateEngine.Edge.TemplateConstraintManager.Dispose() -> void
-Microsoft.TemplateEngine.Edge.TemplateConstraintManager.EvaluateConstraintAsync(string! type, string! args, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.TemplateEngine.Abstractions.TemplateConstraintResult!>!
+Microsoft.TemplateEngine.Edge.TemplateConstraintManager.EvaluateConstraintAsync(string! type, string? args, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.TemplateEngine.Abstractions.TemplateConstraintResult!>!
 Microsoft.TemplateEngine.Edge.TemplateConstraintManager.GetConstraintsAsync(System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!>? templates = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ITemplateConstraint!>!>!
 Microsoft.TemplateEngine.Edge.TemplateConstraintManager.TemplateConstraintManager(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! engineEnvironmentSettings) -> void
 Microsoft.TemplateEngine.Edge.TemplateConstraintManager.UnknownConstraintException

--- a/src/Microsoft.TemplateEngine.Edge/TemplateConstraintManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/TemplateConstraintManager.cs
@@ -101,7 +101,7 @@ namespace Microsoft.TemplateEngine.Edge
         /// <exception cref="UnknownConstraintException">when the constraint of type <paramref name="type"/> is unknown.</exception>
         /// <exception cref="ConstraintInitializationException">when the constraint of type <paramref name="type"/> failed to initialize.</exception>
         /// <exception cref="ConstraintEvaluationException">when the constraint of type <paramref name="type"/> failed to evaluate for <paramref name="args"/>.</exception>
-        public async Task<TemplateConstraintResult> EvaluateConstraintAsync(string type, string args, CancellationToken cancellationToken)
+        public async Task<TemplateConstraintResult> EvaluateConstraintAsync(string type, string? args, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             if (!_templateConstrains.TryGetValue(type, out Task<ITemplateConstraint> task))

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModel.cs
@@ -199,7 +199,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     continue;
                 }
                 obj.TryGetValue(nameof(TemplateConstraintInfo.Args), StringComparison.OrdinalIgnoreCase, out JToken? args);
-                constraints.Add(new TemplateConstraintInfo(type!, args?.ToString()));
+                constraints.Add(new TemplateConstraintInfo(type!, args.ToJSONString()));
             }
             Constraints = constraints;
         }

--- a/src/Shared/JExtensions.cs
+++ b/src/Shared/JExtensions.cs
@@ -344,5 +344,23 @@ namespace Microsoft.TemplateEngine
             return token.ArrayAsStrings();
         }
 
+        /// <summary>
+        /// Converts <paramref name="token"/> to valid JSON string.
+        /// JToken.ToString() doesn't provide a valid JSON string for JTokenType == String.
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        internal static string? ToJSONString(this JToken? token)
+        {
+            if (token == null)
+            {
+                return null;
+            }
+            using StringWriter stringWriter = new StringWriter();
+            using JsonWriter jsonWriter = new JsonTextWriter(stringWriter);
+            token.WriteTo(jsonWriter);
+            return stringWriter.ToString();
+        }
+
     }
 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/ConstraintsTest.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/ConstraintsTest.cs
@@ -62,9 +62,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             Assert.Equal("con3", model.Constraints[2].Type);
             Assert.Equal("con4", model.Constraints[3].Type);
 
-            Assert.Equal("arg", model.Constraints[0].Args);
-            Assert.Equal(JArray.FromObject(new[] { "one", "two", "three" }).ToString(), model.Constraints[1].Args);
-            Assert.Equal(JObject.FromObject(new { one = "one", two = "two" }).ToString(), model.Constraints[2].Args);
+            Assert.Equal("\"arg\"", model.Constraints[0].Args);
+            Assert.Equal("[\"one\",\"two\",\"three\"]", model.Constraints[1].Args);
+            Assert.Equal("{\"one\":\"one\",\"two\":\"two\"}", model.Constraints[2].Args);
             Assert.Null(model.Constraints[3].Args);
         }
 


### PR DESCRIPTION
### Problem
Arguments were not read correctly when args was string.

### Solution
Fixed implementation so `string` also works.

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)