### PR TITLE
Implemented constraint on host and version

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Components.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Components.cs
@@ -28,7 +28,8 @@ namespace Microsoft.TemplateEngine.Edge
                 (typeof(ITemplatePackageProviderFactory), new GlobalSettingsTemplatePackageProviderFactory()),
                 (typeof(IInstallerFactory), new FolderInstallerFactory()),
                 (typeof(IInstallerFactory), new NuGetInstallerFactory()),
-                (typeof(ITemplateConstraintFactory), new OSConstraintFactory())
+                (typeof(ITemplateConstraintFactory), new OSConstraintFactory()),
+                (typeof(ITemplateConstraintFactory), new HostConstraintFactory())
             };
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Constraints/ConfigurationException.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Constraints/ConfigurationException.cs
@@ -21,5 +21,4 @@ namespace Microsoft.TemplateEngine.Edge.Constraints
         {
         }
     }
-
 }

--- a/src/Microsoft.TemplateEngine.Edge/Constraints/HostConstraint.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Constraints/HostConstraint.cs
@@ -1,0 +1,170 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Utils;
+using Newtonsoft.Json.Linq;
+using NuGet.Configuration;
+
+namespace Microsoft.TemplateEngine.Edge.Constraints
+{
+    internal class HostConstraintFactory : ITemplateConstraintFactory
+    {
+        public Guid Id { get; } = Guid.Parse("{93721B30-6890-403F-BAE7-5925990865A2}");
+
+        public string Type => "host";
+
+        public Task<ITemplateConstraint> CreateTemplateConstraintAsync(IEngineEnvironmentSettings environmentSettings, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult((ITemplateConstraint)new HostConstraint(environmentSettings, this));
+        }
+
+        internal class HostConstraint : ITemplateConstraint
+        {
+            private readonly IEngineEnvironmentSettings _environmentSettings;
+            private readonly ITemplateConstraintFactory _factory;
+
+            internal HostConstraint(IEngineEnvironmentSettings environmentSettings, ITemplateConstraintFactory factory)
+            {
+                _environmentSettings = environmentSettings;
+                _factory = factory;
+            }
+
+            public string Type => _factory.Type;
+
+            public string DisplayName => "Template engine host";
+
+            public TemplateConstraintResult Evaluate(string? args)
+            {
+                try
+                {
+                    IEnumerable<HostInformation> supportedHosts = ParseArgs(args);
+
+                    foreach (HostInformation hostInfo in supportedHosts)
+                    {
+                        if (hostInfo.HostName.Equals(_environmentSettings.Host.HostIdentifier, StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (hostInfo.Version == null || hostInfo.Version.CheckIfVersionIsValid(_environmentSettings.Host.Version))
+                            {
+                                return new TemplateConstraintResult(TemplateConstraintResult.Status.Allowed);
+                            }
+                        }
+                    }
+                    string errorMessage = string.Format(LocalizableStrings.HostConstraint_Message_Restricted, _environmentSettings.Host.HostIdentifier, _environmentSettings.Host.Version, string.Join(", ", supportedHosts));
+                    return new TemplateConstraintResult(TemplateConstraintResult.Status.Restricted, errorMessage);
+                }
+                catch (ConfigurationException ce)
+                {
+                    return new TemplateConstraintResult(TemplateConstraintResult.Status.NotEvaluated, ce.Message, LocalizableStrings.Generic_Constraint_WrongConfigurationCTA);
+                }
+            }
+
+            // configuration examples
+            // "args": [
+            //      {
+            //          "hostName": "dotnetcli",
+            //          "version": "5.0.100"
+            //      },
+            //      {
+            //          "hostName": "ide",
+            //          "version": "[16.0-*]"
+            //      }]
+            private static IEnumerable<HostInformation> ParseArgs(string? args)
+            {
+                if (string.IsNullOrWhiteSpace(args))
+                {
+                    throw new ConfigurationException(LocalizableStrings.HostConstraint_Error_ArgumentsNotSpecified);
+                }
+
+                JToken? token;
+                try
+                {
+                    token = JToken.Parse(args!);
+                }
+                catch (Exception e)
+                {
+                    throw new ConfigurationException(string.Format(LocalizableStrings.HostConstraint_Error_InvalidJson, args), e);
+                }
+
+                if (token is not JArray array)
+                {
+                    throw new ConfigurationException(string.Format(LocalizableStrings.HostConstraint_Error_InvalidJsonArray, args));
+                }
+
+                List<HostInformation> hostInformation = new List<HostInformation>();
+
+                foreach (JToken value in array)
+                {
+                    if (value is not JObject jobj)
+                    {
+                        throw new ConfigurationException(string.Format(LocalizableStrings.HostConstraint_Error_InvalidJsonArray_Objects, args));
+                    }
+
+                    string? hostName = jobj.ToString("hostname");
+                    string? version = jobj.ToString("version");
+
+                    if (string.IsNullOrWhiteSpace(hostName))
+                    {
+                        throw new ConfigurationException(string.Format(LocalizableStrings.HostConstraint_Error_MissingMandatoryProperty, jobj, "hostname"));
+                    }
+                    if (string.IsNullOrWhiteSpace(version))
+                    {
+                        hostInformation.Add(new HostInformation(hostName!));
+                        continue;
+                    }
+                    if (ExactVersionSpecification.TryParse(version!, out IVersionSpecification? exactVersion))
+                    {
+                        hostInformation.Add(new HostInformation(hostName!, exactVersion));
+                        continue;
+                    }
+                    else if (RangeVersionSpecification.TryParse(version!, out IVersionSpecification? rangeVersion))
+                    {
+                        hostInformation.Add(new HostInformation(hostName!, rangeVersion));
+                        continue;
+                    }
+                    throw new ConfigurationException(string.Format(LocalizableStrings.HostConstraint_Error_InvalidVersion, version));
+                }
+
+                if (!hostInformation.Any())
+                {
+                    throw new ConfigurationException(string.Format(LocalizableStrings.HostConstraint_Error_ArrayHasNoObjects, args));
+                }
+                return hostInformation;
+            }
+
+            private class HostInformation
+            {
+                public HostInformation(string host, IVersionSpecification? version = null)
+                {
+                    if (string.IsNullOrWhiteSpace(host))
+                    {
+                        throw new ArgumentException($"'{nameof(host)}' cannot be null or whitespace.", nameof(host));
+                    }
+
+                    HostName = host;
+                    Version = version;
+                }
+
+                public string HostName { get; }
+
+                public IVersionSpecification? Version { get; }
+
+                public override string ToString()
+                {
+                    return Version == null
+                        ? HostName
+                        : $"{HostName}({Version})";
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Constraints/HostConstraint.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Constraints/HostConstraint.cs
@@ -49,9 +49,20 @@ namespace Microsoft.TemplateEngine.Edge.Constraints
                 {
                     IEnumerable<HostInformation> supportedHosts = ParseArgs(args);
 
-                    foreach (HostInformation hostInfo in supportedHosts)
+                    //check primary host name first
+                    bool primaryHostNameMatch = false;
+                    foreach (HostInformation hostInfo in supportedHosts.Where(h => h.HostName.Equals(_environmentSettings.Host.HostIdentifier, StringComparison.OrdinalIgnoreCase)))
                     {
-                        if (hostInfo.HostName.Equals(_environmentSettings.Host.HostIdentifier, StringComparison.OrdinalIgnoreCase))
+                        primaryHostNameMatch = true;
+                        if (hostInfo.Version == null || hostInfo.Version.CheckIfVersionIsValid(_environmentSettings.Host.Version))
+                        {
+                            return TemplateConstraintResult.CreateAllowed(Type);
+                        }
+                    }
+                    if (!primaryHostNameMatch)
+                    {
+                        //if there is no primary host name, check fallback host names
+                        foreach (HostInformation hostInfo in supportedHosts.Where(h => _environmentSettings.Host.FallbackHostTemplateConfigNames.Contains(h.HostName, StringComparer.OrdinalIgnoreCase)))
                         {
                             if (hostInfo.Version == null || hostInfo.Version.CheckIfVersionIsValid(_environmentSettings.Host.Version))
                             {

--- a/src/Microsoft.TemplateEngine.Edge/Constraints/NuGetFloatRangeSpecification.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Constraints/NuGetFloatRangeSpecification.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.TemplateEngine.Utils;
+using NuGet.Versioning;
+
+namespace Microsoft.TemplateEngine.Edge.Constraints
+{
+    internal class NuGetFloatRangeSpecification : IVersionSpecification
+    {
+        private readonly FloatRange _version;
+
+        internal NuGetFloatRangeSpecification(FloatRange version)
+        {
+            _version = version;
+        }
+
+        public bool CheckIfVersionIsValid(string versionToCheck)
+        {
+            if (NuGetVersion.TryParse(versionToCheck, out NuGetVersion nuGetVersion2))
+            {
+                return _version.Satisfies(nuGetVersion2);
+            }
+            return false;
+        }
+
+        public override string ToString() => _version.ToString();
+
+        internal static bool TryParse(string value, out NuGetFloatRangeSpecification? version)
+        {
+            if (FloatRange.TryParse(value, out FloatRange versionRange))
+            {
+                version = new NuGetFloatRangeSpecification(versionRange);
+                return true;
+            }
+            version = null;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Constraints/NuGetVersionRangeSpecification.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Constraints/NuGetVersionRangeSpecification.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.TemplateEngine.Utils;
+using NuGet.Versioning;
+
+namespace Microsoft.TemplateEngine.Edge.Constraints
+{
+    internal class NuGetVersionRangeSpecification : IVersionSpecification
+    {
+        private readonly VersionRange _versionRange;
+
+        internal NuGetVersionRangeSpecification(VersionRange versionRange)
+        {
+            _versionRange = versionRange;
+        }
+
+        public bool CheckIfVersionIsValid(string versionToCheck)
+        {
+            if (NuGetVersion.TryParse(versionToCheck, out NuGetVersion nuGetVersion2))
+            {
+                return _versionRange.Satisfies(nuGetVersion2);
+            }
+            return false;
+        }
+
+        public override string ToString() => _versionRange.ToString();
+
+        internal static bool TryParse(string value, out NuGetVersionRangeSpecification? version)
+        {
+            if (VersionRange.TryParse(value, out VersionRange versionRange))
+            {
+                version = new NuGetVersionRangeSpecification(versionRange);
+                return true;
+            }
+            version = null;
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Constraints/NuGetVersionSpecification.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Constraints/NuGetVersionSpecification.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.TemplateEngine.Utils;
+using NuGet.Versioning;
+
+namespace Microsoft.TemplateEngine.Edge.Constraints
+{
+    internal class NuGetVersionSpecification : IVersionSpecification
+    {
+        private readonly NuGetVersion _version;
+
+        internal NuGetVersionSpecification (NuGetVersion version)
+        {
+            _version = version;
+        }
+
+        public bool CheckIfVersionIsValid(string versionToCheck)
+        {
+            if (NuGetVersion.TryParse(versionToCheck, out NuGetVersion nuGetVersion2))
+            {
+                return _version == nuGetVersion2;
+            }
+            return false;
+        }
+
+        public override string ToString() => _version.ToString();
+
+        internal static bool TryParse(string value, out NuGetVersionSpecification? version)
+        {
+            if (NuGetVersion.TryParse(value, out NuGetVersion nuGetVersion))
+            {
+                version = new NuGetVersionSpecification(nuGetVersion);
+                return true;
+            }
+            version = null;
+            return false;
+        }
+
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
@@ -106,6 +106,15 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Check the constraint configuration in template.json..
+        /// </summary>
+        internal static string Generic_Constraint_WrongConfigurationCTA {
+            get {
+                return ResourceManager.GetString("Generic_Constraint_WrongConfigurationCTA", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to latest version.
         /// </summary>
         internal static string Generic_LatestVersion {
@@ -168,6 +177,78 @@ namespace Microsoft.TemplateEngine.Edge {
         internal static string GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled {
             get {
                 return ResourceManager.GetString("GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Argument(s) were not specified. At least one argument should be specified..
+        /// </summary>
+        internal static string HostConstraint_Error_ArgumentsNotSpecified {
+            get {
+                return ResourceManager.GetString("HostConstraint_Error_ArgumentsNotSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; does not contain valid host configurations..
+        /// </summary>
+        internal static string HostConstraint_Error_ArrayHasNoObjects {
+            get {
+                return ResourceManager.GetString("HostConstraint_Error_ArrayHasNoObjects", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid JSON.
+        /// </summary>
+        internal static string HostConstraint_Error_InvalidJson {
+            get {
+                return ResourceManager.GetString("HostConstraint_Error_InvalidJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid JSON array..
+        /// </summary>
+        internal static string HostConstraint_Error_InvalidJsonArray {
+            get {
+                return ResourceManager.GetString("HostConstraint_Error_InvalidJsonArray", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; should be an array of objects..
+        /// </summary>
+        internal static string HostConstraint_Error_InvalidJsonArray_Objects {
+            get {
+                return ResourceManager.GetString("HostConstraint_Error_InvalidJsonArray_Objects", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid version or version range..
+        /// </summary>
+        internal static string HostConstraint_Error_InvalidVersion {
+            get {
+                return ResourceManager.GetString("HostConstraint_Error_InvalidVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; does not have mandatory property &apos;{1}&apos;..
+        /// </summary>
+        internal static string HostConstraint_Error_MissingMandatoryProperty {
+            get {
+                return ResourceManager.GetString("HostConstraint_Error_MissingMandatoryProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}..
+        /// </summary>
+        internal static string HostConstraint_Message_Restricted {
+            get {
+                return ResourceManager.GetString("HostConstraint_Message_Restricted", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -134,6 +134,9 @@
   <data name="FolderInstaller_InstallResult_Error_FolderDoesNotExist" xml:space="preserve">
     <value>The folder {0} doesn't exist.</value>
   </data>
+  <data name="Generic_Constraint_WrongConfigurationCTA" xml:space="preserve">
+    <value>Check the constraint configuration in template.json.</value>
+  </data>
   <data name="Generic_LatestVersion" xml:space="preserve">
     <value>latest version</value>
     <comment>small letters, string is used in the sentence</comment>
@@ -156,6 +159,39 @@
   </data>
   <data name="GlobalSettingsTemplatePackagesProvider_Info_PackageUninstalled" xml:space="preserve">
     <value>{0} was successfully uninstalled.</value>
+  </data>
+  <data name="HostConstraint_Error_ArgumentsNotSpecified" xml:space="preserve">
+    <value>Argument(s) were not specified. At least one argument should be specified.</value>
+  </data>
+  <data name="HostConstraint_Error_ArrayHasNoObjects" xml:space="preserve">
+    <value>'{0}' does not contain valid host configurations.</value>
+    <comment>{0} is JSON configuration for constraint</comment>
+  </data>
+  <data name="HostConstraint_Error_InvalidJson" xml:space="preserve">
+    <value>'{0}' is not a valid JSON</value>
+    <comment>{0} is JSON configuration for constraint</comment>
+  </data>
+  <data name="HostConstraint_Error_InvalidJsonArray" xml:space="preserve">
+    <value>'{0}' is not a valid JSON array.</value>
+    <comment>{0} is JSON configuration for constraint</comment>
+  </data>
+  <data name="HostConstraint_Error_InvalidJsonArray_Objects" xml:space="preserve">
+    <value>'{0}' should be an array of objects.</value>
+    <comment>{0} is JSON configuration for constraint</comment>
+  </data>
+  <data name="HostConstraint_Error_InvalidVersion" xml:space="preserve">
+    <value>'{0}' is not a valid version or version range.</value>
+    <comment>{0} is version range specified in JSON configuration</comment>
+  </data>
+  <data name="HostConstraint_Error_MissingMandatoryProperty" xml:space="preserve">
+    <value>'{0}' does not have mandatory property '{1}'.</value>
+    <comment>{0} is JSON configuration, {1} mandatory JSON property name</comment>
+  </data>
+  <data name="HostConstraint_Message_Restricted" xml:space="preserve">
+    <value>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</value>
+    <comment>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</comment>
   </data>
   <data name="NuGetApiPackageManager_Error_FailedToLoadSource" xml:space="preserve">
     <value>Failed to load the NuGet source {0}.</value>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Složka {0} neexistuje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">nejnovější verze</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">Balíček {0} se úspěšně odinstaloval.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Der Ordner \"{0}\" ist nicht vorhanden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">Aktuelle Version</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">\"{0}\" wurde erfolgreich deinstalliert.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -27,6 +27,11 @@
         <target state="translated">La carpeta de origen {0} no existe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">la versión más reciente</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">{0} se desinstaló correctamente.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Le dossier {0} n’existe pas.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">Dernière version</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">{0} a été désinstallé.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -27,6 +27,11 @@
         <target state="translated">La cartella {0} non esiste.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">ultima versione</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">{0} è stato disinstallato.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -27,6 +27,11 @@
         <target state="translated">フォルダー {0} が存在しません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">最新バージョン</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">{0} が正常にアンインストールされました。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -27,6 +27,11 @@
         <target state="translated">폴더 {0}이(가) 존재하지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">최신 버전</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">{0}이(가) 성공적으로 제거되었습니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Folder{0} nie istnieje.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">najnowszą wersją</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">Pomyślnie odinstalowano pakiet {0}.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="translated">A pasta {0} não existe.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">versão mais recente</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">{0} foi desinstalado com sucesso.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -27,6 +27,11 @@
         <target state="translated">Папка {0} не существует.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">последняя версия</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">Выполнено удаление {0}.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -27,6 +27,11 @@
         <target state="translated">{0} klasörü yok.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">en son sürüm</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">{0} başarıyla kaldırıldı.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="translated">文件夹 {0} 不存在。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">最新版本</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">已成功卸载 {0}。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="translated">資料夾 {0} 不存在。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generic_Constraint_WrongConfigurationCTA">
+        <source>Check the constraint configuration in template.json.</source>
+        <target state="new">Check the constraint configuration in template.json.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generic_LatestVersion">
         <source>latest version</source>
         <target state="translated">最新版本</target>
@@ -61,6 +66,48 @@
         <source>{0} was successfully uninstalled.</source>
         <target state="translated">{0} 已成功解除安裝。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArgumentsNotSpecified">
+        <source>Argument(s) were not specified. At least one argument should be specified.</source>
+        <target state="new">Argument(s) were not specified. At least one argument should be specified.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_ArrayHasNoObjects">
+        <source>'{0}' does not contain valid host configurations.</source>
+        <target state="new">'{0}' does not contain valid host configurations.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJson">
+        <source>'{0}' is not a valid JSON</source>
+        <target state="new">'{0}' is not a valid JSON</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray">
+        <source>'{0}' is not a valid JSON array.</source>
+        <target state="new">'{0}' is not a valid JSON array.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidJsonArray_Objects">
+        <source>'{0}' should be an array of objects.</source>
+        <target state="new">'{0}' should be an array of objects.</target>
+        <note>{0} is JSON configuration for constraint</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_InvalidVersion">
+        <source>'{0}' is not a valid version or version range.</source>
+        <target state="new">'{0}' is not a valid version or version range.</target>
+        <note>{0} is version range specified in JSON configuration</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
+        <source>'{0}' does not have mandatory property '{1}'.</source>
+        <target state="new">'{0}' does not have mandatory property '{1}'.</target>
+        <note>{0} is JSON configuration, {1} mandatory JSON property name</note>
+      </trans-unit>
+      <trans-unit id="HostConstraint_Message_Restricted">
+        <source>Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</source>
+        <target state="new">Running template on {0} (version: {1}) is not supported, supported hosts is/are: {2}.</target>
+        <note>{0} - host name ("dotnetcli", "ide"..)
+{1} - host version (usually matches VS or SDK version)
+{2} - comma-separated list of supported hosts and their versions (example: host1, host2(1.0.0), host3([1.0.0-*]))</note>
       </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Error_FailedToLoadSource">
         <source>Failed to load the NuGet source {0}.</source>

--- a/src/Microsoft.TemplateEngine.Utils/ExactVersionSpecification.cs
+++ b/src/Microsoft.TemplateEngine.Utils/ExactVersionSpecification.cs
@@ -31,5 +31,8 @@ namespace Microsoft.TemplateEngine.Utils
             int? result = VersionStringHelpers.CompareVersions(RequiredVersion, versionToCheck);
             return result.HasValue && result.Value == 0;
         }
+
+        /// <inheritdoc/>
+        public override string ToString() => RequiredVersion;
     }
 }

--- a/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
@@ -4,10 +4,12 @@ Microsoft.TemplateEngine.Utils.MultiValueParameter.MultiValueParameter(System.Co
 Microsoft.TemplateEngine.Utils.MultiValueParameter.Values.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateEngine.Utils.TemplateParameter.AllowMultipleValues.get -> bool
 Microsoft.TemplateEngine.Utils.TemplateParameter.TemplateParameter(string! name, string! type, string! datatype, Microsoft.TemplateEngine.Abstractions.TemplateParameterPriority priority = Microsoft.TemplateEngine.Abstractions.TemplateParameterPriority.Required, bool isName = false, string? defaultValue = null, string? defaultIfOptionWithoutValue = null, string? description = null, string? displayName = null, bool allowMultipleValues = false, System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Abstractions.ParameterChoice!>? choices = null) -> void
+override Microsoft.TemplateEngine.Utils.ExactVersionSpecification.ToString() -> string!
 override Microsoft.TemplateEngine.Utils.MultiValueParameter.ToString() -> string!
 static Microsoft.TemplateEngine.Utils.MultiValueParameter.MultiValueSeparators.get -> char[]!
 static Microsoft.TemplateEngine.Utils.TemplateParameterExtensions.IsValidMultiValueParameterValue(this string! value) -> bool
 static Microsoft.TemplateEngine.Utils.TemplateParameterExtensions.TokenizeMultiValueParameter(this string! literal) -> System.Collections.Generic.IReadOnlyList<string!>!
+override Microsoft.TemplateEngine.Utils.RangeVersionSpecification.ToString() -> string!
 static Microsoft.TemplateEngine.Utils.WellKnownSearchFilters.AuthorFilter(string? author) -> System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo?>!
 static Microsoft.TemplateEngine.Utils.WellKnownSearchFilters.BaselineFilter(string? baselineName) -> System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo?>!
 static Microsoft.TemplateEngine.Utils.WellKnownSearchFilters.ClassificationFilter(string? classification) -> System.Func<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!, Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo?>!

--- a/src/Microsoft.TemplateEngine.Utils/RangeVersionSpecification.cs
+++ b/src/Microsoft.TemplateEngine.Utils/RangeVersionSpecification.cs
@@ -3,6 +3,8 @@
 
 #nullable enable
 
+using System.Text;
+
 namespace Microsoft.TemplateEngine.Utils
 {
     public class RangeVersionSpecification : IVersionSpecification
@@ -130,6 +132,12 @@ namespace Microsoft.TemplateEngine.Utils
             }
 
             return isStartValid && isEndValid;
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"{(IsStartInclusive ? "[" : "(")}{MinVersion}-{MaxVersion}{(IsEndInclusive ? "]" : ")")}";
         }
 
         private static bool IsWildcardVersion(string version)

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/HostConstraintTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/HostConstraintTests.cs
@@ -1,0 +1,196 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FakeItEasy;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Edge.Constraints;
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.TemplateEngine.Edge.UnitTests
+{
+    public class HostConstraintTests
+    {   
+        [Fact]
+        public async Task CanReadConfiguration_WithoutVersion()
+        {
+            var config = new
+            {
+                identity = "test",
+                constraints = new
+                {
+                    host = new
+                    {
+                        type = "host",
+                        args = new[]
+                        {
+                            new
+                            {
+                                hostName = "host1",
+                                version = ""
+                            },
+                            new
+                            {
+                                hostName = "host2",
+                                version = "1.0.0"
+                            },
+                            new
+                            {
+                                hostName = "host3",
+                                version = "[1.0.0-*]"
+                            },
+
+                        }
+                    }
+                }
+            };
+
+            var configModel = SimpleConfigModel.FromJObject(JObject.FromObject(config));
+            IEngineEnvironmentSettings settings = A.Fake<IEngineEnvironmentSettings>();
+            A.CallTo(() => settings.Host.HostIdentifier).Returns("host1");
+            A.CallTo(() => settings.Host.Version).Returns("2.0.0");
+            A.CallTo(() => settings.Components.OfType<ITemplateConstraintFactory>()).Returns(new[] { new HostConstraintFactory() });
+
+            var constraintManager = new TemplateConstraintManager(settings);
+            var evaluateResult = await constraintManager.EvaluateConstraintAsync(configModel.Constraints.Single().Type, configModel.Constraints.Single().Args, default).ConfigureAwait(false);
+            Assert.Equal(TemplateConstraintResult.Status.Allowed, evaluateResult.EvaluationStatus);
+        }
+
+        [Fact]
+        public async Task CanReadConfiguration_ExactVersion()
+        {
+            var config = new
+            {
+                identity = "test",
+                constraints = new
+                {
+                    host = new
+                    {
+                        type = "host",
+                        args = new[]
+                        {
+                            new
+                            {
+                                hostName = "host1",
+                                version = ""
+                            },
+                            new
+                            {
+                                hostName = "host2",
+                                version = "1.0.0"
+                            },
+                            new
+                            {
+                                hostName = "host3",
+                                version = "[1.0.0-*]"
+                            },
+
+                        }
+                    }
+                }
+            };
+
+            var configModel = SimpleConfigModel.FromJObject(JObject.FromObject(config));
+            IEngineEnvironmentSettings settings = A.Fake<IEngineEnvironmentSettings>();
+            A.CallTo(() => settings.Host.HostIdentifier).Returns("host2");
+            A.CallTo(() => settings.Host.Version).Returns("2.0.0");
+            A.CallTo(() => settings.Components.OfType<ITemplateConstraintFactory>()).Returns(new[] { new HostConstraintFactory() });
+
+            var constraintManager = new TemplateConstraintManager(settings);
+            var evaluateResult = await constraintManager.EvaluateConstraintAsync(configModel.Constraints.Single().Type, configModel.Constraints.Single().Args, default).ConfigureAwait(false);
+            Assert.Equal(TemplateConstraintResult.Status.Restricted, evaluateResult.EvaluationStatus);
+            Assert.Equal("Running template on host2 (version: 2.0.0) is not supported, supported hosts is/are: host1, host2(1.0.0), host3([1.0.0-*]).", evaluateResult.LocalizedErrorMessage);
+            Assert.Null(evaluateResult.CallToAction);
+
+        }
+
+        [Fact]
+        public async Task CanReadConfiguration_VersionRange()
+        {
+            var config = new
+            {
+                identity = "test",
+                constraints = new
+                {
+                    host = new
+                    {
+                        type = "host",
+                        args = new[]
+                        {
+                            new
+                            {
+                                hostName = "host1",
+                                version = ""
+                            },
+                            new
+                            {
+                                hostName = "host2",
+                                version = "1.0.0"
+                            },
+                            new
+                            {
+                                hostName = "host3",
+                                version = "[1.0.0-*]"
+                            },
+
+                        }
+                    }
+                }
+            };
+
+            var configModel = SimpleConfigModel.FromJObject(JObject.FromObject(config));
+
+            IEngineEnvironmentSettings settings = A.Fake<IEngineEnvironmentSettings>();
+            A.CallTo(() => settings.Host.HostIdentifier).Returns("host3");
+            A.CallTo(() => settings.Host.Version).Returns("2.0.0");
+            A.CallTo(() => settings.Components.OfType<ITemplateConstraintFactory>()).Returns(new[] { new HostConstraintFactory() });
+
+            var constraintManager = new TemplateConstraintManager(settings);
+            var evaluateResult = await constraintManager.EvaluateConstraintAsync(configModel.Constraints.Single().Type, configModel.Constraints.Single().Args, default).ConfigureAwait(false);
+            Assert.Equal(TemplateConstraintResult.Status.Allowed, evaluateResult.EvaluationStatus);
+        }
+
+        [Fact]
+        public async Task FailsOnWrongConfiguration()
+        {
+            var config = new
+            {
+                identity = "test",
+                constraints = new
+                {
+                    host = new
+                    {
+                        type = "host",
+                        args =
+                            new
+                            {
+                                hostName = "host2",
+                                version = "1.0.0"
+                            }
+                    }
+                }
+            };
+
+            var configModel = SimpleConfigModel.FromJObject(JObject.FromObject(config));
+
+            IEngineEnvironmentSettings settings = A.Fake<IEngineEnvironmentSettings>();
+            A.CallTo(() => settings.Host.HostIdentifier).Returns("host3");
+            A.CallTo(() => settings.Host.Version).Returns("2.0.0");
+            A.CallTo(() => settings.Components.OfType<ITemplateConstraintFactory>()).Returns(new[] { new HostConstraintFactory() });
+
+            var constraintManager = new TemplateConstraintManager(settings);
+            var evaluateResult = await constraintManager.EvaluateConstraintAsync(configModel.Constraints.Single().Type, configModel.Constraints.Single().Args, default).ConfigureAwait(false);
+            Assert.Equal(TemplateConstraintResult.Status.NotEvaluated, evaluateResult.EvaluationStatus);
+            Assert.Equal("'{\"hostName\":\"host2\",\"version\":\"1.0.0\"}' is not a valid JSON array.", evaluateResult.LocalizedErrorMessage);
+            Assert.Equal("Check the constraint configuration in template.json.", evaluateResult.CallToAction);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/HostConstraintTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/HostConstraintTests.cs
@@ -192,5 +192,110 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             Assert.Equal("'{\"hostName\":\"host2\",\"version\":\"1.0.0\"}' is not a valid JSON array.", evaluateResult.LocalizedErrorMessage);
             Assert.Equal("Check the constraint configuration in template.json.", evaluateResult.CallToAction);
         }
+
+        [Theory]
+        [InlineData("1.0.0", "1.0", true)]
+        [InlineData("(, 1.0.0]", "1.0", true)]
+        [InlineData("(, 1.0.0]", "2.0", false)]
+        [InlineData("[1.0.0]", "1.0.0", true)]
+        [InlineData("[1.0.0]", "2.0.0", false)]
+        [InlineData("[1.0, 2.0-preview3]", "2.0-preview1", true)]
+        [InlineData("[1.0, 2.0-preview3]", "2.0-preview4", false)]
+        [InlineData("[1.0, 2.0-preview3]", "2.0", false)]
+        [InlineData("[1.0, 2.0]", "1.2", true)]
+        [InlineData("[1.0, 2.0]", "2.2", false)]
+        //legacy format
+        [InlineData("[1.0-*]", "2.2", true)]
+        [InlineData("[*-2.0]", "2.2", false)]
+        public async Task CanProcessDifferentVersions(string configuredVersion, string hostVersion, bool expectedResult)
+        {
+            var config = new
+            {
+                identity = "test",
+                constraints = new
+                {
+                    host = new
+                    {
+                        type = "host",
+                        args = new[]
+                        {
+                            new
+                            {
+                                hostName = "host1",
+                                version = configuredVersion
+                            }
+                        }
+                    }
+                }
+            };
+
+            var configModel = SimpleConfigModel.FromJObject(JObject.FromObject(config));
+            IEngineEnvironmentSettings settings = A.Fake<IEngineEnvironmentSettings>();
+            A.CallTo(() => settings.Host.HostIdentifier).Returns("host1");
+            A.CallTo(() => settings.Host.Version).Returns(hostVersion);
+            A.CallTo(() => settings.Components.OfType<ITemplateConstraintFactory>()).Returns(new[] { new HostConstraintFactory() });
+
+            var constraintManager = new TemplateConstraintManager(settings);
+            var evaluateResult = await constraintManager.EvaluateConstraintAsync(configModel.Constraints.Single().Type, configModel.Constraints.Single().Args, default).ConfigureAwait(false);
+            if (expectedResult)
+            {
+                Assert.Equal(TemplateConstraintResult.Status.Allowed, evaluateResult.EvaluationStatus);
+            }
+            else
+            {
+                Assert.Equal(TemplateConstraintResult.Status.Restricted, evaluateResult.EvaluationStatus);
+            }
+        }
+
+        [Theory]
+        [InlineData("host1", "fallback|other", "1.1", true)]
+        [InlineData("host1", "fallback|other", "2.1", false)]
+        [InlineData("host2", "fallback|other", "2.1", true)]
+        [InlineData("host2", "fallback|other", "3.1", false)]
+        public async Task CanProcessDifferentHostNames(string hostName, string fallbackHostNames, string hostVersion,  bool expectedResult)
+        {
+            var config = new
+            {
+                identity = "test",
+                constraints = new
+                {
+                    host = new
+                    {
+                        type = "host",
+                        args = new[]
+                        {
+                            new
+                            {
+                                hostName = "host1",
+                                version = "[1.0, 2.0]"
+                            },
+                            new
+                            {
+                                hostName = "fallback",
+                                version = "[2.0, 3.0]"
+                            },
+                        }
+                    }
+                }
+            };
+
+            var configModel = SimpleConfigModel.FromJObject(JObject.FromObject(config));
+            IEngineEnvironmentSettings settings = A.Fake<IEngineEnvironmentSettings>();
+            A.CallTo(() => settings.Host.HostIdentifier).Returns(hostName);
+            A.CallTo(() => settings.Host.Version).Returns(hostVersion);
+            A.CallTo(() => settings.Host.FallbackHostTemplateConfigNames).Returns(fallbackHostNames.Split('|'));
+            A.CallTo(() => settings.Components.OfType<ITemplateConstraintFactory>()).Returns(new[] { new HostConstraintFactory() });
+
+            var constraintManager = new TemplateConstraintManager(settings);
+            var evaluateResult = await constraintManager.EvaluateConstraintAsync(configModel.Constraints.Single().Type, configModel.Constraints.Single().Args, default).ConfigureAwait(false);
+            if (expectedResult)
+            {
+                Assert.Equal(TemplateConstraintResult.Status.Allowed, evaluateResult.EvaluationStatus);
+            }
+            else
+            {
+                Assert.Equal(TemplateConstraintResult.Status.Restricted, evaluateResult.EvaluationStatus);
+            }
+        }
     }
 }

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/TemplateConstraintManagerTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/TemplateConstraintManagerTests.cs
@@ -61,8 +61,8 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
 
             var constraints = await constraintManager.GetConstraintsAsync().ConfigureAwait(false);
 
-            Assert.Equal(3, constraints.Count);
-            Assert.Equal(new[] { "os", "test-1", "test-2" }, constraints.Select(c => c.Type).OrderBy(t => t));
+            Assert.Equal(4, constraints.Count);
+            Assert.Equal(new[] { "host", "os", "test-1", "test-2" }, constraints.Select(c => c.Type).OrderBy(t => t));
         }
 
         [Fact]
@@ -96,8 +96,8 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             var constraintManager = new TemplateConstraintManager(engineEnvironmentSettings);
             var constraints = await constraintManager.GetConstraintsAsync().ConfigureAwait(false);
 
-            Assert.Equal(2, constraints.Count);
-            Assert.Equal(new[] { "os", "test-2" }, constraints.Select(c => c.Type).OrderBy(t => t));
+            Assert.Equal(3, constraints.Count);
+            Assert.Equal(new[] { "host", "os", "test-2" }, constraints.Select(c => c.Type).OrderBy(t => t));
         }
 
         [Fact]


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/3107

### Solution
Implemented constraint on host and version.
For versions parsing, I'm using implementation from `TemplateEngine.Utils`. Let's discuss if it's enough for the purpose.


### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)