### PR TITLE
Adjust help text wording

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/Commands/HelpStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/HelpStrings.Designer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Allow multiple values: {0}.
+        ///   Looks up a localized string similar to Multiple values are allowed: {0}.
         /// </summary>
         internal static string RowHeader_AllowMultiValue {
             get {

--- a/src/Microsoft.TemplateEngine.Cli/Commands/HelpStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/HelpStrings.resx
@@ -137,7 +137,7 @@
     <value>This template contains technologies from parties other than Microsoft, see {0} for details.</value>
   </data>
   <data name="RowHeader_AllowMultiValue" xml:space="preserve">
-    <value>Allow multiple values: {0}</value>
+    <value>Multiple values are allowed: {0}</value>
     <comment>{0} is a boolean flag</comment>
   </data>
   <data name="RowHeader_DefaultIfOptionWithoutValue" xml:space="preserve">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.cs.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">Povolit více hodnot: {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">Povolit více hodnot: {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.de.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">Mehrere Werte zulassen: {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">Mehrere Werte zulassen: {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.es.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">Permitir varios valores: {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">Permitir varios valores: {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.fr.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">Autoriser les valeurs multiples : {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">Autoriser les valeurs multiples : {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.it.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">Consenti più valori: {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">Consenti più valori: {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.ja.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">複数の値を許可: {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">複数の値を許可: {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.ko.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">다중 값 허용: {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">다중 값 허용: {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.pl.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">Zezwalaj na wiele wartości: {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">Zezwalaj na wiele wartości: {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.pt-BR.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">Permitir vários valores: {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">Permitir vários valores: {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.ru.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">Разрешить несколько значений: {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">Разрешить несколько значений: {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.tr.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">Birden çok değere izin ver: {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">Birden çok değere izin ver: {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.zh-Hans.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">允许多个值: {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">允许多个值: {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/xlf/HelpStrings.zh-Hant.xlf
@@ -28,8 +28,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RowHeader_AllowMultiValue">
-        <source>Allow multiple values: {0}</source>
-        <target state="translated">允許多個值: {0}</target>
+        <source>Multiple values are allowed: {0}</source>
+        <target state="needs-review-translation">允許多個值: {0}</target>
         <note>{0} is a boolean flag</note>
       </trans-unit>
       <trans-unit id="RowHeader_DefaultIfOptionWithoutValue">

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MultipleValueChoice.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewHelp.CanShowHelpForTemplate_MultipleValueChoice.verified.txt
@@ -20,5 +20,5 @@ Template options:
                                                                  iOS           iOS mobile
                                                                  android       android mobile
                                                                  nix           Linux distributions
-                                                               Allow multiple values: True
+                                                               Multiple values are allowed: True
                                                                Default: MacOS|iOS

--- a/test/dotnet-new3.UnitTests/DotnetNewHelp.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewHelp.Approval.cs
@@ -208,7 +208,7 @@ namespace Dotnet_new3.IntegrationTests
         }
 
         [Fact]
-        public Task CannotShowHelpForTemplate_MultipleValueChoice()
+        public Task CanShowHelpForTemplate_MultipleValueChoice()
         {
             string workingDirectory = TestUtils.CreateTemporaryFolder();
             Helpers.InstallTestTemplate("TemplateWithMultiValueChoice", _log, _fixture.HomeDirectory, workingDirectory);


### PR DESCRIPTION
### Problem
Some translations of `Allow multiple values` text were missleading. So adjusting the english wording as well - to make it more explicit in english and hopefully in the generated translations as well


### Checks: Not applicable
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)