### PR TITLE
added persistence scope settings for UseProgramMain in console template

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/ide.host.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/ide.host.json
@@ -10,7 +10,9 @@
   "symbolInfo": [
     {
       "id": "UseProgramMain",
-      "isVisible": "true"
+      "isVisible": true,
+      "PersistenceScope": "Shared",
+      "PersistenceScopeName": "Microsoft"
     }
   ]
 }


### PR DESCRIPTION
### Problem
fixes https://github.com/dotnet/templating/issues/4719
User selection for `UseProgramMain` in VS is not preserved.

### Solution
Added persistence scope settings for UseProgramMain in console template

### Checks:
- [ ] Added unit tests - NA
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - NA