### PR TITLE
[feature/constraints-cli] constraints in tab completion

### DIFF
--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/TabCompletionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/TabCompletionTests.cs
@@ -440,5 +440,167 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
 
             Assert.Equal(new[] { "project", "solution" }, result);
         }
+
+        [Fact]
+        public void CanIgnoreTemplateGroupsWithConstraints()
+        {
+            var template1 = new MockTemplateInfo("foo1", identity: "foo.1")
+                .WithConstraints(new TemplateConstraintInfo("test", "yes"));
+
+            var template2 = new MockTemplateInfo("foo2", identity: "foo.2")
+                .WithConstraints(new TemplateConstraintInfo("test", "no"));
+
+            var template3 = new MockTemplateInfo("foo3", identity: "foo.3")
+             .WithConstraints(new TemplateConstraintInfo("test", "bad-params"));
+
+            var templateGroups = TemplateGroup.FromTemplateList(
+                CliTemplateInfo.FromTemplateInfo(new[] { template1, template2, template3 }, A.Fake<IHostSpecificDataLoader>()));
+
+            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
+            IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+            TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
+
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host, _ => new TelemetryLogger(null, false), new NewCommandCallbacks());
+            var parseResult = myCommand.Parse($" new fo");
+            InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
+            var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
+            Assert.NotNull(completionContext);
+
+            var result = InstantiateCommand.GetTemplateNameCompletions(args.ShortName, templateGroups, settings).Select(l => l.Label);
+
+            Assert.Equal(new[] { "foo1" }, result);
+        }
+
+        [Fact]
+        public void CanIgnoreTemplateGroupsWithConstraints_IgnoresLongEvaluationTemplateGroups()
+        {
+            var template1 = new MockTemplateInfo("foo1", identity: "foo.1")
+                .WithConstraints(new TemplateConstraintInfo("test", "yes"));
+
+            var template2 = new MockTemplateInfo("foo2", identity: "foo.2")
+                .WithConstraints(new TemplateConstraintInfo("test", "no"));
+
+            var template3 = new MockTemplateInfo("foo3", identity: "foo.3")
+             .WithConstraints(new TemplateConstraintInfo("test", "bad-params"));
+
+            var templateGroups = TemplateGroup.FromTemplateList(
+                CliTemplateInfo.FromTemplateInfo(new[] { template1, template2, template3 }, A.Fake<IHostSpecificDataLoader>()));
+
+            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new LongRunningConstraintFactory("test", 1500)) });
+            IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+            TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
+
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host, _ => new TelemetryLogger(null, false), new NewCommandCallbacks());
+            var parseResult = myCommand.Parse($" new fo");
+            InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
+            var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
+            Assert.NotNull(completionContext);
+
+            var result = InstantiateCommand.GetTemplateNameCompletions(args.ShortName, templateGroups, settings).Select(l => l.Label);
+
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void CanIgnoreTemplatesInGroupWithConstraints()
+        {
+            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "group")
+                .WithConstraints(new TemplateConstraintInfo("test", "yes"))
+                .WithParameter("a");
+
+            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "group")
+                .WithConstraints(new TemplateConstraintInfo("test", "no"))
+                .WithParameter("b"); 
+
+            var template3 = new MockTemplateInfo("foo", identity: "foo.3", groupIdentity: "group")
+             .WithConstraints(new TemplateConstraintInfo("test", "bad-params"))
+             .WithParameter("c");
+
+            var templateGroups = TemplateGroup.FromTemplateList(
+                CliTemplateInfo.FromTemplateInfo(new[] { template1, template2, template3 }, A.Fake<IHostSpecificDataLoader>()));
+
+            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new TestConstraintFactory("test")) });
+            IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+            TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
+
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host, _ => new TelemetryLogger(null, false), new NewCommandCallbacks());
+            var parseResult = myCommand.Parse($" new foo ");
+            InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
+            var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
+            Assert.NotNull(completionContext);
+
+            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+
+            Assert.Contains("--a", result);
+            Assert.DoesNotContain("--b", result);
+            Assert.DoesNotContain("--c", result);
+        }
+
+        [Fact]
+        public void IncludesTemplatesInGroupWithLongEvaluatedConstraints()
+        {
+            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "group")
+                .WithConstraints(new TemplateConstraintInfo("test", "yes"))
+                .WithParameter("a");
+
+            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "group")
+                .WithConstraints(new TemplateConstraintInfo("test", "no"))
+                .WithParameter("b");
+
+            var template3 = new MockTemplateInfo("foo", identity: "foo.3", groupIdentity: "group")
+             .WithConstraints(new TemplateConstraintInfo("test", "bad-params"))
+             .WithParameter("c");
+
+            var templateGroups = TemplateGroup.FromTemplateList(
+                CliTemplateInfo.FromTemplateInfo(new[] { template1, template2, template3 }, A.Fake<IHostSpecificDataLoader>()));
+
+            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new LongRunningConstraintFactory("test", 1500)) });
+            IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+            TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
+
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host, _ => new TelemetryLogger(null, false), new NewCommandCallbacks());
+            var parseResult = myCommand.Parse($" new foo ");
+            InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
+            var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
+            Assert.NotNull(completionContext);
+
+            var result = InstantiateCommand.GetTemplateCompletions(args, templateGroups, settings, packageManager, completionContext!).Select(l => l.Label);
+
+            Assert.Contains("--a", result);
+            Assert.Contains("--b", result);
+            Assert.Contains("--c", result);
+        }
+
+        [Fact]
+        public void WillNotEvaluateConstraints_WhenAtLeastOneTemplateInGroupDoesNotHaveConstraints()
+        {
+            var template1 = new MockTemplateInfo("foo", identity: "foo.1", groupIdentity: "group")
+                .WithParameter("a");
+
+            var template2 = new MockTemplateInfo("foo", identity: "foo.2", groupIdentity: "group")
+                .WithConstraints(new TemplateConstraintInfo("test", "no"))
+                .WithParameter("b");
+
+            var template3 = new MockTemplateInfo("foo", identity: "foo.3", groupIdentity: "group")
+             .WithConstraints(new TemplateConstraintInfo("test", "bad-params"))
+             .WithParameter("c");
+
+            var templateGroups = TemplateGroup.FromTemplateList(
+                CliTemplateInfo.FromTemplateInfo(new[] { template1, template2, template3 }, A.Fake<IHostSpecificDataLoader>()));
+
+            ITemplateEngineHost host = TestHost.GetVirtualHost(additionalComponents: new[] { (typeof(ITemplateConstraintFactory), (IIdentifiedComponent)new LongRunningConstraintFactory("test", 3000)) });
+            IEngineEnvironmentSettings settings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+            TemplatePackageManager packageManager = A.Fake<TemplatePackageManager>();
+
+            NewCommand myCommand = (NewCommand)NewCommandFactory.Create("new", _ => host, _ => new TelemetryLogger(null, false), new NewCommandCallbacks());
+            var parseResult = myCommand.Parse($" new fo");
+            InstantiateCommandArgs args = InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(myCommand, parseResult));
+            var completionContext = parseResult.GetCompletionContext() as TextCompletionContext;
+            Assert.NotNull(completionContext);
+
+            var result = InstantiateCommand.GetTemplateNameCompletions(args.ShortName, templateGroups, settings).Select(l => l.Label);
+
+            Assert.Equal(new[] { "foo" }, result);
+        }
     }
 }

--- a/test/Microsoft.TemplateEngine.TestHelper/LongRunningConstraintFactory.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/LongRunningConstraintFactory.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.TemplateEngine.Abstractions;
+
+namespace Microsoft.TemplateEngine.TestHelper
+{
+    /// <summary>
+    /// Test cosnstraint factory. Creates a constraint wtih given type. Constraint creation takes time passed as parameter to factory.
+    /// If args == yes, the constraint returns <see cref="TemplateConstraintResult.Status.Allowed"/>,
+    /// if args == no, the constraint returns <see cref="TemplateConstraintResult.Status.Restricted"/>, otherwise <see cref="TemplateConstraintResult.Status.NotEvaluated"/>.
+    /// </summary>
+    public class LongRunningConstraintFactory : ITemplateConstraintFactory
+    {
+        private readonly int _msDelay;
+
+        public LongRunningConstraintFactory(string type, int msDelay)
+        {
+            Type = type;
+            _msDelay = msDelay;
+            Id = Guid.NewGuid();
+        }
+
+        public string Type { get; }
+
+        public Guid Id { get; }
+
+        public async Task<ITemplateConstraint> CreateTemplateConstraintAsync(IEngineEnvironmentSettings environmentSettings, CancellationToken cancellationToken)
+        {
+            await Task.Delay(_msDelay).ConfigureAwait(false);
+            return new TestConstraint(this);
+        }
+
+        private class TestConstraint : ITemplateConstraint
+        {
+            public TestConstraint(ITemplateConstraintFactory factory)
+            {
+                Type = factory.Type;
+            }
+
+            public string Type { get; }
+
+            public string DisplayName => "Test Constraint";
+
+            public TemplateConstraintResult Evaluate(string? args)
+            {
+                if (args == "yes")
+                {
+                    return TemplateConstraintResult.CreateAllowed(Type);
+                }
+                else if (args == "no")
+                {
+                    return TemplateConstraintResult.CreateRestricted(Type, "cannot run", "do smth");
+                }
+                return TemplateConstraintResult.CreateFailure(Type, "bad params");
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/3107 - tab completion adjustments

### Solution
The logic follows:
- the constraints are taken into account on template group name and parameters completion
- the constraints are evaluated only when absolutely needed as this is an async call
- if at least one template in template group doesn't have constraints, constraint evaluation for template group on name completion is skipped.
- for template group name: if the constraints are not evaluated within the timeout, the template group is ignored. The reason for this: if template group constraints will result in restriction likely there will be no matches on the following completion. Open for discussion here.
- for template in a group: if the constraints are not evaluated within the timeout, the template is accepted for completion. Worst case scenario: the template won't run.
- timeout for evaluation: 1000 ms

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)