### PR TITLE
addressing template packages caching issues

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -350,6 +350,8 @@ namespace Microsoft.TemplateEngine.Cli
                     }
                 }
             }
+            //rebuild cache after uninstall to remove deleted templates.
+            await _templatePackageManager.RebuildTemplateCacheAsync(cancellationToken).ConfigureAwait(false);
             return result;
         }
 

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/FolderInstallerTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/FolderInstallerTests.cs
@@ -107,7 +107,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
 
             FolderInstaller folderInstaller = new FolderInstaller(engineEnvironmentSettings, factory);
 
-            FolderManagedTemplatePackage source = new FolderManagedTemplatePackage(engineEnvironmentSettings, folderInstaller, provider, Path.GetRandomFileName());
+            FolderManagedTemplatePackage source = new FolderManagedTemplatePackage(engineEnvironmentSettings, folderInstaller, provider, Path.GetRandomFileName(), DateTime.UtcNow);
             IReadOnlyList<CheckUpdateResult> results = await folderInstaller.GetLatestVersionAsync(new[] { source }, provider, CancellationToken.None).ConfigureAwait(false);
 
             Assert.Single(results);
@@ -141,14 +141,15 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
 
             FolderInstaller folderInstaller = new FolderInstaller(engineEnvironmentSettings, factory);
 
-            FolderManagedTemplatePackage source = new FolderManagedTemplatePackage(engineEnvironmentSettings, folderInstaller, provider, Path.GetRandomFileName());
+            FolderManagedTemplatePackage source = new FolderManagedTemplatePackage(engineEnvironmentSettings, folderInstaller, provider, Path.GetRandomFileName(), DateTime.UtcNow);
             UpdateRequest updateRequest = new UpdateRequest(source, "1.0.0");
             UpdateResult result = await folderInstaller.UpdateAsync(updateRequest, provider, CancellationToken.None).ConfigureAwait(false);
 
             Assert.True(result.Success);
             Assert.Equal(updateRequest, result.UpdateRequest);
             Assert.Equal(InstallerErrorCode.Success, result.Error);
-            Assert.Equal(source, result.TemplatePackage);
+            Assert.Equal(source.MountPointUri, result.TemplatePackage.MountPointUri);
+            Assert.NotEqual(source.LastChangeTime, result.TemplatePackage.LastChangeTime);
         }
 
         [Fact]


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/4543
partially https://github.com/dotnet/templating/issues/4155

### Solution
- rebuild the cache after uninstall to remove uninstall templates
- take into account installation date for folder as last modification date, as folder last write date may not change on reinstall.

TODO: 
- tests
- taking into account last modification date of template files
- implementing a way to force to reinstall folder package

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)