### PR TITLE
Adjust and document exit codes

### DIFF
--- a/docs/Exit-Codes.md
+++ b/docs/Exit-Codes.md
@@ -1,0 +1,190 @@
+# `dotnet new` exit codes and their meaning
+
+Exit codes are chosen to confrom to existing standards or standardization attempts and well known exit code. See [Related resources](#related) for more details 
+
+| Exit&nbsp;Code | Reason |
+|:-----|----------|
+| 0 | Success |
+| [70](#70) | Unexpected internal software issue. |
+| [73](#73) | Can't create output file. |
+| [100](#100) | Instantiation Failed - Processing issues. |
+| [101](#101) | Instantiation Failed - Missing mandatory parameter(s) for template. |
+| [102](#102) | Instantiation/Search Failed - parameter(s) value(s) invalid. |
+| [103](#103) | The template was not found. |
+| [104](#104) | The operation was cancelled. |
+| [105](#105) | Instantiation Failed - Post action failed. |
+| [106](#106) | Installation/Uninstallation Failed. |
+| [107 - 113](#107) | Reserved |
+
+## <a name="70"></a>70 - Unexpected internal software issue
+
+The result received from template engine core is not expected. [File a bug](https://github.com/dotnet/templating/issues/new) if you encounter this exit code.
+
+This is a semi-standardized exit code (see [EX_SOFTWARE in /usr/include/sysexits.h](https://github.com/openbsd/src/blob/master/include/sysexits.h#L107))
+
+
+## <a name="73"></a>73 - Can't create output file.
+
+The operation was cancelled due to detection of an attempt to perform destructive changes to existing files. This can happen if you are attempting to instantiate template into the same folder where it was previously instantiated under same target name (specified via `--name` option)
+
+_Example:_
+```console
+> dotnet new console
+
+The template "Console App" was created successfully.
+
+Processing post-creation actions...
+Running 'dotnet restore' on C:\tmp\tmp.csproj...
+  Determining projects to restore...
+  Restored C:\tmp\tmp.csproj (in 47 ms).
+Restore succeeded.
+
+> dotnet new console
+
+Creating this template will make changes to existing files:
+  Overwrite   ./tmp.csproj
+  Overwrite   ./Program.cs
+
+Rerun the command and pass --force to accept and create.
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#73
+```
+
+Destructive changes can be forced with `--force` option
+
+This is a semi-standardized exit code (see [EX_CANTCREAT in /usr/include/sysexits.h](https://github.com/openbsd/src/blob/master/include/sysexits.h#L110))
+
+
+## 100 - Instantiation Failed - Processing issues
+
+The template instantiation failed due to error(s). Caused either by environment (failure to read/write templates or cache) or by errorneous templates (incomplete conditions, symbols or macros etc.). Exact error reason will be output to stderr.
+
+_Examples:_
+
+Missing mandatory properties in template.json
+```json
+{
+    "author": "John Doe",
+    "name": "name",
+}
+```
+
+Incomplete condition in template file:
+
+```C#
+// #if( MySwitch == "DefineFunc"
+    static void Foo() { } 
+```
+
+## 101 - Instantiation Failed - Missing mandatory parameter(s) for template.
+
+A parameter [marked as required](Reference-for-template.json.md#isrequired) was not supplied during template instantiation.
+
+_Example:_
+```console
+> dotnet new my-template
+Mandatory option --MyMandatoryParam missing for template My Template.
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#101
+```
+
+## 102 - Instantiation/Search Failed - parameter(s) value(s) invalid.
+
+Usually a mismatch in type of the specified parameter or unrecognized choice option. Applicable to `search` command with not enough information as well.
+
+_Examples:_
+```console
+> dotnet new console --framework xyz
+Error: Invalid option(s):
+--framework xyz
+   'xyz' is not a valid value for --framework. The possible values are:
+      net6.0   - Target net6.0
+      net7.0   - Target net7.0
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#102
+```
+
+```
+> dotnet new search
+Search failed: not enough information specified for search.
+To search for templates, specify partial template name or use one of the supported filters: '--author', '--baseline', '--language', '--type', '--tag', '--package'.
+Examples:
+   dotnet new search web
+   dotnet new search --author Microsoft
+   dotnet new search web --language C#
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#102
+```
+
+## 103 - The template was not found.
+
+Applicable to instantiation, listing and remote sources searching.
+
+_Examples:_
+```
+> dotnet new xyz
+No templates found matching: 'xyz'.
+
+To list installed templates, run:
+   dotnet new list
+To search for the templates on NuGet.org, run:
+   dotnet new search xyz
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103
+```
+
+```
+> dotnet new list xyz
+No templates found matching: 'xyz'.
+
+To search for the templates on NuGet.org, run:
+   dotnet new search xyz
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103
+```
+
+```
+> dotnet new search xyz
+Searching for the templates...
+Matches from template source: NuGet.org
+No templates found matching: 'xyz'.
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103
+```
+
+## 104 - The operation was cancelled. 
+
+Currently applicable only to case when user aborts custom post action.
+
+
+## 105 - Instantiation Failed - Post action failed.
+
+## 106 - Installation/Uninstallation Failed
+
+Failure to download packages, read/write templates or cache, erorrneous or corrupted template, or an attempt to install same package multiple times.
+
+_Example:_
+```
+> dotnet new install foobarbaz
+The following template packages will be installed:
+   foobarbaz
+
+foobarbaz could not be installed, the package does not exist.
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#106
+```
+
+## <a name="107"></a><a name="108"></a><a name="109"></a><a name="110"></a><a name="111"></a><a name="112"></a><a name="113"></a>107 - 113
+
+Reserved for future use.
+
+[File a bug](https://github.com/dotnet/templating/issues/new) if you encounter any of this exit codes.
+
+
+<BR/>
+<BR/>
+<BR/>
+
+### Related Resources
+* [`BSD sysexit.h`](https://github.com/openbsd/src/blob/master/include/sysexits.h)
+* [`Special exit codes - Lynux documentation project`](https://tldp.org/LDP/abs/html/exitcodes.html)

--- a/docs/Reference-for-template.json.md
+++ b/docs/Reference-for-template.json.md
@@ -140,7 +140,7 @@ A symbol for which the config provides literal and/or default values.
 |`replaces`|The text to be replaced by the symbol value in the template files content|	 
 |`fileRename`|The portion of template filenames to be replaced by the symbol value.| 
 |`description`|Human readable text describing the meaning of the symbol. This has no effect on template generation.|
-|`isRequired`|Indicates if the parameter is required or not.|
+|<a name="isRequired"></a>`isrequired`|Indicates if the parameter is required or not.|
 |`choices`|List of available choices. Applicable only when `datatype=choice.` Contains array of the elements: <br />- `choice`: possible value of the symbol.<br />- `description`: human readable text describing the meaning of the choice. This has no effect on template generation. <br /> If not provided, there are no valid choices for the symbol, so it can never be assigned a value.|
 |`onlyIf`| |
 |`forms`|Defines the set of transforms that can be referenced by symbol definitions. Forms allow the specification of a "replaces"/"replacement" pair to also apply to other ways the "replaces" value may have been specified in the source by specifying a transform from the original value of "replaces" in configuration to the one that may be found in the source. [Details](https://github.com/dotnet/templating/wiki/Runnable-Project-Templates---Value-Forms)|

--- a/src/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/BaseCommand.cs
@@ -98,12 +98,15 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             CancellationToken cancellationToken = context.GetCancellationToken();
 
+            NewCommandStatus returnCode;
+
             try
             {
                 using (Timing.Over(environmentSettings.Host.Logger, "Execute"))
                 {
                     await HandleGlobalOptionsAsync(args, environmentSettings, cancellationToken).ConfigureAwait(false);
-                    return (int)await ExecuteAsync(args, environmentSettings, telemetryLogger, context).ConfigureAwait(false);
+                    // Todo: here handle the error codes
+                    returnCode = await ExecuteAsync(args, environmentSettings, telemetryLogger, context).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)
@@ -136,8 +139,16 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 {
                     Reporter.Error.WriteLine(ex.StackTrace.Bold().Red());
                 }
-                return 1;
+                returnCode = NewCommandStatus.Unexpected;
             }
+
+            if (returnCode != NewCommandStatus.Success)
+            {
+                Reporter.Error.WriteLine();
+                Reporter.Error.WriteLine(string.Format(LocalizableStrings.BaseCommand_ExitCodeHelp, (int)returnCode));
+            }
+
+            return (int)returnCode;
         }
 
         public int Invoke(InvocationContext context) => InvokeAsync(context).GetAwaiter().GetResult();

--- a/src/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.NoMatchHandling.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.NoMatchHandling.cs
@@ -157,7 +157,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                         .WithHelpOption());
             }
 
-            return NewCommandStatus.InvalidParamValues;
+            return NewCommandStatus.NotFound;
         }
 
         private static void HandleNoMatchOnTemplateBaseOptions(IEnumerable<TemplateResult> matchInfos, InstantiateCommandArgs args, TemplateGroup templateGroup)

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -500,6 +500,15 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}.
+        /// </summary>
+        internal static string BaseCommand_ExitCodeHelp {
+            get {
+                return ResourceManager.GetString("BaseCommand_ExitCodeHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Change.
         /// </summary>
         internal static string Change {

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -805,4 +805,8 @@ The header is followed by the list of parameters and their errors (might be seve
     <value>To reinstall the same version of the template package, use '{0}' option:</value>
     <comment>{0} - option name (--force). Followed by command example on new line.</comment>
   </data>
+  <data name="BaseCommand_ExitCodeHelp" xml:space="preserve">
+    <value>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</value>
+    <comment>{0} is the exit code</comment>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/NewCommandStatus.cs
+++ b/src/Microsoft.TemplateEngine.Cli/NewCommandStatus.cs
@@ -3,66 +3,63 @@
 
 namespace Microsoft.TemplateEngine.Cli
 {
+    /// <summary>
+    /// Exit codes based on
+    ///  * https://tldp.org/LDP/abs/html/exitcodes.html
+    ///  * https://github.com/openbsd/src/blob/master/include/sysexits.h.
+    /// Further documentation: https://aka.ms/templating-exit-codes.
+    /// Future exit codes should be allocated in a range of 107 - 113. If not sufficient, a range of 79 - 99 may be used as well.
+    /// </summary>
     internal enum NewCommandStatus
     {
+        /// <summary>
+        /// Unexpected internal software issue. The result received from template engine core is not expected.
+        /// </summary>
+        Unexpected = 70,
+
+        /// <summary>
+        /// Can't create output file. The operation was cancelled due to detection of an attempt to perform destructive changes to existing files.
+        /// </summary>
+        DestructiveChangesDetected = 73,
+
         /// <summary>
         /// The template was instantiated successfully.
         /// </summary>
         Success = 0,
 
         /// <summary>
-        /// The template instantiation failed.
+        /// Instantiation Failed - Processing issues.
         /// </summary>
-        CreateFailed = unchecked((int)0x80020009),
+        CreateFailed = 100,
 
         /// <summary>
-        /// The mandatory parameters for template are missing.
+        /// Instantiation Failed - Missing mandatory parameter(s) for template.
         /// </summary>
-        MissingMandatoryParam = unchecked((int)0x8002000F),
+        MissingMandatoryParam = 101,
 
         /// <summary>
-        /// The values passed for template parameters are invalid.
+        /// Instantiation/Search Failed - parameter(s) value(s) invalid.
         /// </summary>
-        InvalidParamValues = unchecked((int)0x80020005),
+        InvalidParamValues = 102,
 
         /// <summary>
-        /// The subcommand to run is not specified.
+        /// The template was not found.
         /// </summary>
-        OperationNotSpecified = unchecked((int)0x8002000E),
+        NotFound = 103,
 
         /// <summary>
-        /// The template is not found.
+        /// The operation was cancelled.
         /// </summary>
-        NotFound = unchecked((int)0x800200006),
+        Cancelled = 104,
 
         /// <summary>
-        /// The operation is cancelled.
+        /// Instantiation Failed - Post action failed.
         /// </summary>
-        Cancelled = unchecked((int)0x80004004),
+        PostActionFailed = 105,
 
         /// <summary>
-        /// The result received from template engine core is not expected.
+        /// Installation/Uninstallation Failed - Processing issues.
         /// </summary>
-        UnexpectedResult = unchecked((int)0x80010001),
-
-        /// <summary>
-        /// The manipulation with alias has failed.
-        /// </summary>
-        AliasFailed = unchecked((int)0x80010002),
-
-        /// <summary>
-        /// The operation is cancelled due to destructive changes to existing files are detected.
-        /// </summary>
-        DestructiveChangesDetected = unchecked((int)0x8002000D),
-
-        /// <summary>
-        /// Post action failed.
-        /// </summary>
-        PostActionFailed = unchecked((int)0x80010003),
-
-        /// <summary>
-        /// Generic error when displaying help.
-        /// </summary>
-        DisplayHelpFailed = unchecked((int)0x80010004)
+        InstallFailed = 106,
     }
 }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateInvoker.cs
@@ -150,7 +150,7 @@ namespace Microsoft.TemplateEngine.Cli
                 string printableChars = string.Join(", ", invalidChars.Where(x => !char.IsControl(x)).Select(x => $"'{x}'"));
                 string nonPrintableChars = string.Join(", ", invalidChars.Where(char.IsControl).Select(x => $"char({(int)x})"));
                 Reporter.Error.WriteLine(string.Format(LocalizableStrings.InvalidNameParameter, printableChars, nonPrintableChars).Bold().Red());
-                return NewCommandStatus.CreateFailed;
+                return NewCommandStatus.InvalidParamValues;
             }
 
             string? fallbackName = new DirectoryInfo(
@@ -283,7 +283,7 @@ namespace Microsoft.TemplateEngine.Cli
                     Reporter.Error.WriteLine(LocalizableStrings.RerunCommandAndPassForceToCreateAnyway.Bold().Red());
                     return NewCommandStatus.DestructiveChangesDetected;
                 default:
-                    return NewCommandStatus.UnexpectedResult;
+                    return NewCommandStatus.Unexpected;
             }
         }
 
@@ -297,7 +297,7 @@ namespace Microsoft.TemplateEngine.Cli
                 PostActionExecutionStatus.Failure => NewCommandStatus.PostActionFailed,
                 PostActionExecutionStatus.Cancelled => NewCommandStatus.Cancelled,
                 PostActionExecutionStatus.Failure | PostActionExecutionStatus.Cancelled => NewCommandStatus.PostActionFailed,
-                _ => NewCommandStatus.UnexpectedResult
+                _ => NewCommandStatus.Unexpected
             };
         }
     }

--- a/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplatePackageCoordinator.cs
@@ -225,7 +225,7 @@ namespace Microsoft.TemplateEngine.Cli
                     continue;
                 }
                 Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Install_Error_SameInstallRequests, installRequest.PackageIdentifier));
-                return NewCommandStatus.Cancelled;
+                return NewCommandStatus.InstallFailed;
             }
 
             Reporter.Output.WriteLine(LocalizableStrings.TemplatePackageCoordinator_Install_Info_PackagesToBeInstalled);
@@ -238,7 +238,7 @@ namespace Microsoft.TemplateEngine.Cli
             bool validated = await ValidateInstallationRequestsAsync(args, installRequests, cancellationToken).ConfigureAwait(false);
             if (!validated)
             {
-                return NewCommandStatus.CreateFailed;
+                return NewCommandStatus.InstallFailed;
             }
 
             IReadOnlyList<InstallResult> installResults = await managedSourceProvider.InstallAsync(installRequests, cancellationToken).ConfigureAwait(false);
@@ -247,7 +247,7 @@ namespace Microsoft.TemplateEngine.Cli
                 await DisplayInstallResultAsync(result.InstallRequest.DisplayName, result, args.ParseResult, cancellationToken).ConfigureAwait(false);
                 if (!result.Success)
                 {
-                    resultStatus = NewCommandStatus.CreateFailed;
+                    resultStatus = NewCommandStatus.InstallFailed;
                 }
             }
             return resultStatus;
@@ -274,7 +274,7 @@ namespace Microsoft.TemplateEngine.Cli
                 DisplayUpdateCheckResults(checkUpdateResults, commandArgs, showUpdates: !applyUpdates);
                 if (checkUpdateResults.Any(result => !result.Success))
                 {
-                    success = NewCommandStatus.CreateFailed;
+                    success = NewCommandStatus.InstallFailed;
                 }
                 allTemplatesUpToDate = checkUpdateResults.All(result => result.Success && result.IsLatestVersion);
 
@@ -347,7 +347,7 @@ namespace Microsoft.TemplateEngine.Cli
                     else
                     {
                         Reporter.Error.WriteLine(string.Format(LocalizableStrings.TemplatePackageCoordinator_Uninstall_Error_GenericError, uninstallResult.TemplatePackage.DisplayName, uninstallResult.ErrorMessage));
-                        result = NewCommandStatus.CreateFailed;
+                        result = NewCommandStatus.InstallFailed;
                     }
                 }
             }

--- a/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/TemplateSearch/CliTemplateSearchCoordinator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateEngine.Cli.TemplateSearch
         /// <param name="defaultLanguage">default language for the host.</param>
         /// <param name="cancellationToken"></param>
         /// <returns><see cref="NewCommandStatus.Success"/> when the templates were found and displayed;
-        /// <see cref="NewCommandStatus.Cancelled"/> when the command validation fails;
+        /// <see cref="NewCommandStatus.InvalidParamValues"/> when the command validation fails;
         /// <see cref="NewCommandStatus.NotFound"/> when no templates found based on the filter criteria.
         /// </returns>
         internal static async Task<NewCommandStatus> SearchForTemplateMatchesAsync(

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -258,6 +258,11 @@ Pokud si chcete zobrazit všechny aliasy, spusťte bez argumentů příkaz dotne
         <target state="translated">Nejednoznačná hodnota parametru volby znemožňuje jednoznačně zvolit šablonu, která se má vyvolat.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">Změnit</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -258,6 +258,11 @@ Führen Sie \"dotnet {1}--show-aliases\" ohne Argumente aus, um alle Aliase anzu
         <target state="translated">Ein mehrdeutiger Auswahlparameterwert verhinderte die eindeutige Auswahl einer aufzurufenden Vorlage.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">Ändern</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -258,6 +258,11 @@ Ejecute \"dotnet {1} --show-aliases\" sin argumentos para mostrar todos los alia
         <target state="translated">Un valor de parámetro de opción ambiguo impidió la elección sin ambigüedad de una plantilla para invocarla.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">Cambiar</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -258,6 +258,11 @@ Exécutez « dotnet {1} --show-aliases » sans arguments pour afficher tous le
         <target state="translated">Une valeur de paramètre de choix ambiguë empêchait de choisir sans ambiguïté un modèle à appeler.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">Modification</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -258,6 +258,11 @@ Eseguire 'dotnet {1}--show-alias ' senza argomenti per mostrare tutti gli alias.
         <target state="translated">Un valore di parametro di scelta ambiguo ha impedito la scelta non ambigua di un modello da richiamare.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">Cambiare</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -258,6 +258,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">あいまいな choice パラメーター値が指定されているため、呼び出すテンプレートを明確に選択できませんでした。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">変更</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -258,6 +258,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">애매한 선택 매개 변수 값으로 인해 호출할 템플릿을 명확하게 선택할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">변경</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -258,6 +258,11 @@ Uruchom polecenie \"dotnet {1}--show-aliases\" bez argumentów, aby wyświetlić
         <target state="translated">Niejednoznaczna wartość parametru wyboru uniemożliwiła jednoznaczne wybranie szablonu do wywołania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">Zmień</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -258,6 +258,11 @@ Execute 'dotnet {1} --mostrar- aliases' sem nenhum args para mostrar todos os al
         <target state="translated">Um valor de parâmetro de escolha ambíguo impediu a escolha não ambígua de um modelo para invocar.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">Alterar</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -258,6 +258,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">Неоднозначное значение параметра выбора не позволяет однозначно выбрать шаблон для вызова.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">Изменение</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -258,6 +258,11 @@ Tüm diğer adları göstermek için 'dotnet {1} --show-aliases' komutunu bağı
         <target state="translated">Belirsiz bir seçim parametresi değeri, çağrılacak bir şablon seçilmesini açık bir şekilde engelledi.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">Değişiklik</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -258,6 +258,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">不明确的选择参数值阻止了明确选择要调用的模板。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">更改</target>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -258,6 +258,11 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</source>
         <target state="translated">不明確的選擇參數值無法明確地選擇要叫用的範本。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BaseCommand_ExitCodeHelp">
+        <source>For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</source>
+        <target state="new">For details on current exit code please visit https://aka.ms/templating-exit-codes#{0}</target>
+        <note>{0} is the exit code</note>
+      </trans-unit>
       <trans-unit id="Change">
         <source>Change</source>
         <target state="translated">變更</target>

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallMultiplePackageAvailableFromBuiltIns.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallMultiplePackageAvailableFromBuiltIns.verified.txt
@@ -4,3 +4,5 @@ The following template package(s) are already available:
 
 To install the template package(s) anyway, apply '--force' option:
    dotnet-new3 new3 install Microsoft.DotNet.Common.ItemTemplates::6.0.100 Microsoft.DotNet.Web.ItemTemplates::5.0.0 --force
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#106

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallPackageAvailableFromBuiltIns.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallPackageAvailableFromBuiltIns.verified.txt
@@ -4,3 +4,5 @@ The following template package(s) are already available:
 
 To install the template package(s) anyway, apply '--force' option:
    dotnet-new3 new3 install Microsoft.DotNet.Common.ItemTemplates::6.0.100 --force
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#106

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallSameSourceTwice_Folder.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallSameSourceTwice_Folder.verified.txt
@@ -1,3 +1,5 @@
 ﻿%TEMPLATE FOLDER% is already installed.
 To reinstall the same version of the template package, use '--force' option:
    dotnet-new3 new3 install %TEMPLATE FOLDER% --force
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#106

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallSameSourceTwice_NuGet.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstallTests.CannotInstallSameSourceTwice_NuGet.verified.txt
@@ -1,3 +1,5 @@
 ﻿Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0 is already installed.
 To reinstall the same version of the template package, use '--force' option:
    dotnet-new3 new3 install Microsoft.DotNet.Common.ProjectTemplates.5.0::5.0.0 --force
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#106

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CanShowError_OnTemplatesWithSameShortName.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CanShowError_OnTemplatesWithSameShortName.verified.txt
@@ -5,3 +5,5 @@ Invalid.SameShortName.TemplateA  Invalid.SameSho...  sameshortname            Te
 Invalid.SameShortName.TemplateB  Invalid.SameSho...  sameshortname            Test Asset  %TEMPLATE LOCATION%
 
 Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWithUnknownLanguage.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWithUnknownLanguage.verified.txt
@@ -5,3 +5,6 @@ To list installed templates, run:
    dotnet-new3 new3 list
 To search for the templates on NuGet.org, run:
    dotnet-new3 new3 search console
+
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWithUnknownType.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWithUnknownType.verified.txt
@@ -5,3 +5,6 @@ To list installed templates, run:
    dotnet-new3 new3 list
 To search for the templates on NuGet.org, run:
    dotnet-new3 new3 search console
+
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_OnMultipleParameterErrors.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_OnMultipleParameterErrors.verified.txt
@@ -9,3 +9,5 @@
 
 For more information, run:
    dotnet-new3 new3 console -h
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenAmbiguousLanguageChoice.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenAmbiguousLanguageChoice.verified.txt
@@ -4,3 +4,5 @@ Template Name  Short Name  Language  Tags
 Basic FSharp   basic       F#,VB     Test Asset
 
 Re-run the command specifying the language to use with --language option.
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenAmbiguousShortNameChoice.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenAmbiguousShortNameChoice.verified.txt
@@ -5,3 +5,5 @@ TestAssets.Group1  Basic FSharp   basic       F#        Test Asset  %TEMPLATE ON
 TestAssets.Group2  Basic VB       basic       VB        Test Asset  %TEMPLATE TWO LOCATION%    
 
 Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenChoiceParameterValueIsInvalid.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenChoiceParameterValueIsInvalid.verified.txt
@@ -7,3 +7,5 @@
 
 For more information, run:
    dotnet-new3 new3 console -h
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenChoiceParameterValueIsNotComplete.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenChoiceParameterValueIsNotComplete.verified.txt
@@ -7,3 +7,5 @@
 
 For more information, run:
    dotnet-new3 new3 console -h
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenFullNameIsUsed.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenFullNameIsUsed.verified.txt
@@ -4,3 +4,6 @@ To list installed templates, run:
    dotnet-new3 new3 list
 To search for the templates on NuGet.org, run:
    dotnet-new3 new3 search 'Console App'
+
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenParameterIsInvalid.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenParameterIsInvalid.verified.txt
@@ -4,3 +4,5 @@
 
 For more information, run:
    dotnet-new3 new3 console -h
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenPrecedenceIsSame.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplate_WhenPrecedenceIsSame.verified.txt
@@ -5,3 +5,5 @@ TestAssets.SamePrecedenceGroup.BasicTemplate1  Basic Template  basic       C#   
 TestAssets.SamePrecedenceGroup.BasicTemplate2  Basic Template  basic       C#        100         Test Asset  %TEMPLATE TWO LOCATION%
 
 Uninstall the template packages containing the templates to keep only one template from the list or add the template options which differentiate the template to run.
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateUnknownTemplate.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateUnknownTemplate.verified.txt
@@ -4,3 +4,6 @@ To list installed templates, run:
    dotnet-new3 new3 list
 To search for the templates on NuGet.org, run:
    dotnet-new3 new3 search webapp
+
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#103

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotOverwriteFilesWithoutForce.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotOverwriteFilesWithoutForce.verified.txt
@@ -3,3 +3,5 @@
   Overwrite   folderA/%FILENAME%
 
 Rerun the command and pass --force to accept and create.
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#73

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewSearch.CannotExecuteEmptyCriteria_common.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewSearch.CannotExecuteEmptyCriteria_common.verified.txt
@@ -4,3 +4,5 @@ Examples:
    dotnet-new3 new3 search web
    dotnet-new3 new3 search --author Microsoft
    dotnet-new3 new3 search web --language C#
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#102

--- a/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewUpdateCheck.cs
@@ -75,7 +75,10 @@ namespace Dotnet_new3.IntegrationTests
                 .Execute()
                 .Should()
                 .Fail()
-                .And.HaveStdErr($"Failed to check update for {nugetFullName}: the package is not available in configured NuGet feeds.");
+                .And.HaveStdErr($@"Failed to check update for {nugetFullName}: the package is not available in configured NuGet feeds.
+
+
+For details on current exit code please visit https://aka.ms/templating-exit-codes#106");
         }
 
         [Theory]


### PR DESCRIPTION
### Problem
Fixes #3186
Fixes #4253

### Solution
* Used well know exit codes where applicable
* Defined user exit codes in 100-106 for others
* Reviewed usages of `NewCommandStatus`, fixed some of the controversial usages
* Documented our exit codes
* Created aka.ms alias link pointing to our help (once merged)
* Added spitting of help link in case of nonzero exit

### Checks: N/A
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)