### PR TITLE
Remove Windows Phone example option from docs

### DIFF
--- a/docs/Reference-for-template.json.md
+++ b/docs/Reference-for-template.json.md
@@ -218,10 +218,6 @@ Multichoice symbols have similar behavior and usage scenarios as [C# Flag enums]
           "description": "Windows Desktop"
         },
         {
-          "choice": "WindowsPhone",
-          "description": "Windows Phone"
-        },
-        {
           "choice": "MacOS",
           "description": "Macintosh computers"
         },


### PR DESCRIPTION
It was pointed out to me that this was confusing and could send the message that we supported windows phone in any way, so let's just remove this to sidestep any confusion.