### PR TITLE
template discovery: added package description and icon URL to search cache

### DIFF
--- a/src/Microsoft.TemplateSearch.Common/Abstractions/ITemplatePackageInfo.cs
+++ b/src/Microsoft.TemplateSearch.Common/Abstractions/ITemplatePackageInfo.cs
@@ -38,5 +38,15 @@ namespace Microsoft.TemplateSearch.Common.Abstractions
         /// For NuGet.org 'verified' means that package ID is under reserved namespaces, see  <see href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation"/>.
         /// </remarks>
         public bool Verified { get; }
+
+        /// <summary>
+        /// Gets the NuGet package description.
+        /// </summary>
+        public string? Description { get; }
+
+        /// <summary>
+        /// Gets the URL to the package icon.
+        /// </summary>
+        public string? IconUrl { get; }
     }
 }

--- a/src/Microsoft.TemplateSearch.Common/Abstractions/TemplatePackageSearchData.cs
+++ b/src/Microsoft.TemplateSearch.Common/Abstractions/TemplatePackageSearchData.cs
@@ -32,6 +32,8 @@ namespace Microsoft.TemplateSearch.Common
             Owners = packInfo.Owners;
             Verified = packInfo.Verified;
             Templates = templates.ToList();
+            Description = packInfo.Description;
+            IconUrl = packInfo.IconUrl;
             AdditionalData = data ?? new Dictionary<string, object>();
         }
 
@@ -49,6 +51,12 @@ namespace Microsoft.TemplateSearch.Common
 
         /// <inheritdoc/>
         public bool Verified { get; }
+
+        /// <inheritdoc/>
+        public string? Description { get; }
+
+        /// <inheritdoc/>
+        public string? IconUrl { get; }
 
         /// <summary>
         /// Gets the list of templates in template package.

--- a/src/Microsoft.TemplateSearch.Common/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateSearch.Common/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
-﻿
+﻿Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.Description.get -> string?
+Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.IconUrl.get -> string?
+Microsoft.TemplateSearch.Common.TemplatePackageSearchData.Description.get -> string?
+Microsoft.TemplateSearch.Common.TemplatePackageSearchData.IconUrl.get -> string?

--- a/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/PackInfo.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/PackInfo.cs
@@ -41,5 +41,11 @@ namespace Microsoft.TemplateSearch.Common
 
         [JsonProperty]
         public bool Verified { get; }
+
+        //not supported for v1
+        public string? Description => null;
+
+        //not supported for v1
+        public string? IconUrl => null;
     }
 }

--- a/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplatePackageSearchData.Json.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplatePackageSearchData.Json.cs
@@ -33,6 +33,9 @@ namespace Microsoft.TemplateSearch.Common
             Owners = jObject.Get<JToken>(nameof(Owners)).JTokenStringOrArrayToCollection(Array.Empty<string>());
             Verified = jObject.ToBool(nameof(Verified));
 
+            Description = jObject.ToString(nameof(Description));
+            IconUrl = jObject.ToString(nameof(IconUrl));
+
             JArray? templatesData = jObject.Get<JArray>(nameof(Templates));
             if (templatesData == null)
             {
@@ -116,6 +119,16 @@ namespace Microsoft.TemplateSearch.Common
                 {
                     writer.WritePropertyName(nameof(Verified));
                     writer.WriteValue(value.Verified);
+                }
+                if (!string.IsNullOrWhiteSpace(value.Description))
+                {
+                    writer.WritePropertyName(nameof(Description));
+                    writer.WriteValue(value.Description);
+                }
+                if (!string.IsNullOrWhiteSpace(value.IconUrl))
+                {
+                    writer.WritePropertyName(nameof(IconUrl));
+                    writer.WriteValue(value.IconUrl);
                 }
 
                 writer.WritePropertyName(nameof(Templates));

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Globals.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Globals.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo(@"Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100f33a29044fa9d740c9b3213a93e57c84b472c84e0b8a0e1ae48e67a9f8f6de9d5f7f3d52ac23e48ac51801f1dc950abe901da34d2a9e3baadb141a17c77ef3c565dd5ee5054b91cf63bb3c6ab83f72ab3aafe93d0fc3c2348b764fafb0b1c0733de51459aeab46580384bf9d74c4e28164b7cde247f891ba07891c9d872ad2bb")]

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
@@ -266,6 +266,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
                 Version = packageSearchMetadata.Identity.Version.ToString();
                 TotalDownloads = packageSearchMetadata.DownloadCount ?? 0;
                 Verified = packageSearchMetadata.PrefixReserved;
+                Description = packageSearchMetadata.Description;
+                IconUrl = packageSearchMetadata.IconUrl.ToString();
             }
 
             public string Name { get; }
@@ -277,6 +279,10 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
             public IReadOnlyList<string> Owners => Array.Empty<string>();
 
             public bool Verified { get; }
+
+            public string? Description { get; }
+
+            public string? IconUrl { get; }
         }
     }
 }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSourceInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackageSourceInfo.cs
@@ -35,6 +35,10 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
 
         public bool Verified { get; private set; }
 
+        public string? Description { get; private set; }
+
+        public string? IconUrl { get; private set; }
+
         //property names are explained here: https://docs.microsoft.com/en-us/nuget/api/search-query-service-resource
         internal static NuGetPackageSourceInfo FromJObject (JObject entry)
         {
@@ -44,6 +48,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
             sourceInfo.TotalDownloads = entry.ToInt32("totalDownloads");
             sourceInfo.Owners = entry.Get<JToken>("owners").JTokenStringOrArrayToCollection(Array.Empty<string>());
             sourceInfo.Verified = entry.ToBool("verified");
+            sourceInfo.Description = entry.ToString("description");
+            sourceInfo.IconUrl = entry.ToString("iconUrl");
 
             return sourceInfo;
         }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/DownloadedPackInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/DownloadedPackInfo.cs
@@ -31,5 +31,9 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
         public IReadOnlyList<string> Owners => _info.Owners;
 
         public bool Verified => _info.Verified;
+
+        public string? Description => _info.Description;
+
+        public string? IconUrl => _info.IconUrl;
     }
 }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/FilteredPackageInfo.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/FilteredPackageInfo.cs
@@ -16,6 +16,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
             Owners = info.Owners;
             TotalDownloads = info.TotalDownloads;
             Verified = info.Verified;
+            Description = info.Description;
+            IconUrl = info.IconUrl;
         }
 
         [JsonConstructor]
@@ -42,6 +44,12 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
 
         [JsonProperty]
         public bool Verified { get; private set; }
+
+        [JsonIgnore]
+        public string? Description { get; private set; }
+
+        [JsonIgnore]
+        public string? IconUrl { get; private set; }
     }
 }
 

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/TestProvider/TestPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/TestProvider/TestPackProvider.cs
@@ -89,6 +89,10 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
             public IReadOnlyList<string> Owners => new[] { "TestAuthor" };
 
             public bool Verified => false;
+
+            public string? Description => "description";
+
+            public string? IconUrl => "https://icon";
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Mocks/MockTemplatePackageInfo.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockTemplatePackageInfo.cs
@@ -34,5 +34,9 @@ namespace Microsoft.TemplateEngine.Mocks
         public IReadOnlyList<string> Owners { get; }
 
         public bool Verified => false;
+
+        public string? Description => null;
+
+        public string? IconUrl => null;
     }
 }

--- a/test/Microsoft.TemplateSearch.Common.UnitTests/TemplateSearchCacheReaderTests.cs
+++ b/test/Microsoft.TemplateSearch.Common.UnitTests/TemplateSearchCacheReaderTests.cs
@@ -136,6 +136,8 @@ namespace Microsoft.TemplateSearch.Common.UnitTests
             var mockPackage = A.Fake<ITemplatePackageInfo>();
             A.CallTo(() => mockPackage.Name).Returns("pack");
             A.CallTo(() => mockPackage.Version).Returns("packVer");
+            A.CallTo(() => mockPackage.Description).Returns("description");
+            A.CallTo(() => mockPackage.IconUrl).Returns("https://icon");
 
             TemplatePackageSearchData package = new TemplatePackageSearchData(mockPackage, new[] { template });
             TemplateSearchCache cache = new TemplateSearchCache(new[] { package });
@@ -150,6 +152,8 @@ namespace Microsoft.TemplateSearch.Common.UnitTests
 
             Assert.Equal("pack", deserializedCache.TemplatePackages[0].Name);
             Assert.Equal("packVer", deserializedCache.TemplatePackages[0].Version);
+            Assert.Equal("description", deserializedCache.TemplatePackages[0].Description);
+            Assert.Equal("https://icon", deserializedCache.TemplatePackages[0].IconUrl);
 
             var templateToTest = deserializedCache.TemplatePackages[0].Templates[0];
 

--- a/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/NuGetTests.cs
+++ b/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/NuGetTests.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Policy;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.TemplateSearch.TemplateDiscovery.NuGet;
+using Newtonsoft.Json.Linq;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using Xunit;
+
+namespace Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests
+{
+    public class NuGetTests
+    {
+        [Fact]
+        public async Task CanReadPackageInfo()
+        {
+            string nuGetOrgFeed = "https://api.nuget.org/v3/index.json";
+            var repository = Repository.Factory.GetCoreV3(nuGetOrgFeed);
+            ServiceIndexResourceV3 indexResource = repository.GetResource<ServiceIndexResourceV3>();
+            IReadOnlyList<ServiceIndexEntry> searchResources = indexResource.GetServiceEntries("SearchQueryService");
+            string queryString = $"{searchResources[0].Uri}?q=Microsoft.DotNet.Common.ProjectTemplates.5.0&skip=0&take=10&prerelease=true&semVerLevel=2.0.0";
+            Uri queryUri = new Uri(queryString);
+            using (HttpClient client = new HttpClient())
+            using (HttpResponseMessage response = await client.GetAsync(queryUri, CancellationToken.None).ConfigureAwait(false))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    string responseText = await response.Content.ReadAsStringAsync(CancellationToken.None).ConfigureAwait(false);
+
+                    NuGetPackageSearchResult resultsForPage = NuGetPackageSearchResult.FromJObject(JObject.Parse(responseText));
+                    Assert.Equal(1, resultsForPage.TotalHits);
+                    Assert.Equal(1, resultsForPage.Data.Count);
+
+                    var packageInfo = resultsForPage.Data[0];
+
+                    Assert.Equal("Microsoft.DotNet.Common.ProjectTemplates.5.0", packageInfo.Name);
+                    Assert.NotEmpty(packageInfo.Version);
+                    Assert.True(packageInfo.TotalDownloads > 0);
+                    Assert.True(packageInfo.Verified);
+                    Assert.Contains("Microsoft", packageInfo.Owners);
+                    Assert.NotEmpty (packageInfo.Description);
+                    Assert.NotEmpty(packageInfo.IconUrl);
+                }
+                else
+                {
+                    Assert.True(false, "HTTP request failed.");
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/TemplateDiscoveryTests.cs
+++ b/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/TemplateDiscoveryTests.cs
@@ -114,6 +114,52 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests
         }
 
         [Fact]
+        public void CanReadDescription()
+        {
+            string testDir = TestUtils.CreateTemporaryFolder();
+            using var packageManager = new PackageManager();
+            string packageLocation = packageManager.PackTestTemplatesNuGetPackage();
+
+            new DotnetCommand(
+                _log,
+                "Microsoft.TemplateSearch.TemplateDiscovery.dll",
+                "--basePath",
+                testDir,
+                "--packagesPath",
+                Path.GetDirectoryName(packageLocation),
+                "-v")
+                .Execute()
+                .Should()
+                .ExitWith(0);
+
+            var jObjectV2 = JObject.Parse(File.ReadAllText(Path.Combine(testDir, "SearchCache", "NuGetTemplateSearchInfoVer2.json")))!;
+            Assert.Equal("description", jObjectV2!["TemplatePackages"]![0]!["Description"]!.Value<string>());
+        }
+
+        [Fact]
+        public void CanReadIconUrl()
+        {
+            string testDir = TestUtils.CreateTemporaryFolder();
+            using var packageManager = new PackageManager();
+            string packageLocation = packageManager.PackTestTemplatesNuGetPackage();
+
+            new DotnetCommand(
+                _log,
+                "Microsoft.TemplateSearch.TemplateDiscovery.dll",
+                "--basePath",
+                testDir,
+                "--packagesPath",
+                Path.GetDirectoryName(packageLocation),
+                "-v")
+                .Execute()
+                .Should()
+                .ExitWith(0);
+
+            var jObjectV2 = JObject.Parse(File.ReadAllText(Path.Combine(testDir, "SearchCache", "NuGetTemplateSearchInfoVer2.json")))!;
+            Assert.Equal("https://icon", jObjectV2!["TemplatePackages"]![0]!["IconUrl"]!.Value<string>());
+        }
+
+        [Fact]
         public async Task CanDetectNewPackagesInDiffMode()
         {
             string testDir = TestUtils.CreateTemporaryFolder();


### PR DESCRIPTION
### Problem
Visual Studio needs additional metadata to be returned as result of searching NuGet packages:
- package description (unlocalized)
- icon URL

### Solution
Added package description and icon URL to search cache.

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)