### PR TITLE
fix NullReferenceException in search cache run

### DIFF
--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
@@ -267,7 +267,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
                 TotalDownloads = packageSearchMetadata.DownloadCount ?? 0;
                 Verified = packageSearchMetadata.PrefixReserved;
                 Description = packageSearchMetadata.Description;
-                IconUrl = packageSearchMetadata.IconUrl.ToString();
+                IconUrl = packageSearchMetadata.IconUrl?.ToString();
             }
 
             public string Name { get; }


### PR DESCRIPTION
### Problem
`NullReferenceException` in search cache run

### Solution
fixed above

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)