### PR TITLE
add support for renamed projects in the add reference post action

### DIFF
--- a/docs/Post-Action-Registry.md
+++ b/docs/Post-Action-Registry.md
@@ -174,6 +174,8 @@ Note: when using `targetFiles` argument it should contain the path to the file i
 
 ### Example
 
+Adds a reference `Microsoft.NET.Sdk.Functions` to the project file.
+
 ```
 "postActions": [{
   "Description": "Adding Reference to Microsoft.NET.Sdk.Functions NuGet package",
@@ -187,6 +189,24 @@ Note: when using `targetFiles` argument it should contain the path to the file i
     "reference": "Microsoft.NET.Sdk.Functions",
     "version": "1.0.0",
     "projectFileExtensions": ".csproj"
+  }
+}]
+```
+
+Includes a reference to `SomeDependency` into `MyProjectFile`. The referenced project file is in the `SomeDependency` folder.
+
+```
+"postActions": [{
+  "Description": "Adding a reference to another project",
+  "ActionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+  "ContinueOnError": "false",
+  "ManualInstructions": [{
+    "Text": "Manually add the reference to SomeDependency to MyProjectFile"
+  }],
+  "args": {
+    "targetFiles": ["MyProjectFile.csproj"]
+    "referenceType": "project",
+    "reference": "SomeDependency/SomeDependency.csproj"
   }
 }]
 ```

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddReferencePostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddReferencePostActionProcessor.cs
@@ -104,10 +104,8 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
                 }
 
                 // replace the referenced project file's name in case it has been renamed
-                Glob g = Glob.Parse(referenceToAdd);
-                var referenceNameChange = creationEffects.FileChanges.OfType<IFileChange2>().FirstOrDefault(change => g.IsMatch(change.SourceRelativePath));
-
-                string relativeProjectReference = referenceNameChange != null ? referenceNameChange.TargetRelativePath : referenceToAdd;
+                string? referenceNameChange = GetTargetForSource((ICreationEffects2)creationEffects, referenceToAdd, outputBasePath).SingleOrDefault();
+                string relativeProjectReference = referenceNameChange ?? referenceToAdd;
 
                 referenceToAdd = Path.GetFullPath(relativeProjectReference, outputBasePath);
 

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddReferencePostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddReferencePostActionProcessor.cs
@@ -68,7 +68,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
             bool success = true;
             foreach (string projectFile in projectsToProcess)
             {
-                success &= AddReference(environment, action, projectFile, outputBasePath);
+                success &= AddReference(environment, action, projectFile, outputBasePath, creationEffects);
 
                 if (!success)
                 {
@@ -78,7 +78,7 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
             return true;
         }
 
-        private bool AddReference(IEngineEnvironmentSettings environment, IPostAction actionConfig, string projectFile, string outputBasePath)
+        private bool AddReference(IEngineEnvironmentSettings environment, IPostAction actionConfig, string projectFile, string outputBasePath, ICreationEffects creationEffects)
         {
             if (actionConfig.Args == null || !actionConfig.Args.TryGetValue("reference", out string? referenceToAdd))
             {
@@ -102,7 +102,26 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
                     Reporter.Error.WriteLine(LocalizableStrings.Generic_NoCallbackError);
                     return false;
                 }
+
+                // replace the path to the project file in case it has been renamed
+                Glob g = Glob.Parse(referenceToAdd);
+
+                if (creationEffects.FileChanges != null)
+                {
+                    foreach (IFileChange2 change in creationEffects.FileChanges)
+                    {
+                        if (g.IsMatch(change.SourceRelativePath))
+                        {
+                            referenceToAdd = Path.GetFullPath(change.TargetRelativePath, outputBasePath);
+
+                            break;
+                        }
+                    }
+                }
+
+                // retrieve the full path in case the file has not been renamed
                 referenceToAdd = Path.GetFullPath(referenceToAdd, outputBasePath);
+
                 Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostAction_AddReference_AddProjectReference, referenceToAdd, projectFile));
                 succeeded = Callbacks.AddProjectReference(projectFile, new[] { referenceToAdd });
                 if (succeeded)

--- a/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddReferencePostActionProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionProcessors/AddReferencePostActionProcessor.cs
@@ -103,24 +103,13 @@ namespace Microsoft.TemplateEngine.Cli.PostActionProcessors
                     return false;
                 }
 
-                // replace the path to the project file in case it has been renamed
+                // replace the referenced project file's name in case it has been renamed
                 Glob g = Glob.Parse(referenceToAdd);
+                var referenceNameChange = creationEffects.FileChanges.OfType<IFileChange2>().FirstOrDefault(change => g.IsMatch(change.SourceRelativePath));
 
-                if (creationEffects.FileChanges != null)
-                {
-                    foreach (IFileChange2 change in creationEffects.FileChanges)
-                    {
-                        if (g.IsMatch(change.SourceRelativePath))
-                        {
-                            referenceToAdd = Path.GetFullPath(change.TargetRelativePath, outputBasePath);
+                string relativeProjectReference = referenceNameChange != null ? referenceNameChange.TargetRelativePath : referenceToAdd;
 
-                            break;
-                        }
-                    }
-                }
-
-                // retrieve the full path in case the file has not been renamed
-                referenceToAdd = Path.GetFullPath(referenceToAdd, outputBasePath);
+                referenceToAdd = Path.GetFullPath(relativeProjectReference, outputBasePath);
 
                 Reporter.Output.WriteLine(string.Format(LocalizableStrings.PostAction_AddReference_AddProjectReference, referenceToAdd, projectFile));
                 succeeded = Callbacks.AddProjectReference(projectFile, new[] { referenceToAdd });

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/AddReferencePostActionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/AddReferencePostActionTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.PostActionProcessors;
+using Microsoft.TemplateEngine.Mocks;
 using Microsoft.TemplateEngine.TestHelper;
 using Xunit;
 
@@ -147,6 +148,51 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             AddReferencePostActionProcessor actionProcessor = new AddReferencePostActionProcessor();
             IReadOnlyList<string> projFilesFound = actionProcessor.FindProjFileAtOrAbovePath(_engineEnvironmentSettings.Host.FileSystem, outputBasePath, new HashSet<string>());
             Assert.Equal(2, projFilesFound.Count);
+        }
+
+        [Fact(DisplayName = nameof(AddRefCanHandleProjectFileRenames))]
+        public void AddRefCanHandleProjectFileRenames()
+        {
+            AddReferencePostActionProcessor actionProcessor = new AddReferencePostActionProcessor();
+
+            string targetBasePath = _engineEnvironmentSettings.GetNewVirtualizedPath();
+            string projFileFullPath = Path.Combine(targetBasePath, "MyApp.csproj");
+            string referencedProjFileFullPath = Path.Combine(targetBasePath, "NewName.csproj");
+            
+            var args = new Dictionary<string, string>() { { "targetFiles", "[\"MyApp.csproj\"]" }, { "referenceType", "project" }, { "reference", "./OldName.csproj" } };
+            var postAction = new MockPostAction { ActionId = AddReferencePostActionProcessor.ActionProcessorId, Args = args };
+
+            var creationEffects = new MockCreationEffects()
+                .WithFileChange(new MockFileChange("./OldName.csproj", "./NewName.csproj", ChangeKind.Change))
+                .WithFileChange(new MockFileChange("./MyApp.csproj", "./MyApp.csproj", ChangeKind.Create));
+
+            var callback = new MockAddProjectReferenceCallback();
+            actionProcessor.Callbacks = new NewCommandCallbacks { AddProjectReference = callback.AddProjectReference };
+
+            actionProcessor.Process(
+                _engineEnvironmentSettings,
+                postAction,
+                creationEffects,
+                new MockCreationResult(),
+                targetBasePath);
+
+            Assert.Equal(projFileFullPath, callback.Target);
+            Assert.Equal(new [] { referencedProjFileFullPath }, callback.References);
+        }
+
+        private class MockAddProjectReferenceCallback
+        {
+            public string? Target { get; private set; }
+
+            public IReadOnlyList<string>? References { get; private set; }
+
+            public bool AddProjectReference(string target, IReadOnlyList<string> references)
+            {
+                this.Target = target;
+                this.References = references;
+
+                return true;
+            }
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/AddReferencePostActionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/AddReferencePostActionTests.cs
@@ -163,7 +163,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             var postAction = new MockPostAction { ActionId = AddReferencePostActionProcessor.ActionProcessorId, Args = args };
 
             var creationEffects = new MockCreationEffects()
-                .WithFileChange(new MockFileChange("./OldName.csproj", "./NewName.csproj", ChangeKind.Change))
+                .WithFileChange(new MockFileChange("./OldName.csproj", "./NewName.csproj", ChangeKind.Create))
                 .WithFileChange(new MockFileChange("./MyApp.csproj", "./MyApp.csproj", ChangeKind.Create));
 
             var callback = new MockAddProjectReferenceCallback();

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/AddReferencePostActionTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/AddReferencePostActionTests.cs
@@ -180,6 +180,35 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests
             Assert.Equal(new [] { referencedProjFileFullPath }, callback.References);
         }
 
+        [Fact(DisplayName = nameof(AddRefCanHandleProjectFilesWithoutRenames))]
+        public void AddRefCanHandleProjectFilesWithoutRenames()
+        {
+            AddReferencePostActionProcessor actionProcessor = new AddReferencePostActionProcessor();
+
+            string targetBasePath = _engineEnvironmentSettings.GetNewVirtualizedPath();
+            string projFileFullPath = Path.Combine(targetBasePath, "MyApp.csproj");
+            string referencedProjFileFullPath = Path.Combine(targetBasePath, "Reference.csproj");
+
+            var args = new Dictionary<string, string>() { { "targetFiles", "[\"MyApp.csproj\"]" }, { "referenceType", "project" }, { "reference", "./Reference.csproj" } };
+            var postAction = new MockPostAction { ActionId = AddReferencePostActionProcessor.ActionProcessorId, Args = args };
+
+            var creationEffects = new MockCreationEffects()
+                .WithFileChange(new MockFileChange("./MyApp.csproj", "./MyApp.csproj", ChangeKind.Create));
+
+            var callback = new MockAddProjectReferenceCallback();
+            actionProcessor.Callbacks = new NewCommandCallbacks { AddProjectReference = callback.AddProjectReference };
+
+            actionProcessor.Process(
+                _engineEnvironmentSettings,
+                postAction,
+                creationEffects,
+                new MockCreationResult(),
+                targetBasePath);
+
+            Assert.Equal(projFileFullPath, callback.Target);
+            Assert.Equal(new[] { referencedProjFileFullPath }, callback.References);
+        }
+
         private class MockAddProjectReferenceCallback
         {
             public string? Target { get; private set; }


### PR DESCRIPTION
### Problem
The post action AddReference (B17581D1-C5C9-4489-8F0A-004BE667B814) is unable to add project references if the referenced project has been renamed during template instantiation. This is because the post action does not check for renames, but only looks for the old project name.

### Solution
The post action should replace the name of the referenced project in case it has been renamed. This is a similar functionality as in the _targetFiles_ argument, where the name replacement works fine.