### PR TITLE
Use package version properties for dependabot project during source build

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -1,30 +1,80 @@
 <Project>
-  <!-- Packages in this file have versions updated periodically by Dependabot. Versions managed by Darc/Maestro should be in ..\Package.props. -->
+
+  <!-- Packages in this file have versions updated periodically by Dependabot. Versions managed by Darc/Maestro should be in ..\Package.props.
+
+  Packages must be set to their package version property if it exists (ex. BenchmarkDotNetVersion) since source-build uses
+  these properties to override package versions if necessary. -->
+
   <ItemGroup>
     <PackageReference Update="System.Diagnostics.Process" Version="4.3.0" />
+    <PackageReference Update="System.Diagnostics.Process" Condition="'$(SystemDiagnosticsProcessVersion)' != ''" Version="$(SystemDiagnosticsProcessVersion)" />
+
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
+    <PackageReference Update="System.IO.Compression" Condition="'$(SystemIOCompressionVersion)' != ''" Version="$(SystemIOCompressionVersion)" />
+
     <PackageReference Update="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Update="System.Runtime.Loader" Condition="'$(SystemRuntimeLoader)' != ''" Version="$(SystemRuntimeLoader)" />
+
     <PackageReference Update="Microsoft.Build.Framework" Version="17.2.0" />
+    <PackageReference Update="Microsoft.Build.Framework" Condition="'$(MicrosoftBuildFramework)' != ''" Version="$(MicrosoftBuildFramework)" />
+
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="17.2.0" />
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Condition="'$(MicrosoftBuildUtilitiesCore)' != ''" Version="$(MicrosoftBuildUtilitiesCore)" />
+
     <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJson)' != ''" Version="$(NewtonsoftJson)" />
+
     <PackageReference Update="Wcwidth.Sources" Version="0.6.0" />
+    <PackageReference Update="Wcwidth.Sources" Condition="'$(WcwidthSources)' != ''" Version="$(WcwidthSources)" />
+
     <PackageReference Update="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Condition="'$(MicrosoftExtensionsLogging)' != ''" Version="$(MicrosoftExtensionsLogging)" />
+
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Console" Condition="'$(MicrosoftExtensionsLoggingConsole)' != ''" Version="$(MicrosoftExtensionsLoggingConsole)" />
+
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Condition="'$(MicrosoftExtensionsLoggingAbstractions)' != ''" Version="$(MicrosoftExtensionsLoggingAbstractions)" />
+
     <PackageReference Update="NuGet.Configuration" Version="6.2.1" />
+    <PackageReference Update="NuGet.Configuration" Condition="'$(NuGetConfiguration)' != ''" Version="$(NuGetConfiguration)" />
+
     <PackageReference Update="NuGet.Credentials" Version="6.2.1" />
+    <PackageReference Update="NuGet.Credentials" Condition="'$(NuGetCredentials)' != ''" Version="$(NuGetCredentials)" />
+
     <PackageReference Update="NuGet.Protocol" Version="6.2.1" />
+    <PackageReference Update="NuGet.Protocol" Condition="'$(NuGetProtocol)' != ''" Version="$(NuGetProtocol)" />
+
     <!--Analyzers-->
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Condition="'$(MicrosoftNetCompilersToolset)' != ''" Version="$(MicrosoftNetCompilersToolset)" />
+
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.2.0" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Condition="'$(MicrosoftCodeAnalysisCSharpCodeStyle)' != ''" Version="$(MicrosoftCodeAnalysisCSharpCodeStyle)" />
+
     <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4-beta1.22277.2" />
+    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzers)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzers)" />
+
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435" />
+    <PackageReference Update="StyleCop.Analyzers" Condition="'$(StyleCopAnalyzers)' != ''" Version="$(StyleCopAnalyzers)" />
+
     <!--Test dependencies-->
     <PackageReference Update="FakeItEasy" Version="7.3.1" />
+    <PackageReference Update="FakeItEasy" Condition="'$(FakeItEasy)' != ''" Version="$(BenchmarkDotNetVersion)" />
+
     <PackageReference Update="FluentAssertions" Version="6.7.0" />
+    <PackageReference Update="FluentAssertions" Condition="'$(FluentAssertions)' != ''" Version="$(FluentAssertions)" />
+
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Condition="'$(MicrosoftNETTestSdk)' != ''" Version="$(MicrosoftNETTestSdk)" />
+
     <PackageReference Update="xunit.abstractions" Version="2.0.3" />
+    <PackageReference Update="xunit.abstractions" Condition="'$(xunitabstractions)' != ''" Version="$(xunitabstractions)" />
+
     <PackageReference Update="Newtonsoft.Json.Schema" Version="3.0.14" />
+    <PackageReference Update="Newtonsoft.Json.Schema" Condition="'$(NewtonsoftJsonSchema)' != ''" Version="$(NewtonsoftJsonSchema)" />
+
     <PackageReference Update="Verify.XUnit" Version="17.2.1" />
+    <PackageReference Update="Verify.XUnit" Condition="'$(VerifyXUnit)' != ''" Version="$(VerifyXUnit)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -7,74 +7,59 @@
 
   <ItemGroup>
     <PackageReference Update="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Update="System.Diagnostics.Process" Condition="'$(SystemDiagnosticsProcessVersion)' != ''" Version="$(SystemDiagnosticsProcessVersion)" />
-
     <PackageReference Update="System.IO.Compression" Version="4.3.0" />
-    <PackageReference Update="System.IO.Compression" Condition="'$(SystemIOCompressionVersion)' != ''" Version="$(SystemIOCompressionVersion)" />
-
     <PackageReference Update="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Update="System.Runtime.Loader" Condition="'$(SystemRuntimeLoader)' != ''" Version="$(SystemRuntimeLoaderVersion)" />
-
     <PackageReference Update="Microsoft.Build.Framework" Version="17.2.0" />
-    <PackageReference Update="Microsoft.Build.Framework" Condition="'$(MicrosoftBuildFramework)' != ''" Version="$(MicrosoftBuildFrameworkVersion)" />
-
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="17.2.0" />
-    <PackageReference Update="Microsoft.Build.Utilities.Core" Condition="'$(MicrosoftBuildUtilitiesCore)' != ''" Version="$(MicrosoftBuildUtilitiesCore)" />
-
     <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJson)' != ''" Version="$(NewtonsoftJsonVersion)" />
-
     <PackageReference Update="Wcwidth.Sources" Version="0.6.0" />
-    <PackageReference Update="Wcwidth.Sources" Condition="'$(WcwidthSources)' != ''" Version="$(WcwidthSourcesVersion)" />
-
     <PackageReference Update="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Logging" Condition="'$(MicrosoftExtensionsLogging)' != ''" Version="$(MicrosoftExtensionsLoggingVersion)" />
-
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Console" Condition="'$(MicrosoftExtensionsLoggingConsole)' != ''" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
-
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Condition="'$(MicrosoftExtensionsLoggingAbstractions)' != ''" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
-
     <PackageReference Update="NuGet.Configuration" Version="6.2.1" />
-    <PackageReference Update="NuGet.Configuration" Condition="'$(NuGetConfiguration)' != ''" Version="$(NuGetConfigurationVersion)" />
-
     <PackageReference Update="NuGet.Credentials" Version="6.2.1" />
-    <PackageReference Update="NuGet.Credentials" Condition="'$(NuGetCredentials)' != ''" Version="$(NuGetCredentialsVersion)" />
-
     <PackageReference Update="NuGet.Protocol" Version="6.2.1" />
-    <PackageReference Update="NuGet.Protocol" Condition="'$(NuGetProtocol)' != ''" Version="$(NuGetProtocolVersion)" />
 
     <!--Analyzers-->
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Condition="'$(MicrosoftNetCompilersToolset)' != ''" Version="$(MicrosoftNetCompilersToolsetVersion)" />
-
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.2.0" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Condition="'$(MicrosoftCodeAnalysisCSharpCodeStyle)' != ''" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" />
-
     <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4-beta1.22277.2" />
-    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzers)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
-
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435" />
-    <PackageReference Update="StyleCop.Analyzers" Condition="'$(StyleCopAnalyzers)' != ''" Version="$(StyleCopAnalyzersVersion)" />
 
     <!--Test dependencies-->
     <PackageReference Update="FakeItEasy" Version="7.3.1" />
-    <PackageReference Update="FakeItEasy" Condition="'$(FakeItEasy)' != ''" Version="$(FakeItEasyVersion)" />
-
     <PackageReference Update="FluentAssertions" Version="6.7.0" />
-    <PackageReference Update="FluentAssertions" Condition="'$(FluentAssertions)' != ''" Version="$(FluentAssertionsVersion)" />
-
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Condition="'$(MicrosoftNETTestSdk)' != ''" Version="$(MicrosoftNETTestSdkVersion)" />
-
     <PackageReference Update="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Update="xunit.abstractions" Condition="'$(xunitabstractions)' != ''" Version="$(xunitabstractionsVersion)" />
-
     <PackageReference Update="Newtonsoft.Json.Schema" Version="3.0.14" />
-    <PackageReference Update="Newtonsoft.Json.Schema" Condition="'$(NewtonsoftJsonSchema)' != ''" Version="$(NewtonsoftJsonSchemaVersion)" />
-
     <PackageReference Update="Verify.XUnit" Version="17.2.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <PackageReference Update="System.Diagnostics.Process" Condition="'$(SystemDiagnosticsProcessVersion)' != ''" Version="$(SystemDiagnosticsProcessVersion)" />
+    <PackageReference Update="System.IO.Compression" Condition="'$(SystemIOCompressionVersion)' != ''" Version="$(SystemIOCompressionVersion)" />
+    <PackageReference Update="System.Runtime.Loader" Condition="'$(SystemRuntimeLoader)' != ''" Version="$(SystemRuntimeLoaderVersion)" />
+    <PackageReference Update="Microsoft.Build.Framework" Condition="'$(MicrosoftBuildFramework)' != ''" Version="$(MicrosoftBuildFrameworkVersion)" />
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Condition="'$(MicrosoftBuildUtilitiesCore)' != ''" Version="$(MicrosoftBuildUtilitiesCore)" />
+    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJson)' != ''" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Update="Wcwidth.Sources" Condition="'$(WcwidthSources)' != ''" Version="$(WcwidthSourcesVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Condition="'$(MicrosoftExtensionsLogging)' != ''" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Console" Condition="'$(MicrosoftExtensionsLoggingConsole)' != ''" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Condition="'$(MicrosoftExtensionsLoggingAbstractions)' != ''" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
+    <PackageReference Update="NuGet.Configuration" Condition="'$(NuGetConfiguration)' != ''" Version="$(NuGetConfigurationVersion)" />
+    <PackageReference Update="NuGet.Credentials" Condition="'$(NuGetCredentials)' != ''" Version="$(NuGetCredentialsVersion)" />
+    <PackageReference Update="NuGet.Protocol" Condition="'$(NuGetProtocol)' != ''" Version="$(NuGetProtocolVersion)" />
+
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Condition="'$(MicrosoftNetCompilersToolset)' != ''" Version="$(MicrosoftNetCompilersToolsetVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Condition="'$(MicrosoftCodeAnalysisCSharpCodeStyle)' != ''" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzers)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
+    <PackageReference Update="StyleCop.Analyzers" Condition="'$(StyleCopAnalyzers)' != ''" Version="$(StyleCopAnalyzersVersion)" />
+
+    <PackageReference Update="FakeItEasy" Condition="'$(FakeItEasy)' != ''" Version="$(FakeItEasyVersion)" />
+    <PackageReference Update="FluentAssertions" Condition="'$(FluentAssertions)' != ''" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Condition="'$(MicrosoftNETTestSdk)' != ''" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Update="xunit.abstractions" Condition="'$(xunitabstractions)' != ''" Version="$(xunitabstractionsVersion)" />
+    <PackageReference Update="Newtonsoft.Json.Schema" Condition="'$(NewtonsoftJsonSchema)' != ''" Version="$(NewtonsoftJsonSchemaVersion)" />
     <PackageReference Update="Verify.XUnit" Condition="'$(VerifyXUnit)' != ''" Version="$(VerifyXUnitVersion)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -13,68 +13,68 @@
     <PackageReference Update="System.IO.Compression" Condition="'$(SystemIOCompressionVersion)' != ''" Version="$(SystemIOCompressionVersion)" />
 
     <PackageReference Update="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Update="System.Runtime.Loader" Condition="'$(SystemRuntimeLoader)' != ''" Version="$(SystemRuntimeLoader)" />
+    <PackageReference Update="System.Runtime.Loader" Condition="'$(SystemRuntimeLoader)' != ''" Version="$(SystemRuntimeLoaderVersion)" />
 
     <PackageReference Update="Microsoft.Build.Framework" Version="17.2.0" />
-    <PackageReference Update="Microsoft.Build.Framework" Condition="'$(MicrosoftBuildFramework)' != ''" Version="$(MicrosoftBuildFramework)" />
+    <PackageReference Update="Microsoft.Build.Framework" Condition="'$(MicrosoftBuildFramework)' != ''" Version="$(MicrosoftBuildFrameworkVersion)" />
 
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="17.2.0" />
     <PackageReference Update="Microsoft.Build.Utilities.Core" Condition="'$(MicrosoftBuildUtilitiesCore)' != ''" Version="$(MicrosoftBuildUtilitiesCore)" />
 
     <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJson)' != ''" Version="$(NewtonsoftJson)" />
+    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJson)' != ''" Version="$(NewtonsoftJsonVersion)" />
 
     <PackageReference Update="Wcwidth.Sources" Version="0.6.0" />
-    <PackageReference Update="Wcwidth.Sources" Condition="'$(WcwidthSources)' != ''" Version="$(WcwidthSources)" />
+    <PackageReference Update="Wcwidth.Sources" Condition="'$(WcwidthSources)' != ''" Version="$(WcwidthSourcesVersion)" />
 
     <PackageReference Update="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Logging" Condition="'$(MicrosoftExtensionsLogging)' != ''" Version="$(MicrosoftExtensionsLogging)" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Condition="'$(MicrosoftExtensionsLogging)' != ''" Version="$(MicrosoftExtensionsLoggingVersion)" />
 
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Console" Condition="'$(MicrosoftExtensionsLoggingConsole)' != ''" Version="$(MicrosoftExtensionsLoggingConsole)" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Console" Condition="'$(MicrosoftExtensionsLoggingConsole)' != ''" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
 
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Condition="'$(MicrosoftExtensionsLoggingAbstractions)' != ''" Version="$(MicrosoftExtensionsLoggingAbstractions)" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Condition="'$(MicrosoftExtensionsLoggingAbstractions)' != ''" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
 
     <PackageReference Update="NuGet.Configuration" Version="6.2.1" />
-    <PackageReference Update="NuGet.Configuration" Condition="'$(NuGetConfiguration)' != ''" Version="$(NuGetConfiguration)" />
+    <PackageReference Update="NuGet.Configuration" Condition="'$(NuGetConfiguration)' != ''" Version="$(NuGetConfigurationVersion)" />
 
     <PackageReference Update="NuGet.Credentials" Version="6.2.1" />
-    <PackageReference Update="NuGet.Credentials" Condition="'$(NuGetCredentials)' != ''" Version="$(NuGetCredentials)" />
+    <PackageReference Update="NuGet.Credentials" Condition="'$(NuGetCredentials)' != ''" Version="$(NuGetCredentialsVersion)" />
 
     <PackageReference Update="NuGet.Protocol" Version="6.2.1" />
-    <PackageReference Update="NuGet.Protocol" Condition="'$(NuGetProtocol)' != ''" Version="$(NuGetProtocol)" />
+    <PackageReference Update="NuGet.Protocol" Condition="'$(NuGetProtocol)' != ''" Version="$(NuGetProtocolVersion)" />
 
     <!--Analyzers-->
     <PackageReference Update="Microsoft.Net.Compilers.Toolset" Version="4.2.0" />
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Condition="'$(MicrosoftNetCompilersToolset)' != ''" Version="$(MicrosoftNetCompilersToolset)" />
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Condition="'$(MicrosoftNetCompilersToolset)' != ''" Version="$(MicrosoftNetCompilersToolsetVersion)" />
 
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.2.0" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Condition="'$(MicrosoftCodeAnalysisCSharpCodeStyle)' != ''" Version="$(MicrosoftCodeAnalysisCSharpCodeStyle)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Condition="'$(MicrosoftCodeAnalysisCSharpCodeStyle)' != ''" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" />
 
     <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4-beta1.22277.2" />
-    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzers)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzers)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzers)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
 
     <PackageReference Update="StyleCop.Analyzers" Version="1.2.0-beta.435" />
-    <PackageReference Update="StyleCop.Analyzers" Condition="'$(StyleCopAnalyzers)' != ''" Version="$(StyleCopAnalyzers)" />
+    <PackageReference Update="StyleCop.Analyzers" Condition="'$(StyleCopAnalyzers)' != ''" Version="$(StyleCopAnalyzersVersion)" />
 
     <!--Test dependencies-->
     <PackageReference Update="FakeItEasy" Version="7.3.1" />
-    <PackageReference Update="FakeItEasy" Condition="'$(FakeItEasy)' != ''" Version="$(BenchmarkDotNetVersion)" />
+    <PackageReference Update="FakeItEasy" Condition="'$(FakeItEasy)' != ''" Version="$(FakeItEasyVersion)" />
 
     <PackageReference Update="FluentAssertions" Version="6.7.0" />
-    <PackageReference Update="FluentAssertions" Condition="'$(FluentAssertions)' != ''" Version="$(FluentAssertions)" />
+    <PackageReference Update="FluentAssertions" Condition="'$(FluentAssertions)' != ''" Version="$(FluentAssertionsVersion)" />
 
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Condition="'$(MicrosoftNETTestSdk)' != ''" Version="$(MicrosoftNETTestSdk)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Condition="'$(MicrosoftNETTestSdk)' != ''" Version="$(MicrosoftNETTestSdkVersion)" />
 
     <PackageReference Update="xunit.abstractions" Version="2.0.3" />
-    <PackageReference Update="xunit.abstractions" Condition="'$(xunitabstractions)' != ''" Version="$(xunitabstractions)" />
+    <PackageReference Update="xunit.abstractions" Condition="'$(xunitabstractions)' != ''" Version="$(xunitabstractionsVersion)" />
 
     <PackageReference Update="Newtonsoft.Json.Schema" Version="3.0.14" />
-    <PackageReference Update="Newtonsoft.Json.Schema" Condition="'$(NewtonsoftJsonSchema)' != ''" Version="$(NewtonsoftJsonSchema)" />
+    <PackageReference Update="Newtonsoft.Json.Schema" Condition="'$(NewtonsoftJsonSchema)' != ''" Version="$(NewtonsoftJsonSchemaVersion)" />
 
     <PackageReference Update="Verify.XUnit" Version="17.2.1" />
-    <PackageReference Update="Verify.XUnit" Condition="'$(VerifyXUnit)' != ''" Version="$(VerifyXUnit)" />
+    <PackageReference Update="Verify.XUnit" Condition="'$(VerifyXUnit)' != ''" Version="$(VerifyXUnitVersion)" />
   </ItemGroup>
 </Project>

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -38,28 +38,28 @@
   <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
     <PackageReference Update="System.Diagnostics.Process" Condition="'$(SystemDiagnosticsProcessVersion)' != ''" Version="$(SystemDiagnosticsProcessVersion)" />
     <PackageReference Update="System.IO.Compression" Condition="'$(SystemIOCompressionVersion)' != ''" Version="$(SystemIOCompressionVersion)" />
-    <PackageReference Update="System.Runtime.Loader" Condition="'$(SystemRuntimeLoader)' != ''" Version="$(SystemRuntimeLoaderVersion)" />
-    <PackageReference Update="Microsoft.Build.Framework" Condition="'$(MicrosoftBuildFramework)' != ''" Version="$(MicrosoftBuildFrameworkVersion)" />
-    <PackageReference Update="Microsoft.Build.Utilities.Core" Condition="'$(MicrosoftBuildUtilitiesCore)' != ''" Version="$(MicrosoftBuildUtilitiesCore)" />
-    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJson)' != ''" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Update="Wcwidth.Sources" Condition="'$(WcwidthSources)' != ''" Version="$(WcwidthSourcesVersion)" />
-    <PackageReference Update="Microsoft.Extensions.Logging" Condition="'$(MicrosoftExtensionsLogging)' != ''" Version="$(MicrosoftExtensionsLoggingVersion)" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Console" Condition="'$(MicrosoftExtensionsLoggingConsole)' != ''" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Condition="'$(MicrosoftExtensionsLoggingAbstractions)' != ''" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
-    <PackageReference Update="NuGet.Configuration" Condition="'$(NuGetConfiguration)' != ''" Version="$(NuGetConfigurationVersion)" />
-    <PackageReference Update="NuGet.Credentials" Condition="'$(NuGetCredentials)' != ''" Version="$(NuGetCredentialsVersion)" />
-    <PackageReference Update="NuGet.Protocol" Condition="'$(NuGetProtocol)' != ''" Version="$(NuGetProtocolVersion)" />
+    <PackageReference Update="System.Runtime.Loader" Condition="'$(SystemRuntimeLoaderVersion)' != ''" Version="$(SystemRuntimeLoaderVersion)" />
+    <PackageReference Update="Microsoft.Build.Framework" Condition="'$(MicrosoftBuildFrameworkVersion)' != ''" Version="$(MicrosoftBuildFrameworkVersion)" />
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Condition="'$(MicrosoftBuildUtilitiesCoreVersion)' != ''" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJsonVersion)' != ''" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Update="Wcwidth.Sources" Condition="'$(WcwidthSourcesVersion)' != ''" Version="$(WcwidthSourcesVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Condition="'$(MicrosoftExtensionsLoggingVersion)' != ''" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Console" Condition="'$(MicrosoftExtensionsLoggingConsoleVersion)' != ''" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Condition="'$(MicrosoftExtensionsLoggingAbstractionsVersion)' != ''" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
+    <PackageReference Update="NuGet.Configuration" Condition="'$(NuGetConfigurationVersion)' != ''" Version="$(NuGetConfigurationVersion)" />
+    <PackageReference Update="NuGet.Credentials" Condition="'$(NuGetCredentialsVersion)' != ''" Version="$(NuGetCredentialsVersion)" />
+    <PackageReference Update="NuGet.Protocol" Condition="'$(NuGetProtocolVersion)' != ''" Version="$(NuGetProtocolVersion)" />
 
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Condition="'$(MicrosoftNetCompilersToolset)' != ''" Version="$(MicrosoftNetCompilersToolsetVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Condition="'$(MicrosoftCodeAnalysisCSharpCodeStyle)' != ''" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzers)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
-    <PackageReference Update="StyleCop.Analyzers" Condition="'$(StyleCopAnalyzers)' != ''" Version="$(StyleCopAnalyzersVersion)" />
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Condition="'$(MicrosoftNetCompilersToolsetVersion)' != ''" Version="$(MicrosoftNetCompilersToolsetVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Condition="'$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)' != ''" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
+    <PackageReference Update="StyleCop.Analyzers" Condition="'$(StyleCopAnalyzersVersion)' != ''" Version="$(StyleCopAnalyzersVersion)" />
 
-    <PackageReference Update="FakeItEasy" Condition="'$(FakeItEasy)' != ''" Version="$(FakeItEasyVersion)" />
-    <PackageReference Update="FluentAssertions" Condition="'$(FluentAssertions)' != ''" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Condition="'$(MicrosoftNETTestSdk)' != ''" Version="$(MicrosoftNETTestSdkVersion)" />
-    <PackageReference Update="xunit.abstractions" Condition="'$(xunitabstractions)' != ''" Version="$(xunitabstractionsVersion)" />
-    <PackageReference Update="Newtonsoft.Json.Schema" Condition="'$(NewtonsoftJsonSchema)' != ''" Version="$(NewtonsoftJsonSchemaVersion)" />
-    <PackageReference Update="Verify.XUnit" Condition="'$(VerifyXUnit)' != ''" Version="$(VerifyXUnitVersion)" />
+    <PackageReference Update="FakeItEasy" Condition="'$(FakeItEasyVersion)' != ''" Version="$(FakeItEasyVersion)" />
+    <PackageReference Update="FluentAssertions" Condition="'$(FluentAssertionsVersion)' != ''" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Condition="'$(MicrosoftNETTestSdkVersion)' != ''" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Update="xunit.abstractions" Condition="'$(xunitabstractionsVersion)' != ''" Version="$(xunitabstractionsVersion)" />
+    <PackageReference Update="Newtonsoft.Json.Schema" Condition="'$(NewtonsoftJsonSchemaVersion)' != ''" Version="$(NewtonsoftJsonSchemaVersion)" />
+    <PackageReference Update="Verify.XUnit" Condition="'$(VerifyXUnitVersion)' != ''" Version="$(VerifyXUnitVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Context
See https://github.com/dotnet/source-build/issues/2933 and https://github.com/dotnet/msbuild/pull/7798

### Changes Made

- Set PackageReferences to versions specified by their respective `*Version` properties (like `SystemCodeDomVersion` for example). We define and import properties for packages that are available during source-build and use this to overwrite the dependabot-managed versions of these packages.
- During a non-source-build build, these dependencies should all be set to their dependabot-managed versions, since none of these dependencies have versions properties defined in `eng/Versions.props`.

If dependabot has trouble reading and updating these dependencies after this update, then of course we can revert this change and re-evaluate our approach.