### PR TITLE
`IBindSymbolSource`: added `RequiresPrefixMatch` property 

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/Components/IBindSymbolSource.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Components/IBindSymbolSource.cs
@@ -26,6 +26,11 @@ namespace Microsoft.TemplateEngine.Abstractions.Components
         public string? SourcePrefix { get; }
 
         /// <summary>
+        /// If set to true, the component required exact prefix match to be used.
+        /// </summary>
+        public bool RequiresPrefixMatch { get; }
+
+        /// <summary>
         /// Gets the value corresponding to <paramref name="bindname"/>.
         /// </summary>
         /// <param name="settings">template engine environment settings.</param>

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
@@ -4,6 +4,7 @@ const Microsoft.TemplateEngine.Abstractions.TemplateFiltering.MatchInfo.BuiltIn.
 Microsoft.TemplateEngine.Abstractions.Components.IBindSymbolSource
 Microsoft.TemplateEngine.Abstractions.Components.IBindSymbolSource.DisplayName.get -> string!
 Microsoft.TemplateEngine.Abstractions.Components.IBindSymbolSource.GetBoundValueAsync(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! settings, string! bindname, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string?>!
+Microsoft.TemplateEngine.Abstractions.Components.IBindSymbolSource.RequiresPrefixMatch.get -> bool
 Microsoft.TemplateEngine.Abstractions.Components.IBindSymbolSource.SourcePrefix.get -> string?
 Microsoft.TemplateEngine.Abstractions.Components.ISdkInfoProvider
 Microsoft.TemplateEngine.Abstractions.Components.ISdkInfoProvider.GetCurrentVersionAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<string!>!

--- a/src/Microsoft.TemplateEngine.Edge/Components/EnvironmentVariablesBindSource.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Components/EnvironmentVariablesBindSource.cs
@@ -23,6 +23,8 @@ namespace Microsoft.TemplateEngine.Edge
 
         string? IBindSymbolSource.SourcePrefix => "env";
 
+        bool IBindSymbolSource.RequiresPrefixMatch => false;
+
         Guid IIdentifiedComponent.Id => Guid.Parse("{8420EB0D-2FD7-49A7-966D-0914C86A14E4}");
 
         string IBindSymbolSource.DisplayName => LocalizableStrings.EnvironmentVariablesBindSource_Name;

--- a/src/Microsoft.TemplateEngine.Edge/Components/HostParametersBindSource.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Components/HostParametersBindSource.cs
@@ -24,6 +24,8 @@ namespace Microsoft.TemplateEngine.Edge
 
         string? IBindSymbolSource.SourcePrefix => "host";
 
+        bool IBindSymbolSource.RequiresPrefixMatch => false;
+
         Guid IIdentifiedComponent.Id => Guid.Parse("{63AB8956-DBFA-4DA4-8089-93CC8272D7C5}");
 
         string IBindSymbolSource.DisplayName => LocalizableStrings.HostParametersBindSource_Name;


### PR DESCRIPTION
### Problem
MSBuild `IBindSymbolSource` is time-consuming as it needs to do MSBuild evaluation. Using it as the fallback is not an option, as it impacts many existing templates which do not need this source.

### Solution
Added `IBindSymbolSource.RequiresPrefixMatch` property. If set to `true`, the source will be called only on exact prefix match.
MSBuild `IBindSymbolSource` will use `true` to avoid fallback calls.

Note: opted in to use property vs putting the logic of parsing prefix and further actions in `GetBoundValueAsync`, though it is slightly more work. This will avoid creating extra tasks in `BindSymbolEvaluator` which immediately return null because the prefix is not matched. 
Alternative is to add parsing prefix logic to `GetBoundValueAsync` and let the source decide what to do if the prefix is not given or not matched.

Open for discussion here.

Draft PR that implements MSBuild `IBindSymbolSource`: https://github.com/dotnet/sdk/pull/26523

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)