### PR TITLE
Pin newtonsoft.json to 13.0.1

### DIFF
--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -16,6 +16,7 @@
   <!-- xunit.assert has this dependency, so applying to all test projects-->
   <ItemGroup>
     <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" /> 
+    <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" />
+    <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.TemplateEngine.Cli.TestHelper/Microsoft.TemplateEngine.Cli.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.TestHelper/Microsoft.TemplateEngine.Cli.TestHelper.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="xunit.abstractions" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
### Problem
Pinning newtonsoft.json to 13.0.1 for the test projects (to prevent pulling older versions by transitive dependencies)

### Checks: N/A
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)