### PR TITLE
Pin System.Security.Cryptography.X509Certificates for tests

### DIFF
--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -16,5 +16,6 @@
   <!-- xunit.assert has this dependency, so applying to all test projects-->
   <ItemGroup>
     <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" /> 
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Problem
Vulnerable System.Security.Cryptography.X509Certificates is brought by the test framework - so pinning the updated version

This is not influencing production bits

### Checks: N/A
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)