### PR TITLE
`console` template: accelerator keys for "do not use top-level statements"

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/ITemplateParameter.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ITemplateParameter.cs
@@ -61,6 +61,7 @@ namespace Microsoft.TemplateEngine.Abstractions
         /// <summary>
         /// Gets the friendly name of the parameter to be displayed to the user.
         /// This property is localized if localizations are provided.
+        /// May contain accelerator key (_) which should be processed or removed.
         /// </summary>
         string? DisplayName { get; }
 

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.en.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/localize/templatestrings.en.json
@@ -13,7 +13,8 @@
   "symbols/skipRestore/description": "If specified, skips the automatic restore of the project on create.",
   "symbols/skipRestore/displayName": "Skip restore",
   "symbols/UseProgramMain/description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
-  "symbols/UseProgramMain/displayName": "Do not use top-level statements",
+  "symbols/UseProgramMain/displayName": "Do not use _top-level statements",
+  "_symbols/UseProgramMain/displayName.comment": "Use '_' as accelerator key when translating.",
   "postActions/restore/description": "Restore NuGet packages required by this project.",
   "postActions/restore/manualInstructions/default/text": "Run 'dotnet restore'",
   "postActions/open-file/description": "Opens Program.cs in the editor"

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.7.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -66,7 +66,7 @@
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
-      "displayName": "Do not use top-level statements"
+      "displayName": "Do not use _top-level statements"
     },
     "csharp10orLater": {
       "type": "generated",


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/4961

### Solution/Description
We have recently added "do not use top-level statements" option for this template to be visible in VS, but at the moment its display name doesn’t have an accelerator key defined.
PR defines accelerator keys in default value, merging it will trigger translations update to contain accelerator key in translations as well (will be added as the separated automated PR).


### Customer impact
At the moment accelerator for `console` template options are not defined, which is considered to be a bug in VS. After PR and translations are done, the accelerator key will be defined.
![image](https://user-images.githubusercontent.com/56045248/181040740-8cf54ddc-b3b2-4a02-8c33-a39b0442e74e.png)


### Regression: 
no - new feature recently added with this defect

### Risk
Very low

### Verification
Manual