### PR TITLE
`CppStyleEvaluatorDefinition`: do not advance the buffer after all the tokens are read

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -58,7 +58,7 @@ dotnet_style_predefined_type_for_member_access = true:suggestion
 # name all constant fields using PascalCase
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
 dotnet_naming_symbols.constant_fields.applicable_kinds   = field
 dotnet_naming_symbols.constant_fields.required_modifiers = const
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
@@ -66,7 +66,7 @@ dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 # static fields should have s_ prefix
 dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
 dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
-dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
 dotnet_naming_symbols.static_fields.applicable_kinds   = field
 dotnet_naming_symbols.static_fields.required_modifiers = static
 dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
@@ -76,7 +76,7 @@ dotnet_naming_style.static_prefix_style.capitalization = camel_case
 # internal and private fields should be _camelCase
 dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
 dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
-dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
 dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
 dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
 dotnet_naming_style.camel_case_underscore_style.required_prefix = _
@@ -594,6 +594,7 @@ dotnet_diagnostic.xUnit2017.severity = none
 
 # Do not use obsolete throws check to check for asynchronously thrown exception
 dotnet_diagnostic.xUnit2019.severity = warning
+
 
 # test code files
 [test/**/*.{cs,vb}]

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IOperation.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IOperation.cs
@@ -7,9 +7,9 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 {
     public interface IOperation
     {
-        IReadOnlyList<IToken> Tokens { get; }
+        IReadOnlyList<IToken?> Tokens { get; }
 
-        string Id { get; }
+        string? Id { get; }
 
         bool IsInitialStateOn { get; }
 

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IOperationProvider.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IOperationProvider.cs
@@ -7,7 +7,7 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 {
     public interface IOperationProvider
     {
-        string Id { get; }
+        string? Id { get; }
 
         IOperation GetOperation(Encoding encoding, IProcessorState processorState);
     }

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IProcessorState.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IProcessorState.cs
@@ -24,17 +24,17 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 
         bool AdvanceBuffer(int bufferPosition);
 
-        void SeekForwardUntil(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition);
+        void SeekBufferForwardUntil(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition);
 
-        void SeekForwardThrough(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition);
+        void SeekBufferForwardThrough(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition);
 
-        void SeekForwardWhile(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition);
+        void SeekBufferForwardWhile(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition);
 
-        void SeekBackUntil(ITokenTrie match);
+        void SeekTargetBackUntil(ITokenTrie match);
 
-        void SeekBackUntil(ITokenTrie match, bool consume);
+        void SeekTargetBackUntil(ITokenTrie match, bool consume);
 
-        void SeekBackWhile(ITokenTrie match);
+        void SeekTargetBackWhile(ITokenTrie match);
 
         void Write(byte[] buffer, int offset, int count);
 

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IToken.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IToken.cs
@@ -5,12 +5,24 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 {
     public interface IToken
     {
+        /// <summary>
+        /// The value to match.
+        /// </summary>
         byte[] Value { get; }
 
+        /// <summary>
+        /// Start of actual token. May be not 0, when look arounds are used.
+        /// </summary>
         int Start { get; }
 
+        /// <summary>
+        /// Start of actual token. May be not Value.Length, when look arounds are used.
+        /// </summary>
         int End { get; }
 
+        /// <summary>
+        /// The length of the actual token.
+        /// </summary>
         int Length { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Core.Contracts/ITokenTrie.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/ITokenTrie.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 
         int AddToken(IToken token);
 
-        void AddToken(IToken token, int index);
+        void AddToken(IToken? token, int index);
 
         bool GetOperation(byte[] buffer, int bufferLength, ref int currentBufferPosition, out int token);
 

--- a/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Shipped.txt
@@ -58,10 +58,7 @@ Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.RootVariableCollection.ge
 Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.Special.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<Microsoft.TemplateEngine.Core.Contracts.IPathMatcher!, Microsoft.TemplateEngine.Core.Contracts.IRunSpec!>>!
 Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.TryGetTargetRelPath(string! sourceRelPath, out string! targetRelPath) -> bool
 Microsoft.TemplateEngine.Core.Contracts.IOperation.HandleMatch(Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processor, int bufferLength, ref int currentBufferPosition, int token) -> int
-Microsoft.TemplateEngine.Core.Contracts.IOperation.Id.get -> string!
-Microsoft.TemplateEngine.Core.Contracts.IOperation.Tokens.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IToken!>!
 Microsoft.TemplateEngine.Core.Contracts.IOperationProvider.GetOperation(System.Text.Encoding! encoding, Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processorState) -> Microsoft.TemplateEngine.Core.Contracts.IOperation!
-Microsoft.TemplateEngine.Core.Contracts.IOperationProvider.Id.get -> string!
 Microsoft.TemplateEngine.Core.Contracts.IOrchestrator.GetFileChanges(Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec! spec, Microsoft.TemplateEngine.Abstractions.Mount.IDirectory! sourceDir, string! targetDir) -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.IFileChange2!>!
 Microsoft.TemplateEngine.Core.Contracts.IOrchestrator.GetFileChanges(string! runSpecPath, Microsoft.TemplateEngine.Abstractions.Mount.IDirectory! sourceDir, string! targetDir) -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.IFileChange2!>!
 Microsoft.TemplateEngine.Core.Contracts.IOrchestrator.Run(Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec! spec, Microsoft.TemplateEngine.Abstractions.Mount.IDirectory! sourceDir, string! targetDir) -> void
@@ -77,12 +74,6 @@ Microsoft.TemplateEngine.Core.Contracts.IProcessorState.CurrentBuffer.get -> byt
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.Encoding.get -> System.Text.Encoding!
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.EncodingConfig.get -> Microsoft.TemplateEngine.Core.Contracts.IEncodingConfig!
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.Inject(System.IO.Stream! staged) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, bool consume) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekBackWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekForwardThrough(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekForwardUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekForwardWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.Write(byte[]! buffer, int offset, int count) -> void
 Microsoft.TemplateEngine.Core.Contracts.IReplacementTokens.OriginalValue.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig!
 Microsoft.TemplateEngine.Core.Contracts.IReplacementTokens.VariableName.get -> string!
@@ -95,7 +86,6 @@ Microsoft.TemplateEngine.Core.Contracts.ITokenConfig.Before.get -> string!
 Microsoft.TemplateEngine.Core.Contracts.ITokenConfig.ToToken(System.Text.Encoding! encoding) -> Microsoft.TemplateEngine.Core.Contracts.IToken!
 Microsoft.TemplateEngine.Core.Contracts.ITokenConfig.Value.get -> string!
 Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.AddToken(Microsoft.TemplateEngine.Core.Contracts.IToken! token) -> int
-Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.AddToken(Microsoft.TemplateEngine.Core.Contracts.IToken! token, int index) -> void
 Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.Append(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie) -> void
 Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.CreateEvaluator() -> Microsoft.TemplateEngine.Core.Contracts.ITokenTrieEvaluator!
 Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.GetOperation(byte[]! buffer, int bufferLength, ref int currentBufferPosition, bool mustMatchPosition, out int token) -> bool

--- a/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
@@ -1,1 +1,10 @@
-﻿
+﻿Microsoft.TemplateEngine.Core.Contracts.IOperation.Id.get -> string?
+Microsoft.TemplateEngine.Core.Contracts.IOperation.Tokens.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IToken?>!
+Microsoft.TemplateEngine.Core.Contracts.IOperationProvider.Id.get -> string?
+Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekBufferForwardThrough(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
+Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekBufferForwardUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
+Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekBufferForwardWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
+Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekTargetBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
+Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekTargetBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, bool consume) -> void
+Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekTargetBackWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
+Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.AddToken(Microsoft.TemplateEngine.Core.Contracts.IToken? token, int index) -> void

--- a/src/Microsoft.TemplateEngine.Core/CommonOperations.cs
+++ b/src/Microsoft.TemplateEngine.Core/CommonOperations.cs
@@ -1,13 +1,22 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Core
 {
-    public static class CommonOperations
+    internal static class CommonOperations
     {
-        public static void WhitespaceHandler(this IProcessorState processor, ref int bufferLength, ref int currentBufferPosition, bool wholeLine = false, bool trim = false, bool trimForward = false, bool trimBackward = false)
+        internal static void WhitespaceHandler(
+            this IProcessorState processor,
+            ref int bufferLength,
+            ref int currentBufferPosition,
+            bool wholeLine = false,
+            bool trim = false,
+            bool trimForward = false,
+            bool trimBackward = false)
         {
             if (wholeLine)
             {
@@ -24,25 +33,24 @@ namespace Microsoft.TemplateEngine.Core
             processor.TrimWhitespace(trimForward, trimBackward, ref bufferLength, ref currentBufferPosition);
         }
 
-        public static void ConsumeWholeLine(this IProcessorState processor, ref int bufferLength, ref int currentBufferPosition)
+        internal static void ConsumeWholeLine(this IProcessorState processor, ref int bufferLength, ref int currentBufferPosition)
         {
-            processor.SeekBackWhile(processor.EncodingConfig.Whitespace);
-            processor.SeekForwardThrough(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition);
+            processor.SeekTargetBackWhile(processor.EncodingConfig.Whitespace);
+            processor.SeekBufferForwardThrough(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition);
         }
 
-        public static void TrimWhitespace(this IProcessorState processor, bool forward, bool backward, ref int bufferLength, ref int currentBufferPosition)
+        internal static void TrimWhitespace(this IProcessorState processor, bool forward, bool backward, ref int bufferLength, ref int currentBufferPosition)
         {
             if (backward)
             {
-                processor.SeekBackWhile(processor.EncodingConfig.Whitespace);
+                processor.SeekTargetBackWhile(processor.EncodingConfig.Whitespace);
             }
 
             if (forward)
             {
-                processor.SeekForwardWhile(processor.EncodingConfig.Whitespace, ref bufferLength, ref currentBufferPosition);
+                processor.SeekBufferForwardWhile(processor.EncodingConfig.Whitespace, ref bufferLength, ref currentBufferPosition);
                 //Consume the trailing line end if possible
-                int tok;
-                processor.EncodingConfig.LineEndings.GetOperation(processor.CurrentBuffer, bufferLength, ref currentBufferPosition, out tok);
+                processor.EncodingConfig.LineEndings.GetOperation(processor.CurrentBuffer, bufferLength, ref currentBufferPosition, out _);
             }
         }
     }

--- a/src/Microsoft.TemplateEngine.Core/Matching/OperationTerminal.cs
+++ b/src/Microsoft.TemplateEngine.Core/Matching/OperationTerminal.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Core.Matching
@@ -14,8 +16,14 @@ namespace Microsoft.TemplateEngine.Core.Matching
             Token = token;
         }
 
+        /// <summary>
+        /// Operation to perform. The tokens that operation matches are part of <see cref="IOperation"/> itself.
+        /// </summary>
         public IOperation Operation { get; }
 
+        /// <summary>
+        /// This is not an actual token to match, but index of token defined in <see cref="IOperation"/>.
+        /// </summary>
         public int Token { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Core/Matching/TerminalBase.cs
+++ b/src/Microsoft.TemplateEngine.Core/Matching/TerminalBase.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace Microsoft.TemplateEngine.Core.Matching
 {
     public abstract class TerminalBase
@@ -12,10 +14,19 @@ namespace Microsoft.TemplateEngine.Core.Matching
             Length = tokenLength;
         }
 
+        /// <summary>
+        /// Start position of the token.
+        /// </summary>
         public int Start { get; protected set; }
 
+        /// <summary>
+        /// End position of the token.
+        /// </summary>
         public int End { get; protected set; }
 
+        /// <summary>
+        /// Length of the token.
+        /// </summary>
         public int Length { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Core/Matching/TerminalLocation.cs
+++ b/src/Microsoft.TemplateEngine.Core/Matching/TerminalLocation.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace Microsoft.TemplateEngine.Core.Matching
 {
     public class TerminalLocation<T>
@@ -12,6 +14,9 @@ namespace Microsoft.TemplateEngine.Core.Matching
             Location = location;
         }
 
+        /// <summary>
+        /// Start position of the terminal. Relative location of matching token is defined in <see cref="TerminalBase"/>.
+        /// </summary>
         public int Location { get; set; }
 
         public T Terminal { get; }

--- a/src/Microsoft.TemplateEngine.Core/Operations/SetFlag.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/SetFlag.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.TemplateEngine.Core.Contracts;
@@ -10,11 +12,9 @@ namespace Microsoft.TemplateEngine.Core.Operations
     public class SetFlag : IOperationProvider
     {
         public static readonly string OperationName = "flags";
-
-        private readonly string _id;
         private readonly bool _initialState;
 
-        public SetFlag(string name, ITokenConfig on, ITokenConfig off, ITokenConfig onNoEmit, ITokenConfig offNoEmit, string id, bool initialState, bool? @default = null)
+        public SetFlag(string name, ITokenConfig on, ITokenConfig off, ITokenConfig onNoEmit, ITokenConfig offNoEmit, string? id, bool initialState, bool? @default = null)
         {
             Name = name;
             On = on;
@@ -22,11 +22,11 @@ namespace Microsoft.TemplateEngine.Core.Operations
             OnNoEmit = onNoEmit;
             OffNoEmit = offNoEmit;
             Default = @default;
-            _id = id;
+            Id = id;
             _initialState = initialState;
         }
 
-        public string Id => _id;
+        public string? Id { get; private set; }
 
         public string Name { get; }
 
@@ -55,25 +55,24 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 processorState.Config.Flags[Name] = Default.Value;
             }
 
-            return new Impl(this, tokens, _id, _initialState);
+            return new Impl(this, tokens, Id, _initialState);
         }
 
         private class Impl : IOperation
         {
             private readonly SetFlag _owner;
-            private readonly string _id;
 
-            public Impl(SetFlag owner, IReadOnlyList<IToken> tokens, string id, bool initialState)
+            public Impl(SetFlag owner, IReadOnlyList<IToken> tokens, string? id, bool initialState)
             {
                 _owner = owner;
                 Tokens = tokens;
-                _id = id;
+                Id = id;
                 IsInitialStateOn = string.IsNullOrEmpty(id) || initialState;
             }
 
             public IReadOnlyList<IToken> Tokens { get; }
 
-            public string Id => _id;
+            public string? Id { get; private set; }
 
             public bool IsInitialStateOn { get; }
 
@@ -96,7 +95,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 else
                 {
                     // consume the entire line when not emitting. Otherwise the newlines on the falg tokens get emitted
-                    processor.SeekForwardThrough(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition);
+                    processor.SeekBufferForwardThrough(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition);
                 }
 
                 //Only turn the flag in question back on if it's the "flags" flag.

--- a/src/Microsoft.TemplateEngine.Core/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Core/PublicAPI.Shipped.txt
@@ -1,6 +1,5 @@
 ﻿#nullable enable
 abstract Microsoft.TemplateEngine.Core.Expressions.Shared.SharedEvaluatorDefinition<TSelf, TTokens>.DereferenceInLiterals.get -> bool
-Microsoft.TemplateEngine.Core.CommonOperations
 Microsoft.TemplateEngine.Core.Expressions.BinaryScope<TOperator>
 Microsoft.TemplateEngine.Core.Expressions.BinaryScope<TOperator>.IsFull.get -> bool
 Microsoft.TemplateEngine.Core.Expressions.BinaryScope<TOperator>.IsIndivisible.get -> bool
@@ -333,11 +332,6 @@ override Microsoft.TemplateEngine.Core.TokenConfig.GetHashCode() -> int
 ~Microsoft.TemplateEngine.Core.Expressions.UnaryScope<TOperator>.Parent.set -> void
 ~Microsoft.TemplateEngine.Core.Expressions.UnaryScope<TOperator>.TryAccept(Microsoft.TemplateEngine.Core.Expressions.IEvaluable child) -> bool
 ~Microsoft.TemplateEngine.Core.Expressions.UnaryScope<TOperator>.UnaryScope(Microsoft.TemplateEngine.Core.Expressions.IEvaluable parent, TOperator operator, System.Func<object, object> evaluate) -> void
-~Microsoft.TemplateEngine.Core.Matching.OperationTerminal.Operation.get -> Microsoft.TemplateEngine.Core.Contracts.IOperation
-~Microsoft.TemplateEngine.Core.Matching.OperationTerminal.OperationTerminal(Microsoft.TemplateEngine.Core.Contracts.IOperation operation, int token, int tokenLength, int start = 0, int end = -1) -> void
-~Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>
-~Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>.Terminal.get -> T
-~Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>.TerminalLocation(T terminal, int location) -> void
 ~Microsoft.TemplateEngine.Core.Matching.Trie<T>
 ~Microsoft.TemplateEngine.Core.Matching.Trie<T>.AddPath(byte[] path, T terminal) -> void
 ~Microsoft.TemplateEngine.Core.Matching.Trie<T>.NextNodes.get -> System.Collections.Generic.Dictionary<byte, Microsoft.TemplateEngine.Core.Matching.TrieNode<T>>
@@ -355,11 +349,6 @@ override Microsoft.TemplateEngine.Core.TokenConfig.GetHashCode() -> int
 ~Microsoft.TemplateEngine.Core.Operations.BalancedNesting.BalancedNesting(Microsoft.TemplateEngine.Core.Contracts.ITokenConfig startToken, Microsoft.TemplateEngine.Core.Contracts.ITokenConfig realEndToken, Microsoft.TemplateEngine.Core.Contracts.ITokenConfig pseudoEndToken, string id, string resetFlag, bool initialState) -> void
 ~Microsoft.TemplateEngine.Core.Operations.BalancedNesting.GetOperation(System.Text.Encoding encoding, Microsoft.TemplateEngine.Core.Contracts.IProcessorState processorState) -> Microsoft.TemplateEngine.Core.Contracts.IOperation
 ~Microsoft.TemplateEngine.Core.Operations.BalancedNesting.Id.get -> string
-~Microsoft.TemplateEngine.Core.Operations.Conditional.Conditional(Microsoft.TemplateEngine.Core.Operations.ConditionalTokens tokenVariants, bool wholeLine, bool trimWhitespace, Microsoft.TemplateEngine.Core.Operations.ConditionEvaluator evaluator, string id, bool initialState) -> void
-~Microsoft.TemplateEngine.Core.Operations.Conditional.Evaluator.get -> Microsoft.TemplateEngine.Core.Operations.ConditionEvaluator
-~Microsoft.TemplateEngine.Core.Operations.Conditional.GetOperation(System.Text.Encoding encoding, Microsoft.TemplateEngine.Core.Contracts.IProcessorState processorState) -> Microsoft.TemplateEngine.Core.Contracts.IOperation
-~Microsoft.TemplateEngine.Core.Operations.Conditional.Id.get -> string
-~Microsoft.TemplateEngine.Core.Operations.Conditional.Tokens.get -> Microsoft.TemplateEngine.Core.Operations.ConditionalTokens
 ~Microsoft.TemplateEngine.Core.Operations.ConditionalTokens.ActionableElseIfTokens.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.ITokenConfig>
 ~Microsoft.TemplateEngine.Core.Operations.ConditionalTokens.ActionableElseIfTokens.set -> void
 ~Microsoft.TemplateEngine.Core.Operations.ConditionalTokens.ActionableElseTokens.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.ITokenConfig>
@@ -416,14 +405,6 @@ Microsoft.TemplateEngine.Core.Operations.MarkupTokens.OpenOpenElementToken.get -
 ~Microsoft.TemplateEngine.Core.Operations.ReplacementTokens.OriginalValue.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig
 ~Microsoft.TemplateEngine.Core.Operations.ReplacementTokens.ReplacementTokens(string identity, Microsoft.TemplateEngine.Core.Contracts.ITokenConfig originalValue) -> void
 ~Microsoft.TemplateEngine.Core.Operations.ReplacementTokens.VariableName.get -> string
-~Microsoft.TemplateEngine.Core.Operations.SetFlag.GetOperation(System.Text.Encoding encoding, Microsoft.TemplateEngine.Core.Contracts.IProcessorState processorState) -> Microsoft.TemplateEngine.Core.Contracts.IOperation
-~Microsoft.TemplateEngine.Core.Operations.SetFlag.Id.get -> string
-~Microsoft.TemplateEngine.Core.Operations.SetFlag.Name.get -> string
-~Microsoft.TemplateEngine.Core.Operations.SetFlag.Off.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig
-~Microsoft.TemplateEngine.Core.Operations.SetFlag.OffNoEmit.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig
-~Microsoft.TemplateEngine.Core.Operations.SetFlag.On.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig
-~Microsoft.TemplateEngine.Core.Operations.SetFlag.OnNoEmit.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig
-~Microsoft.TemplateEngine.Core.Operations.SetFlag.SetFlag(string name, Microsoft.TemplateEngine.Core.Contracts.ITokenConfig on, Microsoft.TemplateEngine.Core.Contracts.ITokenConfig off, Microsoft.TemplateEngine.Core.Contracts.ITokenConfig onNoEmit, Microsoft.TemplateEngine.Core.Contracts.ITokenConfig offNoEmit, string id, bool initialState, bool? default = null) -> void
 ~Microsoft.TemplateEngine.Core.TokenConfig.After.get -> string
 ~Microsoft.TemplateEngine.Core.TokenConfig.Before.get -> string
 ~Microsoft.TemplateEngine.Core.TokenConfig.Equals(Microsoft.TemplateEngine.Core.Contracts.ITokenConfig other) -> bool
@@ -460,12 +441,6 @@ Microsoft.TemplateEngine.Core.Util.ProcessorState.Encoding.get -> System.Text.En
 Microsoft.TemplateEngine.Core.Util.ProcessorState.EncodingConfig.get -> Microsoft.TemplateEngine.Core.Contracts.IEncodingConfig!
 Microsoft.TemplateEngine.Core.Util.ProcessorState.Inject(System.IO.Stream! staged) -> void
 Microsoft.TemplateEngine.Core.Util.ProcessorState.ProcessorState(System.IO.Stream! source, System.IO.Stream! target, int bufferSize, int flushThreshold, Microsoft.TemplateEngine.Core.Contracts.IEngineConfig! config, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider!>! operationProviders) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, bool consume) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBackWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardThrough(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
 ~Microsoft.TemplateEngine.Core.Util.Token.Token(byte[] token, int index, int start = 0, int end = -1) -> void
 ~Microsoft.TemplateEngine.Core.Util.Token.Value.get -> byte[]
 ~Microsoft.TemplateEngine.Core.Util.TokenTrie.AddToken(byte[] literalToken) -> int
@@ -492,9 +467,6 @@ Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardWhile(Microsoft.Tem
 ~override Microsoft.TemplateEngine.Core.Expressions.VisualBasic.VisualBasicStyleEvaluatorDefintion.GetSymbols(Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor) -> Microsoft.TemplateEngine.Core.Contracts.ITokenTrie
 ~override Microsoft.TemplateEngine.Core.Expressions.VisualBasic.VisualBasicStyleEvaluatorDefintion.NullTokenValue.get -> string
 ~override Microsoft.TemplateEngine.Core.TokenConfig.Equals(object obj) -> bool
-~static Microsoft.TemplateEngine.Core.CommonOperations.ConsumeWholeLine(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor, ref int bufferLength, ref int currentBufferPosition) -> void
-~static Microsoft.TemplateEngine.Core.CommonOperations.TrimWhitespace(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor, bool forward, bool backward, ref int bufferLength, ref int currentBufferPosition) -> void
-~static Microsoft.TemplateEngine.Core.CommonOperations.WhitespaceHandler(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor, ref int bufferLength, ref int currentBufferPosition, bool wholeLine = false, bool trim = false, bool trimForward = false, bool trimBackward = false) -> void
 ~static Microsoft.TemplateEngine.Core.Expressions.Converter.TryConvert<T>(object source, out T result) -> bool
 ~static Microsoft.TemplateEngine.Core.Expressions.Cpp.CppStyleEvaluatorDefinition.Evaluate(Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor, ref int bufferLength, ref int currentBufferPosition, out bool faulted) -> bool
 ~static Microsoft.TemplateEngine.Core.Expressions.ScopeBuilderHelper.ScopeBuilder<TOperator, TToken>(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor, Microsoft.TemplateEngine.Core.Contracts.ITokenTrie tokens, Microsoft.TemplateEngine.Core.Expressions.IOperatorMap<TOperator, TToken> operatorMap, bool dereferenceInLiterals = false) -> Microsoft.TemplateEngine.Core.Expressions.ScopeBuilder<TOperator, TToken>
@@ -521,12 +493,10 @@ Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardWhile(Microsoft.Tem
 ~static Microsoft.TemplateEngine.Core.Util.Processor.Create(Microsoft.TemplateEngine.Core.Util.EngineConfig config, params Microsoft.TemplateEngine.Core.Contracts.IOperationProvider[] operations) -> Microsoft.TemplateEngine.Core.Contracts.IProcessor
 ~static Microsoft.TemplateEngine.Core.Util.Processor.Create(Microsoft.TemplateEngine.Core.Util.EngineConfig config, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider> operations) -> Microsoft.TemplateEngine.Core.Contracts.IProcessor
 ~static readonly Microsoft.TemplateEngine.Core.Operations.BalancedNesting.OperationName -> string
-~static readonly Microsoft.TemplateEngine.Core.Operations.Conditional.OperationName -> string
 ~static readonly Microsoft.TemplateEngine.Core.Operations.ExpandVariables.OperationName -> string
 ~static readonly Microsoft.TemplateEngine.Core.Operations.Include.OperationName -> string
 ~static readonly Microsoft.TemplateEngine.Core.Operations.Region.OperationName -> string
 ~static readonly Microsoft.TemplateEngine.Core.Operations.Replacement.OperationName -> string
-~static readonly Microsoft.TemplateEngine.Core.Operations.SetFlag.OperationName -> string
 ~virtual Microsoft.TemplateEngine.Core.Util.Orchestrator.RunSpecLoader(System.IO.Stream runSpec) -> Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec
 Microsoft.TemplateEngine.Core.Util.Orchestrator.GetFileChanges(string! runSpecPath, Microsoft.TemplateEngine.Abstractions.Mount.IDirectory! sourceDir, string! targetDir) -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.IFileChange2!>!
 Microsoft.TemplateEngine.Core.Util.Orchestrator.GetFileChanges(Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec! spec, Microsoft.TemplateEngine.Abstractions.Mount.IDirectory! sourceDir, string! targetDir) -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.IFileChange2!>!

--- a/src/Microsoft.TemplateEngine.Core/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,26 @@
+Microsoft.TemplateEngine.Core.Matching.OperationTerminal.Operation.get -> Microsoft.TemplateEngine.Core.Contracts.IOperation!
+Microsoft.TemplateEngine.Core.Matching.OperationTerminal.OperationTerminal(Microsoft.TemplateEngine.Core.Contracts.IOperation! operation, int token, int tokenLength, int start = 0, int end = -1) -> void
+Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>
+Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>.Terminal.get -> T!
+Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>.TerminalLocation(T! terminal, int location) -> void
+Microsoft.TemplateEngine.Core.Operations.Conditional.Conditional(Microsoft.TemplateEngine.Core.Operations.ConditionalTokens! tokenVariants, bool wholeLine, bool trimWhitespace, Microsoft.TemplateEngine.Core.Operations.ConditionEvaluator! evaluator, string! id, bool initialState) -> void
+Microsoft.TemplateEngine.Core.Operations.Conditional.Evaluator.get -> Microsoft.TemplateEngine.Core.Operations.ConditionEvaluator!
+Microsoft.TemplateEngine.Core.Operations.Conditional.GetOperation(System.Text.Encoding! encoding, Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processorState) -> Microsoft.TemplateEngine.Core.Contracts.IOperation!
+Microsoft.TemplateEngine.Core.Operations.Conditional.Id.get -> string!
+Microsoft.TemplateEngine.Core.Operations.Conditional.Tokens.get -> Microsoft.TemplateEngine.Core.Operations.ConditionalTokens!
+Microsoft.TemplateEngine.Core.Operations.SetFlag.GetOperation(System.Text.Encoding! encoding, Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processorState) -> Microsoft.TemplateEngine.Core.Contracts.IOperation!
+Microsoft.TemplateEngine.Core.Operations.SetFlag.Id.get -> string?
+Microsoft.TemplateEngine.Core.Operations.SetFlag.Name.get -> string!
+Microsoft.TemplateEngine.Core.Operations.SetFlag.Off.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig!
+Microsoft.TemplateEngine.Core.Operations.SetFlag.OffNoEmit.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig!
+Microsoft.TemplateEngine.Core.Operations.SetFlag.On.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig!
+Microsoft.TemplateEngine.Core.Operations.SetFlag.OnNoEmit.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig!
+Microsoft.TemplateEngine.Core.Operations.SetFlag.SetFlag(string! name, Microsoft.TemplateEngine.Core.Contracts.ITokenConfig! on, Microsoft.TemplateEngine.Core.Contracts.ITokenConfig! off, Microsoft.TemplateEngine.Core.Contracts.ITokenConfig! onNoEmit, Microsoft.TemplateEngine.Core.Contracts.ITokenConfig! offNoEmit, string? id, bool initialState, bool? default = null) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBufferForwardThrough(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBufferForwardUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBufferForwardWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekTargetBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekTargetBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, bool consume) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekTargetBackWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
+static readonly Microsoft.TemplateEngine.Core.Operations.Conditional.OperationName -> string!
+static readonly Microsoft.TemplateEngine.Core.Operations.SetFlag.OperationName -> string!

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.ITemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.ITemplateInfo.cs
@@ -18,25 +18,25 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
     {
         IDirectory? ITemplate.TemplateSourceRoot => TemplateSourceRoot;
 
-        string ITemplateInfo.Identity => _configuration.Identity ?? _configuration.Name ?? throw new TemplateValidationException("Template configuration should have name defined");
+        string ITemplateInfo.Identity => ConfigurationModel.Identity ?? ConfigurationModel.Name ?? throw new TemplateValidationException("Template configuration should have name defined");
 
         Guid ITemplateInfo.GeneratorId => _generator.Id;
 
-        string? ITemplateInfo.Author => _configuration.Author;
+        string? ITemplateInfo.Author => ConfigurationModel.Author;
 
-        string? ITemplateInfo.Description => _configuration.Description;
+        string? ITemplateInfo.Description => ConfigurationModel.Description;
 
-        IReadOnlyList<string> ITemplateInfo.Classifications => _configuration.Classifications;
+        IReadOnlyList<string> ITemplateInfo.Classifications => ConfigurationModel.Classifications;
 
-        string? ITemplateInfo.DefaultName => _configuration.DefaultName;
+        string? ITemplateInfo.DefaultName => ConfigurationModel.DefaultName;
 
         IGenerator ITemplate.Generator => _generator;
 
-        string? ITemplateInfo.GroupIdentity => _configuration.GroupIdentity;
+        string? ITemplateInfo.GroupIdentity => ConfigurationModel.GroupIdentity;
 
-        int ITemplateInfo.Precedence => _configuration.Precedence;
+        int ITemplateInfo.Precedence => ConfigurationModel.Precedence;
 
-        string ITemplateInfo.Name => _configuration.Name ?? throw new TemplateValidationException("Template configuration should have name defined");
+        string ITemplateInfo.Name => ConfigurationModel.Name ?? throw new TemplateValidationException("Template configuration should have name defined");
 
         [Obsolete]
         string ITemplateInfo.ShortName
@@ -52,14 +52,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             }
         }
 
-        IReadOnlyList<string> ITemplateInfo.ShortNameList => _configuration.ShortNameList ?? new List<string>();
+        IReadOnlyList<string> ITemplateInfo.ShortNameList => ConfigurationModel.ShortNameList ?? new List<string>();
 
         [Obsolete]
         IReadOnlyDictionary<string, ICacheTag> ITemplateInfo.Tags
         {
             get
             {
-                Dictionary<string, ICacheTag> tags = new Dictionary<string, ICacheTag>();
+                Dictionary<string, ICacheTag> tags = new();
                 foreach (KeyValuePair<string, string> tag in ((ITemplateInfo)this).TagsCollection)
                 {
                     tags[tag.Key] = new CacheTag(null, null, new Dictionary<string, ParameterChoice> { { tag.Value, new ParameterChoice(null, null) } }, tag.Value);
@@ -78,7 +78,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         {
             get
             {
-                Dictionary<string, ICacheParameter> cacheParameters = new Dictionary<string, ICacheParameter>();
+                Dictionary<string, ICacheParameter> cacheParameters = new();
                 foreach (ITemplateParameter parameter in ((ITemplateInfo)this).ParameterDefinitions.Where(TemplateParameterExtensions.IsChoice))
                 {
                     cacheParameters[parameter.Name] = new CacheParameter()
@@ -118,21 +118,21 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         string? ITemplateInfo.LocaleConfigPlace => _localeConfigFile?.FullPath;
 
         //read in simple template model instead
-        bool ITemplate.IsNameAgreementWithFolderPreferred => _configuration.PreferNameDirectory;
+        bool ITemplate.IsNameAgreementWithFolderPreferred => ConfigurationModel.PreferNameDirectory;
 
         string? ITemplateInfo.HostConfigPlace => _hostConfigFile?.FullPath;
 
         //read in simple template model instead
-        string? ITemplateInfo.ThirdPartyNotices => _configuration.ThirdPartyNotices;
+        string? ITemplateInfo.ThirdPartyNotices => ConfigurationModel.ThirdPartyNotices;
 
-        IReadOnlyDictionary<string, IBaselineInfo> ITemplateInfo.BaselineInfo => _configuration.BaselineInfo;
+        IReadOnlyDictionary<string, IBaselineInfo> ITemplateInfo.BaselineInfo => ConfigurationModel.BaselineInfo;
 
-        IReadOnlyDictionary<string, string> ITemplateInfo.TagsCollection => _configuration.Tags;
+        IReadOnlyDictionary<string, string> ITemplateInfo.TagsCollection => ConfigurationModel.Tags;
 
         bool ITemplateInfo.HasScriptRunningPostActions { get; set; }
 
-        IReadOnlyList<Guid> ITemplateInfo.PostActions => _configuration.PostActionModels.Select(pam => pam.ActionId).ToArray();
+        IReadOnlyList<Guid> ITemplateInfo.PostActions => ConfigurationModel.PostActionModels.Select(pam => pam.ActionId).ToArray();
 
-        IReadOnlyList<TemplateConstraintInfo> ITemplateInfo.Constraints => _configuration.Constraints;
+        IReadOnlyList<TemplateConstraintInfo> ITemplateInfo.Constraints => ConfigurationModel.Constraints;
     }
 }

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
@@ -1532,7 +1532,32 @@ There";
             IProcessor processor = SetupCStyleNoCommentsProcessor(vc);
 
             //Changes should be made
-            bool changed = processor.Run(input, output, 28);
+            bool changed = processor.Run(input, output, 50);
+            Verify(Encoding.UTF8, output, changed, value, expected);
+        }
+
+#pragma warning disable xUnit1004 // Test methods should not be skipped
+        [Fact(Skip = "https://github.com/dotnet/templating/issues/4988")]
+#pragma warning restore xUnit1004 // Test methods should not be skipped
+        public void VerifyXMLConditionAtEnd()
+        {
+            string value = @"Hello
+<!--#if (B)
+bar
+#endif -->
+";
+            string expected = @"Hello
+";
+
+            byte[] valueBytes = Encoding.UTF8.GetBytes(value);
+            MemoryStream input = new MemoryStream(valueBytes);
+            MemoryStream output = new MemoryStream();
+
+            VariableCollection vc = new VariableCollection();
+            IProcessor processor = SetupXmlStyleProcessor(vc);
+
+            //Changes should be made
+            bool changed = processor.Run(input, output, 50);
             Verify(Encoding.UTF8, output, changed, value, expected);
         }
 

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
@@ -1658,8 +1658,7 @@ There";
         {
             string value = @"#ifdef
 GAGA
-#endif
-";
+#endif";
             string expected = varName == "def" && varValue ? @"GAGA
 " : "";
 

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Expressions.Cpp;
@@ -14,7 +16,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 {
     public partial class ConditionalTests : TestBase, IClassFixture<EnvironmentSettingsHelper>
     {
-        private IEngineEnvironmentSettings _engineEnvironmentSettings;
+        private readonly IEngineEnvironmentSettings _engineEnvironmentSettings;
 
         public ConditionalTests(EnvironmentSettingsHelper environmentSettingsHelper)
         {
@@ -36,7 +38,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 // It lets BalanceNesting know it's been reset
                 string commentFixingResetId = "Reset pseudo comment fixer";
 
-                ConditionalTokens tokenVariants = new ConditionalTokens
+                ConditionalTokens tokenVariants = new()
                 {
                     EndIfTokens = new[] { "#endif", "<!--#endif" }.TokenConfigs(),
                     ActionableIfTokens = new[] { "<!--#if" }.TokenConfigs(),
@@ -47,7 +49,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
                 IOperationProvider[] operations =
                 {
-                    new Conditional(tokenVariants, true, true, CppStyleEvaluatorDefinition.Evaluate, null, true),
+                    new Conditional(tokenVariants, true, true, CppStyleEvaluatorDefinition.Evaluate, "testId", true),
                     new BalancedNesting("<!--".TokenConfig(), "-->".TokenConfig(), "-- >".TokenConfig(), commentFixingOperationId, commentFixingResetId, false)
                 };
 
@@ -70,7 +72,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 // Tt lets BalanceNesting know it's been reset
                 string commentFixingResetId = "Reset pseudo comment fixer";
 
-                ConditionalTokens tokenVariants = new ConditionalTokens
+                ConditionalTokens tokenVariants = new()
                 {
                     EndIfTokens = new[] { "#endif", "@*#endif" }.TokenConfigs(),
                     ActionableIfTokens = new[] { "@*#if" }.TokenConfigs(),
@@ -81,7 +83,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
                 IOperationProvider[] operations =
                 {
-                    new Conditional(tokenVariants, true, true, CppStyleEvaluatorDefinition.Evaluate, null, true),
+                    new Conditional(tokenVariants, true, true, CppStyleEvaluatorDefinition.Evaluate, "testId", true),
                     new BalancedNesting("@*".TokenConfig(), "*@".TokenConfig(), "* @".TokenConfig(), commentFixingOperationId, commentFixingResetId, false)
                 };
 
@@ -102,7 +104,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 string replaceOperationId = "Replacement (//) ()";
                 string uncommentOperationId = "Uncomment (////) -> (//)";
 
-                ConditionalTokens tokenVariants = new ConditionalTokens
+                ConditionalTokens tokenVariants = new()
                 {
                     IfTokens = new[] { "//#if", "//#check" }.TokenConfigs(),
                     ElseTokens = new[] { "//#else", "//#otherwise" }.TokenConfigs(),
@@ -116,7 +118,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
                 IOperationProvider[] operations =
                 {
-                    new Conditional(tokenVariants, true, true, CppStyleEvaluatorDefinition.Evaluate, null, true),
+                    new Conditional(tokenVariants, true, true, CppStyleEvaluatorDefinition.Evaluate, "testId", true),
                     new Replacement("////".TokenConfig(), "//", uncommentOperationId, false),
                     new Replacement("//".TokenConfig(), string.Empty, replaceOperationId, false)
                 };
@@ -133,7 +135,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 string replaceOperationId = "Replacement: (//) ()";
                 string uncommentOperationId = "Uncomment (////) -> (//)";
 
-                ConditionalTokens tokenVariants = new ConditionalTokens
+                ConditionalTokens tokenVariants = new()
                 {
                     IfTokens = new[] { "//#if" }.TokenConfigs(),
                     ElseTokens = new[] { "//#else" }.TokenConfigs(),
@@ -147,7 +149,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
                 IOperationProvider[] operations =
                 {
-                    new Conditional(tokenVariants, true, true, CppStyleEvaluatorDefinition.Evaluate, null, true),
+                    new Conditional(tokenVariants, true, true, CppStyleEvaluatorDefinition.Evaluate, "testId", true),
                     new Replacement("////".TokenConfig(), "//", uncommentOperationId, false),
                     new Replacement("//".TokenConfig(), string.Empty, replaceOperationId, false)
                 };
@@ -160,7 +162,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
         {
             get
             {
-                ConditionalTokens tokenVariants = new ConditionalTokens
+                ConditionalTokens tokenVariants = new()
                 {
                     IfTokens = new[] { "#if" }.TokenConfigs(),
                     ElseTokens = new[] { "#else" }.TokenConfigs(),
@@ -170,7 +172,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
                 IOperationProvider[] operations =
                 {
-                    new Conditional(tokenVariants, true, true, CppStyleEvaluatorDefinition.Evaluate, null, true)
+                    new Conditional(tokenVariants, true, true, CppStyleEvaluatorDefinition.Evaluate, "testId", true)
                 };
 
                 return operations;
@@ -181,7 +183,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
         {
             get
             {
-                ConditionalTokens tokenVariants = new ConditionalTokens
+                ConditionalTokens tokenVariants = new()
                 {
                     IfTokens = new[] { "#If" }.TokenConfigs(),
                     ElseTokens = new[] { "#Else" }.TokenConfigs(),
@@ -191,7 +193,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
                 IOperationProvider[] operations =
                 {
-                    new Conditional(tokenVariants, true, true, VisualBasicStyleEvaluatorDefintion.Evaluate, null, true)
+                    new Conditional(tokenVariants, true, true, VisualBasicStyleEvaluatorDefintion.Evaluate, "testId", true)
                 };
 
                 return operations;
@@ -205,7 +207,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 string uncommentOperationId = "Uncomment (hash line): (##) -> (#)";
                 string replaceOperationId = "Replacement (hash line): (#) -> ()";
 
-                ConditionalTokens tokens = new ConditionalTokens
+                ConditionalTokens tokens = new()
                 {
                     IfTokens = new[] { "#if" }.TokenConfigs(),
                     ElseTokens = new[] { "#else" }.TokenConfigs(),
@@ -219,7 +221,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
                 IOperationProvider[] operations =
                 {
-                    new Conditional(tokens, true, true, CppStyleEvaluatorDefinition.Evaluate, null, true),
+                    new Conditional(tokens, true, true, CppStyleEvaluatorDefinition.Evaluate, "testId", true),
                     new Replacement("##".TokenConfig(), "#", uncommentOperationId, false),
                     new Replacement("#".TokenConfig(), "", replaceOperationId, false),
                 };
@@ -235,7 +237,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 string uncommentOperationId = "Uncomment (bat rem): (rem rem) -> (rem)";
                 string replaceOperationId = "Replacement (bat rem): (rem) -> ()";
 
-                ConditionalTokens tokens = new ConditionalTokens
+                ConditionalTokens tokens = new()
                 {
                     IfTokens = new[] { "rem #if" }.TokenConfigs(),
                     ElseTokens = new[] { "rem #else" }.TokenConfigs(),
@@ -249,7 +251,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
                 IOperationProvider[] operations =
                 {
-                    new Conditional(tokens, true, true, CppStyleEvaluatorDefinition.Evaluate, null, true),
+                    new Conditional(tokens, true, true, CppStyleEvaluatorDefinition.Evaluate, "testId", true),
                     new Replacement("rem rem".TokenConfig(), "rem", uncommentOperationId, false),
                     new Replacement("rem".TokenConfig(), "", replaceOperationId, false)
                 };
@@ -265,7 +267,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 string reduceCommentOperationId = "Reduce comment (line): (-#-#) -> (-#)";
                 string uncommentOperationId = "Uncomment (line): (-#) -> ()";
 
-                ConditionalTokens tokens = new ConditionalTokens
+                ConditionalTokens tokens = new()
                 {
                     IfTokens = new[] { "-#if" }.TokenConfigs(),
                     ElseTokens = new[] { "-#else" }.TokenConfigs(),
@@ -279,7 +281,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
                 IOperationProvider[] operations =
                 {
-                    new Conditional(tokens, true, true, CppStyleEvaluatorDefinition.Evaluate, null, true),
+                    new Conditional(tokens, true, true, CppStyleEvaluatorDefinition.Evaluate, "testId", true),
                     new Replacement("-#-#".TokenConfig(), "-#", reduceCommentOperationId, false),
                     new Replacement("-#".TokenConfig(), "", uncommentOperationId, false),
                 };
@@ -303,7 +305,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                 // It lets BalanceNesting know it's been reset
                 string commentFixingResetId = "Reset pseudo comment fixer";
 
-                ConditionalTokens tokenVariants = new ConditionalTokens
+                ConditionalTokens tokenVariants = new()
                 {
                     EndIfTokens = new[] { "#endif", "{/*#endif" }.TokenConfigs(),
                     ActionableIfTokens = new[] { "{/*#if" }.TokenConfigs(),
@@ -314,7 +316,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
 
                 IOperationProvider[] operations =
                 {
-                    new Conditional(tokenVariants, true, true, CppStyleEvaluatorDefinition.Evaluate, null, true),
+                    new Conditional(tokenVariants, true, true, CppStyleEvaluatorDefinition.Evaluate, "testId", true),
                     new BalancedNesting("{/*".TokenConfig(), "*/}".TokenConfig(), "*/ }".TokenConfig(), commentFixingOperationId, commentFixingResetId, false)
                 };
 
@@ -387,7 +389,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
         /// </summary>
         private IProcessor SetupTestProcessor(IOperationProvider[] operations, VariableCollection vc)
         {
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, vc);
+            EngineConfig cfg = new(_engineEnvironmentSettings.Host.Logger, vc);
             return Processor.Create(cfg, operations);
         }
     }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectGeneratorTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectGeneratorTests.cs
@@ -15,13 +15,15 @@ using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config;
 using Microsoft.TemplateEngine.TestHelper;
 using Microsoft.TemplateEngine.Utils;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 {
     public class RunnableProjectGeneratorTests : IClassFixture<EnvironmentSettingsHelper>
     {
-        private EnvironmentSettingsHelper _environmentSettingsHelper;
+        private readonly EnvironmentSettingsHelper _environmentSettingsHelper;
 
         public RunnableProjectGeneratorTests(EnvironmentSettingsHelper environmentSettingsHelper)
         {
@@ -35,9 +37,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
             // Template content preparation
             //
 
-            Guid inputTestGuid = new Guid("12aa8f4e-a4aa-4ac1-927c-94cb99485ef1");
+            Guid inputTestGuid = new("12aa8f4e-a4aa-4ac1-927c-94cb99485ef1");
             string contentFileNamePrefix = "content - ";
-            TemplateConfigModel config = new TemplateConfigModel()
+            TemplateConfigModel config = new()
             {
                 Identity = "test",
                 Guids = new List<Guid>()
@@ -46,9 +48,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
                 }
             };
 
-            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>();
-            // template.json
-            templateSourceFiles.Add(TestFileSystemHelper.DefaultConfigRelativePath, config.ToJObject().ToString());
+            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>
+            {
+                // template.json
+                { TestFileSystemHelper.DefaultConfigRelativePath, config.ToJObject().ToString() }
+            };
 
             //content
             foreach (string guidFormat in GuidMacroConfig.DefaultFormats.Select(c => c.ToString()))
@@ -63,12 +67,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
             IEngineEnvironmentSettings environment = _environmentSettingsHelper.CreateEnvironment();
             string sourceBasePath = FileSystemHelpers.GetNewVirtualizedPath(environment);
             string targetDir = FileSystemHelpers.GetNewVirtualizedPath(environment);
-            RunnableProjectGenerator rpg = new RunnableProjectGenerator();
+            RunnableProjectGenerator rpg = new();
 
             TestFileSystemHelper.WriteTemplateSource(environment, sourceBasePath, templateSourceFiles);
             IMountPoint? sourceMountPoint = TestFileSystemHelper.CreateMountPoint(environment, sourceBasePath);
-            RunnableProjectConfig runnableConfig = new RunnableProjectConfig(environment, rpg, config, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
-            ParameterSetData parametersData = new ParameterSetData(runnableConfig);
+            RunnableProjectConfig runnableConfig = new(environment, rpg, config, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
+            ParameterSetData parametersData = new(runnableConfig);
             IDirectory sourceDir = sourceMountPoint!.DirectoryInfo("/")!;
 
             //
@@ -85,9 +89,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
             foreach (string guidFormat in GuidMacroConfig.DefaultFormats.Select(c => c.ToString()))
             {
                 string resultContent = environment.Host.FileSystem.ReadAllText(Path.Combine(targetDir, contentFileNamePrefix + guidFormat));
-                Guid resultGuid;
                 Assert.True(
-                    Guid.TryParseExact(resultContent, guidFormat, out resultGuid),
+                    Guid.TryParseExact(resultContent, guidFormat, out Guid resultGuid),
                     $"Expected the result conent ({resultContent}) to be parseable by Guid format '{guidFormat}'");
 
                 if (expectedResultGuid == Guid.Empty)
@@ -180,12 +183,13 @@ UNKNOWN
 //#endif
 ";
 
-            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>();
-            // template.json
-            templateSourceFiles.Add(TestFileSystemHelper.DefaultConfigRelativePath, templateConfig);
-
-            //content
-            templateSourceFiles.Add("sourcFile", sourceSnippet);
+            Dictionary<string, string?> templateSourceFiles = new()
+            {
+                // template.json
+                { TestFileSystemHelper.DefaultConfigRelativePath, templateConfig },
+                //content
+                { "sourcFile", sourceSnippet }
+            };
 
             //
             // Dependencies preparation and mounting
@@ -197,10 +201,10 @@ UNKNOWN
 
             TestFileSystemHelper.WriteTemplateSource(environment, sourceBasePath, templateSourceFiles);
             IMountPoint? sourceMountPoint = TestFileSystemHelper.CreateMountPoint(environment, sourceBasePath);
-            RunnableProjectGenerator rpg = new RunnableProjectGenerator();
+            RunnableProjectGenerator rpg = new();
             TemplateConfigModel configModel = TemplateConfigModel.FromString(templateConfig);
-            RunnableProjectConfig runnableConfig = new RunnableProjectConfig(environment, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
-            ParameterSetData parametersData = new ParameterSetData(
+            RunnableProjectConfig runnableConfig = new(environment, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
+            ParameterSetData parametersData = new(
                 runnableConfig,
                 new Dictionary<string, string?>() { { "ChoiceParam", "SecondChoice" } });
             IDirectory sourceDir = sourceMountPoint!.DirectoryInfo("/")!;
@@ -276,12 +280,14 @@ SECOND
 THIRD
 ";
 
-            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>();
-            // template.json
-            templateSourceFiles.Add(TestFileSystemHelper.DefaultConfigRelativePath, templateConfig);
+            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>
+            {
+                // template.json
+                { TestFileSystemHelper.DefaultConfigRelativePath, templateConfig },
 
-            //content
-            templateSourceFiles.Add("sourcFile", sourceSnippet);
+                //content
+                { "sourcFile", sourceSnippet }
+            };
 
             //
             // Dependencies preparation and mounting
@@ -293,10 +299,10 @@ THIRD
 
             TestFileSystemHelper.WriteTemplateSource(environment, sourceBasePath, templateSourceFiles);
             IMountPoint? sourceMountPoint = TestFileSystemHelper.CreateMountPoint(environment, sourceBasePath);
-            RunnableProjectGenerator rpg = new RunnableProjectGenerator();
+            RunnableProjectGenerator rpg = new();
             TemplateConfigModel configModel = TemplateConfigModel.FromString(templateConfig);
-            RunnableProjectConfig runnableConfig = new RunnableProjectConfig(environment, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
-            ParameterSetData parametersData = new ParameterSetData(
+            RunnableProjectConfig runnableConfig = new(environment, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
+            ParameterSetData parametersData = new(
                 runnableConfig,
                 new Dictionary<string, object?>() { { "ChoiceParam", new MultiValueParameter(new[] { "SecondChoice", "ThirdChoice" }) } });
             IDirectory sourceDir = sourceMountPoint!.DirectoryInfo("/")!;
@@ -422,12 +428,14 @@ Console.WriteLine(""Hello, World!"");
 // Plats: android, iOS
 ";
 
-            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>();
-            // template.json
-            templateSourceFiles.Add(TestFileSystemHelper.DefaultConfigRelativePath, templateConfig);
+            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>
+            {
+                // template.json
+                { TestFileSystemHelper.DefaultConfigRelativePath, templateConfig },
 
-            //content
-            templateSourceFiles.Add("sourcFile", sourceSnippet);
+                //content
+                { "sourcFile", sourceSnippet }
+            };
 
             //
             // Dependencies preparation and mounting
@@ -439,10 +447,10 @@ Console.WriteLine(""Hello, World!"");
 
             TestFileSystemHelper.WriteTemplateSource(environment, sourceBasePath, templateSourceFiles);
             IMountPoint? sourceMountPoint = TestFileSystemHelper.CreateMountPoint(environment, sourceBasePath);
-            RunnableProjectGenerator rpg = new RunnableProjectGenerator();
+            RunnableProjectGenerator rpg = new();
             TemplateConfigModel configModel = TemplateConfigModel.FromString(templateConfig);
-            RunnableProjectConfig runnableConfig = new RunnableProjectConfig(environment, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
-            ParameterSetData parametersData = new ParameterSetData(
+            RunnableProjectConfig runnableConfig = new(environment, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
+            ParameterSetData parametersData = new(
                 runnableConfig,
                 new Dictionary<string, object?>() { { "Platform", new MultiValueParameter(new[] { "android", "iOS" }) } });
             IDirectory sourceDir = sourceMountPoint!.DirectoryInfo("/")!;
@@ -532,12 +540,14 @@ Console.WriteLine(""Hello, World!"");
 // This file is generated for platfrom: MacOS, iOS
 ";
 
-            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>();
-            // template.json
-            templateSourceFiles.Add(TestFileSystemHelper.DefaultConfigRelativePath, templateConfig);
+            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>
+            {
+                // template.json
+                { TestFileSystemHelper.DefaultConfigRelativePath, templateConfig },
 
-            //content
-            templateSourceFiles.Add("sourcFile", sourceSnippet);
+                //content
+                { "sourcFile", sourceSnippet }
+            };
 
             //
             // Dependencies preparation and mounting
@@ -549,10 +559,10 @@ Console.WriteLine(""Hello, World!"");
 
             TestFileSystemHelper.WriteTemplateSource(environment, sourceBasePath, templateSourceFiles);
             IMountPoint? sourceMountPoint = TestFileSystemHelper.CreateMountPoint(environment, sourceBasePath);
-            RunnableProjectGenerator rpg = new RunnableProjectGenerator();
+            RunnableProjectGenerator rpg = new();
             TemplateConfigModel configModel = TemplateConfigModel.FromString(templateConfig);
-            RunnableProjectConfig runnableConfig = new RunnableProjectConfig(environment, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
-            ParameterSetData parametersData = new ParameterSetData(
+            RunnableProjectConfig runnableConfig = new(environment, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
+            ParameterSetData parametersData = new(
                 runnableConfig,
                 new Dictionary<string, object?>() { { "Platform", new MultiValueParameter(new[] { "MacOS", "iOS" }) } });
             IDirectory sourceDir = sourceMountPoint!.DirectoryInfo("/")!;
@@ -617,12 +627,14 @@ This text ensures that buffer is long enough even considering very-very-long env
 foo
 ";
 
-            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>();
-            // template.json
-            templateSourceFiles.Add(TestFileSystemHelper.DefaultConfigRelativePath, JsonConvert.SerializeObject(templateConfig, Formatting.Indented));
+            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>
+            {
+                // template.json
+                { TestFileSystemHelper.DefaultConfigRelativePath, JsonConvert.SerializeObject(templateConfig, Formatting.Indented) },
 
-            //content
-            templateSourceFiles.Add("sourceFile.md", sourceSnippet);
+                //content
+                { "sourceFile.md", sourceSnippet }
+            };
 
             //
             // Dependencies preparation and mounting
@@ -633,12 +645,13 @@ foo
 
             TestFileSystemHelper.WriteTemplateSource(settings, sourceBasePath, templateSourceFiles);
             IMountPoint? sourceMountPoint = TestFileSystemHelper.CreateMountPoint(settings, sourceBasePath);
-            RunnableProjectGenerator rpg = new RunnableProjectGenerator();
-            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(JObject.FromObject(templateConfig));
-            IRunnableProjectConfig runnableConfig = new RunnableProjectConfig(settings, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
-            IParameterSet parameters = new ParameterSet(runnableConfig);
-            parameters.TryGetParameterDefinition("A", out ITemplateParameter aParam);
-            parameters.ResolvedValues[aParam] = true;
+            RunnableProjectGenerator rpg = new();
+
+            TemplateConfigModel configModel = TemplateConfigModel.FromJObject(JObject.FromObject(templateConfig));
+            RunnableProjectConfig runnableConfig = new(settings, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
+            ParameterSetData parameters = new(
+                runnableConfig,
+                new Dictionary<string, object?>() { { "A", true } });
             IDirectory sourceDir = sourceMountPoint!.DirectoryInfo("/")!;
 
             //
@@ -700,12 +713,14 @@ This text ensures that buffer is long enough even considering very-very-long env
 foo
 ";
 
-            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>();
-            // template.json
-            templateSourceFiles.Add(TestFileSystemHelper.DefaultConfigRelativePath, JsonConvert.SerializeObject(templateConfig, Formatting.Indented));
+            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>
+            {
+                // template.json
+                { TestFileSystemHelper.DefaultConfigRelativePath, JsonConvert.SerializeObject(templateConfig, Formatting.Indented) },
 
-            //content
-            templateSourceFiles.Add("sourceFile.yaml", sourceSnippet);
+                //content
+                { "sourceFile.yaml", sourceSnippet }
+            };
 
             //
             // Dependencies preparation and mounting
@@ -716,12 +731,12 @@ foo
 
             TestFileSystemHelper.WriteTemplateSource(settings, sourceBasePath, templateSourceFiles);
             IMountPoint? sourceMountPoint = TestFileSystemHelper.CreateMountPoint(settings, sourceBasePath);
-            RunnableProjectGenerator rpg = new RunnableProjectGenerator();
-            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(JObject.FromObject(templateConfig));
-            IRunnableProjectConfig runnableConfig = new RunnableProjectConfig(settings, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
-            IParameterSet parameters = new ParameterSet(runnableConfig);
-            parameters.TryGetParameterDefinition("A", out ITemplateParameter aParam);
-            parameters.ResolvedValues[aParam] = true;
+            RunnableProjectGenerator rpg = new();
+            TemplateConfigModel configModel = TemplateConfigModel.FromJObject(JObject.FromObject(templateConfig));
+            RunnableProjectConfig runnableConfig = new(settings, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
+            ParameterSetData parameters = new(
+                runnableConfig,
+                new Dictionary<string, object?>() { { "A", true } });
             IDirectory sourceDir = sourceMountPoint!.DirectoryInfo("/")!;
 
             //

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectGeneratorTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/RunnableProjectGeneratorTests.cs
@@ -570,5 +570,171 @@ Console.WriteLine(""Hello, World!"");
             string resultContent = environment.Host.FileSystem.ReadAllText(Path.Combine(targetDir, "sourcFile"));
             Assert.Equal(expectedSnippet, resultContent);
         }
+
+#pragma warning disable xUnit1004 // Test methods should not be skipped
+        [Fact(Skip = "https://github.com/dotnet/templating/issues/4988")]
+#pragma warning restore xUnit1004 // Test methods should not be skipped
+        public async void XMLConditionFailure()
+        {
+            //
+            // Template content preparation
+            //
+
+            var templateConfig = new
+            {
+                identity = "test.template",
+                symbols = new
+                {
+                    A = new
+                    {
+                        type = "parameter",
+                        dataType = "bool",
+                        defaultValue = "false"
+                    },
+                    B = new
+                    {
+                        type = "parameter",
+                        dataType = "bool",
+                        defaultValue = "false"
+                    },
+                }
+            };
+
+            string sourceSnippet = @"
+<!--#if (A) -->
+<!-- comment foo -->
+foo
+<!--#endif -->
+<!--#if (B) -->
+This text should not be generated, just to make file content longer to prove the bug.
+If the buffer is advanced when evaluating condition, the bug won't be reproduced. 
+This text ensures that buffer is long enough even considering very-very-long env variable names available on CI machine.
+<!--#endif -->
+";
+
+            string expectedSnippet = @"
+<!-- comment foo -->
+foo
+";
+
+            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>();
+            // template.json
+            templateSourceFiles.Add(TestFileSystemHelper.DefaultConfigRelativePath, JsonConvert.SerializeObject(templateConfig, Formatting.Indented));
+
+            //content
+            templateSourceFiles.Add("sourceFile.md", sourceSnippet);
+
+            //
+            // Dependencies preparation and mounting
+            //
+            IEngineEnvironmentSettings settings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            string sourceBasePath = FileSystemHelpers.GetNewVirtualizedPath(settings);
+            string targetDir = FileSystemHelpers.GetNewVirtualizedPath(settings);
+
+            TestFileSystemHelper.WriteTemplateSource(settings, sourceBasePath, templateSourceFiles);
+            IMountPoint? sourceMountPoint = TestFileSystemHelper.CreateMountPoint(settings, sourceBasePath);
+            RunnableProjectGenerator rpg = new RunnableProjectGenerator();
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(JObject.FromObject(templateConfig));
+            IRunnableProjectConfig runnableConfig = new RunnableProjectConfig(settings, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
+            IParameterSet parameters = new ParameterSet(runnableConfig);
+            parameters.TryGetParameterDefinition("A", out ITemplateParameter aParam);
+            parameters.ResolvedValues[aParam] = true;
+            IDirectory sourceDir = sourceMountPoint!.DirectoryInfo("/")!;
+
+            //
+            // Running the actual scenario: template files processing and generating output (including macros processing)
+            //
+            await rpg.CreateAsync(settings, runnableConfig, sourceDir, parameters, targetDir, CancellationToken.None);
+
+            //
+            // Veryfying the outputs
+            //
+
+            string resultContent = settings.Host.FileSystem.ReadAllText(Path.Combine(targetDir, "sourceFile.md"));
+            Assert.Equal(expectedSnippet, resultContent);
+        }
+
+#pragma warning disable xUnit1004 // Test methods should not be skipped
+        [Fact(Skip = "https://github.com/dotnet/templating/issues/4988")]
+#pragma warning restore xUnit1004 // Test methods should not be skipped
+        public async void HashConditionFailure()
+        {
+            //
+            // Template content preparation
+            //
+
+            var templateConfig = new
+            {
+                identity = "test.template",
+                symbols = new
+                {
+                    A = new
+                    {
+                        type = "parameter",
+                        dataType = "bool",
+                        defaultValue = "false"
+                    },
+                    B = new
+                    {
+                        type = "parameter",
+                        dataType = "bool",
+                        defaultValue = "false"
+                    },
+                }
+            };
+
+            string sourceSnippet = @"
+#if (A)
+# comment foo
+foo
+#endif
+##if (B)
+This text should not be generated, just to make file content longer to prove the bug.
+If the buffer is advanced when evaluating condition, the bug won't be reproduced. 
+This text ensures that buffer is long enough even considering very-very-long env variable names available on CI machine.
+#endif
+";
+
+            string expectedSnippet = @"
+# comment foo
+foo
+";
+
+            IDictionary<string, string?> templateSourceFiles = new Dictionary<string, string?>();
+            // template.json
+            templateSourceFiles.Add(TestFileSystemHelper.DefaultConfigRelativePath, JsonConvert.SerializeObject(templateConfig, Formatting.Indented));
+
+            //content
+            templateSourceFiles.Add("sourceFile.yaml", sourceSnippet);
+
+            //
+            // Dependencies preparation and mounting
+            //
+            IEngineEnvironmentSettings settings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+            string sourceBasePath = FileSystemHelpers.GetNewVirtualizedPath(settings);
+            string targetDir = FileSystemHelpers.GetNewVirtualizedPath(settings);
+
+            TestFileSystemHelper.WriteTemplateSource(settings, sourceBasePath, templateSourceFiles);
+            IMountPoint? sourceMountPoint = TestFileSystemHelper.CreateMountPoint(settings, sourceBasePath);
+            RunnableProjectGenerator rpg = new RunnableProjectGenerator();
+            SimpleConfigModel configModel = SimpleConfigModel.FromJObject(JObject.FromObject(templateConfig));
+            IRunnableProjectConfig runnableConfig = new RunnableProjectConfig(settings, rpg, configModel, sourceMountPoint.FileInfo(TestFileSystemHelper.DefaultConfigRelativePath));
+            IParameterSet parameters = new ParameterSet(runnableConfig);
+            parameters.TryGetParameterDefinition("A", out ITemplateParameter aParam);
+            parameters.ResolvedValues[aParam] = true;
+            IDirectory sourceDir = sourceMountPoint!.DirectoryInfo("/")!;
+
+            //
+            // Running the actual scenario: template files processing and generating output (including macros processing)
+            //
+            await rpg.CreateAsync(settings, runnableConfig, sourceDir, parameters, targetDir, CancellationToken.None);
+
+            //
+            // Veryfying the outputs
+            //
+
+            string resultContent = settings.Host.FileSystem.ReadAllText(Path.Combine(targetDir, "sourceFile.yaml"));
+            Assert.Equal(expectedSnippet, resultContent);
+        }
     }
 }

--- a/test/Microsoft.TemplateEngine.TestHelper/TestHost.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/TestHost.cs
@@ -52,7 +52,7 @@ namespace Microsoft.TemplateEngine.TestHelper
 
             _loggerFactory = new TestLoggerFactory();
             addLoggerProviders?.ToList().ForEach(_loggerFactory.AddProvider);
-            _logger = _loggerFactory.CreateLogger("Test Host");
+            _logger = _loggerFactory.CreateLogger(hostIdentifier);
             _fallbackNames = fallbackNames ?? new[] { "dotnetcli" };
         }
 


### PR DESCRIPTION
This PR keeps the work done when investigating https://github.com/dotnet/templating/issues/4988.

Mainly adds logging and documentation.
Also fixes one minor bug in `CppStyleEvaluatorDefinition`: if the next token is not a token this means the expression is read; no need to advance the buffer, the evaluation can be started.

Another bug in `ProcessorState` when calculating the position to advance to:  if `headSequenceNumber` is higher than `_trie.OldestRequiredSequenceNumber`, this means we cannot continue with `_trie.OldestRequiredSequenceNumber` position already as it is left in previous window, the buffer should be advanced to new chunk (`CurrentBufferLength`) instead. In current code processing was stopped at this point (buffer was advanced to 0).

.NET 8 only: changing public APIs
