### PR TITLE
Removed adding environment variables implicitly to variable collection by default

### DIFF
--- a/docs/Runnable-Project-Templates.md
+++ b/docs/Runnable-Project-Templates.md
@@ -392,11 +392,6 @@ But since there can be many instances of the SpecialCustomOperations, each appli
 
 The `configuration details` options are identical in both situations, they only differ in the scopes they're applied in. The below sections are labelled CustomOperations.<Item>, but are equally applicable to SpecialCustomOperations.<fileglob>.<Item>
 
-
-### CustomOperations.VariableFormat (optional)
-Defines the format of variable names, and general processing infomation.
-Need help documenting this!!!
-
 ### CustomOperations.FlagPrefix (optional)
 Overrides the default prefix to indicate a flag option in a file being processed.
 

--- a/src/Microsoft.TemplateEngine.Abstractions/IParameterSet.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IParameterSet.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateEngine.Abstractions
         /// <summary>
         /// Gets a collection of template parameters and their values.
         /// </summary>
-        IDictionary<ITemplateParameter, object> ResolvedValues { get; }
+        IDictionary<ITemplateParameter, object?> ResolvedValues { get; }
 
         /// <summary>
         /// Gets a parameter definition with the specified <paramref name="name"/>.

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
@@ -53,6 +53,7 @@ Microsoft.TemplateEngine.Abstractions.ILocalizationLocator.Identity.get -> strin
 Microsoft.TemplateEngine.Abstractions.ILocalizationLocator.Locale.get -> string!
 Microsoft.TemplateEngine.Abstractions.ILocalizationLocator.Name.get -> string!
 Microsoft.TemplateEngine.Abstractions.ILocalizationLocator.ParameterSymbols.get -> System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Abstractions.IParameterSymbolLocalizationModel!>!
+Microsoft.TemplateEngine.Abstractions.IParameterSet.ResolvedValues.get -> System.Collections.Generic.IDictionary<Microsoft.TemplateEngine.Abstractions.ITemplateParameter!, object?>!
 Microsoft.TemplateEngine.Abstractions.Mount.IDirectory.EnumerateDirectories(string! pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<Microsoft.TemplateEngine.Abstractions.Mount.IDirectory!>!
 Microsoft.TemplateEngine.Abstractions.Mount.IDirectory.EnumerateFiles(string! pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<Microsoft.TemplateEngine.Abstractions.Mount.IFile!>!
 Microsoft.TemplateEngine.Abstractions.Mount.IDirectory.EnumerateFileSystemInfos(string! pattern, System.IO.SearchOption searchOption) -> System.Collections.Generic.IEnumerable<Microsoft.TemplateEngine.Abstractions.Mount.IFileSystemInfo!>!
@@ -100,7 +101,6 @@ Microsoft.TemplateEngine.Abstractions.Installer.UpdateRequest.UpdateRequest(Micr
 Microsoft.TemplateEngine.Abstractions.Installer.UpdateRequest.Version.get -> string!
 Microsoft.TemplateEngine.Abstractions.Installer.UpdateResult.UpdateRequest.get -> Microsoft.TemplateEngine.Abstractions.Installer.UpdateRequest!
 Microsoft.TemplateEngine.Abstractions.IParameterSet.ParameterDefinitions.get -> System.Collections.Generic.IEnumerable<Microsoft.TemplateEngine.Abstractions.ITemplateParameter!>!
-Microsoft.TemplateEngine.Abstractions.IParameterSet.ResolvedValues.get -> System.Collections.Generic.IDictionary<Microsoft.TemplateEngine.Abstractions.ITemplateParameter!, object!>!
 Microsoft.TemplateEngine.Abstractions.IParameterSet.TryGetParameterDefinition(string! name, out Microsoft.TemplateEngine.Abstractions.ITemplateParameter! parameter) -> bool
 Microsoft.TemplateEngine.Abstractions.ISearchPackFilter.ShouldPackBeFiltered(string! candidatePackName, string! candidatePackVersion) -> bool
 Microsoft.TemplateEngine.Abstractions.ISettingsLoader.AddMountPoint(Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint! mountPoint) -> void

--- a/src/Microsoft.TemplateEngine.Core/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Core/PublicAPI.Shipped.txt
@@ -251,8 +251,6 @@ Microsoft.TemplateEngine.Core.VariableCollection
 Microsoft.TemplateEngine.Core.VariableCollection.Clear() -> void
 Microsoft.TemplateEngine.Core.VariableCollection.Count.get -> int
 Microsoft.TemplateEngine.Core.VariableCollection.IsReadOnly.get -> bool
-Microsoft.TemplateEngine.Core.VariableCollection.KeysChanged -> Microsoft.TemplateEngine.Core.Contracts.KeysChangedEventHander
-Microsoft.TemplateEngine.Core.VariableCollection.ValueRead -> Microsoft.TemplateEngine.Core.Contracts.ValueReadEventHander
 Microsoft.TemplateEngine.Core.VariableCollection.VariableCollection() -> void
 override Microsoft.TemplateEngine.Core.Expressions.Cpp2.Cpp2StyleEvaluatorDefinition.DereferenceInLiterals.get -> bool
 override Microsoft.TemplateEngine.Core.Expressions.MSBuild.MSBuildStyleEvaluatorDefinition.DereferenceInLiterals.get -> bool
@@ -495,23 +493,6 @@ override Microsoft.TemplateEngine.Core.TokenConfig.GetHashCode() -> int
 ~Microsoft.TemplateEngine.Core.ValueReadEventArgs.Value.get -> object
 ~Microsoft.TemplateEngine.Core.ValueReadEventArgs.Value.set -> void
 ~Microsoft.TemplateEngine.Core.ValueReadEventArgs.ValueReadEventArgs(string key, object value) -> void
-~Microsoft.TemplateEngine.Core.VariableCollection.Add(string key, object value) -> void
-~Microsoft.TemplateEngine.Core.VariableCollection.Add(System.Collections.Generic.KeyValuePair<string, object> item) -> void
-~Microsoft.TemplateEngine.Core.VariableCollection.Contains(System.Collections.Generic.KeyValuePair<string, object> item) -> bool
-~Microsoft.TemplateEngine.Core.VariableCollection.ContainsKey(string key) -> bool
-~Microsoft.TemplateEngine.Core.VariableCollection.CopyTo(System.Collections.Generic.KeyValuePair<string, object>[] array, int arrayIndex) -> void
-~Microsoft.TemplateEngine.Core.VariableCollection.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string, object>>
-~Microsoft.TemplateEngine.Core.VariableCollection.Keys.get -> System.Collections.Generic.ICollection<string>
-~Microsoft.TemplateEngine.Core.VariableCollection.Parent.get -> Microsoft.TemplateEngine.Core.Contracts.IVariableCollection
-~Microsoft.TemplateEngine.Core.VariableCollection.Parent.set -> void
-~Microsoft.TemplateEngine.Core.VariableCollection.Remove(string key) -> bool
-~Microsoft.TemplateEngine.Core.VariableCollection.Remove(System.Collections.Generic.KeyValuePair<string, object> item) -> bool
-~Microsoft.TemplateEngine.Core.VariableCollection.this[string key].get -> object
-~Microsoft.TemplateEngine.Core.VariableCollection.this[string key].set -> void
-~Microsoft.TemplateEngine.Core.VariableCollection.TryGetValue(string key, out object value) -> bool
-~Microsoft.TemplateEngine.Core.VariableCollection.Values.get -> System.Collections.Generic.ICollection<object>
-~Microsoft.TemplateEngine.Core.VariableCollection.VariableCollection(Microsoft.TemplateEngine.Core.Contracts.IVariableCollection parent, System.Collections.Generic.IDictionary<string, object> values) -> void
-~Microsoft.TemplateEngine.Core.VariableCollection.VariableCollection(Microsoft.TemplateEngine.Core.VariableCollection parent) -> void
 ~override Microsoft.TemplateEngine.Core.Expressions.BinaryScope<TOperator>.ToString() -> string
 ~override Microsoft.TemplateEngine.Core.Expressions.Cpp2.Cpp2StyleEvaluatorDefinition.GenerateMap() -> Microsoft.TemplateEngine.Core.Expressions.IOperatorMap<Microsoft.TemplateEngine.Core.Expressions.Operators, Microsoft.TemplateEngine.Core.Expressions.Cpp2.Cpp2StyleEvaluatorDefinition.Tokens>
 ~override Microsoft.TemplateEngine.Core.Expressions.Cpp2.Cpp2StyleEvaluatorDefinition.GetSymbols(Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor) -> Microsoft.TemplateEngine.Core.Contracts.ITokenTrie
@@ -554,17 +535,6 @@ override Microsoft.TemplateEngine.Core.TokenConfig.GetHashCode() -> int
 ~static Microsoft.TemplateEngine.Core.Util.EngineConfig.DefaultWhitespaces.get -> System.Collections.Generic.IReadOnlyList<string>
 ~static Microsoft.TemplateEngine.Core.Util.Processor.Create(Microsoft.TemplateEngine.Core.Util.EngineConfig config, params Microsoft.TemplateEngine.Core.Contracts.IOperationProvider[] operations) -> Microsoft.TemplateEngine.Core.Contracts.IProcessor
 ~static Microsoft.TemplateEngine.Core.Util.Processor.Create(Microsoft.TemplateEngine.Core.Util.EngineConfig config, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider> operations) -> Microsoft.TemplateEngine.Core.Contracts.IProcessor
-~static Microsoft.TemplateEngine.Core.VariableCollection.Environment(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings environmentSettings) -> Microsoft.TemplateEngine.Core.VariableCollection
-~static Microsoft.TemplateEngine.Core.VariableCollection.Environment(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings environmentSettings, bool changeCase, bool upperCase) -> Microsoft.TemplateEngine.Core.VariableCollection
-~static Microsoft.TemplateEngine.Core.VariableCollection.Environment(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings environmentSettings, bool changeCase, bool upperCase, string formatString) -> Microsoft.TemplateEngine.Core.VariableCollection
-~static Microsoft.TemplateEngine.Core.VariableCollection.Environment(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings environmentSettings, Microsoft.TemplateEngine.Core.VariableCollection parent) -> Microsoft.TemplateEngine.Core.VariableCollection
-~static Microsoft.TemplateEngine.Core.VariableCollection.Environment(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings environmentSettings, Microsoft.TemplateEngine.Core.VariableCollection parent, bool changeCase, bool upperCase, string formatString) -> Microsoft.TemplateEngine.Core.VariableCollection
-~static Microsoft.TemplateEngine.Core.VariableCollection.Environment(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings environmentSettings, Microsoft.TemplateEngine.Core.VariableCollection parent, string formatString) -> Microsoft.TemplateEngine.Core.VariableCollection
-~static Microsoft.TemplateEngine.Core.VariableCollection.Environment(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings environmentSettings, string formatString) -> Microsoft.TemplateEngine.Core.VariableCollection
-~static Microsoft.TemplateEngine.Core.VariableCollection.Root() -> Microsoft.TemplateEngine.Core.VariableCollection
-~static Microsoft.TemplateEngine.Core.VariableCollection.Root(System.Collections.Generic.IDictionary<string, object> values) -> Microsoft.TemplateEngine.Core.VariableCollection
-~static Microsoft.TemplateEngine.Core.VariableCollection.SetupVariables(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings environmentSettings, Microsoft.TemplateEngine.Abstractions.IParameterSet parameters, Microsoft.TemplateEngine.Core.Contracts.IVariableConfig variableConfig) -> Microsoft.TemplateEngine.Core.Contracts.IVariableCollection
-~static Microsoft.TemplateEngine.Core.VariableCollection.VariableCollectionFromParameters(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings environmentSettings, Microsoft.TemplateEngine.Abstractions.IParameterSet parameters, string format) -> Microsoft.TemplateEngine.Core.VariableCollection
 ~static readonly Microsoft.TemplateEngine.Core.Operations.BalancedNesting.OperationName -> string
 ~static readonly Microsoft.TemplateEngine.Core.Operations.Conditional.OperationName -> string
 ~static readonly Microsoft.TemplateEngine.Core.Operations.ExpandVariables.OperationName -> string

--- a/src/Microsoft.TemplateEngine.Core/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Core/PublicAPI.Unshipped.txt
@@ -12,15 +12,37 @@ Microsoft.TemplateEngine.Core.Util.Orchestrator.GetFileChanges(Microsoft.Templat
 Microsoft.TemplateEngine.Core.Util.Orchestrator.Run(string! runSpecPath, Microsoft.TemplateEngine.Abstractions.Mount.IDirectory! sourceDir, string! targetDir) -> void
 Microsoft.TemplateEngine.Core.Util.Orchestrator.Orchestrator(Microsoft.Extensions.Logging.ILogger! logger, Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem! fileSystem) -> void
 Microsoft.TemplateEngine.Core.Util.Orchestrator.Run(Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec! spec, Microsoft.TemplateEngine.Abstractions.Mount.IDirectory! sourceDir, string! targetDir) -> void
+Microsoft.TemplateEngine.Core.VariableCollection.Add(string! key, object! value) -> void
+Microsoft.TemplateEngine.Core.VariableCollection.Add(System.Collections.Generic.KeyValuePair<string!, object!> item) -> void
+Microsoft.TemplateEngine.Core.VariableCollection.Contains(System.Collections.Generic.KeyValuePair<string!, object!> item) -> bool
+Microsoft.TemplateEngine.Core.VariableCollection.ContainsKey(string! key) -> bool
+Microsoft.TemplateEngine.Core.VariableCollection.CopyTo(System.Collections.Generic.KeyValuePair<string!, object!>[]! array, int arrayIndex) -> void
+Microsoft.TemplateEngine.Core.VariableCollection.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string!, object!>>!
+Microsoft.TemplateEngine.Core.VariableCollection.Keys.get -> System.Collections.Generic.ICollection<string!>!
+Microsoft.TemplateEngine.Core.VariableCollection.KeysChanged -> Microsoft.TemplateEngine.Core.Contracts.KeysChangedEventHander?
+Microsoft.TemplateEngine.Core.VariableCollection.Parent.get -> Microsoft.TemplateEngine.Core.Contracts.IVariableCollection?
+Microsoft.TemplateEngine.Core.VariableCollection.Parent.set -> void
+Microsoft.TemplateEngine.Core.VariableCollection.Remove(string! key) -> bool
+Microsoft.TemplateEngine.Core.VariableCollection.Remove(System.Collections.Generic.KeyValuePair<string!, object!> item) -> bool
+Microsoft.TemplateEngine.Core.VariableCollection.this[string! key].get -> object!
+Microsoft.TemplateEngine.Core.VariableCollection.this[string! key].set -> void
+Microsoft.TemplateEngine.Core.VariableCollection.TryGetValue(string! key, out object! value) -> bool
+Microsoft.TemplateEngine.Core.VariableCollection.ValueRead -> Microsoft.TemplateEngine.Core.Contracts.ValueReadEventHander?
+Microsoft.TemplateEngine.Core.VariableCollection.Values.get -> System.Collections.Generic.ICollection<object!>!
+Microsoft.TemplateEngine.Core.VariableCollection.VariableCollection(Microsoft.TemplateEngine.Core.Contracts.IVariableCollection? parent, System.Collections.Generic.IDictionary<string!, object!>! values) -> void
+Microsoft.TemplateEngine.Core.VariableCollection.VariableCollection(Microsoft.TemplateEngine.Core.VariableCollection? parent) -> void
 static Microsoft.TemplateEngine.Core.Expressions.Cpp.CppStyleEvaluatorDefinition.EvaluateFromString(Microsoft.Extensions.Logging.ILogger! logger, string! text, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection! variables) -> bool
 static Microsoft.TemplateEngine.Core.Expressions.Cpp.CppStyleEvaluatorDefinition.Evaluate(Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processor, ref int bufferLength, ref int currentBufferPosition, out bool faulted) -> bool
 static Microsoft.TemplateEngine.Core.Util.EngineConfig.DefaultLineEndings.get -> System.Collections.Generic.IReadOnlyList<string!>!
 static Microsoft.TemplateEngine.Core.Util.EngineConfig.DefaultLineEndings.set -> void
 static Microsoft.TemplateEngine.Core.Util.EngineConfig.DefaultWhitespaces.get -> System.Collections.Generic.IReadOnlyList<string!>!
 static Microsoft.TemplateEngine.Core.Util.EngineConfig.DefaultWhitespaces.set -> void
+static Microsoft.TemplateEngine.Core.VariableCollection.Root() -> Microsoft.TemplateEngine.Core.VariableCollection!
+static Microsoft.TemplateEngine.Core.VariableCollection.Root(System.Collections.Generic.IDictionary<string!, object!>! values) -> Microsoft.TemplateEngine.Core.VariableCollection!
+static Microsoft.TemplateEngine.Core.VariableCollection.SetupVariables(Microsoft.TemplateEngine.Abstractions.IParameterSet! parameters, Microsoft.TemplateEngine.Core.Contracts.IVariableConfig! variableConfig) -> Microsoft.TemplateEngine.Core.Contracts.IVariableCollection!
 virtual Microsoft.TemplateEngine.Core.Util.Orchestrator.RunSpecLoader(System.IO.Stream! runSpec) -> Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec!
 virtual Microsoft.TemplateEngine.Core.Util.Orchestrator.TryGetBufferSize(Microsoft.TemplateEngine.Abstractions.Mount.IFile! sourceFile, out int bufferSize) -> bool
 virtual Microsoft.TemplateEngine.Core.Util.Orchestrator.TryGetFlushThreshold(Microsoft.TemplateEngine.Abstractions.Mount.IFile! sourceFile, out int threshold) -> bool
+~static Microsoft.TemplateEngine.Core.Expressions.Shared.SharedEvaluatorDefinition<TSelf, TTokens>.EvaluateFromString(Microsoft.Extensions.Logging.ILogger logger, string text, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection variables) -> bool
 ~Microsoft.TemplateEngine.Core.Expressions.Token<TToken>.Token(TToken family, object value) -> void
 ~Microsoft.TemplateEngine.Core.Expressions.Token<TToken>.Value.get -> object
-~static Microsoft.TemplateEngine.Core.Expressions.Shared.SharedEvaluatorDefinition<TSelf, TTokens>.EvaluateFromString(Microsoft.Extensions.Logging.ILogger logger, string text, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection variables) -> bool

--- a/src/Microsoft.TemplateEngine.Core/VariableCollection.cs
+++ b/src/Microsoft.TemplateEngine.Core/VariableCollection.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -15,19 +17,19 @@ namespace Microsoft.TemplateEngine.Core
     {
         private static readonly IEnumerable<string> NoKeys = Array.Empty<string>();
         private readonly IDictionary<string, object> _values;
-        private IVariableCollection _parent;
+        private IVariableCollection? _parent;
 
         public VariableCollection()
             : this(null)
         {
         }
 
-        public VariableCollection(VariableCollection parent)
+        public VariableCollection(VariableCollection? parent)
             : this(parent, new Dictionary<string, object>())
         {
         }
 
-        public VariableCollection(IVariableCollection parent, IDictionary<string, object> values)
+        public VariableCollection(IVariableCollection? parent, IDictionary<string, object> values)
         {
             _parent = parent;
             _values = values ?? new Dictionary<string, object>();
@@ -38,9 +40,9 @@ namespace Microsoft.TemplateEngine.Core
             }
         }
 
-        public event KeysChangedEventHander KeysChanged;
+        public event KeysChangedEventHander? KeysChanged;
 
-        public event ValueReadEventHander ValueRead;
+        public event ValueReadEventHander? ValueRead;
 
         public int Count => Keys.Count;
 
@@ -48,7 +50,7 @@ namespace Microsoft.TemplateEngine.Core
 
         public ICollection<string> Keys => _values.Keys.Union(_parent?.Keys ?? NoKeys).ToList();
 
-        public IVariableCollection Parent
+        public IVariableCollection? Parent
         {
             get { return _parent; }
 
@@ -91,37 +93,11 @@ namespace Microsoft.TemplateEngine.Core
             }
         }
 
-        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings) => Environment(environmentSettings, null, true, true, "{0}");
-
-        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings, string formatString) => Environment(environmentSettings, null, true, true, formatString);
-
-        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings, VariableCollection parent) => Environment(environmentSettings, parent, true, true, "{0}");
-
-        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings, VariableCollection parent, string formatString) => Environment(environmentSettings, parent, true, true, formatString);
-
-        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings, bool changeCase, bool upperCase) => Environment(environmentSettings, null, changeCase, upperCase, "{0}");
-
-        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings, bool changeCase, bool upperCase, string formatString) => Environment(environmentSettings, null, changeCase, upperCase, formatString);
-
-        public static VariableCollection Environment(IEngineEnvironmentSettings environmentSettings, VariableCollection parent, bool changeCase, bool upperCase, string formatString)
-        {
-            VariableCollection vc = new VariableCollection(parent);
-            IReadOnlyDictionary<string, string> variables = environmentSettings.Environment.GetEnvironmentVariables();
-
-            foreach (KeyValuePair<string, string> entry in variables)
-            {
-                string name = string.Format(formatString, !changeCase ? entry.Key : upperCase ? entry.Key.ToUpperInvariant() : entry.Key.ToLowerInvariant());
-                vc[name] = entry.Value;
-            }
-
-            return vc;
-        }
-
-        public static VariableCollection Root() => Root(null);
+        public static VariableCollection Root() => Root(new Dictionary<string, object>());
 
         public static VariableCollection Root(IDictionary<string, object> values) => new VariableCollection(null, values);
 
-        public static IVariableCollection SetupVariables(IEngineEnvironmentSettings environmentSettings, IParameterSet parameters, IVariableConfig variableConfig)
+        public static IVariableCollection SetupVariables(IParameterSet parameters, IVariableConfig variableConfig)
         {
             IVariableCollection variables = Root();
 
@@ -129,32 +105,27 @@ namespace Microsoft.TemplateEngine.Core
 
             foreach (KeyValuePair<string, string> source in variableConfig.Sources)
             {
-                VariableCollection variablesForSource = null;
+                VariableCollection? variablesForSource = null;
                 string format = source.Value;
 
                 switch (source.Key)
                 {
-                    case "environment":
-                        variablesForSource = Environment(environmentSettings, format);
-
-                        if (variableConfig.FallbackFormat != null)
-                        {
-                            variablesForSource = Environment(environmentSettings, variablesForSource, variableConfig.FallbackFormat);
-                        }
-                        break;
+                    //may be extended for other categories in future if needed.
                     case "user":
-                        variablesForSource = VariableCollectionFromParameters(environmentSettings, parameters, format);
+                        variablesForSource = VariableCollectionFromParameters(parameters, format);
 
                         if (variableConfig.FallbackFormat != null)
                         {
-                            VariableCollection variablesFallback = VariableCollectionFromParameters(environmentSettings, parameters, variableConfig.FallbackFormat);
+                            VariableCollection variablesFallback = VariableCollectionFromParameters(parameters, variableConfig.FallbackFormat);
                             variablesFallback.Parent = variablesForSource;
                             variablesForSource = variablesFallback;
                         }
                         break;
                 }
-
-                collections[source.Key] = variablesForSource;
+                if (variablesForSource != null)
+                {
+                    collections[source.Key] = variablesForSource;
+                }
             }
 
             foreach (string order in variableConfig.Order)
@@ -172,36 +143,6 @@ namespace Microsoft.TemplateEngine.Core
             }
 
             return variables;
-        }
-
-        public static VariableCollection VariableCollectionFromParameters(IEngineEnvironmentSettings environmentSettings, IParameterSet parameters, string format)
-        {
-            VariableCollection vc = new VariableCollection();
-            foreach (ITemplateParameter param in parameters.ParameterDefinitions)
-            {
-                string key = string.Format(format ?? "{0}", param.Name);
-
-                if (!parameters.ResolvedValues.TryGetValue(param, out object value))
-                {
-                    if (param.Priority != TemplateParameterPriority.Optional)
-                    {
-                        parameters.ResolvedValues[param] = value;
-                    }
-                }
-                else if (value == null)
-                {
-                    if (param.Priority != TemplateParameterPriority.Optional)
-                    {
-                        parameters.ResolvedValues[param] = value;
-                    }
-                }
-                else
-                {
-                    vc[key] = value;
-                }
-            }
-
-            return vc;
         }
 
         public void Add(KeyValuePair<string, object> item)
@@ -286,6 +227,36 @@ namespace Microsoft.TemplateEngine.Core
             }
 
             return _parent?.TryGetValue(key, out value) ?? false;
+        }
+
+        private static VariableCollection VariableCollectionFromParameters(IParameterSet parameters, string format)
+        {
+            VariableCollection vc = new VariableCollection();
+            foreach (ITemplateParameter param in parameters.ParameterDefinitions)
+            {
+                string key = string.Format(format ?? "{0}", param.Name);
+
+                if (!parameters.ResolvedValues.TryGetValue(param, out object? value))
+                {
+                    if (param.Priority != TemplateParameterPriority.Optional)
+                    {
+                        parameters.ResolvedValues[param] = value;
+                    }
+                }
+                else if (value == null)
+                {
+                    if (param.Priority != TemplateParameterPriority.Optional)
+                    {
+                        parameters.ResolvedValues[param] = value;
+                    }
+                }
+                else
+                {
+                    vc[key] = value;
+                }
+            }
+
+            return vc;
         }
 
         private void OnKeysChanged()

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CustomFileGlobModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CustomFileGlobModel.cs
@@ -23,15 +23,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         internal static CustomFileGlobModel FromJObject(JObject globData, string globName)
         {
             // setup the variable config
-            IVariableConfig variableConfig;
-            if (globData.TryGetValue(nameof(VariableFormat), System.StringComparison.OrdinalIgnoreCase, out JToken variableData))
-            {
-                variableConfig = VariableConfig.FromJObject((JObject)variableData);
-            }
-            else
-            {
-                variableConfig = VariableConfig.DefaultVariableSetup(null);
-            }
+            IVariableConfig variableConfig = VariableConfig.DefaultVariableSetup();
 
             // setup the custom operations
             List<ICustomOperationModel> customOpsForGlob = new List<ICustomOperationModel>();

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -88,7 +88,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 throw new InvalidOperationException($"{nameof(templateData.TemplateSourceRoot)} cannot be null to continue.");
             }
 
-            IVariableCollection variables = SetupVariables(environmentSettings, parameters, templateConfig.OperationConfig.VariableSetup);
+            IVariableCollection variables = SetupVariables(parameters, templateConfig.OperationConfig.VariableSetup);
             await templateConfig.EvaluateBindSymbolsAsync(environmentSettings, variables, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             ProcessMacros(environmentSettings, templateConfig.OperationConfig, variables);
@@ -482,7 +482,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            IVariableCollection variables = SetupVariables(environmentSettings, parameters, runnableProjectConfig.OperationConfig.VariableSetup);
+            IVariableCollection variables = SetupVariables(parameters, runnableProjectConfig.OperationConfig.VariableSetup);
             await runnableProjectConfig.EvaluateBindSymbolsAsync(environmentSettings, variables, cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
@@ -504,9 +504,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             return GetCreationResult(environmentSettings.Host.Logger, runnableProjectConfig, variables);
         }
 
-        private static IVariableCollection SetupVariables(IEngineEnvironmentSettings environmentSettings, IParameterSet parameters, IVariableConfig variableConfig)
+        private static IVariableCollection SetupVariables(IParameterSet parameters, IVariableConfig variableConfig)
         {
-            IVariableCollection variables = VariableCollection.SetupVariables(environmentSettings, parameters, variableConfig);
+            IVariableCollection variables = VariableCollection.SetupVariables(parameters, variableConfig);
 
             foreach (Parameter param in parameters.ParameterDefinitions.OfType<Parameter>())
             {
@@ -666,7 +666,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
             public IEnumerable<ITemplateParameter> ParameterDefinitions => _parameters.Values;
 
-            public IDictionary<ITemplateParameter, object> ResolvedValues { get; } = new Dictionary<ITemplateParameter, object>();
+            public IDictionary<ITemplateParameter, object?> ResolvedValues { get; } = new Dictionary<ITemplateParameter, object?>();
 
             public bool TryGetParameterDefinition(string name, out ITemplateParameter parameter)
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SymbolModel/BindSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SymbolModel/BindSymbol.cs
@@ -27,6 +27,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.SymbolModel
             Binding = binding!;
         }
 
+        internal BindSymbol(string name, string binding) : base(name, null)
+        {
+            Binding = binding;
+        }
+
         /// <summary>
         /// Gets the name of the host property or the environment variable which will provide the value of this symbol.
         /// </summary>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/VariableConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/VariableConfig.cs
@@ -11,32 +11,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
     internal class VariableConfig : IVariableConfig
     {
-        private VariableConfig(JObject configData)
-        {
-            Dictionary<string, string> sourceFormats = new Dictionary<string, string>();
-            List<string> order = new List<string>();
-
-            if (configData.TryGetValue("sources", System.StringComparison.OrdinalIgnoreCase, out JToken? sourcesData))
-            {
-                foreach (JObject source in (JArray)sourcesData)
-                {
-                    string? name = source.ToString("name");
-                    string? format = source.ToString("format");
-
-                    if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(format))
-                    {
-                        sourceFormats[name!] = format!;
-                        order.Add(name!);
-                    }
-                }
-            }
-
-            Sources = sourceFormats;
-            Order = order;
-            FallbackFormat = configData.ToString(nameof(FallbackFormat));
-            Expand = configData.ToBool(nameof(Expand));
-        }
-
         private VariableConfig(
             IReadOnlyDictionary<string, string> sources,
             IReadOnlyList<string> order,
@@ -57,21 +31,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         public bool Expand { get; private init; }
 
-        internal static IVariableConfig DefaultVariableSetup(string fallbackFormat = "{0}")
+        internal static IVariableConfig DefaultVariableSetup()
         {
             return new VariableConfig(
                 new Dictionary<string, string>
                 {
-                    { "environment", "env_{0}" },
-                    { "user", "usr_{0}" }
+                    { "user", "{0}" }
                 },
-                new List<string>() { "environment", "user" },
-                fallbackFormat ?? "{0}");
-        }
-
-        internal static IVariableConfig FromJObject(JObject configData)
-        {
-            return new VariableConfig(configData);
+                new[] { "user" },
+                null);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Utils/RuntimeValueUtil.cs
+++ b/src/Microsoft.TemplateEngine.Utils/RuntimeValueUtil.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TemplateEngine.Utils
         public static bool TryGetRuntimeValue(this IParameterSet parameters, IEngineEnvironmentSettings environmentSettings, string name, out object? value, bool skipEnvironmentVariableSearch = false)
         {
             if (parameters.TryGetParameterDefinition(name, out ITemplateParameter param)
-                && parameters.ResolvedValues.TryGetValue(param, out object newValueObject)
+                && parameters.ResolvedValues.TryGetValue(param, out object? newValueObject)
                 && newValueObject != null)
             {
                 value = newValueObject;

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ChunkStreamReadTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ChunkStreamReadTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             ChunkMemoryStream output = new ChunkMemoryStream(1024);
 
             IOperationProvider[] operations = Array.Empty<IOperationProvider>();
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             processor.Run(input, output, 1024);
@@ -74,7 +74,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             ChunkMemoryStream output = new ChunkMemoryStream(10);
 
             IOperationProvider[] operations = { new Replacement("value".TokenConfig(), "foo", null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -108,7 +108,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
                     new Replacement("valueA".TokenConfigBuilder().OnlyIfBefore(" before"), "foo", null, true),
                     new Replacement("valueB".TokenConfigBuilder().OnlyIfAfter("after "), "bar", null, true),
                 };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/LookaroundTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/LookaroundTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Replacement("b".TokenConfigBuilder().OnlyIfAfter("ca"), "!", null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -52,7 +52,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Replacement("b".TokenConfigBuilder().OnlyIfBefore("cab"), "!", null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -71,7 +71,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Replacement("b".TokenConfigBuilder().OnlyIfBefore("cab").OnlyIfAfter("ba"), "!", null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -96,7 +96,7 @@ color:red;";
                 new Replacement("white".TokenConfigBuilder().OnlyIfBefore(";").OnlyIfAfter("background-color:"), "blue", null, true),
                 new Replacement("white".TokenConfigBuilder().OnlyIfBefore(";").OnlyIfAfter("color:"), "red", null, true)
             };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -120,7 +120,7 @@ color:red;";
                 new Replacement("bar".TokenConfigBuilder().OnlyIfBefore("baz").OnlyIfAfter("foo"), "b", null, true),
                 new Replacement("baz".TokenConfigBuilder().OnlyIfAfter("bar"), "c", null, true)
             };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -144,7 +144,7 @@ color:red;";
                 new Replacement("bar".TokenConfigBuilder().OnlyIfAfter("foo"), "b", null, true),
                 new Replacement("xaz".TokenConfigBuilder().OnlyIfAfter("bar"), "c", null, true)
             };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -168,7 +168,7 @@ color:red;";
                 new Replacement("bar".TokenConfigBuilder().OnlyIfBefore("baz"), "b", null, true),
                 new Replacement("baz".TokenConfigBuilder().OnlyIfAfter("bar"), "c", null, true)
             };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -191,7 +191,7 @@ color:red;";
                 new MockOperationProvider(new MockOperation(null, ReadaheadOneByte, true, Encoding.UTF8.GetBytes("foo"))),
                 new Replacement("bar".TokenConfigBuilder().OnlyIfAfter("foot"), "b", null, true)
             };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -215,7 +215,7 @@ color:red;";
                 new Replacement("bar".TokenConfigBuilder().OnlyIfAfter("foo"), "b", null, true),
                 new Replacement("baz".TokenConfigBuilder().OnlyIfAfter("bar"), "c", null, true)
             };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -238,7 +238,7 @@ color:red;";
                 new Replacement("baz".TokenConfigBuilder().OnlyIfAfter("foobar"), "a", null, true),
                 new Replacement("bar".TokenConfigBuilder().OnlyIfAfter("foo"), "b", null, true)
             };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -260,7 +260,7 @@ color:red;";
             {
                 new Replacement("".TokenConfigBuilder().OnlyIfAfter("foo").OnlyIfBefore("baz"), "bar", null, true)
             };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -283,7 +283,7 @@ color:red;";
                 new Replacement("foob".TokenConfigBuilder().OnlyIfBefore("arbaz"), "test", null, true),
                 new Replacement("foo".TokenConfigBuilder().OnlyIfBefore("barbaz"), "test2", null, true)
             };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/RegionTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/RegionTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("value".TokenConfig(), "foo".TokenConfig(), false, false, false, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -51,7 +51,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("value".TokenConfig(), "foo".TokenConfig(), true, false, false, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("value".TokenConfig(), "foo".TokenConfig(), true, false, false, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -89,7 +89,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("region".TokenConfig(), "region".TokenConfig(), true, false, false, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -108,7 +108,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("region".TokenConfig(), "region".TokenConfig(), false, false, false, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -127,7 +127,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("value".TokenConfig(), "foo".TokenConfig(), true, false, true, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -153,7 +153,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin".TokenConfig(), "#end".TokenConfig(), true, false, true, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -178,7 +178,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin".TokenConfig(), "#end".TokenConfig(), true, true, true, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -205,7 +205,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin2".TokenConfig(), "#end2".TokenConfig(), true, true, true, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -230,7 +230,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin".TokenConfig(), "#end".TokenConfig(), true, true, true, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -255,7 +255,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin".TokenConfig(), "#end".TokenConfig(), true, true, true, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -280,7 +280,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin".TokenConfig(), "#end".TokenConfig(), true, true, true, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -305,7 +305,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin".TokenConfig(), "#end".TokenConfig(), true, true, true, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -336,7 +336,7 @@ There";
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Region("#begin".TokenConfig(), "#end".TokenConfig(), false, true, true, null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ReplacementTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ReplacementTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Replacement("value".TokenConfig(), "foo", null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -51,7 +51,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Replacement("value2".TokenConfig(), "foo", null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Replacement("value".TokenConfig(), "foo", null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made
@@ -89,7 +89,7 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MemoryStream output = new MemoryStream();
 
             IOperationProvider[] operations = { new Replacement("value".TokenConfig(), "foo", null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "${0}$");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Root());
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/VariablesTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/VariablesTests.cs
@@ -24,15 +24,20 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
         [Fact(DisplayName = nameof(VerifyVariables))]
         public void VerifyVariables()
         {
-            string value = @"test %PATH% test";
-            string expected = @"test " + _engineEnvironmentSettings.Environment.GetEnvironmentVariable("PATH") + " test";
+            string value = @"test VAL test";
+            string expected = @"test testValue test";
 
             byte[] valueBytes = Encoding.UTF8.GetBytes(value);
             MemoryStream input = new MemoryStream(valueBytes);
             MemoryStream output = new MemoryStream();
 
+            VariableCollection vc = new VariableCollection
+            {
+                ["VAL"] = "testValue"
+            };
+
             IOperationProvider[] operations = { new ExpandVariables(null, true) };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, VariableCollection.Environment(_engineEnvironmentSettings), "%{0}%");
+            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, vc);
             IProcessor processor = Processor.Create(cfg, operations);
 
             //Changes should be made

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/.dockerignore
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/.dockerignore
@@ -6,3 +6,4 @@ foo
 ## comment bar
 #bar
 #endif
+baz

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/.editorconfig
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/.editorconfig
@@ -6,3 +6,4 @@ foo
 ## comment bar
 #bar
 #endif
+baz

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/.gitattributes
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/.gitattributes
@@ -6,3 +6,4 @@ foo
 ## comment bar
 #bar
 #endif
+baz

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/.gitignore
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/.gitignore
@@ -6,3 +6,4 @@ foo
 ## comment bar
 #bar
 #endif
+baz

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/Dockerfile
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/Dockerfile
@@ -6,3 +6,4 @@ foo
 ## comment bar
 #bar
 #endif
+baz

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/nuget.config
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/nuget.config
@@ -6,3 +6,4 @@ foo
 <!-- comment bar -- >
 bar
 #endif -->
+baz

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/test.cake
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/test.cake
@@ -6,3 +6,4 @@ foo
 // comment bar
 bar
 #endif
+baz

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/test.md
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/test.md
@@ -6,3 +6,4 @@ foo
 <!-- comment bar -- >
 bar
 #endif -->
+baz

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/test.sln
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/test.sln
@@ -6,3 +6,4 @@ foo
 ## comment bar
 #bar
 #endif
+baz

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/test.yaml
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/test.yaml
@@ -6,3 +6,4 @@ foo
 ## comment bar
 #bar
 #endif
+baz

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.cs
@@ -274,6 +274,7 @@ namespace Dotnet_new3.IntegrationTests
             //## comment bar
             //#bar
             //#endif
+            //baz
             //For extension test cases the template has 'test.<extension>' file defined.
 
             Helpers.InstallTestTemplate("TemplateWithConditions", _log, home, workingDirectory);
@@ -288,7 +289,7 @@ namespace Dotnet_new3.IntegrationTests
 
             string testFile = Path.Combine(workingDirectory, fileName);
             Assert.True(File.Exists(testFile));
-            Assert.Equal($"{string.Format(expectedCommandFormat, "foo")}{expectedEol}foo{expectedEol}", File.ReadAllText(testFile));
+            Assert.Equal($"{string.Format(expectedCommandFormat, "foo")}{expectedEol}foo{expectedEol}baz{expectedEol}", File.ReadAllText(testFile));
 
             workingDirectory = TestUtils.CreateTemporaryFolder();
             new DotnetNewCommand(_log, "TestAssets.TemplateWithConditions", "--A", "false")
@@ -302,7 +303,7 @@ namespace Dotnet_new3.IntegrationTests
 
             testFile = Path.Combine(workingDirectory, fileName);
             Assert.True(File.Exists(testFile));
-            Assert.Equal($"", File.ReadAllText(testFile));
+            Assert.Equal($"baz{expectedEol}", File.ReadAllText(testFile));
 
             workingDirectory = TestUtils.CreateTemporaryFolder();
             new DotnetNewCommand(_log, "TestAssets.TemplateWithConditions", "--B", "true")
@@ -316,7 +317,7 @@ namespace Dotnet_new3.IntegrationTests
 
             testFile = Path.Combine(workingDirectory, fileName);
             Assert.True(File.Exists(testFile));
-            Assert.Equal($"{string.Format(expectedCommandFormat, "bar")}{expectedEol}bar{expectedEol}", File.ReadAllText(testFile));
+            Assert.Equal($"{string.Format(expectedCommandFormat, "bar")}{expectedEol}bar{expectedEol}baz{expectedEol}", File.ReadAllText(testFile));
         }
 
         [Fact]


### PR DESCRIPTION
### Problem
At the moment all env variables are added to any variable collection defined, for regular and fallback syntax.
This leads to:
- overprocessing each time variable collection is used (thousand of times in `Microsoft.TemplateEngine.Core`).
- not wanted matches when env variable name matches other variable name (and author is not aware)
- core processing depends on environment leading to even basic tests result in different behavior on different environment

### Solution
Removed adding environment variables to `VariableCollection`
Removed variable setup configuration via json (not used and not documented).

In case environment variables need to be used as variable in template processing, they can be bound using `bind` symbol to a name and used this way.

Addition: added `OS` to be bound by default: there are known templates where `OS` is used, and it is also shown in Wiki examples.

### Checks:
- [ ] Added unit tests - well covered by existing tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)