### PR TITLE
Exposes components for custom registration

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsTemplatePackageProviderFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsTemplatePackageProviderFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
 
 namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
 {
-    public class GlobalSettingsTemplatePackageProviderFactory : ITemplatePackageProviderFactory, IPrioritizedComponent
+    public sealed class GlobalSettingsTemplatePackageProviderFactory : ITemplatePackageProviderFactory, IPrioritizedComponent
     {
         internal static readonly Guid FactoryId = new Guid("{3AACE22E-E978-4BAF-8BC1-568B290A238C}");
 

--- a/src/Microsoft.TemplateEngine.Edge/Components/EnvironmentVariablesBindSource.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Components/EnvironmentVariablesBindSource.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TemplateEngine.Edge
     /// <summary>
     /// The component allows to bind environment variables.
     /// </summary>
-    public class EnvironmentVariablesBindSource : IBindSymbolSource
+    public sealed class EnvironmentVariablesBindSource : IBindSymbolSource
     {
         int IPrioritizedComponent.Priority => 0;
 

--- a/src/Microsoft.TemplateEngine.Edge/Components/HostParametersBindSource.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Components/HostParametersBindSource.cs
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateEngine.Edge
     /// <summary>
     /// The component allows custom host parameters.
     /// </summary>
-    public class HostParametersBindSource : IBindSymbolSource
+    public sealed class HostParametersBindSource : IBindSymbolSource
     {
         int IPrioritizedComponent.Priority => 100;
 

--- a/src/Microsoft.TemplateEngine.Edge/Constraints/HostConstraint.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Constraints/HostConstraint.cs
@@ -17,7 +17,7 @@ using NuGet.Configuration;
 
 namespace Microsoft.TemplateEngine.Edge.Constraints
 {
-    public class HostConstraintFactory : ITemplateConstraintFactory
+    public sealed class HostConstraintFactory : ITemplateConstraintFactory
     {
         Guid IIdentifiedComponent.Id { get; } = Guid.Parse("{93721B30-6890-403F-BAE7-5925990865A2}");
 

--- a/src/Microsoft.TemplateEngine.Edge/Constraints/OSConstraint.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Constraints/OSConstraint.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Edge.Constraints
 {
-    public class OSConstraintFactory : ITemplateConstraintFactory
+    public sealed class OSConstraintFactory : ITemplateConstraintFactory
     {
         private static readonly Dictionary<string, OSPlatform> _platformMap = new Dictionary<string, OSPlatform>(StringComparer.OrdinalIgnoreCase)
         {

--- a/src/Microsoft.TemplateEngine.Edge/Constraints/SdkVersionConstraintFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Constraints/SdkVersionConstraintFactory.cs
@@ -16,7 +16,7 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Edge.Constraints
 {
-    public class SdkVersionConstraintFactory : ITemplateConstraintFactory
+    public sealed class SdkVersionConstraintFactory : ITemplateConstraintFactory
     {
         Guid IIdentifiedComponent.Id { get; } = Guid.Parse("{4E9721EF-0C02-4C09-A5A4-56C3D29BFC8E}");
 

--- a/src/Microsoft.TemplateEngine.Edge/Constraints/WorkloadConstraintFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Constraints/WorkloadConstraintFactory.cs
@@ -18,7 +18,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Edge.Constraints
 {
-    public class WorkloadConstraintFactory : ITemplateConstraintFactory
+    public sealed class WorkloadConstraintFactory : ITemplateConstraintFactory
     {
         Guid IIdentifiedComponent.Id { get; } = Guid.Parse("{F8BA5B13-7BD6-47C8-838C-66626526817B}");
 

--- a/src/Microsoft.TemplateEngine.Edge/Installers/Folder/FolderInstallerFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/Folder/FolderInstallerFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.TemplateEngine.Abstractions.Installer;
 
 namespace Microsoft.TemplateEngine.Edge.Installers.Folder
 {
-    public class FolderInstallerFactory : IInstallerFactory
+    public sealed class FolderInstallerFactory : IInstallerFactory
     {
         internal static readonly Guid FactoryId = new Guid("{F01DEA33-E89C-46D1-89C2-1CA1F394C5AA}");
 

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstallerFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstallerFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.TemplateEngine.Abstractions.Installer;
 
 namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 {
-    public class NuGetInstallerFactory : IInstallerFactory
+    public sealed class NuGetInstallerFactory : IInstallerFactory
     {
         internal static readonly Guid FactoryId = new Guid("{015DCBAC-B4A5-49EA-94A6-061616EB60E2}");
 

--- a/src/Microsoft.TemplateEngine.Edge/Mount/Archive/ZipFileMountPointFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/Archive/ZipFileMountPointFactory.cs
@@ -9,7 +9,7 @@ using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Edge.Mount.Archive
 {
-    public class ZipFileMountPointFactory : IMountPointFactory
+    public sealed class ZipFileMountPointFactory : IMountPointFactory
     {
         internal static readonly Guid FactoryId = new Guid("94E92610-CF4C-4F6D-AEB6-9E42DDE1899D");
 

--- a/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemMountPointFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Mount/FileSystem/FileSystemMountPointFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.TemplateEngine.Abstractions.Mount;
 
 namespace Microsoft.TemplateEngine.Edge.Mount.FileSystem
 {
-    public class FileSystemMountPointFactory : IMountPointFactory
+    public sealed class FileSystemMountPointFactory : IMountPointFactory
     {
         internal static readonly Guid FactoryId = new Guid("8C19221B-DEA3-4250-86FE-2D4E189A11D2");
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 ﻿Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro.EvaluateConfig(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! environmentSettings, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection! vars, Microsoft.TemplateEngine.Core.Contracts.IMacroConfig! config) -> void
+Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator
+Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator.RunnableProjectGenerator() -> void

--- a/src/Microsoft.TemplateSearch.Common/Providers/NuGetMetadataSearchProviderFactory.cs
+++ b/src/Microsoft.TemplateSearch.Common/Providers/NuGetMetadataSearchProviderFactory.cs
@@ -8,13 +8,13 @@ using Microsoft.TemplateSearch.Common.Abstractions;
 
 namespace Microsoft.TemplateSearch.Common.Providers
 {
-    internal class NuGetMetadataSearchProviderFactory : ITemplateSearchProviderFactory
+    public sealed class NuGetMetadataSearchProviderFactory : ITemplateSearchProviderFactory
     {
-        public string DisplayName => "NuGet.org";
+        string ITemplateSearchProviderFactory.DisplayName => "NuGet.org";
 
-        public Guid Id => new Guid("6EA368C4-8A56-444C-91D1-55150B296BF2");
+        Guid IIdentifiedComponent.Id => new Guid("6EA368C4-8A56-444C-91D1-55150B296BF2");
 
-        public ITemplateSearchProvider CreateProvider(
+        ITemplateSearchProvider ITemplateSearchProviderFactory.CreateProvider(
             IEngineEnvironmentSettings environmentSettings,
             IReadOnlyDictionary<string, Func<object, object>> additionalDataReaders)
         {

--- a/src/Microsoft.TemplateSearch.Common/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateSearch.Common/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 ﻿Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.Description.get -> string?
 Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.IconUrl.get -> string?
+Microsoft.TemplateSearch.Common.Providers.NuGetMetadataSearchProviderFactory
+Microsoft.TemplateSearch.Common.Providers.NuGetMetadataSearchProviderFactory.NuGetMetadataSearchProviderFactory() -> void
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData.Description.get -> string?
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData.IconUrl.get -> string?

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ScanTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ScanTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 
             IMountPoint mountPoint = environmentSettings.MountPath(sourceBasePath);
             RunnableProjectGenerator generator = new RunnableProjectGenerator();
-            var templates = generator.GetTemplatesAndLangpacksFromDir(mountPoint, out _);
+            var templates = (generator as IGenerator).GetTemplatesAndLangpacksFromDir(mountPoint, out _);
 
             Assert.Single(templates);
             var template = templates[0];


### PR DESCRIPTION
### Problem
fixes https://github.com/dotnet/templating/issues/4767

### Solution
Exposed the following components for custom registration, in addition to components already exposed in `Edge`.
- `NuGetMetadataSearchProviderFactory`
- `RunnableProjectGenerator`

Sealed exposed components in Edge.
I see no reason to expose other components at the moment as they are native part of `RunnableProjectGenerator`.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)