### PR TITLE
Template-specific help should differentiate options with different casing

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/ChoiceTemplateParameter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/ChoiceTemplateParameter.cs
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateEngine.Cli
             };
         }
 
-        protected override Option GetBaseOption(IReadOnlyList<string> aliases)
+        protected override Option GetBaseOption(IReadOnlySet<string> aliases)
         {
             Option<string> option = new Option<string>(
                 aliases.ToArray(),

--- a/src/Microsoft.TemplateEngine.Cli/CliTemplateParameter.cs
+++ b/src/Microsoft.TemplateEngine.Cli/CliTemplateParameter.cs
@@ -129,7 +129,7 @@ namespace Microsoft.TemplateEngine.Cli
         /// Creates <see cref="Option"/> for template parameter.
         /// </summary>
         /// <param name="aliases">aliases to be used for option.</param>
-        internal Option GetOption(IReadOnlyList<string> aliases)
+        internal Option GetOption(IReadOnlySet<string> aliases)
         {
             Option option = GetBaseOption(aliases);
             option.IsHidden = IsHidden;
@@ -163,7 +163,7 @@ namespace Microsoft.TemplateEngine.Cli
             };
         }
 
-        protected virtual Option GetBaseOption(IReadOnlyList<string> aliases)
+        protected virtual Option GetBaseOption(IReadOnlySet<string> aliases)
         {
             return Type switch
             {

--- a/src/Microsoft.TemplateEngine.Cli/Commands/AliasAssignmentCoordinator.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/AliasAssignmentCoordinator.cs
@@ -8,9 +8,9 @@ namespace Microsoft.TemplateEngine.Cli.Commands
     /// </summary>
     internal class AliasAssignmentCoordinator
     {
-        internal static IReadOnlyList<(CliTemplateParameter Parameter, IReadOnlyList<string> Aliases, IReadOnlyList<string> Errors)> AssignAliasesForParameter(IEnumerable<CliTemplateParameter> parameters, HashSet<string> takenAliases)
+        internal static IReadOnlyList<(CliTemplateParameter Parameter, IReadOnlySet<string> Aliases, IReadOnlyList<string> Errors)> AssignAliasesForParameter(IEnumerable<CliTemplateParameter> parameters, HashSet<string> takenAliases)
         {
-            List<(CliTemplateParameter Parameter, IReadOnlyList<string> Aliases, IReadOnlyList<string> Errors)> result = new();
+            List<(CliTemplateParameter Parameter, IReadOnlySet<string> Aliases, IReadOnlyList<string> Errors)> result = new();
 
             List<string> predefinedLongOverrides = parameters.SelectMany(p => p.LongNameOverrides).Where(n => !string.IsNullOrEmpty(n)).Select(n => $"--{n}").ToList();
             List<string> predefinedShortOverrides = parameters.SelectMany(p => p.ShortNameOverrides).Where(n => !string.IsNullOrEmpty(n)).Select(n => $"-{n}").ToList();
@@ -21,7 +21,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
             foreach (var parameter in parameters)
             {
-                List<string> aliases = new List<string>();
+                HashSet<string> aliases = new HashSet<string>(StringComparer.Ordinal);
                 List<string> errors = new List<string>();
                 if (parameter.Name.Contains(':'))
                 {
@@ -49,7 +49,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         private static void HandleShortOverrides(
             HashSet<string> takenAliases,
-            List<string> aliases,
+            HashSet<string> aliases,
             List<string> errors,
             Func<string, bool> isAliasTaken,
             CliTemplateParameter parameter)
@@ -87,7 +87,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         private static void HandleLongOverrides(
             HashSet<string> takenAliases,
-            List<string> aliases,
+            HashSet<string> aliases,
             List<string> errors,
             Func<string, bool> isAliasTaken,
             Func<string, bool> isLongNamePredefined,
@@ -130,7 +130,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         private static void GenerateShortName(
             HashSet<string> takenAliases,
-            List<string> aliases,
+            HashSet<string> aliases,
             List<string> errors,
             Func<string, bool> isAliasTaken,
             Func<string, bool> isShortNamePredefined,

--- a/src/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommand.cs
@@ -324,7 +324,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                 throw new InvalidTemplateParametersException(templateInfo, errors);
             }
 
-            foreach ((CliTemplateParameter parameter, IReadOnlyList<string> aliases, IReadOnlyList<string> _) in parametersWithAliasAssignments)
+            foreach ((CliTemplateParameter parameter, IReadOnlySet<string> aliases, IReadOnlyList<string> _) in parametersWithAliasAssignments)
             {
                 TemplateOption option = new TemplateOption(parameter, aliases);
                 this.AddOption(option.Option);

--- a/src/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommandArgs.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/create/TemplateCommandArgs.cs
@@ -94,7 +94,7 @@ namespace Microsoft.TemplateEngine.Cli.Commands
         {
             if (_command.TemplateOptions.ContainsKey(canonicalName))
             {
-                alias = _command.TemplateOptions[canonicalName].Aliases[0];
+                alias = _command.TemplateOptions[canonicalName].Aliases.First();
                 return true;
             }
             alias = null;

--- a/src/Microsoft.TemplateEngine.Cli/Commands/create/TemplateOption.cs
+++ b/src/Microsoft.TemplateEngine.Cli/Commands/create/TemplateOption.cs
@@ -5,24 +5,87 @@ using System.CommandLine;
 
 namespace Microsoft.TemplateEngine.Cli.Commands
 {
-    internal class TemplateOption
+    internal class TemplateOption : IEquatable<TemplateOption>
     {
-        private readonly Option _option;
+        private Option _option;
 
         internal TemplateOption(
             CliTemplateParameter parameter,
-            IReadOnlyList<string> aliases)
+            IReadOnlySet<string> aliases)
         {
             TemplateParameter = parameter;
             Aliases = aliases;
-            _option = parameter.GetOption(aliases);
+            _option = TemplateParameter.GetOption(Aliases);
         }
 
         internal CliTemplateParameter TemplateParameter { get; private set; }
 
-        internal IReadOnlyList<string> Aliases { get; private set; }
+        internal IReadOnlySet<string> Aliases { get; private set; }
 
         internal Option Option => _option;
 
+        public bool Equals(TemplateOption? other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (!string.Equals(TemplateParameter.Name, other.TemplateParameter.Name, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (TemplateParameter.Type != other.TemplateParameter.Type)
+            {
+                return false;
+            }
+
+            if (Aliases.Count != other.Aliases.Count)
+            {
+                return false;
+            }
+
+            foreach (string alias in other.Aliases)
+            {
+                if (!Aliases.Contains(alias))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as TemplateOption);
+
+        public override int GetHashCode()
+        {
+            return new { a = TemplateParameter.Name, b = TemplateParameter.Type, c = Aliases.Aggregate(0, (sum, next) => sum ^ next.GetHashCode()) }.GetHashCode();
+        }
+
+        internal void MergeChoices(ChoiceTemplateParameter choiceParam)
+        {
+            if (TemplateParameter is not ChoiceTemplateParameter currentChoiceParam)
+            {
+                return;
+            }
+
+            if (TemplateParameter is CombinedChoiceTemplateParameter combinedParam)
+            {
+                combinedParam.MergeChoices(choiceParam);
+            }
+            else
+            {
+                var combinedChoice = new CombinedChoiceTemplateParameter(currentChoiceParam);
+                combinedChoice.MergeChoices(choiceParam);
+                TemplateParameter = combinedChoice;
+            }
+            _option = TemplateParameter.GetOption(Aliases);
+        }
     }
 }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/HelpTests.DoesNotCombineParametersWhenAliasesAreDifferent.verified.txt
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/Approvals/HelpTests.DoesNotCombineParametersWhenAliasesAreDifferent.verified.txt
@@ -1,0 +1,16 @@
+﻿Template options:
+  -C, --Choice <choice>  my description
+                         Type: choice
+                           val1  
+                         Default: def-val
+                         Default if option is 
+                         provided without a 
+                         value: def-val-no-arg
+  -C, --choice <choice>  my description
+                         Type: choice
+                           val2  
+                         Default: def-val
+                         Default if option is 
+                         provided without a 
+                         value: def-val-no-arg
+


### PR DESCRIPTION
### Problem
fixes #4894 

### Solution
When combining template specific options for help output, the logic should consider if aliases are the same.
If aliases are not the same, the options should not be combined.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)