### PR TITLE
Improved message when template from the cache is not available

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.Designer.cs
@@ -911,15 +911,6 @@ namespace Microsoft.TemplateEngine.Cli {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to locate the specified template content, the template cache may be corrupted. Try running &apos;dotnet {0} --debug:reinit&apos; to fix the issue..
-        /// </summary>
-        internal static string MissingTemplateContentDetected {
-            get {
-                return ResourceManager.GetString("MissingTemplateContentDetected", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Mount Point Factories.
         /// </summary>
         internal static string MountPointFactories {
@@ -1486,6 +1477,42 @@ namespace Microsoft.TemplateEngine.Cli {
         internal static string TemplateCommand_DisplayConstraintResults_Warning {
             get {
                 return ResourceManager.GetString("TemplateCommand_DisplayConstraintResults_Warning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to locate the specified template content, the template package might be removed or corrupted..
+        /// </summary>
+        internal static string TemplateCreator_Error_TemplateNotFound {
+            get {
+                return ResourceManager.GetString("TemplateCreator_Error_TemplateNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To install the template package, run:.
+        /// </summary>
+        internal static string TemplateCreator_Hint_Install {
+            get {
+                return ResourceManager.GetString("TemplateCreator_Hint_Install", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To rescan installed template packages, run:.
+        /// </summary>
+        internal static string TemplateCreator_Hint_RebuildCache {
+            get {
+                return ResourceManager.GetString("TemplateCreator_Hint_RebuildCache", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to To uninstall the template package, run:.
+        /// </summary>
+        internal static string TemplateCreator_Hint_Uninstall {
+            get {
+                return ResourceManager.GetString("TemplateCreator_Hint_Uninstall", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Cli/LocalizableStrings.resx
@@ -413,8 +413,8 @@ Run 'dotnet {1} --show-aliases' with no args to show all aliases.</value>
   <data name="FileActionsWouldHaveBeenTaken" xml:space="preserve">
     <value>File actions would have been taken:</value>
   </data>
-  <data name="MissingTemplateContentDetected" xml:space="preserve">
-    <value>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</value>
+  <data name="TemplateCreator_Error_TemplateNotFound" xml:space="preserve">
+    <value>Unable to locate the specified template content, the template package might be removed or corrupted.</value>
   </data>
   <data name="InvalidNameParameter" xml:space="preserve">
     <value>Name cannot contain any of the following characters {0} or character codes {1}</value>
@@ -833,5 +833,17 @@ The header is followed by the list of parameters and their errors (might be seve
   </data>
   <data name="PostAction_AddReference_AddPackageReference_WithVersion" xml:space="preserve">
     <value>Adding a package reference {0} (version: {1}) to project file {2}:</value>
+  </data>
+  <data name="TemplateCreator_Hint_Install" xml:space="preserve">
+    <value>To install the template package, run:</value>
+    <comment>The sentence is followed by the command to run the action</comment>
+  </data>
+  <data name="TemplateCreator_Hint_RebuildCache" xml:space="preserve">
+    <value>To rescan installed template packages, run:</value>
+    <comment>The sentence is followed by the command to run the action</comment>
+  </data>
+  <data name="TemplateCreator_Hint_Uninstall" xml:space="preserve">
+    <value>To uninstall the template package, run:</value>
+    <comment>The sentence is followed by the command to run the action</comment>
   </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.cs.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">U šablony {1} chybí povinná možnost {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">Nedá se najít zadaný obsah šablony, mezipaměť šablony může být poškozená. Zkuste problém vyřešit spuštěním příkazu dotnet {0} --debug:reinit.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">Továrny bodů připojení</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">Upozornění: Pro šablonu {0} nejsou splněna následující omezení:</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.de.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Die obligatorische Option „{0}“ fehlt für die Vorlage „{1}“.</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">Der angegebene Vorlageninhalt wurde nicht gefunden, der Vorlagencache ist möglicherweise beschädigt. Führen Sie \"dotnet {0} --debug:reinit\" aus, um das Problem zu beheben.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">Bereitstellungspunkt-Factorys</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">Warnung: Die folgenden Einschränkungen für die Vorlage „{0}“ sind nicht erfüllt:</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.es.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Falta la opción obligatoria '{0}' para la plantilla '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">No se puede encontrar el contenido especificado de la plantilla, es posible que la caché de plantillas esté dañada. Pruebe a ejecutar \"dotnet {0} --debug:reinit\" para corregir el problema.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">Generadores de puntos de montaje</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">Advertencia: no se cumplen las siguientes restricciones para la plantilla '{0}':</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.fr.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">L’option obligatoire '{0}' est manquante pour le modèle '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">Impossible de localiser le contenu du modèle spécifié, le cache de modèle est peut-être endommagé. Essayez d’exécuter « dotnet {0} --debug:reinit » pour résoudre le problème.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">Fabriques de points de montage</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">Avertissement : les contraintes suivantes pour le modèle « {0} » ne sont pas remplies :</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.it.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Manca '{0}' l'opzione obbligatoria per il modello '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">Impossibile trovare il contenuto del modello specificato, la cache dei modelli potrebbe essere danneggiata. Provare a eseguire 'dotnet {0}--debug: reinit' per risolvere il problema.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">Fabbriche punto di montaggio</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">Avviso: i vincoli seguenti per il modello '{0}' non sono soddisfatti:</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ja.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">テンプレート '{1}' の必須パラメーター '{0}' がありません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">指定されたテンプレートのコンテンツが見つからないため、テンプレートキャッシュが壊れている可能性があります。'dotnet {0}--debug: reinit ' を実行して、問題を解決してください。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">マウント ポイントのファクトリ</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">警告: テンプレート '{0}' は次の制約を満たされていません:</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ko.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">'{1}' 템플릿에 대한 '{0}' 필수 옵션이 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">지정된 템플릿 콘텐츠를 찾을 수 없습니다. 템플릿 캐시가 손상되었을 수 있습니다. 문제를 해결하려면 'dotnet {0} --debug : reinit'를 실행 해보세요.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">마운트 포인트 팩토리</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">경고: '{0}' 템플릿에 대한 다음 제약 조건이 충족되지 않습니다.</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pl.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">W przypadku szablonu „{1}” brakuje opcji obowiązkowej „{0}”.</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">Nie można zlokalizować określonej zawartości szablonu, ponieważ pamięć podręczna szablonu może być uszkodzona. Spróbuj uruchomić polecenie \"dotnet {0}--debug:reinit\", aby rozwiązać problem.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">Fabryki punktów instalacji</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">Ostrzeżenie: następujące ograniczenia szablonu „{0}”nie są spełnione:</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.pt-BR.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">A opção obrigatória '{0}' está faltando para o modelo '{1}'.</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">Não é possível localizar o conteúdo do modelo especificado, o cache do modelo pode estar corrompido. Tente executar 'dotnet {0} -- depurar: reinit' para corrigir o problema.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">Fábricas de Ponto de Montagem</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">Aviso: as seguintes restrições para o modelo '{0}' não são atendidas:</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.ru.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">Отсутствует обязательный параметр "{0}" для шаблона "{1}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">Не удалось найти указанное содержимое шаблона, возможно, кэш шаблона поврежден. Попробуйте запустить \"dotnet {0} --debug:reinit\", чтобы устранить проблему.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">Фабрики точек подключения</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">Предупреждение: не соблюдены следующие ограничения для шаблона «{0}»:</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.tr.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">'{1}' şablonunda zorunlu '{0}' seçeneği eksik.</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">Belirtilen şablon içeriği bulunamıyor, şablon önbelleği bozulmuş olabilir. Sorunu düzeltmek için “dotnet {0} --debug:reinit” komutunu çalıştırmayı deneyin.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">Bağlama Noktası Fabrikaları</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">Uyarı: '{0}' şablonu için şu kısıtlamalar karşılanmıyor:</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hans.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">模板“{1}”缺少必备选项“{0}”。</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">找不到指定的模板内容，模板缓存可能已损坏。请尝试运行“dotnet {0} --debug:reinit”已修复该问题。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">装入点工厂</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">警告: 未满足模板“{0}”的以下约束:</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Cli/xlf/LocalizableStrings.zh-Hant.xlf
@@ -483,11 +483,6 @@ The header is followed by the list of parameters and their errors (might be seve
         <target state="translated">範本 '{1}'缺少強制選項 '{0}'。</target>
         <note />
       </trans-unit>
-      <trans-unit id="MissingTemplateContentDetected">
-        <source>Unable to locate the specified template content, the template cache may be corrupted. Try running 'dotnet {0} --debug:reinit' to fix the issue.</source>
-        <target state="translated">找不到指定的範本內容，範本快取記憶體可能已損毀。嘗試執行 'dotnet {0} --debug: reinit' 以修正問題。</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MountPointFactories">
         <source>Mount Point Factories</source>
         <target state="translated">裝載點處理站</target>
@@ -826,6 +821,26 @@ The header is followed by the list of parameters and their errors (might be seve
         <source>Warning: the following constraints for the template '{0}' are not met:</source>
         <target state="translated">警告: 不符合下列範本 '{0}' 的條件約束:</target>
         <note>{0} - template name (user friendly)</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Error_TemplateNotFound">
+        <source>Unable to locate the specified template content, the template package might be removed or corrupted.</source>
+        <target state="new">Unable to locate the specified template content, the template package might be removed or corrupted.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Install">
+        <source>To install the template package, run:</source>
+        <target state="new">To install the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_RebuildCache">
+        <source>To rescan installed template packages, run:</source>
+        <target state="new">To rescan installed template packages, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
+      </trans-unit>
+      <trans-unit id="TemplateCreator_Hint_Uninstall">
+        <source>To uninstall the template package, run:</source>
+        <target state="new">To uninstall the template package, run:</target>
+        <note>The sentence is followed by the command to run the action</note>
       </trans-unit>
       <trans-unit id="TemplateInformationCoordinator_DotnetNew_Description">
         <source>The '{0}' command creates a .NET project based on a template.</source>

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWhenFolderIsRemoved.Linux.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWhenFolderIsRemoved.Linux.verified.txt
@@ -1,0 +1,14 @@
+﻿StdErr:
+Unable to locate the specified template content, the template package might be removed or corrupted.
+
+
+For details on the exit code, refer to https://aka.ms/templating-exit-codes#103
+StdOut:
+To rescan installed template packages, run:
+   dotnet-new3 new3 --debug:rebuild-cache
+
+To uninstall the template package, run:
+   dotnet-new3 new3 uninstall {TempPath}TemplateEngine.Tests/Guid_1/template
+
+To install the template package, run:
+   dotnet-new3 new3 install {TempPath}TemplateEngine.Tests/Guid_1/template

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWhenFolderIsRemoved.OSX.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWhenFolderIsRemoved.OSX.verified.txt
@@ -1,0 +1,14 @@
+﻿StdErr:
+Unable to locate the specified template content, the template package might be removed or corrupted.
+
+
+For details on the exit code, refer to https://aka.ms/templating-exit-codes#103
+StdOut:
+To rescan installed template packages, run:
+   dotnet-new3 new3 --debug:rebuild-cache
+
+To uninstall the template package, run:
+   dotnet-new3 new3 uninstall {TempPath}TemplateEngine.Tests/Guid_1/template
+
+To install the template package, run:
+   dotnet-new3 new3 install {TempPath}TemplateEngine.Tests/Guid_1/template

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWhenFolderIsRemoved.Windows.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CannotInstantiateTemplateWhenFolderIsRemoved.Windows.verified.txt
@@ -1,0 +1,14 @@
+﻿StdErr:
+Unable to locate the specified template content, the template package might be removed or corrupted.
+
+
+For details on the exit code, refer to https://aka.ms/templating-exit-codes#103
+StdOut:
+To rescan installed template packages, run:
+   dotnet-new3 new3 --debug:rebuild-cache
+
+To uninstall the template package, run:
+   dotnet-new3 new3 uninstall {TempPath}TemplateEngine.Tests\Guid_1\template
+
+To install the template package, run:
+   dotnet-new3 new3 install {TempPath}TemplateEngine.Tests\Guid_1\template

--- a/test/dotnet-new3.UnitTests/DotnetNewInstantiate.Approval.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewInstantiate.Approval.cs
@@ -536,5 +536,37 @@ namespace Dotnet_new3.IntegrationTests
             return Verifier.Verify(commandResult.StdOut, _verifySettings);
         }
 
+        [Fact]
+        public Task CannotInstantiateTemplateWhenFolderIsRemoved()
+        {
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDir = TestUtils.CreateTemporaryFolder();
+            string templateLocation = Path.Combine(workingDir, "template");
+            TestUtils.DirectoryCopy(TestUtils.GetTestTemplateLocation("TemplateWithSourceName"), templateLocation, true);
+
+            new DotnetNewCommand(_log, "install", templateLocation)
+                .WithCustomHive(home)
+                .WithWorkingDirectory(workingDir)
+                .Execute()
+                .Should()
+                .ExitWith(0)
+                .And.NotHaveStdErr();
+
+            Directory.Delete(templateLocation, true);
+            // Template should be removed from the template list, and it's unknown template now.
+            var commandResult = new DotnetNewCommand(_log, "TestAssets.TemplateWithSourceName")
+                .WithCustomHive(home)
+                .Execute();
+
+            commandResult
+                .Should()
+                .Fail();
+
+            return Verifier.Verify(commandResult.FormatOutputStreams(), _verifySettings)
+                .UniqueForOSPlatform()
+                .ScrubInlineGuids();
+                
+        }
+
     }
 }

--- a/test/dotnet-new3.UnitTests/Helpers.cs
+++ b/test/dotnet-new3.UnitTests/Helpers.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using FluentAssertions;
+using Microsoft.DotNet.Cli.Utils;
 using Microsoft.NET.TestFramework.Assertions;
 using Microsoft.TemplateEngine.TestHelper;
 using Xunit.Abstractions;
@@ -44,6 +45,11 @@ namespace Dotnet_new3.IntegrationTests
                   .And
                   .NotHaveStdErr();
             return Path.GetFullPath(testTemplate);
+        }
+
+        internal static string FormatOutputStreams(this CommandResult commandResult)
+        {
+            return "StdErr:" + Environment.NewLine + commandResult.StdErr + Environment.NewLine + "StdOut:" + Environment.NewLine + commandResult.StdOut;
         }
     }
 }


### PR DESCRIPTION
### Problem
fixes dotnet/templating#3124 
The message when the template content is not available is misleading

### Solution
Improved message, corrected command examples

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)