### PR TITLE
Added ability to have `defaultValue` for `bind` symbol

### DIFF
--- a/docs/Reference-for-template.json.md
+++ b/docs/Reference-for-template.json.md
@@ -449,6 +449,7 @@ It is also posible to bind the parameter without the prefix as the fallback beha
 |`binding`| Mandatory. The name of the source and parameter in the source to take the value from. The syntax follows: `<source prefix>:<parameter name>`.|
 |`replaces`|The text to be replaced by the symbol value in the template files content.|
 |`fileRename`|The portion of template filenames to be replaced by the symbol value.| 	 
+|`defaultValue`|The value assigned to the symbol if no value was provided from external source(s).|
 
  
 ##### Example  

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/BindSymbolEvaluator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/BindSymbolEvaluator.cs
@@ -49,6 +49,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 "Configured bind sources are: {0}.",
                 string.Join(", ", _bindSymbolSources.Select(s => $"{s.DisplayName}({s.GetType().Name})")));
 
+            //set default values for symbols that have them defined
+            foreach (var bindSymbol in symbols)
+            {
+                if (!variableCollection.ContainsKey(bindSymbol.Name) && bindSymbol.DefaultValue != null)
+                {
+                    variableCollection[bindSymbol.Name] = RunnableProjectGenerator.InferTypeAndConvertLiteral(bindSymbol.DefaultValue);
+                }
+            }
+
             var bindSymbols = symbols.Where(bs => !string.IsNullOrWhiteSpace(bs.Binding));
             if (!bindSymbols.Any())
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
@@ -1010,12 +1010,20 @@
             "required": ["binding"],
             "properties": {
               "type": {
-                "description": "Defines a symbol that has its value provided by the host",
-                "enum": ["bind"]
+                "description": "The symbol binds value from external sources.",
+                "enum": [ "bind" ]
               },
               "binding": {
-                "description": "The name of the host property to take the value from",
+                "description": "The source and the name of parameter to take the value from. The syntax is: <external source>:<parameter name>. Well known external sources are: host - a value that is defined by the template engine host; env - environment variable.",
                 "type": "string"
+              },
+              "defaultValue": {
+                "description": "The value assigned to the symbol if no value was provided from external source(s).",
+                "type": "string"
+              },
+              "fileRename": {
+                "type": "string",
+                "description": "Defines the portion of file names which will be replaced by symbol value."
               }
             }
           },

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SymbolModel/BindSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SymbolModel/BindSymbol.cs
@@ -25,6 +25,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.SymbolModel
             }
 
             Binding = binding!;
+            DefaultValue = jObject.ToString(nameof(DefaultValue));
         }
 
         internal BindSymbol(string name, string binding) : base(name, null)
@@ -38,5 +39,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.SymbolModel
         public string Binding { get; }
 
         internal override string Type => TypeName;
+
+        internal string? DefaultValue { get; init; }
     }
 }


### PR DESCRIPTION
### Problem
fixes #5017 

### Solution
Added ability to have `defaultValue` for bind symbol
Also adapted JSON schema and documentation


### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)