### PR TITLE
configure and use Verify.DiffPlex to generate deltas for failing tests

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -32,6 +32,7 @@
     <PackageReference Update="xunit.abstractions" Version="2.0.3" />
     <PackageReference Update="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Update="Verify.XUnit" Version="17.2.1" />
+    <PackageReference Update="Verify.DiffPlex" Version="1.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
@@ -60,5 +61,6 @@
     <PackageReference Update="xunit.abstractions" Condition="'$(xunitabstractionsVersion)' != ''" Version="$(xunitabstractionsVersion)" />
     <PackageReference Update="Newtonsoft.Json.Schema" Condition="'$(NewtonsoftJsonSchemaVersion)' != ''" Version="$(NewtonsoftJsonSchemaVersion)" />
     <PackageReference Update="Verify.XUnit" Condition="'$(VerifyXUnitVersion)' != ''" Version="$(VerifyXUnitVersion)" />
+    <PackageReference Update="Verify.DiffPlex" Condition="'$(VerifyDiffPlexVersion)' != ''" Version="$(VerifyDiffPlexVersion)" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/Microsoft.TemplateEngine.Cli.UnitTests.csproj
@@ -12,7 +12,8 @@
   <ItemGroup>
     <PackageReference Include="FakeItEasy" />
     <PackageReference Include="Verify.XUnit" />
-    
+    <PackageReference Include="Verify.DiffPlex" />
+
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/VerifyFixture.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/VerifyFixture.cs
@@ -16,6 +16,7 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
         {
             Settings = new VerifySettings();
             Settings.UseDirectory("Approvals");
+            VerifyDiffPlex.Initialize(OutputType.Compact);
         }
 
         internal VerifySettings Settings { get; }

--- a/test/dotnet-new3.UnitTests/VerifySettingsFixture.cs
+++ b/test/dotnet-new3.UnitTests/VerifySettingsFixture.cs
@@ -11,6 +11,7 @@ namespace Dotnet_new3.IntegrationTests
         {
             Settings = new VerifySettings();
             Settings.UseDirectory("Approvals");
+            VerifyDiffPlex.Initialize(OutputType.Compact);
         }
 
         internal VerifySettings Settings { get; }

--- a/test/dotnet-new3.UnitTests/dotnet-new3.IntegrationTests.csproj
+++ b/test/dotnet-new3.UnitTests/dotnet-new3.IntegrationTests.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="$(TestDir)Microsoft.TemplateEngine.Cli.TestHelper\Microsoft.TemplateEngine.Cli.TestHelper.csproj" />
     <ProjectReference Include="$(TestDir)Microsoft.TemplateEngine.TestHelper\Microsoft.TemplateEngine.TestHelper.csproj" />
     <PackageReference Include="Verify.XUnit" />
+    <PackageReference Include="Verify.DiffPlex" />
     <PackageReference Include="Wcwidth.Sources" />
   </ItemGroup>
 


### PR DESCRIPTION
### Problem
It can be hard to see the deltas on our large text verifications in the current output format.

### Solution
This configures Verify.DiffPlex so that it uses a git-style +/- display to show the deltas so that it's easier to see the exact problem.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)