### PR TITLE
Investigate test execution time on OSX is obviously longer than other platforms using SDK 7 Preview 4 

### DIFF
--- a/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
+++ b/src/Microsoft.TemplateEngine.Cli/PostActionDispatcher.cs
@@ -4,6 +4,7 @@
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.PostActionProcessors;
 using Microsoft.TemplateEngine.Edge.Template;
+using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Cli
 {
@@ -95,80 +96,86 @@ namespace Microsoft.TemplateEngine.Cli
             }
 
             PostActionExecutionStatus result = PostActionExecutionStatus.Success;
-            foreach (IPostAction action in postActions)
+            using (Timing.Over(_environment.Host.Logger, "Overall Post Action"))
             {
-                if (isDryRun)
+                foreach (IPostAction action in postActions)
                 {
-                    Reporter.Output.WriteLine(LocalizableStrings.ActionWouldHaveBeenTakenAutomatically);
-                    if (!string.IsNullOrWhiteSpace(action.Description))
+                    using (Timing.Over(_environment.Host.Logger, "Post Action"))
                     {
-                        Reporter.Output.WriteLine(action.Description.Indent());
-                    }
-                    continue;
-                }
-
-                IPostActionProcessor? actionProcessor = null;
-                _environment.Components.TryGetComponent(action.ActionId, out actionProcessor);
-
-                if (actionProcessor == null)
-                {
-                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostActionDispatcher_Error_NotSupported, action.ActionId));
-                    if (!string.IsNullOrWhiteSpace(action.Description))
-                    {
-                        Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostActionDescription, action.Description));
-                    }
-                    // The host doesn't know how to handle this action, just display manual instructions.
-                    DisplayInstructionsForAction(action, useErrorOutput: true);
-                    result |= PostActionExecutionStatus.Failure;
-                }
-                else if (actionProcessor is ProcessStartPostActionProcessor)
-                {
-                    if (canRunScripts == AllowRunScripts.No)
-                    {
-                        Reporter.Error.WriteLine(LocalizableStrings.PostActionDispatcher_Error_RunScriptNotAllowed);
-                        if (!string.IsNullOrWhiteSpace(action.Description))
+                        if (isDryRun)
                         {
-                            Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostActionDescription, action.Description));
+                            Reporter.Output.WriteLine(LocalizableStrings.ActionWouldHaveBeenTakenAutomatically);
+                            if (!string.IsNullOrWhiteSpace(action.Description))
+                            {
+                                Reporter.Output.WriteLine(action.Description.Indent());
+                            }
+                            continue;
                         }
-                        DisplayInstructionsForAction(action, useErrorOutput: true);
-                        result |= PostActionExecutionStatus.Cancelled;
-                    }
-                    else if (canRunScripts == AllowRunScripts.Yes)
-                    {
-                        result |= ProcessAction(creationResult.CreationEffects, creationResult.CreationResult!, creationResult.OutputBaseDirectory, action, actionProcessor);
-                    }
-                    else if (canRunScripts == AllowRunScripts.Prompt)
-                    {
-                        // Ask the user if they want to run the action.
-                        // If they do, run it, and return the result.
-                        // Otherwise return cancelled, indicating the action was not run.
-                        if (AskUserIfActionShouldRun(action))
+
+                        IPostActionProcessor? actionProcessor = null;
+                        _environment.Components.TryGetComponent(action.ActionId, out actionProcessor);
+
+                        if (actionProcessor == null)
+                        {
+                            Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostActionDispatcher_Error_NotSupported, action.ActionId));
+                            if (!string.IsNullOrWhiteSpace(action.Description))
+                            {
+                                Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostActionDescription, action.Description));
+                            }
+                            // The host doesn't know how to handle this action, just display manual instructions.
+                            DisplayInstructionsForAction(action, useErrorOutput: true);
+                            result |= PostActionExecutionStatus.Failure;
+                        }
+                        else if (actionProcessor is ProcessStartPostActionProcessor)
+                        {
+                            if (canRunScripts == AllowRunScripts.No)
+                            {
+                                Reporter.Error.WriteLine(LocalizableStrings.PostActionDispatcher_Error_RunScriptNotAllowed);
+                                if (!string.IsNullOrWhiteSpace(action.Description))
+                                {
+                                    Reporter.Error.WriteLine(string.Format(LocalizableStrings.PostActionDescription, action.Description));
+                                }
+                                DisplayInstructionsForAction(action, useErrorOutput: true);
+                                result |= PostActionExecutionStatus.Cancelled;
+                            }
+                            else if (canRunScripts == AllowRunScripts.Yes)
+                            {
+                                result |= ProcessAction(creationResult.CreationEffects, creationResult.CreationResult!, creationResult.OutputBaseDirectory, action, actionProcessor);
+                            }
+                            else if (canRunScripts == AllowRunScripts.Prompt)
+                            {
+                                // Ask the user if they want to run the action.
+                                // If they do, run it, and return the result.
+                                // Otherwise return cancelled, indicating the action was not run.
+                                if (AskUserIfActionShouldRun(action))
+                                {
+                                    result |= ProcessAction(creationResult.CreationEffects, creationResult.CreationResult!, creationResult.OutputBaseDirectory, action, actionProcessor);
+                                }
+                                else
+                                {
+                                    result |= PostActionExecutionStatus.Cancelled;
+                                }
+                            }
+                            // no trailing else - no other cases.
+                        }
+                        else // other post action
                         {
                             result |= ProcessAction(creationResult.CreationEffects, creationResult.CreationResult!, creationResult.OutputBaseDirectory, action, actionProcessor);
                         }
-                        else
+                        if (result != PostActionExecutionStatus.Success)
                         {
-                            result |= PostActionExecutionStatus.Cancelled;
+                            if (action.ContinueOnError)
+                            {
+                                result ^= PostActionExecutionStatus.Failure;
+                            }
+                            else
+                            {
+                                break;
+                            }
                         }
-                    }
-                    // no trailing else - no other cases.
-                }
-                else // other post action
-                {
-                    result |= ProcessAction(creationResult.CreationEffects, creationResult.CreationResult!, creationResult.OutputBaseDirectory, action, actionProcessor);
-                }
-                if (result != PostActionExecutionStatus.Success)
-                {
-                    if (action.ContinueOnError)
-                    {
-                        result ^= PostActionExecutionStatus.Failure;
-                    }
-                    else
-                    {
-                        break;
+                        Reporter.Output.WriteLine();
                     }
                 }
-                Reporter.Output.WriteLine();
             }
             return result;
         }

--- a/test/Microsoft.TemplateEngine.Cli.TestHelper/Sdk/TestCommand.cs
+++ b/test/Microsoft.TemplateEngine.Cli.TestHelper/Sdk/TestCommand.cs
@@ -58,17 +58,21 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public virtual CommandResult Execute(IEnumerable<string> args)
         {
+            var swCommand = Stopwatch.StartNew();
             var command = CreateCommandSpec(args)
                 .ToCommand()
                 .CaptureStdOut()
                 .CaptureStdErr();
+            Log.WriteLine($"Start command execution: {command.CommandName} {command.CommandArgs}");
 
             if (CommandOutputHandler != null)
             {
                 command.OnOutputLine(CommandOutputHandler);
             }
-
+            var swProcess = Stopwatch.StartNew();
             var result = ((Command)command).Execute(ProcessStartedHandler);
+            swProcess.Stop();
+            Log.WriteLine($"Process execution duration: {swProcess.ElapsedMilliseconds} ms");
 
             Log.WriteLine($"> {result.StartInfo.FileName} {result.StartInfo.Arguments}");
             Log.WriteLine(result.StdOut);
@@ -84,7 +88,8 @@ namespace Microsoft.NET.TestFramework.Commands
             {
                 Log.WriteLine($"Exit Code: {result.ExitCode}");
             }
-
+            swCommand.Stop();
+            Log.WriteLine($"End command execution: Elapsed {swCommand.ElapsedMilliseconds} ms");
             return result;
         }
 

--- a/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
+++ b/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
@@ -83,6 +83,7 @@ namespace Dotnet_new3.IntegrationTests
 
             new DotnetNewCommand(_log, args.ToArray())
                 .WithCustomHive(_fixture.HomeDirectory)
+                .WithDebug()
                 .WithWorkingDirectory(workingDir)
                 .Execute()
                 .Should()
@@ -92,6 +93,8 @@ namespace Dotnet_new3.IntegrationTests
 $@"The template ""{expectedTemplateName}"" was created successfully\.
 
 Processing post-creation actions\.\.\.
+.*
+.*
 Restoring {finalProjectName}:
 .*
 Restore succeeded\.",
@@ -183,6 +186,7 @@ Restore succeeded\.",
         [InlineData("global.json file", "globaljson")]
         [InlineData("NuGet Config", "nugetconfig")]
         [InlineData("Solution File", "sln")]
+        [InlineData("Solution File", "solution")]
         [InlineData("Dotnet local tool manifest file", "tool-manifest")]
         [InlineData("Web Config", "webconfig")]
         public void AllCommonItemsCreate(string expectedTemplateName, string templateShortName)
@@ -350,6 +354,7 @@ Restore succeeded\.",
 
             new DotnetNewCommand(_log, args.ToArray())
                 .WithCustomHive(_fixture.HomeDirectory)
+                .WithDebug()
                 .WithWorkingDirectory(workingDir)
                 .Execute()
                 .Should()
@@ -560,6 +565,7 @@ class Program
 
             new DotnetNewCommand(_log, args.ToArray())
                 .WithCustomHive(_fixture.HomeDirectory)
+                .WithDebug()
                 .WithWorkingDirectory(workingDir)
                 .Execute()
                 .Should()
@@ -662,6 +668,7 @@ class Program
 
             new DotnetNewCommand(_log, args.ToArray())
                 .WithCustomHive(_fixture.HomeDirectory)
+                .WithDebug()
                 .WithWorkingDirectory(workingDir)
                 .Execute()
                 .Should()
@@ -749,6 +756,7 @@ class Program
 
             new DotnetNewCommand(_log, args.ToArray())
                 .WithCustomHive(_fixture.HomeDirectory)
+                .WithDebug()
                 .WithWorkingDirectory(workingDir)
                 .Execute()
                 .Should()


### PR DESCRIPTION
### Problem
Test running on OSX takes obviously longer time than other platforms.

### Solution
Add log monitoring execution time for investigation, and use SDK 7 Preview 4 for comparison. Revert commits back to SDK 7 Preview 4.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)