### PR TITLE
Fix .cs conditions commenting style in tests

### DIFF
--- a/docs/Conditions.md
+++ b/docs/Conditions.md
@@ -57,7 +57,7 @@ This allows for easier authoring of nested generated conditions.
 
 Information about multi-choice symbols can be found in [Reference for `template.json`](Reference-for-template.json.md#multichoice-symbols-specifics)
 
-Comparison to multichoice symbol results in operation checking of a presence of any value of a multichoice parameter (meaning `==` operator behaves as `contains()` operation):
+Comparison to multichoice symbol results in operation checking of a presence of any value of a multichoice parameter - meaning `==` operator behaves as `contains()` operation. Example (sourced from [integration test](https://github.com/dotnet/templating/tree/main/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithMultiValueChoice)):
 
 `template.json`:
 ```json

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/TemplateCreatorTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/TemplateCreatorTests.cs
@@ -75,15 +75,15 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
         public async void InstantiateAsync_ParamsProperlyHonored(string? parameterValue, string expectedOutput, bool instantiateShouldFail)
         {
             string sourceSnippet = @"
-//#if( ChoiceParam == FirstChoice )
+#if( ChoiceParam == FirstChoice )
 FIRST
-//#elseif (ChoiceParam == SecondChoice )
+#elseif (ChoiceParam == SecondChoice )
 SECOND
-//#elseif (ChoiceParam == ThirdChoice )
+#elseif (ChoiceParam == ThirdChoice )
 THIRD
-//#else
+#else
 UNKNOWN
-//#endif
+#endif
 ";
             IReadOnlyDictionary<string, string?> parameters = new Dictionary<string, string?>()
             {
@@ -135,17 +135,17 @@ UNKNOWN
             //
 
             string sourceSnippet = @"
-//#if( A )
+#if( A )
 A,
-//#endif
+#endif
 
-//#if( B )
+#if( B )
 B,
-//#endif
+#endif
 
-//#if( C )
+#if( C )
 C
-//#endif
+#endif
 ";
             IReadOnlyDictionary<string, string?> parameters = new Dictionary<string, string?>()
             {
@@ -209,17 +209,17 @@ Details: Parameter conditions contain cyclic dependency: [A, B, A] that is preve
             //
 
             string sourceSnippet = @"
-//#if( A )
+#if( A )
 A,
-//#endif
+#endif
 
-//#if( B )
+#if( B )
 B,
-//#endif
+#endif
 
-//#if( C )
+#if( C )
 C
-//#endif
+#endif
 ";
             IReadOnlyDictionary<string, string?> parameters = new Dictionary<string, string?>()
             {
@@ -282,17 +282,17 @@ C
             //
 
             string sourceSnippet = @"
-//#if( A )
+#if( A )
 A,
-//#endif
+#endif
 
-//#if( B )
+#if( B )
 B,
-//#endif
+#endif
 
-//#if( C )
+#if( C )
 C
-//#endif
+#endif
 ";
             IReadOnlyDictionary<string, string?> parameters = new Dictionary<string, string?>()
             {
@@ -366,17 +366,17 @@ C
             //
 
             string sourceSnippet = @"
-//#if( parA )
+#if( parA )
 parA,
-//#endif
+#endif
 
-//#if( parB )
+#if( parB )
 parB,
-//#endif
+#endif
 
-//#if( C )
+#if( C )
 C
-//#endif
+#endif
 ";
 
             List<InputDataBag> parameters = new List<InputDataBag>(
@@ -414,7 +414,7 @@ C
             templateSourceFiles.Add(TestFileSystemHelper.DefaultConfigRelativePath, templateSnippet);
 
             //content
-            templateSourceFiles.Add("sourceFile", sourceSnippet);
+            templateSourceFiles.Add("sourceFile.cs", sourceSnippet);
 
             //
             // Dependencies preparation and mounting
@@ -491,7 +491,7 @@ C
                 res.ErrorMessage.Should().BeNull();
                 res.OutputBaseDirectory.Should().NotBeNullOrEmpty();
                 string resultContent = _engineEnvironmentSettings.Host.FileSystem
-                    .ReadAllText(Path.Combine(res.OutputBaseDirectory!, "sourceFile")).Trim();
+                    .ReadAllText(Path.Combine(res.OutputBaseDirectory!, "sourceFile.cs")).Trim();
                 resultContent.Should().BeEquivalentTo(expectedOutput);
             }
         }

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithMultiValueChoice/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithMultiValueChoice/.template.config/template.json
@@ -13,7 +13,7 @@
       "description": "The target framework for the project.",
       "datatype": "choice",
       "allowMultipleValues": true,
-	  "enableQuotelessLiterals": true,
+      "enableQuotelessLiterals": true,
       "choices": [
         {
           "choice": "Windows",

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithMultiValueChoice/Test.cs
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithMultiValueChoice/Test.cs
@@ -1,1 +1,39 @@
-// This file is generated for platfrom: SupportedPlatforms//#if( Platform == "Windows" )	// Quoted Windows//#else	// NOT Quoted Windows//#endif						//#if( Platform == Windows )	// Windows//#else	// NOT Windows//#endif	//#if( Platform == "MacOS" )	// Quoted MacOS//#else	// NOT Quoted MacOS//#endif	//#if( Platform == MacOS )	// MacOS//#else	// NOT MacOS//#endif	//#if( Platform == "iOS" )	// Quoted iOS//#else	// NOT Quoted iOS//#endif	//#if( Platform == iOS )	// iOS//#else	// NOT iOS//#endif
+
+// This file is generated for platfrom: SupportedPlatforms
+
+#if( Platform == "Windows" )
+    // Quoted Windows
+#else
+    // NOT Quoted Windows
+#endif
+        
+        
+#if( Platform == Windows )
+    // Windows
+#else
+    // NOT Windows
+#endif
+
+#if( Platform == "MacOS" )
+    // Quoted MacOS
+#else
+    // NOT Quoted MacOS
+#endif
+
+#if( Platform == MacOS )
+    // MacOS
+#else
+    // NOT MacOS
+#endif
+
+#if( Platform == "iOS" )
+    // Quoted iOS
+#else
+    // NOT Quoted iOS
+#endif
+
+#if( Platform == iOS )
+    // iOS
+#else
+    // NOT iOS
+#endif

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CanInstantiateTemplate_MultiValueChoiceParameterConditions.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CanInstantiateTemplate_MultiValueChoiceParameterConditions.verified.txt
@@ -1,15 +1,15 @@
 ﻿
 // This file is generated for platfrom: MacOS, iOS
 
-	// NOT Quoted Windows
-		
-		
-	// NOT Windows
+    // NOT Quoted Windows
+        
+        
+    // NOT Windows
 
-	// Quoted MacOS
+    // Quoted MacOS
 
-	// MacOS
+    // MacOS
 
-	// Quoted iOS
+    // Quoted iOS
 
-	// iOS
+    // iOS

--- a/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CanInstantiateTemplate_MultiValueChoiceParameterExplicitlyUnset.verified.txt
+++ b/test/dotnet-new3.UnitTests/Approvals/DotnetNewInstantiate.CanInstantiateTemplate_MultiValueChoiceParameterExplicitlyUnset.verified.txt
@@ -1,15 +1,15 @@
 ﻿
 // This file is generated for platfrom: 
 
-	// NOT Quoted Windows
-		
-		
-	// NOT Windows
+    // NOT Quoted Windows
+        
+        
+    // NOT Windows
 
-	// NOT Quoted MacOS
+    // NOT Quoted MacOS
 
-	// NOT MacOS
+    // NOT MacOS
 
-	// NOT Quoted iOS
+    // NOT Quoted iOS
 
-	// NOT iOS
+    // NOT iOS


### PR DESCRIPTION
### Problem
Fixes #4971

### Solution
Some conditional processing test files were inconsistent in commenting styles - adjusted.

### Checks: N/A
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)