### PR TITLE
[release/6.0.1xx] changed sln template to version 17 and added `solution` synonym

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/.template.config/template.json
@@ -10,7 +10,10 @@
   "groupIdentity": "ItemSolution",
   "precedence": "100",
   "identity": "Microsoft.Standard.QuickStarts.Solution",
-  "shortName": "sln",
+  "shortName": [
+    "sln",
+    "solution"
+  ],
   "sourceName": "Solution1",
   "primaryOutputs": [
     {

--- a/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
+++ b/template_feed/Microsoft.DotNet.Common.ItemTemplates/content/Solution/Solution1.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30114.105
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
+++ b/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
@@ -212,6 +212,7 @@ Restore succeeded\.",
         [InlineData("global.json file", "globaljson")]
         [InlineData("NuGet Config", "nugetconfig")]
         [InlineData("Solution File", "sln")]
+        [InlineData("Solution File", "solution")]
         [InlineData("Dotnet local tool manifest file", "tool-manifest")]
         [InlineData("Web Config", "webconfig")]
         public void AllCommonItemsCreate(string expectedTemplateName, string templateShortName)

--- a/test/dotnet-new3.UnitTests/DotnetNewList.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewList.cs
@@ -111,7 +111,7 @@ EditorConfig file                             editorconfig               Config
 global.json file                              globaljson                 Config                
 NuGet Config                                  nugetconfig                Config                
 Razor Class Library                           razorclasslib  [C#]        Web/Razor/Library     
-Solution File                                 sln                        Solution              
+Solution File                                 sln,solution               Solution              
 Web Config                                    webconfig                  Config                
 Worker Service                                worker         [C#],F#     Common/Worker/Web     ";
 


### PR DESCRIPTION
Backport: https://github.com/dotnet/templating/pull/4879

**Description**

Updates VS version in solution template
Adds `solution` short name synonym to solution template
**Customer Impact**
Both are customer reported
https://github.com/dotnet/templating/issues/4852
https://github.com/dotnet/templating/issues/4825

- the solution file created using .NET SDK will be opened in Visual Studio 17.x by default (without the change, opens in VS 16.x)
- it is possible to use `dotnet new solution` to create solution template

**Regression**
yes
It was possible to use `dotnet new solution` to create solution template in .NET 5 (due to the bug, not a feature).

Risk
Very low

Solution template is not used in Visual Studio, only in .NET SDK.