### PR TITLE
CFS tool configuration for templating testfile

### DIFF
--- a/.sscignore
+++ b/.sscignore
@@ -1,0 +1,4 @@
+{
+    "__comment": "CFS0013 intended for src\\Assets\\TestPackages\\dotnet-new\\test_templates\\TemplateWithConditions\\nuget.config",
+    "cfs" : ["CFS0013"]
+}

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <UsingToolXliff>true</UsingToolXliff>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
-    <VersionPrefix>6.0.107</VersionPrefix>
+    <VersionPrefix>6.0.108</VersionPrefix>
     <PreReleaseVersionLabel>servicing</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>
     </PreReleaseVersionIteration>

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/nuget.config
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/nuget.config
@@ -2,7 +2,11 @@
 <!-- comment foo -->
 foo
 <!--#endif -->
-<!--#if (B)
-<!-- comment bar -- >
+<!--#if (B) -->
+<!-- comment bar -->
 bar
-#endif -->
+<!--#endif -->
+<!--#if (false) -->
+<!-- added extra content to make a valid nuget.config file -->
+<config />
+<!--#endif -->

--- a/test/Microsoft.TemplateSearch.Common.UnitTests/Microsoft.TemplateSearch.Common.UnitTests.csproj
+++ b/test/Microsoft.TemplateSearch.Common.UnitTests/Microsoft.TemplateSearch.Common.UnitTests.csproj
@@ -16,10 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="NuGetTemplateSearchInfoWithInvalidData.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Problem:
* CFS Scan tool issues due to templating configuration file

## Solution:
* Fix the invalid xml commenting style and missing `config` node in test nuget.config
* Add cfs configuration file