### PR TITLE
enabled internal publishing of `Microsoft.TemplateEngine.TestHelper`

### DIFF
--- a/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
@@ -3,6 +3,8 @@
     <TargetFrameworks Condition="'$(PackSpecific)' != 'true'">$(NETFullTargetFramework);$(NETCoreTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition="'$(PackSpecific)' == 'true'">$(NETCoreTargetFramework)</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 


### PR DESCRIPTION
### Problem
`Microsoft.TemplateEngine.TestHelper` is needed in SDK tests.

### Solution
Enabled internal publishing of `Microsoft.TemplateEngine.TestHelper` to remove the copy of the project in sdk repo

