### PR TITLE
Investigate if FileWatcherTest still fails randomly

### DIFF
--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/GlobalSettingsTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/GlobalSettingsTests.cs
@@ -43,11 +43,21 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             using var settingsLock = await globalSettings2.LockAsync(cts2.Token).ConfigureAwait(false);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "Randomly failing see https://github.com/dotnet/templating/issues/3336")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
-        public async Task TestFileWatcher()
+        public static IEnumerable<object[]> TestData()
         {
+            var list = new List<string>();
+            for (int i = 0; i < 1000; i++)
+            {
+                list.Add(i.ToString());
+            }
+            return list.Select(i => new object[] { i });
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData))]
+        public async Task TestFileWatcher(string index)
+        {
+            Console.WriteLine(index);
             var envSettings = _helper.CreateEnvironment();
             var settingsFile = Path.Combine(_helper.CreateTemporaryFolder(), "settings.json");
             using var globalSettings1 = new GlobalSettings(envSettings, settingsFile);


### PR DESCRIPTION
### Problem
Investigate if FileWatcherTest still fails randomly.

### Solution
Make the test run a large number of times to observe if the issue still repro.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)