### PR TITLE
Docs for project context evaluation

### DIFF
--- a/docs/Binding-and-project-context-evaluation.md
+++ b/docs/Binding-and-project-context-evaluation.md
@@ -1,0 +1,80 @@
+# Binding and project context evaluation
+
+## Overview
+
+Since .NET SDK 7.0.100 template engine supports binding of symbols to various external sources, including MSBuild properties of the current project.
+The feature is available for both `dotnet new` and Visual Studio.
+
+## `bind` symbols
+
+The symbol binds value from external sources. 
+By default, the following sources are available:
+- host parameters - parameters defined at certain host. For .NET SDK the following parameters are defined: `HostIdentifier: dotnetcli`, `GlobalJsonExists: true/false`.  Binding syntax is `host:<param name>`, example: `host:HostIdentifier`. 
+- environment variables - allows to bind environment allowed. Binding syntax is `env:<environment variable name>`, example: `env:MYENVVAR`.
+
+It is also possible to bind the parameter without the prefix as the fallback behavior: `HostIdentifier`, `MYENVVAR`.
+
+The priority of the sources are as the following:
+- host parameters: 100
+- environment variables: 0
+
+The higher value indicates higher priority.
+
+
+|Name|Description|
+|---|---|
+|`type`|`bind`|
+|`binding`| Mandatory. The name of the source and parameter in the source to take the value from. The syntax follows: `<source prefix>:<parameter name>`.|
+|`replaces`|The text to be replaced by the symbol value in the template files content.|
+|`fileRename`|The portion of template filenames to be replaced by the symbol value.| 	 
+|`defaultValue`|The value assigned to the symbol if no value was provided from external source(s).|
+
+ 
+##### Example  
+
+```json
+"symbols": {
+   "HostIdentifier": {
+      "type": "bind",
+      "binding": "host:HostIdentifier"
+    }
+}
+```  
+
+### Binding to MSBuild properties
+
+It is possible to bind symbols to MSBuild properties of the current project. The prefix to be used: `msbuild` and it is mandatory.
+Commonly used with item templates to get the information about the project it is added to.
+
+`dotnet new` attempts to find the closest project file using following rules:
+- the project in current directory or `--output` directory (matching `*.*proj` extension)
+- if not found, the parent of above and so on
+In case of ambiguity, the path to the project can be specified using `--project` option.
+
+Once project is located, its MSBuild properties are evaluated. The project should be restored, otherwise evaluation fails.
+Only .NET [SDK-style projects](https://docs.microsoft.com/en-us/dotnet/core/project-sdk/overview) are supported.
+
+It is recommended to configure `defaultValue` for `bind` symbol that will be used in case evaluation fails. 
+If applicable, it is also recommended to use [project capability constraint](https://github.com/dotnet/templating/wiki/Constraints#Project-capabilities) to define the projects that the template can be added to.
+
+Example - binds `DefaultNamespace` symbol to `RootNamespace` of the project:
+```json
+  "symbols": {
+    "DefaultNamespace": {
+      "type": "bind",
+      "binding": "msbuild:RootNamespace",
+      "replaces": "%NAMESPACE%",
+      "defaultValue": "TestNamespace"
+    }
+  },
+  "constraints": {
+    "csharp-only": {
+      "type": "project-capability",
+      "args": "CSharp + TestContainer" // only allowed in C# test project
+    }
+  }
+```
+
+
+## Visual Studio specifics
+TBD

--- a/docs/Binding-and-project-context-evaluation.md
+++ b/docs/Binding-and-project-context-evaluation.md
@@ -77,4 +77,22 @@ Example - binds `DefaultNamespace` symbol to `RootNamespace` of the project:
 
 
 ## Visual Studio specifics
-TBD
+
+Visual Studio supports binding to host parameters, environment variables and MSBuild properties.
+In addition to that, there is additional `context` source supporting:
+- `context:cratesolutiondirectory` - indicates if a solution directory is to be created as a result of project creation (Place solution and project in same directory is UNCHECKED in NPD).
+- `context:isexclusive` - is the template instantiation is a result of a new project being created (true) vs adding to an existing solution (false).
+- `context:solutionname` - the name of the solution, which may be different from the project name.
+
+Visual Studio also provides a way to bind to "namespace" via host parameters source:
+```
+  "type": "bind"
+  "binding": "namespace"
+```
+
+or 
+
+```
+  "type": "bind"
+  "binding": "host:namespace"
+```

--- a/docs/Constraints.md
+++ b/docs/Constraints.md
@@ -6,6 +6,7 @@
 | [Running template engine host](#template-engine-host) | `host` |
 | [Installed workloads](#installed-workloads) | `workload` |
 | [Current SDK version](#current-sdk-version) | `sdk-version` |
+| [Project capabilities](#project-capabilities) | `project-capability` |
 
 The feature is available since .NET SDK 7.0.100.
 The template may define the constraints all of which must be met in order for the template to be used.  In case constraints are not met, the template will be installed, however will not be visible or used by default. 
@@ -148,7 +149,7 @@ All the installed (queryable via `dotnet workload list`) as well as [extended](h
 - `type`: `workload`
 - `args` (string, array). Mandatory. List of names of supported workloads (running host need to have at least one of the requested workloads installed).
 
-  To see the list of instaled workloads run [`dotnet workload list`](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-list). To see the list of available workloads run [`dotnet workload search`](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-search)
+  To see the list of installed workloads run [`dotnet workload list`](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-list). To see the list of available workloads run [`dotnet workload search`](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-workload-search)
 
 **Supported in**:
    - .NET SDK CLI (`dotnet new`)
@@ -175,7 +176,7 @@ All the installed (queryable via `dotnet workload list`) as well as [extended](h
 ## Current SDK Version
 Defines .NET SDK version(s) the template can be used on.
 
-Only the currently active SDK (queryable via `dotnet --version`, changeable by the [`global.json`](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json)) is being considered. Other available SDKs (queryable via `dotnet --list-sdks`) are checked for possible match and result is reported in the evaluation output wuth possible remedy steps - the form of reporting is dependend on the templating host.
+Only the currently active SDK (queryable via `dotnet --version`, changeable by the [`global.json`](https://docs.microsoft.com/en-us/dotnet/core/tools/global-json)) is being considered. Other available SDKs (queryable via `dotnet --list-sdks`) are checked for possible match and result is reported in the evaluation output with possible remedy steps - the form of reporting is dependent on the templating host.
 
 **Configuration:**
 
@@ -198,8 +199,47 @@ Only the currently active SDK (queryable via `dotnet --version`, changeable by t
 ```json
    "current-with-previews": {
        "web-assembly": {
-           "type": "sdk-varsion",
+           "type": "sdk-version",
            "args": "7.*.*-*"
        },
    }
 ```
+## Project capabilities
+Defines [project capabilities](https://github.com/microsoft/VSProjectSystem/blob/master/doc/overview/about_project_capabilities.md) that the template requires.
+Commonly used with item templates to define the certain projects it is applicable to. 
+`dotnet new` attempts to find the closest project file using following rules:
+- the project in current directory or `--output` directory (matching `*.*proj` extension)
+- if not found, the parent of above and so on
+
+In case of ambiguity, the path to the project can be specified using `--project` option.
+
+Once project is located, its project capabilities are evaluated. The project should be restored, otherwise evaluation fails.
+Only .NET [SDK-style projects](https://docs.microsoft.com/en-us/dotnet/core/project-sdk/overview) are supported.
+
+**Configuration:**
+
+- `type`: `project-capability`
+- `args`: (string) project capability [expression](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualstudio.shell.interop.vsprojectcapabilityexpressionmatcher) that should be satisfied by the project.
+
+**Supported in**:
+   - .NET SDK CLI (`dotnet new`)
+   - Visual Studio - TBD
+
+### Examples
+
+```json
+   "constraints": {
+       "CSharp": {
+           "type": "project-capability",
+           "args": "CSharp",
+       },
+   }
+```  
+```json
+   "constraints": {
+       "CSharpTest": {
+           "type": "project-capability",
+           "args": "CSharp & TestContainer",
+       },
+   }
+``` 

--- a/docs/Constraints.md
+++ b/docs/Constraints.md
@@ -153,6 +153,7 @@ All the installed (queryable via `dotnet workload list`) as well as [extended](h
 
 **Supported in**:
    - .NET SDK CLI (`dotnet new`)
+   - Visual Studio 17.4
 
 ### Examples
 
@@ -185,6 +186,7 @@ Only the currently active SDK (queryable via `dotnet --version`, changeable by t
 
 **Supported in**:
    - .NET SDK CLI (`dotnet new`)
+   - Visual Studio 17.4
 
 ### Examples
 
@@ -223,7 +225,7 @@ Only .NET [SDK-style projects](https://docs.microsoft.com/en-us/dotnet/core/proj
 
 **Supported in**:
    - .NET SDK CLI (`dotnet new`)
-   - Visual Studio - TBD
+   - Visual Studio 17.4 Preview 3
 
 ### Examples
 

--- a/docs/Reference-for-template.json.md
+++ b/docs/Reference-for-template.json.md
@@ -437,31 +437,8 @@ Values of `OrganizationalAuth`, `WindowsAuth`, `MultiOrgAuth`, `SingleOrgAuth`, 
 ```
 
 #### Bind symbol
+See (https://github.com/dotnet/templating/wiki/Binding-and-project-context-evaluation#bind-symbols).
 
-The symbol binds value from external sources. 
-By default, the following sources are available:
-- host parameters - parameters defined at certain host. For .NET SDK the following parameters are defined: `HostIdentifier: dotnetcli`, `GlobalJsonExists: true/false`.  Binding syntax is `host:<param name>`, example: `host:HostIdentifier`. 
-- environment variables - allows to bind environment allowed. Binding syntax is `env:<environment variable name>`, example: `env:MYENVVAR`. 
-
-It is also posible to bind the parameter without the prefix as the fallback behavior: `HostIdentifier`, `MYENVVAR`.
-
-|Name|Description|
-|---|---|
-|`type`|`bind`|
-|`binding`| Mandatory. The name of the source and parameter in the source to take the value from. The syntax follows: `<source prefix>:<parameter name>`.|
-|`replaces`|The text to be replaced by the symbol value in the template files content.|
-|`fileRename`|The portion of template filenames to be replaced by the symbol value.| 	 
-|`defaultValue`|The value assigned to the symbol if no value was provided from external source(s).|
-
- 
-##### Example  
-
-```json
-   "HostIdentifier": {
-      "type": "bind",
-      "binding": "host:HostIdentifier"
-    }
-```  
 
 ### Output Management
 |Name|Description|Default|

--- a/docs/api/Inside-the-Template-Engine.md
+++ b/docs/api/Inside-the-Template-Engine.md
@@ -275,7 +275,7 @@ These components are defined in `Microsoft.TemplateEngine.Edge` and are part of 
 
 If the `binding` does not have prefix, or prefixed value cannot be evaluated the evaluation without prefix is performed as the fallback. 
 In case there are more than one component which returns the value, the component priority will be used to define the value to be bounded. In case of same priorities, the evaluation results in error.
-The template author needs to explicitly specify the prefix in this case.
+The template author needs to explicitly specify the prefix in this case. It is possible to restrict usage of prefix with setting `IBindSymbolSource.RequiresPrefixMatch` to `true`. 
 
 
 ## Registering the components


### PR DESCRIPTION
Updated the documentation and guidelines for `bind` symbols and project context evaluation.

TODO: 
- add Visual Studio related guidelines
- once PR is merged, update the Wiki

This PR to be cherry-picked to release/7.0.1xx