### PR TITLE
Get test execution time with macOS 10.15

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,6 +123,7 @@ stages:
 
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         - job: OSX
+          timeoutInMinutes: 90
           pool:
             vmImage: 'macOS-12'
           strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,7 @@ stages:
         - job: OSX
           timeoutInMinutes: 90
           pool:
-            vmImage: 'macOS-12'
+            vmImage: 'macos-10.15'
           strategy:
             matrix:
               debug_configuration:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,7 @@ stages:
         - job: OSX
           timeoutInMinutes: 90
           pool:
-            vmImage: 'macOS-12'
+            vmImage: 'macOS-10.15'
           strategy:
             matrix:
               debug_configuration:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,7 @@ stages:
         - job: OSX
           timeoutInMinutes: 90
           pool:
-            vmImage: 'macos-10.15'
+            vmImage: 'macOS-12'
           strategy:
             matrix:
               debug_configuration:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,7 +124,7 @@ stages:
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
         - job: OSX
           pool:
-            vmImage: 'macOS-latest'
+            vmImage: 'macOS-12'
           strategy:
             matrix:
               debug_configuration:

--- a/eng/common/templates/job/job.yml
+++ b/eng/common/templates/job/job.yml
@@ -219,7 +219,7 @@ jobs:
         testResultsFormat: 'xUnit'
         testResultsFiles: '*.xml' 
         searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
-        testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}-xunit
+        testRunTitle: ${{ coalesce(parameters.testRunTitle, parameters.name, '$(System.JobName)') }}_'$(_BuildConfig)'-xunit
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
       condition: always()
@@ -234,7 +234,27 @@ jobs:
         mergeTestResults: ${{ parameters.mergeTestResults }}
       continueOnError: true
       condition: always()
-    
+
+  - task: CopyFiles@2
+    displayName: Gather artifacts
+    inputs:
+      SourceFolder: '$(Build.SourcesDirectory)/artifacts'
+      Contents: |
+       log/$(_BuildConfig)/**/*
+       TestResults/$(_BuildConfig)/**/*
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+    continueOnError: true
+    condition: always()
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish artifacts to Temp
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      ArtifactName: ${{ coalesce(parameters.enablePublishBuildArtifacts.artifactName, '$(Agent.Os)_$(Agent.JobName)' ) }}-TMP
+      publishLocation: Container
+    continueOnError: true
+    condition: always()
+
   - ${{ if and(eq(parameters.enablePublishBuildAssets, true), ne(parameters.enablePublishUsingPipelines, 'true'), eq(parameters.runAsPublic, 'false'), ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - task: CopyFiles@2
       displayName: Gather Asset Manifests

--- a/test/Microsoft.TemplateEngine.Cli.TestHelper/Sdk/TestCommand.cs
+++ b/test/Microsoft.TemplateEngine.Cli.TestHelper/Sdk/TestCommand.cs
@@ -58,17 +58,21 @@ namespace Microsoft.NET.TestFramework.Commands
 
         public virtual CommandResult Execute(IEnumerable<string> args)
         {
+            var swCommand = Stopwatch.StartNew();
             var command = CreateCommandSpec(args)
                 .ToCommand()
                 .CaptureStdOut()
                 .CaptureStdErr();
+            Log.WriteLine($"Start command execution: {command.CommandName} {command.CommandArgs}");
 
             if (CommandOutputHandler != null)
             {
                 command.OnOutputLine(CommandOutputHandler);
             }
-
+            var swProcess = Stopwatch.StartNew();
             var result = ((Command)command).Execute(ProcessStartedHandler);
+            swProcess.Stop();
+            Log.WriteLine($"Process execution duration: {swProcess.ElapsedMilliseconds} ms");
 
             Log.WriteLine($"> {result.StartInfo.FileName} {result.StartInfo.Arguments}");
             Log.WriteLine(result.StdOut);
@@ -84,7 +88,8 @@ namespace Microsoft.NET.TestFramework.Commands
             {
                 Log.WriteLine($"Exit Code: {result.ExitCode}");
             }
-
+            swCommand.Stop();
+            Log.WriteLine($"End command execution: Elapsed {swCommand.ElapsedMilliseconds} ms");
             return result;
         }
 

--- a/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
+++ b/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
@@ -83,6 +83,7 @@ namespace Dotnet_new3.IntegrationTests
 
             new DotnetNewCommand(_log, args.ToArray())
                 .WithCustomHive(_fixture.HomeDirectory)
+                .WithDebug()
                 .WithWorkingDirectory(workingDir)
                 .Execute()
                 .Should()
@@ -92,6 +93,8 @@ namespace Dotnet_new3.IntegrationTests
 $@"The template ""{expectedTemplateName}"" was created successfully\.
 
 Processing post-creation actions\.\.\.
+.*
+.*
 Restoring {finalProjectName}:
 .*
 Restore succeeded\.",
@@ -350,6 +353,7 @@ Restore succeeded\.",
 
             new DotnetNewCommand(_log, args.ToArray())
                 .WithCustomHive(_fixture.HomeDirectory)
+                .WithDebug()
                 .WithWorkingDirectory(workingDir)
                 .Execute()
                 .Should()
@@ -560,6 +564,7 @@ class Program
 
             new DotnetNewCommand(_log, args.ToArray())
                 .WithCustomHive(_fixture.HomeDirectory)
+                .WithDebug()
                 .WithWorkingDirectory(workingDir)
                 .Execute()
                 .Should()
@@ -662,6 +667,7 @@ class Program
 
             new DotnetNewCommand(_log, args.ToArray())
                 .WithCustomHive(_fixture.HomeDirectory)
+                .WithDebug()
                 .WithWorkingDirectory(workingDir)
                 .Execute()
                 .Should()
@@ -749,6 +755,7 @@ class Program
 
             new DotnetNewCommand(_log, args.ToArray())
                 .WithCustomHive(_fixture.HomeDirectory)
+                .WithDebug()
                 .WithWorkingDirectory(workingDir)
                 .Execute()
                 .Should()

--- a/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
+++ b/test/dotnet-new3.UnitTests/CommonTemplatesTests.cs
@@ -56,7 +56,7 @@ namespace Dotnet_new3.IntegrationTests
                 "VB" => "vbproj",
                 _ => "csproj"
             };
-            string finalProjectName = Regex.Escape(Path.Combine(workingDir, $"{workingDirName}.{extension}"));
+            string finalProjectName = Path.Combine(workingDir, $"{workingDirName}.{extension}");
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 //on OSX path in restore starts from /private for some reason
@@ -89,16 +89,10 @@ namespace Dotnet_new3.IntegrationTests
                 .Should()
                 .ExitWith(0)
                 .And.NotHaveStdErr()
-                .And.HaveStdOutMatching(
-$@"The template ""{expectedTemplateName}"" was created successfully\.
-
-Processing post-creation actions\.\.\.
-.*
-.*
-Restoring {finalProjectName}:
-.*
-Restore succeeded\.",
-                RegexOptions.Singleline);
+                .And.HaveStdOutContaining($@"The template ""{expectedTemplateName}"" was created successfully.")
+                .And.HaveStdOutContaining("Processing post-creation actions...")
+                .And.HaveStdOutContaining($"Restoring {finalProjectName}:")
+                .And.HaveStdOutContaining("Restore succeeded.");
 
             new DotnetCommand(_log, "restore")
                 .WithWorkingDirectory(workingDir)


### PR DESCRIPTION
### Problem
#4942
Test running time increases investigation.

### Solution
Add log getting execution time for investigation using macOS 10.15.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)