### PR TITLE
Bugfix: Clarify error message on conditional params condition issue

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed..
+        ///   Looks up a localized string similar to Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values..
         /// </summary>
         internal static string ConditionEvaluation_Error_MismatchedCondition {
             get {

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -122,7 +122,7 @@
     <comment>{0} is the dependency chain</comment>
   </data>
   <data name="ConditionEvaluation_Error_MismatchedCondition" xml:space="preserve">
-    <value>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</value>
+    <value>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</value>
     <comment>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">Nepovedlo se vyhodnotit podmínku {0} na {1} parametru (text podmínky: {2}, chyba vyhodnocení: {3}) – podmínka může být poškozená.</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">Nepovedlo se vyhodnotit podmínku {0} na {1} parametru (text podmínky: {2}, chyba vyhodnocení: {3}) – podmínka může být poškozená.</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">Fehler beim Auswerten der Bedingung {0} für Parameter {1} (Bedingungstext: {2}, Auswertungsfehler: {3}) – Die Bedingung ist möglicherweise falsch formatiert.</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">Fehler beim Auswerten der Bedingung {0} für Parameter {1} (Bedingungstext: {2}, Auswertungsfehler: {3}) – Die Bedingung ist möglicherweise falsch formatiert.</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">No se ha podido evaluar la condición {0} en el parámetro {1} (texto de condición: {2}, error de evaluación: {3}): la condición podría tener un formato incorrecto.</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">No se ha podido evaluar la condición {0} en el parámetro {1} (texto de condición: {2}, error de evaluación: {3}): la condición podría tener un formato incorrecto.</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">Échec de l'évaluation de la condition {0} sur le paramètre {1} (texte de la condition : {2}, erreur d'évaluation : {3}) – la condition est peut-être incorrecte.</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">Échec de l'évaluation de la condition {0} sur le paramètre {1} (texte de la condition : {2}, erreur d'évaluation : {3}) – la condition est peut-être incorrecte.</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">Non è stato possibile valutare la condizione {0} nel parametro {1} (testo della condizione: {2}, errore di valutazione: {3}). Il formato della condizione potrebbe non essere valido.</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">Non è stato possibile valutare la condizione {0} nel parametro {1} (testo della condizione: {2}, errore di valutazione: {3}). Il formato della condizione potrebbe non essere valido.</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">パラメーター {1} の条件 {0} を評価できませんでした (条件テキスト: {2}、 評価エラー: {3}) - 条件の形式に誤りがある可能性があります。</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">パラメーター {1} の条件 {0} を評価できませんでした (条件テキスト: {2}、 評価エラー: {3}) - 条件の形式に誤りがある可能性があります。</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">매개 변수 {1}의 조건 {0}을(를) 평가하지 못했습니다(조건 텍스트: {2}, 평가 오류: {3}). 조건의 형식이 잘못되었을 수 있습니다.</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">매개 변수 {1}의 조건 {0}을(를) 평가하지 못했습니다(조건 텍스트: {2}, 평가 오류: {3}). 조건의 형식이 잘못되었을 수 있습니다.</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">Nie można ocenić warunku {0} dla parametru {1} (tekst warunku: {2}, błąd oceny: {3}) — warunek może być źle sformułowany.</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">Nie można ocenić warunku {0} dla parametru {1} (tekst warunku: {2}, błąd oceny: {3}) — warunek może być źle sformułowany.</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">Falha ao avaliar a condição {0} no parâmetro {1} (texto da condição: {2}, erro de avaliação: {3}) - a condição pode estar malformada.</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">Falha ao avaliar a condição {0} no parâmetro {1} (texto da condição: {2}, erro de avaliação: {3}) - a condição pode estar malformada.</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">Не удалось вычислить условие {0} для параметра {1} (текст условия: {2}, ошибка вычисления: {3}). Возможно, условие указано неправильно.</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">Не удалось вычислить условие {0} для параметра {1} (текст условия: {2}, ошибка вычисления: {3}). Возможно, условие указано неправильно.</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">{1} parametresinde {0} koşulu değerlendirilemedi (koşul metni: {2}, değerlendirme hatası: {3}). Koşul hatalı biçimlendirilmiş olabilir.</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">{1} parametresinde {0} koşulu değerlendirilemedi (koşul metni: {2}, değerlendirme hatası: {3}). Koşul hatalı biçimlendirilmiş olabilir.</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">无法计算参数 {1} 上的条件 {0} (条件文本: {2}，计算错误: {3})- 条件可能格式不正确。</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">无法计算参数 {1} 上的条件 {0} (条件文本: {2}，计算错误: {3})- 条件可能格式不正确。</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note>{0} is the dependency chain</note>
       </trans-unit>
       <trans-unit id="ConditionEvaluation_Error_MismatchedCondition">
-        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed.</source>
-        <target state="translated">無法評估參數 {1} 的條件 {0} (條件文字: {2}，評估錯誤: {3}) - 條件的格式可能不正確。</target>
+        <source>Failed to evaluate condition {0} on parameter {1} (condition text: {2}, evaluation error: {3}) - condition might be malformed or referenced parameters do not have default nor explicit values.</source>
+        <target state="needs-review-translation">無法評估參數 {1} 的條件 {0} (條件文字: {2}，評估錯誤: {3}) - 條件的格式可能不正確。</target>
         <note>{0} is the condition type
 {1} is parameter name
 {2} is condition text


### PR DESCRIPTION
### Problem
Error message for evaluation error of conditional parameters was not capturing all possibilities

### Solution
Adjusted the error message
Complement of this change is in SDK repor: https://github.com/dotnet/sdk/pull/27684

### Checks - N/A
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)