### PR TITLE
Value forms fixes

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Shipped.txt
@@ -121,7 +121,7 @@ Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator.
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms.IValueForm
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms.IValueForm.Identifier.get -> string!
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms.IValueForm.Name.get -> string!
-Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms.IValueForm.Process(string? value, System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms.IValueForm!>! otherForms) -> string?
+Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms.IValueForm.Process(string! value, System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms.IValueForm!>! otherForms) -> string!
 override Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.BindSymbol.Type.get -> string!
 override Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.ComputedSymbol.Type.get -> string!
 override Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.DerivedSymbol.Type.get -> string!

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ActionableValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ActionableValueFormFactory.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
@@ -29,7 +30,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
             return new ActionableValueForm(name!, this);
         }
 
-        protected abstract string? Process(string? value);
+        protected abstract string Process(string value);
 
         protected class ActionableValueForm : BaseValueForm
         {
@@ -40,8 +41,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
                 _factory = factory;
             }
 
-            public override string? Process(string? value, IReadOnlyDictionary<string, IValueForm> otherForms)
+            public override string Process(string value, IReadOnlyDictionary<string, IValueForm> otherForms)
             {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
                 return _factory.Process(value);
             }
         }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/BaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/BaseValueFormFactory.cs
@@ -44,7 +44,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
             public string Name { get; }
 
-            public abstract string? Process(string? value, IReadOnlyDictionary<string, IValueForm> otherForms);
+            public abstract string Process(string value, IReadOnlyDictionary<string, IValueForm> otherForms);
         }
     }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ChainValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ChainValueFormFactory.cs
@@ -15,14 +15,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
         internal ChainValueFormFactory()
             : base(FormIdentifier) { }
 
-        protected override string? Process(string? value, IReadOnlyList<string>? steps, IReadOnlyDictionary<string, IValueForm> otherForms)
+        protected override string Process(string value, IReadOnlyList<string>? steps, IReadOnlyDictionary<string, IValueForm> otherForms)
         {
             if (steps == null)
             {
                 return value;
             }
 
-            string? result = value;
+            string result = value;
             foreach (string step in steps)
             {
                 result = otherForms[step].Process(result, otherForms);

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ConfigurableValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ConfigurableValueFormFactory.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
@@ -36,12 +37,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         protected abstract T ReadConfiguration(JObject jobject);
 
-        protected abstract string? Process(string? value, T? configuration);
+        protected abstract string Process(string value, T? configuration);
 
         private class ConfigurableBaseValueForm : BaseValueForm
         {
             private readonly ConfigurableValueFormFactory<T> _factory;
-            private T? _configuration;
+            private readonly T? _configuration;
 
             internal ConfigurableBaseValueForm(string name, ConfigurableValueFormFactory<T> factory, T? configuration) : base(name, factory.Identifier)
             {
@@ -49,8 +50,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
                 _configuration = configuration;
             }
 
-            public override string? Process(string? value, IReadOnlyDictionary<string, IValueForm> otherForms)
+            public override string Process(string value, IReadOnlyDictionary<string, IValueForm> otherForms)
             {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
                 return _factory.Process(value, _configuration);
             }
         }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNameValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNameValueFormFactory.cs
@@ -12,6 +12,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
         internal DefaultLowerSafeNameValueFormFactory()
             : base(FormIdentifier) { }
 
-        protected override string? Process(string? value) => DefaultSafeNameValueFormFactory.ToSafeName(value)?.ToLowerInvariant();
+        protected override string Process(string value) => DefaultSafeNameValueFormFactory.ToSafeName(value).ToLowerInvariant();
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNamespaceValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNamespaceValueFormFactory.cs
@@ -12,9 +12,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
         internal DefaultLowerSafeNamespaceValueFormFactory()
             : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
-            return DefaultSafeNamespaceValueFormFactory.ToSafeNamespace(value)?.ToLowerInvariant();
+            return DefaultSafeNamespaceValueFormFactory.ToSafeNamespace(value).ToLowerInvariant();
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNameValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNameValueFormFactory.cs
@@ -14,19 +14,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
         internal DefaultSafeNameValueFormFactory()
             : base(FormIdentifier) { }
 
-        internal static string? ToSafeName(string? value)
+        internal static string ToSafeName(string value)
         {
-            if (string.IsNullOrEmpty(value))
-            {
-                return value;
-            }
-
+            const string replacement = "_";
             string workingValue = Regex.Replace(value, @"(^\s+|\s+$)", "");
-            workingValue = Regex.Replace(workingValue, @"(((?<=\.)|^)(?=\d)|\W)", "_");
-
+            workingValue = Regex.Replace(workingValue, @"(((?<=\.)|^)(?=\d)|\W)", replacement);
             return workingValue;
         }
 
-        protected override string? Process(string? value) => ToSafeName(value);
+        protected override string Process(string value) => ToSafeName(value);
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNamespaceValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNamespaceValueFormFactory.cs
@@ -16,19 +16,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
         internal DefaultSafeNamespaceValueFormFactory()
             : base(FormIdentifier) { }
 
-        internal static string? ToSafeNamespace(string? value)
+        internal static string ToSafeNamespace(string value)
         {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                return value;
-            }
-
             const char invalidCharacterReplacement = '_';
 
             value = value ?? throw new ArgumentNullException(nameof(value));
             value = value.Trim();
 
-            StringBuilder safeValueStr = new StringBuilder(value.Length);
+            StringBuilder safeValueStr = new(value.Length);
 
             for (int i = 0; i < value.Length; i++)
             {
@@ -62,10 +57,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
                     safeValueStr.Append(invalidCharacterReplacement);
                 }
             }
-
             return safeValueStr.ToString();
         }
 
-        protected override string? Process(string? value) => ToSafeNamespace(value);
+        protected override string Process(string value) => ToSafeNamespace(value);
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DependantValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DependantValueFormFactory.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 
@@ -36,12 +37,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         protected abstract T ReadConfiguration(JObject jobject);
 
-        protected abstract string? Process(string? value, T? configuration, IReadOnlyDictionary<string, IValueForm> otherForms);
+        protected abstract string Process(string value, T? configuration, IReadOnlyDictionary<string, IValueForm> otherForms);
 
         private class DependantValueForm : BaseValueForm
         {
-            private DependantValueFormFactory<T> _factory;
-            private T? _configuration;
+            private readonly DependantValueFormFactory<T> _factory;
+            private readonly T? _configuration;
 
             internal DependantValueForm(string name, DependantValueFormFactory<T> factory, T? configuration) : base(name, factory.Identifier)
             {
@@ -49,8 +50,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
                 _configuration = configuration;
             }
 
-            public override string? Process(string? value, IReadOnlyDictionary<string, IValueForm> otherForms)
+            public override string Process(string value, IReadOnlyDictionary<string, IValueForm> otherForms)
             {
+                if (value is null)
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+
                 return _factory.Process(value, _configuration, otherForms);
             }
         }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstLowerCaseInvariantValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstLowerCaseInvariantValueFormFactory.cs
@@ -13,14 +13,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal FirstLowerCaseInvariantValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
-            switch (value)
+            return value switch
             {
-                case null: return null;
-                case "": return value;
-                default: return value.First().ToString().ToLowerInvariant() + value.Substring(1);
-            }
+                "" => value,
+                _ => value.First().ToString().ToLowerInvariant() + value.Substring(1),
+            };
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstLowerCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstLowerCaseValueFormFactory.cs
@@ -13,14 +13,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal FirstLowerCaseValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
-            switch (value)
+            return value switch
             {
-                case null: return null;
-                case "": return value;
-                default: return value.First().ToString().ToLower() + value.Substring(1);
-            }
+                "" => value,
+                _ => value.First().ToString().ToLower() + value.Substring(1),
+            };
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstUpperCaseInvariantValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstUpperCaseInvariantValueFormFactory.cs
@@ -13,14 +13,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal FirstUpperCaseInvariantValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
-            switch (value)
+            return value switch
             {
-                case null: return null;
-                case "": return value;
-                default: return value.First().ToString().ToUpperInvariant() + value.Substring(1);
-            }
+                "" => value,
+                _ => value.First().ToString().ToUpperInvariant() + value.Substring(1),
+            };
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstUpperCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstUpperCaseValueFormFactory.cs
@@ -13,14 +13,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal FirstUpperCaseValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
-            switch (value)
+            return value switch
             {
-                case null: return null;
-                case "": return value;
-                default: return value.First().ToString().ToUpper() + value.Substring(1);
-            }
+                "" => value,
+                _ => value.First().ToString().ToUpper() + value.Substring(1),
+            };
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IValueForm.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IValueForm.cs
@@ -7,6 +7,9 @@ using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
+    /// <summary>
+    /// Defines an interface for value form.
+    /// </summary>
     public interface IValueForm
     {
         /// <summary>
@@ -26,6 +29,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
         /// <param name="value"></param>
         /// <param name="otherForms">other forms defined in the template.</param>
         /// <returns>transformed value.</returns>
-        string? Process(string? value, IReadOnlyDictionary<string, IValueForm> otherForms);
+        string Process(string value, IReadOnlyDictionary<string, IValueForm> otherForms);
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IdentityValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IdentityValueFormFactory.cs
@@ -11,6 +11,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal IdentityValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value) => value;
+        protected override string Process(string value) => value;
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/JsonEncodeValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/JsonEncodeValueFormFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal JsonEncodeValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
             return JsonConvert.SerializeObject(value);
         }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/KebabCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/KebabCaseValueFormFactory.cs
@@ -14,18 +14,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal KebabCaseValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
-            if (value is null)
-            {
-                return null;
-            }
             if (string.IsNullOrWhiteSpace(value))
             {
                 return string.Empty;
             }
 
-            Regex pattern = new Regex(@"(?:\p{Lu}\p{M}*)?(?:\p{Ll}\p{M}*)+|(?:\p{Lu}\p{M}*)+(?!\p{Ll})|\p{N}+|[^\p{C}\p{P}\p{Z}]+|[\u2700-\u27BF]");
+            Regex pattern = new(@"(?:\p{Lu}\p{M}*)?(?:\p{Ll}\p{M}*)+|(?:\p{Lu}\p{M}*)+(?!\p{Ll})|\p{N}+|[^\p{C}\p{P}\p{Z}]+|[\u2700-\u27BF]");
             return string.Join("-", pattern.Matches(value).Cast<Match>().Select(m => m.Value)).ToLowerInvariant();
         }
     }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/LowerCaseInvariantValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/LowerCaseInvariantValueFormFactory.cs
@@ -11,9 +11,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal LowerCaseInvariantValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
-            return value?.ToLowerInvariant();
+            return value.ToLowerInvariant();
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/LowerCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/LowerCaseValueFormFactory.cs
@@ -11,9 +11,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal LowerCaseValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
-            return value?.ToLower();
+            return value.ToLower();
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ReplacementValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ReplacementValueFormFactory.cs
@@ -27,7 +27,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal ReplacementValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value, ReplacementValueFormSettings? configuration)
+        protected override string Process(string value, ReplacementValueFormSettings? configuration)
         {
             if (configuration == null)
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/TitleCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/TitleCaseValueFormFactory.cs
@@ -13,14 +13,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal TitleCaseValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
-            switch (value)
+            return value switch
             {
-                case null: return null;
-                case "": return value;
-                default: return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value);
-            }
+                "" => value,
+                _ => CultureInfo.CurrentCulture.TextInfo.ToTitleCase(value),
+            };
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/UpperCaseInvariantValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/UpperCaseInvariantValueFormFactory.cs
@@ -11,9 +11,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal UpperCaseInvariantValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
-            return value?.ToUpperInvariant();
+            return value.ToUpperInvariant();
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/UpperCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/UpperCaseValueFormFactory.cs
@@ -11,9 +11,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 
         internal UpperCaseValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
-            return value?.ToUpper();
+            return value.ToUpper();
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/XmlEncodeValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/XmlEncodeValueFormFactory.cs
@@ -11,13 +11,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
     internal class XmlEncodeValueFormFactory : ActionableValueFormFactory
     {
         internal const string FormIdentifier = "xmlEncode";
-        private static readonly XmlWriterSettings Settings = new XmlWriterSettings { ConformanceLevel = ConformanceLevel.Fragment };
+        private static readonly XmlWriterSettings Settings = new() { ConformanceLevel = ConformanceLevel.Fragment };
 
         internal XmlEncodeValueFormFactory() : base(FormIdentifier) { }
 
-        protected override string? Process(string? value)
+        protected override string Process(string value)
         {
-            StringBuilder output = new StringBuilder();
+            StringBuilder output = new();
             using (XmlWriter w = XmlWriter.Create(output, Settings))
             {
                 w.WriteString(value);

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/DefaultLowerSafeNamespaceValueFormModelTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/DefaultLowerSafeNamespaceValueFormModelTests.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 using Xunit;
@@ -25,9 +26,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [InlineData("Company.Product", "company.product")]
         public void LowerSafeNamespaceWorksAsExpected(string input, string expected)
         {
-            var model = new DefaultLowerSafeNamespaceValueFormFactory().Create("test");
-            string? actual = model.Process(input, new Dictionary<string, IValueForm>());
+            IValueForm model = new DefaultLowerSafeNamespaceValueFormFactory().Create("test");
+            string actual = model.Process(input, new Dictionary<string, IValueForm>());
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CanHandleNullValue()
+        {
+            IValueForm model = new DefaultLowerSafeNamespaceValueFormFactory().Create("test");
+            Assert.Throws<ArgumentNullException>(() => model.Process(null!, new Dictionary<string, IValueForm>()));
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/DefaultSafeNamespaceValueFormModelTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/DefaultSafeNamespaceValueFormModelTests.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 using Xunit;
@@ -28,9 +29,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [InlineData("Template.1", "Template._1")]
         public void SafeNamespaceWorksAsExpected(string input, string expected)
         {
-            var model = new DefaultSafeNamespaceValueFormFactory().Create("test");
-            string? actual = model.Process(input, new Dictionary<string, IValueForm>());
+            IValueForm model = new DefaultSafeNamespaceValueFormFactory().Create("test");
+            string actual = model.Process(input, new Dictionary<string, IValueForm>());
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CanHandleNullValue()
+        {
+            IValueForm model = new DefaultSafeNamespaceValueFormFactory().Create("test");
+            Assert.Throws<ArgumentNullException>(() => model.Process(null!, new Dictionary<string, IValueForm>()));
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseInvariantValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseInvariantValueFormTests.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
@@ -17,10 +18,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [InlineData("NO", "nO", null)]
         [InlineData("NEW", "nEW", null)]
         [InlineData("", "", null)]
-        [InlineData(null, null, null)]
         [InlineData("Indigo", "indigo", "tr-TR")]
         [InlineData("İndigo", "İndigo", "tr-TR")]
-        public void FirstLowerCaseInvariantWorksAsExpected(string input, string expected, string culture)
+        public void FirstLowerCaseInvariantWorksAsExpected(string input, string expected, string? culture)
         {
             if (!string.IsNullOrEmpty(culture))
             {
@@ -34,9 +34,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
                 }
             }
 
-            var model = new FirstLowerCaseInvariantValueFormFactory().Create("test");
-            string? actual = model.Process(input, new Dictionary<string, IValueForm>());
+            IValueForm model = new FirstLowerCaseInvariantValueFormFactory().Create("test");
+            string actual = model.Process(input, new Dictionary<string, IValueForm>());
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CanHandleNullValue()
+        {
+            IValueForm model = new FirstLowerCaseInvariantValueFormFactory().Create("test");
+            Assert.Throws<ArgumentNullException>(() => model.Process(null!, new Dictionary<string, IValueForm>()));
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstLowerCaseValueFormTests.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
@@ -17,10 +18,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [InlineData("NO", "nO", null)]
         [InlineData("NEW", "nEW", null)]
         [InlineData("", "", null)]
-        [InlineData(null, null, null)]
         [InlineData("İndigo", "indigo", "tr-TR")]
         [InlineData("Indigo", "ındigo", "tr-TR")]
-        public void FirstLowerCaseWorksAsExpected(string input, string expected, string culture)
+        public void FirstLowerCaseWorksAsExpected(string input, string expected, string? culture)
         {
             if (!string.IsNullOrEmpty(culture))
             {
@@ -34,9 +34,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
                 }
             }
 
-            var model = new FirstLowerCaseValueFormFactory().Create("test");
-            string? actual = model.Process(input, new Dictionary<string, IValueForm>());
+            IValueForm model = new FirstLowerCaseValueFormFactory().Create("test");
+            string actual = model.Process(input, new Dictionary<string, IValueForm>());
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CanHandleNullValue()
+        {
+            IValueForm model = new FirstLowerCaseValueFormFactory().Create("test");
+            Assert.Throws<ArgumentNullException>(() => model.Process(null!, new Dictionary<string, IValueForm>()));
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseInvariantValueFormModel.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseInvariantValueFormModel.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
@@ -17,10 +18,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [InlineData("no", "No", null)]
         [InlineData("new", "New", null)]
         [InlineData("", "", null)]
-        [InlineData(null, null, null)]
         [InlineData("indigo", "Indigo", "tr-TR")]
         [InlineData("ındigo", "ındigo", "tr-TR")]
-        public void FirstUpperCaseInvariantWorksAsExpected(string input, string expected, string culture)
+        public void FirstUpperCaseInvariantWorksAsExpected(string input, string expected, string? culture)
         {
             if (!string.IsNullOrEmpty(culture))
             {
@@ -33,9 +33,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
                     CultureInfo.CurrentCulture = new CultureInfo(culture);
                 }
             }
-            var model = new FirstUpperCaseInvariantValueFormFactory().Create("test");
-            string? actual = model.Process(input, new Dictionary<string, IValueForm>());
+            IValueForm model = new FirstUpperCaseInvariantValueFormFactory().Create("test");
+            string actual = model.Process(input, new Dictionary<string, IValueForm>());
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CanHandleNullValue()
+        {
+            IValueForm model = new FirstUpperCaseInvariantValueFormFactory().Create("test");
+            Assert.Throws<ArgumentNullException>(() => model.Process(null!, new Dictionary<string, IValueForm>()));
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/FirstUpperCaseValueFormTests.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
@@ -17,10 +18,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [InlineData("no", "No", null)]
         [InlineData("new", "New", null)]
         [InlineData("", "", null)]
-        [InlineData(null, null, null)]
         [InlineData("indigo", "İndigo", "tr-TR")]
         [InlineData("ındigo", "Indigo", "tr-TR")]
-        public void FirstUpperCaseWorksAsExpected(string input, string expected, string culture)
+        public void FirstUpperCaseWorksAsExpected(string input, string expected, string? culture)
         {
             if (!string.IsNullOrEmpty(culture))
             {
@@ -34,9 +34,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
                 }
             }
 
-            var model = new FirstUpperCaseValueFormFactory().Create("test");
-            string? actual = model.Process(input, new Dictionary<string, IValueForm>());
+            IValueForm model = new FirstUpperCaseValueFormFactory().Create("test");
+            string actual = model.Process(input, new Dictionary<string, IValueForm>());
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CanHandleNullValue()
+        {
+            IValueForm model = new FirstUpperCaseValueFormFactory().Create("test");
+            Assert.Throws<ArgumentNullException>(() => model.Process(null!, new Dictionary<string, IValueForm>()));
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/JsonEncodeValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/JsonEncodeValueFormTests.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 using Xunit;
@@ -17,8 +18,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         public void JsonEncodingWorksAsExpected(string input, string expected)
         {
             IValueForm form = new JsonEncodeValueFormFactory().Create("test");
-            string? actual = form.Process(input, new Dictionary<string, IValueForm>());
+            string actual = form.Process(input, new Dictionary<string, IValueForm>());
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CanHandleNullValue()
+        {
+            IValueForm model = new JsonEncodeValueFormFactory().Create("test");
+            Assert.Throws<ArgumentNullException>(() => model.Process(null!, new Dictionary<string, IValueForm>()));
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/KebabCaseValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/KebabCaseValueFormTests.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 using Xunit;
@@ -31,7 +32,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [InlineData("Windows10", "windows-10")]
         [InlineData("WindowsServer2016R2", "windows-server-2016-r-2")]
         [InlineData("", "")]
-        [InlineData(null, null)]
         [InlineData(";MyWord;", "my-word")]
         [InlineData("My Word", "my-word")]
         [InlineData("My    Word", "my-word")]
@@ -41,9 +41,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [InlineData("НоваяПеременная", "новая-переменная")]
         public void KebabCaseWorksAsExpected(string input, string expected)
         {
-            var model = new KebabCaseValueFormFactory().Create("test");
-            string? actual = model.Process(input, new Dictionary<string, IValueForm>());
+            IValueForm? model = new KebabCaseValueFormFactory().Create("test");
+            string actual = model.Process(input, new Dictionary<string, IValueForm>());
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CanHandleNullValue()
+        {
+            IValueForm model = new KebabCaseValueFormFactory().Create("test");
+            Assert.Throws<ArgumentNullException>(() => model.Process(null!, new Dictionary<string, IValueForm>()));
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/TitleCaseValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/TitleCaseValueFormTests.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
 using Xunit;
@@ -17,12 +18,18 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Value
         [InlineData("new project name", "New Project Name")]
         [InlineData("new-project%name", "New-Project%Name")]
         [InlineData("", "")]
-        [InlineData(null, null)]
         public void TitleCaseWorksAsExpected(string input, string expected)
         {
-            var model = new TitleCaseValueFormFactory().Create("test");
-            string? actual = model.Process(input, new Dictionary<string, IValueForm>());
+            IValueForm model = new TitleCaseValueFormFactory().Create("test");
+            string actual = model.Process(input, new Dictionary<string, IValueForm>());
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CanHandleNullValue()
+        {
+            IValueForm model = new TitleCaseValueFormFactory().Create("test");
+            Assert.Throws<ArgumentNullException>(() => model.Process(null!, new Dictionary<string, IValueForm>()));
         }
     }
 }


### PR DESCRIPTION
### Problem
Spotted couple of issues while investigating safe forms

### Solution
value forms should not support null `value`
fixed invalid handling in safe namespace and safe name form

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)