### PR TITLE
macros should not assign null values to VariableCollection

### DIFF
--- a/src/Microsoft.TemplateEngine.Core/Operations/Conditional.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/Conditional.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.TemplateEngine.Core.Contracts;

--- a/src/Microsoft.TemplateEngine.Core/VariableCollection.cs
+++ b/src/Microsoft.TemplateEngine.Core/VariableCollection.cs
@@ -31,6 +31,14 @@ namespace Microsoft.TemplateEngine.Core
 
         public VariableCollection(IVariableCollection? parent, IDictionary<string, object> values)
         {
+            if (values != null)
+            {
+                if (values.Values.Any(o => o is null))
+                {
+                    throw new ArgumentException($"The {nameof(values)} should not contain null.", nameof(values));
+                }
+            }
+
             _parent = parent;
             _values = values ?? new Dictionary<string, object>();
 
@@ -69,7 +77,7 @@ namespace Microsoft.TemplateEngine.Core
             {
                 if (_values.TryGetValue(key, out object result))
                 {
-                    ValueReadEventArgs args = new ValueReadEventArgs(key, result);
+                    ValueReadEventArgs args = new(key, result);
                     OnValueRead(args);
                     return result;
                 }
@@ -85,7 +93,7 @@ namespace Microsoft.TemplateEngine.Core
             set
             {
                 bool changing = !_values.ContainsKey(key);
-                _values[key] = value;
+                _values[key] = value ?? throw new ArgumentNullException(nameof(value));
                 if (changing)
                 {
                     OnKeysChanged();
@@ -95,7 +103,7 @@ namespace Microsoft.TemplateEngine.Core
 
         public static VariableCollection Root() => Root(new Dictionary<string, object>());
 
-        public static VariableCollection Root(IDictionary<string, object> values) => new VariableCollection(null, values);
+        public static VariableCollection Root(IDictionary<string, object> values) => new(null, values);
 
         public static IVariableCollection SetupVariables(IParameterSetData parameters, IVariableConfig variableConfig)
         {
@@ -152,6 +160,11 @@ namespace Microsoft.TemplateEngine.Core
                 throw new InvalidOperationException("Key already added");
             }
 
+            if (item.Value is null)
+            {
+                throw new ArgumentException($"The value of key-value pair {nameof(item)} should not be null.", nameof(item));
+            }
+
             _values.Add(item);
             OnKeysChanged();
         }
@@ -161,6 +174,11 @@ namespace Microsoft.TemplateEngine.Core
             if (_parent?.ContainsKey(key) ?? false)
             {
                 throw new InvalidOperationException("Key already added");
+            }
+
+            if (value is null)
+            {
+                throw new ArgumentNullException(nameof(value));
             }
 
             _values.Add(key, value);

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CaseChangeMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CaseChangeMacro.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
@@ -20,7 +22,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
         public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig)
         {
             string value = string.Empty;
-            CaseChangeMacroConfig config = rawConfig as CaseChangeMacroConfig;
+            CaseChangeMacroConfig? config = rawConfig as CaseChangeMacroConfig;
 
             if (config == null)
             {
@@ -39,7 +41,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public IMacroConfig CreateConfig(IEngineEnvironmentSettings environmentSettings, IMacroConfig rawConfig)
         {
-            GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
+            GeneratedSymbolDeferredMacroConfig? deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
             if (deferredConfig == null)
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CoalesceMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CoalesceMacro.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
@@ -19,26 +21,26 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public IMacroConfig CreateConfig(IEngineEnvironmentSettings environmentSettings, IMacroConfig rawConfig)
         {
-            GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
+            GeneratedSymbolDeferredMacroConfig? deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
             if (deferredConfig == null)
             {
                 throw new InvalidCastException("Couldn't cast the rawConfig as a GeneratedSymbolDeferredMacroConfig");
             }
 
-            string sourceVariableName = null;
+            string? sourceVariableName = null;
             if (deferredConfig.Parameters.TryGetValue("sourceVariableName", out JToken sourceVariableToken) && sourceVariableToken.Type == JTokenType.String)
             {
                 sourceVariableName = sourceVariableToken.ToString();
             }
 
-            string defaultValue = null;
+            string? defaultValue = null;
             if (deferredConfig.Parameters.TryGetValue("defaultValue", out JToken defaultValueToken) && defaultValueToken.Type == JTokenType.String)
             {
                 defaultValue = defaultValueToken.ToString();
             }
 
-            string fallbackVariableName = null;
+            string? fallbackVariableName = null;
             if (deferredConfig.Parameters.TryGetValue("fallbackVariableName", out JToken fallbackVariableNameToken) && fallbackVariableNameToken.Type == JTokenType.String)
             {
                 fallbackVariableName = fallbackVariableNameToken.ToString();
@@ -50,27 +52,33 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig config)
         {
-            CoalesceMacroConfig realConfig = config as CoalesceMacroConfig;
+            CoalesceMacroConfig? realConfig = config as CoalesceMacroConfig;
 
             if (realConfig == null)
             {
                 throw new InvalidCastException("Unable to cast config as a CoalesceMacroConfig");
             }
 
-            object targetValue = null;
-            if (vars.TryGetValue(realConfig.SourceVariableName, out object currentSourceValue) && !Equals(currentSourceValue ?? string.Empty, realConfig.DefaultValue ?? string.Empty))
+            object? targetValue = null;
+            if (!string.IsNullOrEmpty(realConfig.SourceVariableName)
+                && vars.TryGetValue(realConfig.SourceVariableName!, out object currentSourceValue)
+                && !Equals(currentSourceValue ?? string.Empty, realConfig.DefaultValue ?? string.Empty))
             {
                 targetValue = currentSourceValue;
             }
             else
             {
-                if (!vars.TryGetValue(realConfig.FallbackVariableName, out targetValue))
+                if (!string.IsNullOrEmpty(realConfig.FallbackVariableName)
+                    && !vars.TryGetValue(realConfig.FallbackVariableName!, out targetValue))
                 {
                     environmentSettings.Host.Logger.LogDebug("Unable to find a variable to fall back to called " + realConfig.FallbackVariableName);
                     targetValue = realConfig.DefaultValue;
                 }
             }
-            vars[config.VariableName] = targetValue?.ToString();
+            if (targetValue is not null)
+            {
+                vars[config.VariableName] = targetValue.ToString();
+            }
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/CaseChangeMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/CaseChangeMacroConfig.cs
@@ -1,13 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 {
     internal class CaseChangeMacroConfig : IMacroConfig
     {
-        internal CaseChangeMacroConfig(string variableName, string dataType, string sourceVariable, bool toLower)
+        internal CaseChangeMacroConfig(string variableName, string? dataType, string sourceVariable, bool toLower)
         {
             DataType = dataType;
             VariableName = variableName;
@@ -19,7 +21,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         public string VariableName { get; }
 
-        internal string DataType { get; }
+        internal string? DataType { get; }
 
         internal string SourceVariable { get; }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/CoalesceMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/CoalesceMacroConfig.cs
@@ -1,13 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 {
     internal class CoalesceMacroConfig : IMacroConfig
     {
-        internal CoalesceMacroConfig(string variableName, string dataType, string sourceVariableName, string defaultValue, string fallbackVariableName)
+        internal CoalesceMacroConfig(string variableName, string? dataType, string? sourceVariableName, string? defaultValue, string? fallbackVariableName)
         {
             DataType = dataType;
             VariableName = variableName;
@@ -20,12 +22,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         public string Type => "coalesce";
 
-        internal string DataType { get; }
+        internal string? DataType { get; }
 
-        internal string SourceVariableName { get; }
+        internal string? SourceVariableName { get; }
 
-        internal string DefaultValue { get; }
+        internal string? DefaultValue { get; }
 
-        internal string FallbackVariableName { get; }
+        internal string? FallbackVariableName { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/ConstantMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/ConstantMacroConfig.cs
@@ -1,13 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 {
     internal class ConstantMacroConfig : IMacroConfig
     {
-        internal ConstantMacroConfig(string dataType, string variableName, string value)
+        internal ConstantMacroConfig(string? dataType, string variableName, string value)
         {
             DataType = dataType;
             VariableName = variableName;
@@ -19,7 +21,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         public string Type { get; private set; }
 
-        internal string DataType { get; }
+        internal string? DataType { get; }
 
         internal string Value { get; private set; }
     }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/EvaluateMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/EvaluateMacroConfig.cs
@@ -1,13 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 {
     internal class EvaluateMacroConfig : IMacroConfig
     {
-        internal EvaluateMacroConfig(string variableName, string dataType, string value, string evaluator)
+        internal EvaluateMacroConfig(string variableName, string dataType, string value, string? evaluator)
         {
             DataType = dataType;
             VariableName = variableName;
@@ -24,6 +26,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         internal string Value { get; private set; }
 
-        internal string Evaluator { get; set; }
+        internal string? Evaluator { get; set; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GeneratePortNumberConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GeneratePortNumberConfig.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
@@ -23,7 +25,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
                     6669, // Alternate IRC [Apple addition]
         };
 
-        internal GeneratePortNumberConfig(string variableName, string dataType, int fallback, int low, int high)
+        internal GeneratePortNumberConfig(string variableName, string? dataType, int fallback, int low, int high)
         {
             DataType = dataType;
             VariableName = variableName;
@@ -31,20 +33,20 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
             for (int testPort = startPort; testPort <= high; testPort++)
             {
-                if (TryAllocatePort(testPort, out Socket testSocket))
+                if (TryAllocatePort(testPort, out Socket? testSocket))
                 {
                     Socket = testSocket;
-                    Port = ((IPEndPoint)Socket.LocalEndPoint).Port;
+                    Port = ((IPEndPoint)Socket!.LocalEndPoint).Port;
                     return;
                 }
             }
 
             for (int testPort = low; testPort < startPort; testPort++)
             {
-                if (TryAllocatePort(testPort, out Socket testSocket))
+                if (TryAllocatePort(testPort, out Socket? testSocket))
                 {
                     Socket = testSocket;
-                    Port = ((IPEndPoint)Socket.LocalEndPoint).Port;
+                    Port = ((IPEndPoint)Socket!.LocalEndPoint).Port;
                     return;
                 }
             }
@@ -56,9 +58,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         public string Type => "port";
 
-        internal string DataType { get; }
+        internal string? DataType { get; }
 
-        internal Socket Socket { get; }
+        internal Socket? Socket { get; }
 
         internal int Port { get; }
 
@@ -66,7 +68,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         internal int High { get; }
 
-        private bool TryAllocatePort(int testPort, out Socket testSocket)
+        private bool TryAllocatePort(int testPort, out Socket? testSocket)
         {
             testSocket = null;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GeneratedSymbolDeferredMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GeneratedSymbolDeferredMacroConfig.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
@@ -10,7 +12,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 {
     internal class GeneratedSymbolDeferredMacroConfig : IMacroConfig
     {
-        internal GeneratedSymbolDeferredMacroConfig(string type, string dataType, string variableName, Dictionary<string, JToken> parameters)
+        internal GeneratedSymbolDeferredMacroConfig(string type, string? dataType, string variableName, Dictionary<string, JToken> parameters)
         {
             DataType = dataType;
             Type = type;
@@ -26,7 +28,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         internal Guid Id => new Guid("12CA34F3-A1B7-4859-B08C-172483C9B0FD");
 
-        internal string DataType { get; }
+        internal string? DataType { get; }
 
         internal IReadOnlyDictionary<string, JToken> Parameters { get; private set; }
     }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GuidMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GuidMacroConfig.cs
@@ -13,7 +13,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
         internal const string UpperCaseDenominator = "-uc-";
         internal const string LowerCaseDenominator = "-lc-";
 
-        internal GuidMacroConfig(string variableName, string dataType, string? format, string? defaultFormat)
+        internal GuidMacroConfig(string variableName, string? dataType, string? format, string? defaultFormat)
         {
             DataType = dataType;
             VariableName = variableName;
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         public string Type { get; }
 
-        internal string DataType { get; }
+        internal string? DataType { get; }
 
         internal string? DefaultFormat { get; }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/JoinMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/JoinMacroConfig.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
@@ -8,7 +10,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 {
     internal class JoinMacroConfig : IMacroConfig
     {
-        internal JoinMacroConfig(string variableName, string dataType, IList<KeyValuePair<string, string>> symbols, string separator, bool removeEmptyValues)
+        internal JoinMacroConfig(string variableName, string? dataType, IList<KeyValuePair<string?, string?>> symbols, string? separator, bool removeEmptyValues)
         {
             VariableName = variableName;
             Type = "join";
@@ -22,12 +24,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         public string Type { get; private set; }
 
-        internal string DataType { get; private set; }
+        internal string? DataType { get; private set; }
 
         // type -> value
-        internal IList<KeyValuePair<string, string>> Symbols { get; private set; }
+        internal IList<KeyValuePair<string?, string?>> Symbols { get; private set; }
 
-        internal string Separator { get; private set; }
+        internal string? Separator { get; private set; }
 
         internal bool RemoveEmptyValues { get; private set; }
     }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/ProcessValueFormMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/ProcessValueFormMacroConfig.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
@@ -9,7 +11,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 {
     internal class ProcessValueFormMacroConfig : IMacroConfig
     {
-        internal ProcessValueFormMacroConfig(string sourceSymbol, string symbolName, string dataType, string valueForm, IReadOnlyDictionary<string, IValueForm> forms)
+        internal ProcessValueFormMacroConfig(string sourceSymbol, string symbolName, string? dataType, string valueForm, IReadOnlyDictionary<string, IValueForm> forms)
         {
             DataType = dataType;
             SourceVariable = sourceSymbol;
@@ -22,7 +24,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         public string Type => "processValueForm";
 
-        internal string DataType { get; }
+        internal string? DataType { get; }
 
         internal string SourceVariable { get; }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/RandomMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/RandomMacroConfig.cs
@@ -1,13 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 {
     internal class RandomMacroConfig : IMacroConfig
     {
-        internal RandomMacroConfig(string variableName, string dataType, int low, int? high)
+        internal RandomMacroConfig(string variableName, string? dataType, int low, int? high)
         {
             DataType = dataType;
             VariableName = variableName;
@@ -20,7 +22,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         public string Type { get; private set; }
 
-        internal string DataType { get; }
+        internal string? DataType { get; }
 
         internal int Low { get; private set; }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/RegexMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/RegexMacroConfig.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
@@ -8,7 +10,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 {
     internal class RegexMacroConfig : IMacroConfig
     {
-        internal RegexMacroConfig(string variableName, string dataType, string sourceVariable, IList<KeyValuePair<string, string>> steps)
+        internal RegexMacroConfig(string variableName, string? dataType, string sourceVariable, IList<KeyValuePair<string?, string?>> steps)
         {
             DataType = dataType;
             VariableName = variableName;
@@ -21,11 +23,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         public string Type { get; private set; }
 
-        internal string DataType { get; }
+        internal string? DataType { get; }
 
         internal string SourceVariable { get; private set; }
 
         // Regex -> Replacement
-        internal IList<KeyValuePair<string, string>> Steps { get; private set; }
+        internal IList<KeyValuePair<string?, string?>> Steps { get; private set; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/RegexMatchMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/RegexMatchMacroConfig.cs
@@ -1,13 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 {
     internal class RegexMatchMacroConfig : IMacroConfig
     {
-        internal RegexMatchMacroConfig(string variableName, string dataType, string sourceVariable, string pattern)
+        internal RegexMatchMacroConfig(string variableName, string? dataType, string sourceVariable, string pattern)
         {
             DataType = dataType ?? "bool";
             VariableName = variableName;
@@ -20,7 +22,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         public string Type { get; }
 
-        internal string DataType { get; }
+        internal string? DataType { get; }
 
         internal string SourceVariable { get; }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/SwitchMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/SwitchMacroConfig.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
@@ -8,7 +10,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 {
     internal class SwitchMacroConfig : IMacroConfig
     {
-        internal SwitchMacroConfig(string variableName, string evaluator, string dataType, IList<KeyValuePair<string, string>> switches)
+        internal SwitchMacroConfig(string variableName, string? evaluator, string? dataType, IList<KeyValuePair<string?, string?>> switches)
         {
             VariableName = variableName;
             Type = "switch";
@@ -21,11 +23,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config
 
         public string Type { get; private set; }
 
-        internal string Evaluator { get; set; }
+        internal string? Evaluator { get; set; }
 
-        internal string DataType { get; set; }
+        internal string? DataType { get; set; }
 
         // condition -> value
-        internal IList<KeyValuePair<string, string>> Switches { get; private set; }
+        internal IList<KeyValuePair<string?, string?>> Switches { get; private set; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ConstantMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ConstantMacro.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
@@ -18,18 +20,21 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig)
         {
-            ConstantMacroConfig config = rawConfig as ConstantMacroConfig;
+            ConstantMacroConfig? config = rawConfig as ConstantMacroConfig;
 
             if (config == null)
             {
                 throw new InvalidCastException("Couldn't cast the rawConfig as ConstantMacroConfig");
             }
-            vars[config.VariableName] = config.Value;
+            if (config.Value != null)
+            {
+                vars[config.VariableName] = config.Value;
+            }
         }
 
         public IMacroConfig CreateConfig(IEngineEnvironmentSettings environmentSettings, IMacroConfig rawConfig)
         {
-            GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
+            GeneratedSymbolDeferredMacroConfig? deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
             if (deferredConfig == null)
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/EvaluateMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/EvaluateMacro.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
@@ -23,7 +25,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig)
         {
-            EvaluateMacroConfig config = rawConfig as EvaluateMacroConfig;
+            EvaluateMacroConfig? config = rawConfig as EvaluateMacroConfig;
 
             if (config == null)
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GeneratePortNumberMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GeneratePortNumberMacro.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
@@ -21,7 +23,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig)
         {
-            GeneratePortNumberConfig config = rawConfig as GeneratePortNumberConfig;
+            GeneratePortNumberConfig? config = rawConfig as GeneratePortNumberConfig;
 
             if (config == null)
             {
@@ -34,7 +36,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public IMacroConfig CreateConfig(IEngineEnvironmentSettings environmentSettings, IMacroConfig rawConfig)
         {
-            GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
+            GeneratedSymbolDeferredMacroConfig? deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
             if (deferredConfig == null)
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/JoinMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/JoinMacro.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,19 +26,19 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             IVariableCollection vars,
             IMacroConfig rawConfig)
         {
-            JoinMacroConfig config = rawConfig as JoinMacroConfig;
+            JoinMacroConfig? config = rawConfig as JoinMacroConfig;
             if (config == null)
             {
                 throw new InvalidCastException("Couldn't cast the rawConfig as ConcatenationMacroConfig");
             }
 
-            List<string> values = new List<string>();
-            foreach (KeyValuePair<string, string> symbol in config.Symbols)
+            List<string?> values = new();
+            foreach (KeyValuePair<string?, string?> symbol in config.Symbols)
             {
                 switch (symbol.Key)
                 {
                     case "ref":
-                        if (!vars.TryGetValue(symbol.Value, out object working))
+                        if (string.IsNullOrEmpty(symbol.Value) || !vars.TryGetValue(symbol.Value!, out object working))
                         {
                             values.Add(string.Empty);
                         }
@@ -70,7 +72,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
                 throw new InvalidCastException("Couldn't cast the rawConfig as a GeneratedSymbolDeferredMacroConfig");
             }
 
-            string separator = string.Empty;
+            string? separator = string.Empty;
             if (deferredConfig.Parameters.TryGetValue("separator", out JToken separatorToken))
             {
                 separator = separatorToken?.ToString();
@@ -81,16 +83,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
                 removeEmptyValuesToken != null &&
                 removeEmptyValuesToken.ToBool();
 
-            List<KeyValuePair<string, string>> symbolsList = new List<KeyValuePair<string, string>>();
+            List<KeyValuePair<string?, string?>> symbolsList = new();
             if (deferredConfig.Parameters.TryGetValue("symbols", out JToken symbolsToken))
             {
                 JArray switchJArray = (JArray)symbolsToken;
                 foreach (JToken switchInfo in switchJArray)
                 {
                     JObject map = (JObject)switchInfo;
-                    string condition = map.ToString("type");
-                    string value = map.ToString("value");
-                    symbolsList.Add(new KeyValuePair<string, string>(condition, value));
+                    string? condition = map.ToString("type");
+                    string? value = map.ToString("value");
+                    symbolsList.Add(new KeyValuePair<string?, string?>(condition, value));
                 }
             }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RandomMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RandomMacro.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
@@ -18,7 +20,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig)
         {
-            RandomMacroConfig config = rawConfig as RandomMacroConfig;
+            RandomMacroConfig? config = rawConfig as RandomMacroConfig;
 
             if (config == null)
             {
@@ -31,7 +33,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public IMacroConfig CreateConfig(IEngineEnvironmentSettings environmentSettings, IMacroConfig rawConfig)
         {
-            GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
+            GeneratedSymbolDeferredMacroConfig? deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
             if (deferredConfig == null)
             {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMacro.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -20,8 +22,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig)
         {
-            string value = null;
-            RegexMacroConfig config = rawConfig as RegexMacroConfig;
+            string value = string.Empty;
+            RegexMacroConfig? config = rawConfig as RegexMacroConfig;
 
             if (config == null)
             {
@@ -39,7 +41,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
             if (config.Steps != null)
             {
-                foreach (KeyValuePair<string, string> stepInfo in config.Steps)
+                foreach (KeyValuePair<string?, string?> stepInfo in config.Steps)
                 {
                     value = Regex.Replace(value, stepInfo.Key, stepInfo.Value);
                 }
@@ -49,7 +51,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public IMacroConfig CreateConfig(IEngineEnvironmentSettings environmentSettings, IMacroConfig rawConfig)
         {
-            GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
+            GeneratedSymbolDeferredMacroConfig? deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
             if (deferredConfig == null)
             {
@@ -62,16 +64,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             }
             string sourceVariable = sourceVarToken.ToString();
 
-            List<KeyValuePair<string, string>> replacementSteps = new List<KeyValuePair<string, string>>();
+            List<KeyValuePair<string?, string?>> replacementSteps = new();
             if (deferredConfig.Parameters.TryGetValue("steps", out JToken stepListToken))
             {
                 JArray stepList = (JArray)stepListToken;
                 foreach (JToken step in stepList)
                 {
                     JObject map = (JObject)step;
-                    string regex = map.ToString("regex");
-                    string replaceWith = map.ToString("replacement");
-                    replacementSteps.Add(new KeyValuePair<string, string>(regex, replaceWith));
+                    string? regex = map.ToString("regex");
+                    string? replaceWith = map.ToString("replacement");
+                    replacementSteps.Add(new KeyValuePair<string?, string?>(regex, replaceWith));
                 }
             }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMatchMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMatchMacro.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/SwitchMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/SwitchMacro.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -24,7 +26,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public void EvaluateConfig(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, IMacroConfig rawConfig)
         {
-            SwitchMacroConfig config = rawConfig as SwitchMacroConfig;
+            SwitchMacroConfig? config = rawConfig as SwitchMacroConfig;
 
             if (config == null)
             {
@@ -34,15 +36,15 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
             ConditionEvaluator evaluator = EvaluatorSelector.Select(config.Evaluator, Cpp2StyleEvaluatorDefinition.Evaluate);
             string result = string.Empty;   // default if no condition assigns a value
 
-            foreach (KeyValuePair<string, string> switchInfo in config.Switches)
+            foreach (KeyValuePair<string?, string?> switchInfo in config.Switches)
             {
-                string condition = switchInfo.Key;
-                string value = switchInfo.Value;
+                string? condition = switchInfo.Key;
+                string? value = switchInfo.Value;
 
                 if (string.IsNullOrEmpty(condition))
                 {
                     // no condition, this is the default.
-                    result = value;
+                    result = value ?? string.Empty;
                     break;
                 }
                 else
@@ -54,7 +56,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
                     if (evaluator(state, ref length, ref position, out bool faulted))
                     {
-                        result = value;
+                        result = value ?? string.Empty;
                         break;
                     }
                 }
@@ -64,35 +66,35 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 
         public IMacroConfig CreateConfig(IEngineEnvironmentSettings environmentSettings, IMacroConfig rawConfig)
         {
-            GeneratedSymbolDeferredMacroConfig deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
+            GeneratedSymbolDeferredMacroConfig? deferredConfig = rawConfig as GeneratedSymbolDeferredMacroConfig;
 
             if (deferredConfig == null)
             {
                 throw new InvalidCastException("Couldn't cast the rawConfig as a SwitchMacroConfig");
             }
 
-            string evaluator = null;
+            string? evaluator = null;
             if (deferredConfig.Parameters.TryGetValue("evaluator", out JToken evaluatorToken))
             {
                 evaluator = evaluatorToken.ToString();
             }
 
-            string dataType = null;
+            string? dataType = null;
             if (deferredConfig.Parameters.TryGetValue("datatype", out JToken dataTypeToken))
             {
                 dataType = dataTypeToken.ToString();
             }
 
-            List<KeyValuePair<string, string>> switchList = new List<KeyValuePair<string, string>>();
+            List<KeyValuePair<string?, string?>> switchList = new();
             if (deferredConfig.Parameters.TryGetValue("cases", out JToken switchListToken))
             {
                 JArray switchJArray = (JArray)switchListToken;
                 foreach (JToken switchInfo in switchJArray)
                 {
                     JObject map = (JObject)switchInfo;
-                    string condition = map.ToString("condition");
-                    string value = map.ToString("value");
-                    switchList.Add(new KeyValuePair<string, string>(condition, value));
+                    string? condition = map.ToString("condition");
+                    string? value = map.ToString("value");
+                    switchList.Add(new KeyValuePair<string?, string?>(condition, value));
                 }
             }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/MacrosOperationConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/MacrosOperationConfig.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
@@ -12,8 +14,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
 {
     internal class MacrosOperationConfig
     {
-        private static IReadOnlyDictionary<string, IMacro> _macroObjects;
-        private static IReadOnlyDictionary<string, IDeferredMacro> _deferredMacroObjects;
+        private static IReadOnlyDictionary<string, IMacro>? _macroObjects;
+        private static IReadOnlyDictionary<string, IDeferredMacro>? _deferredMacroObjects;
 
         // Warning: if there are unknown macro "types", they are quietly ignored here.
         // This applies to both the regular and deferred macros.
@@ -34,7 +36,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
                     continue;
                 }
 
-                if (_macroObjects.TryGetValue(config.Type, out IMacro macroObject))
+                if (_macroObjects!.TryGetValue(config.Type, out IMacro macroObject))
                 {
                     macroObject.EvaluateConfig(environmentSettings, variables, config);
                 }
@@ -48,7 +50,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
             foreach (GeneratedSymbolDeferredMacroConfig deferredConfig in deferredConfigList)
             {
                 IDeferredMacro deferredMacroObject;
-                if (_deferredMacroObjects.TryGetValue(deferredConfig.Type, out deferredMacroObject))
+                if (_deferredMacroObjects!.TryGetValue(deferredConfig.Type, out deferredMacroObject))
                 {
                     deferredConfigs.Add(Tuple.Create((IMacro)deferredMacroObject, deferredMacroObject.CreateConfig(environmentSettings, deferredConfig)));
                 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ReplacementConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ReplacementConfig.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
@@ -23,12 +25,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
         public IEnumerable<IOperationProvider> ConfigureFromJson(string configuration, IDirectory templateRoot)
         {
             JObject rawConfiguration = JObject.Parse(configuration);
-            string original = rawConfiguration.ToString("original");
-            string replacement = rawConfiguration.ToString("replacement");
-            string id = rawConfiguration.ToString("id");
+            string? original = rawConfiguration.ToString("original");
+            string? replacement = rawConfiguration.ToString("replacement");
+            string? id = rawConfiguration.ToString("id");
             bool onByDefault = rawConfiguration.ToBool("onByDefault");
 
-            JArray onlyIf = rawConfiguration.Get<JArray>("onlyIf");
+            JArray? onlyIf = rawConfiguration.Get<JArray>("onlyIf");
             TokenConfig coreConfig = original.TokenConfigBuilder();
 
             if (onlyIf != null)
@@ -40,8 +42,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
                         continue;
                     }
 
-                    string before = entry.ToString("before");
-                    string after = entry.ToString("after");
+                    string? before = entry.ToString("before");
+                    string? after = entry.ToString("after");
                     TokenConfig entryConfig = coreConfig;
 
                     if (!string.IsNullOrEmpty(before))
@@ -63,10 +65,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
             }
         }
 
-        internal static IOperationProvider Setup(IEngineEnvironmentSettings environmentSettings, IReplacementTokens tokens, IVariableCollection variables)
+        internal static IOperationProvider? Setup(IEngineEnvironmentSettings environmentSettings, IReplacementTokens tokens, IVariableCollection variables)
         {
             if (variables.TryGetValue(tokens.VariableName, out object newValueObject))
             {
+                if (newValueObject is null)
+                {
+                    return null;
+                }
                 string newValue = newValueObject.ToString();
                 return new Replacement(tokens.OriginalValue, newValue, null, true);
             }

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/VariablesTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/VariablesTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.IO;
 using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
@@ -45,27 +46,16 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             Verify(Encoding.UTF8, output, changed, value, expected);
         }
 
-        [Fact(DisplayName = nameof(VerifyVariablesNull))]
+        [Fact]
         public void VerifyVariablesNull()
         {
-            string value = @"test %NULL% test";
-            string expected = @"test null test";
-
-            byte[] valueBytes = Encoding.UTF8.GetBytes(value);
-            MemoryStream input = new MemoryStream(valueBytes);
-            MemoryStream output = new MemoryStream();
-
-            IOperationProvider[] operations = { new ExpandVariables(null, true) };
-            VariableCollection vc = new VariableCollection
+            Assert.Throws<ArgumentNullException>(() =>
             {
-                ["NULL"] = null
-            };
-            EngineConfig cfg = new EngineConfig(_engineEnvironmentSettings.Host.Logger, vc, "%{0}%");
-            IProcessor processor = Processor.Create(cfg, operations);
-
-            //Changes should be made
-            bool changed = processor.Run(input, output);
-            Verify(Encoding.UTF8, output, changed, value, expected);
+                VariableCollection vc = new()
+                {
+                    ["NULL"] = null
+                };
+            });
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/GuidMacroTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroTests/GuidMacroTests.cs
@@ -43,8 +43,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Macro
         [Fact(DisplayName = nameof(TestDeferredGuidConfig))]
         public void TestDeferredGuidConfig()
         {
-            Dictionary<string, JToken?> jsonParameters = new();
-            jsonParameters.Add("format", null);
+            Dictionary<string, JToken> jsonParameters = new();
             string variableName = "myGuid1";
             GeneratedSymbolDeferredMacroConfig deferredConfig = new GeneratedSymbolDeferredMacroConfig("GuidMacro", "string", variableName, jsonParameters);
 


### PR DESCRIPTION
### Problem
Using `coalesce` macro for unknown source variables results in having null in `VariableCollection`.

### Solution
Macros should not assign null values to `VariableCollection`

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)