### PR TITLE
Re-enable TestFileWatcher

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
@@ -61,9 +61,8 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
             {
                 return;
             }
-            _disposed = true;
-
             _watcher?.Dispose();
+            _disposed = true;
             _watcher = null;
         }
 


### PR DESCRIPTION
### Problem
#3336

### Solution
Explictly dispose the instances of GlobalSettings after the test data is finally set, to avoid setting volatile _disposed as true that causes throwing ObjectDisposedException when GetInstalledTemplatePackagesAsync is being executed.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)