### PR TITLE
Try to repro unstable FileWatcherTest

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Installer;
 using Microsoft.TemplateEngine.Edge.Settings;
@@ -29,19 +30,24 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
             _globalSettingsFile = globalSettingsFile ?? throw new ArgumentNullException(nameof(globalSettingsFile));
             _paths = new SettingsFilePaths(environmentSettings);
             environmentSettings.Host.FileSystem.CreateDirectory(Path.GetDirectoryName(_globalSettingsFile));
+            Log("Global settings:{0} created settings file at {1}.", Marker.ToString(), _globalSettingsFile);
             if (environmentSettings.Environment.GetEnvironmentVariable("TEMPLATE_ENGINE_DISABLE_FILEWATCHER") != "1")
             {
                 _watcher = environmentSettings.Host.FileSystem.WatchFileChanges(_globalSettingsFile, FileChanged);
             }
+            Log("Global settings:{0} is initialized.", Marker.ToString());
         }
 
         public event Action? SettingsChanged;
+
+        public Guid Marker { get; } = Guid.NewGuid();
 
         public async Task<IDisposable> LockAsync(CancellationToken token)
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(nameof(GlobalSettings));
+                Log("Global settings:{0} -> LockAsync: already disposed!!!!!", Marker.ToString());
+                throw new ObjectDisposedException($"{nameof(GlobalSettings)} -> {Marker.ToString()}");
             }
             token.ThrowIfCancellationRequested();
             if (_mutex?.IsLocked ?? false)
@@ -52,30 +58,37 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
             var escapedFilename = _globalSettingsFile.Replace("\\", "_").Replace("/", "_");
             var mutex = await AsyncMutex.WaitAsync($"Global\\812CA7F3-7CD8-44B4-B3F0-0159355C0BD5{escapedFilename}", token).ConfigureAwait(false);
             _mutex = mutex;
+            Log("Global settings:{0} locked settings file.", Marker.ToString());
             return mutex;
         }
 
         public void Dispose()
         {
+            Log("Global settings:{0} -> Dispose started.", Marker.ToString());
             if (_disposed)
             {
+                Log("Global settings:{0} -> Already disposed!!!!!", Marker.ToString());
                 return;
             }
             _disposed = true;
 
             _watcher?.Dispose();
             _watcher = null;
+            Log("Global settings:{0} -> Marked as disposed and disposed watcher.", Marker.ToString());
         }
 
         public async Task<IReadOnlyList<TemplatePackageData>> GetInstalledTemplatePackagesAsync(CancellationToken cancellationToken)
         {
+            Log("Global settings:{0} -> GetInstalledTemplatePackagesAsync started.", Marker.ToString());
             if (_disposed)
             {
-                throw new ObjectDisposedException(nameof(GlobalSettings));
+                Log("Global settings:{0} -> GetInstalledTemplatePackagesAsync: already disposed!!!!!", Marker.ToString());
+                throw new ObjectDisposedException($"{nameof(GlobalSettings)} -> {Marker.ToString()}");
             }
 
             if (!_environmentSettings.Host.FileSystem.FileExists(_globalSettingsFile))
             {
+                Log("Global settings:{0} -> GetInstalledTemplatePackagesAsync: global settings file not exist!!!", Marker.ToString());
                 return Array.Empty<TemplatePackageData>();
             }
 
@@ -97,6 +110,7 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
                             package.ToStringDictionary(propertyName: nameof(TemplatePackageData.Details))
                         ));
                     }
+                    Log("Global settings:{0} -> GetInstalledTemplatePackagesAsync succeeded.", Marker.ToString());
 
                     return packages;
                 }
@@ -104,19 +118,24 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
                 {
                     if (i == (FileReadWriteRetries - 1))
                     {
+                        Log("Global settings:{0} -> GetInstalledTemplatePackagesAsync: with {1} reties it didn't succeed to get the packages.", Marker.ToString(), FileReadWriteRetries);
                         throw;
                     }
                 }
+                Log("Global settings:{0} -> GetInstalledTemplatePackagesAsync: with {1} reties continue.", Marker.ToString(), i);
                 await Task.Delay(20, cancellationToken).ConfigureAwait(false);
             }
+            Log("Global settings:{0} -> GetInstalledTemplatePackagesAsync throws InvalidOperationException!!!!!!!!", Marker.ToString());
             throw new InvalidOperationException();
         }
 
         public async Task SetInstalledTemplatePackagesAsync(IReadOnlyList<TemplatePackageData> packages, CancellationToken cancellationToken)
         {
+            Log("Global settings:{0} -> SetInstalledTemplatePackagesAsync: started.", Marker.ToString());
             if (_disposed)
             {
-                throw new ObjectDisposedException(nameof(GlobalSettings));
+                Log("Global settings:{0} -> SetInstalledTemplatePackagesAsync: already disposed!!!!!", Marker.ToString());
+                throw new ObjectDisposedException($"{nameof(GlobalSettings)} -> {Marker.ToString()}");
             }
 
             if (!(_mutex?.IsLocked ?? false))
@@ -133,6 +152,11 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
                 try
                 {
                     _environmentSettings.Host.FileSystem.WriteObject(_globalSettingsFile, globalSettingsData);
+                    Log("Global settings:{0} -> SetInstalledTemplatePackagesAsync: finished write settings file.", Marker.ToString());
+                    if (SettingsChanged == null)
+                    {
+                        Log("Global settings:{0} -> SetInstalledTemplatePackagesAsync: SettingsChanged is null.", Marker.ToString());
+                    }
                     SettingsChanged?.Invoke();
                     return;
                 }
@@ -148,8 +172,18 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
             throw new InvalidOperationException();
         }
 
+        public void Log(string? message, params object?[] args)
+        {
+            _environmentSettings.Host.Logger.LogInformation(message, args);
+        }
+
         private void FileChanged(object sender, FileSystemEventArgs e)
         {
+            Log("Global settings:{0} -> FileChanged was triggered.", Marker.ToString());
+            if (!_environmentSettings.Host.FileSystem.FileExists(_globalSettingsFile))
+            {
+                Log("Global settings:{0} -> FileChanged: global settings file not exist!!!", Marker.ToString());
+            }
             SettingsChanged?.Invoke();
         }
     }

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/GlobalSettingsTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/GlobalSettingsTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
                 new Dictionary<string, string>() { { "a", "b" } });
             await globalSettings1.SetInstalledTemplatePackagesAsync(new[] { newData }, default).ConfigureAwait(false);
             mutex.Dispose();
-            var timeoutTask = Task.Delay(3000);
+            var timeoutTask = Task.Delay(1000);
             var firstFinishedTask = await Task.WhenAny(timeoutTask, taskSource.Task).ConfigureAwait(false);
             Assert.Equal(taskSource.Task, firstFinishedTask);
 

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/GlobalSettingsTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/GlobalSettingsTests.cs
@@ -43,9 +43,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             using var settingsLock = await globalSettings2.LockAsync(cts2.Token).ConfigureAwait(false);
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "Randomly failing see https://github.com/dotnet/templating/issues/3336")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public async Task TestFileWatcher()
         {
             var envSettings = _helper.CreateEnvironment();
@@ -62,7 +60,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
                 new Dictionary<string, string>() { { "a", "b" } });
             await globalSettings1.SetInstalledTemplatePackagesAsync(new[] { newData }, default).ConfigureAwait(false);
             mutex.Dispose();
-            var timeoutTask = Task.Delay(1000);
+            var timeoutTask = Task.Delay(3000);
             var firstFinishedTask = await Task.WhenAny(timeoutTask, taskSource.Task).ConfigureAwait(false);
             Assert.Equal(taskSource.Task, firstFinishedTask);
 


### PR DESCRIPTION
### Problem
FileWatcherTest randomly fails.

### Solution
Try to repo with logs

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)