### PR TITLE
`TemplateEngine.Core`: API rename and documentation

### DIFF
--- a/src/Microsoft.TemplateEngine.Core.Contracts/IOperation.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IOperation.cs
@@ -7,9 +7,9 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 {
     public interface IOperation
     {
-        IReadOnlyList<IToken> Tokens { get; }
+        IReadOnlyList<IToken?> Tokens { get; }
 
-        string Id { get; }
+        string? Id { get; }
 
         bool IsInitialStateOn { get; }
 

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IOperationProvider.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IOperationProvider.cs
@@ -7,7 +7,7 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 {
     public interface IOperationProvider
     {
-        string Id { get; }
+        string? Id { get; }
 
         IOperation GetOperation(Encoding encoding, IProcessorState processorState);
     }

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IProcessorState.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IProcessorState.cs
@@ -10,33 +10,68 @@ namespace Microsoft.TemplateEngine.Core.Contracts
     {
         IEngineConfig Config { get; }
 
+        /// <summary>
+        /// Gets the buffer containing the chunk of source stream that is being processed.
+        /// </summary>
         byte[] CurrentBuffer { get; }
 
+        /// <summary>
+        /// Gets the length of useful data in <see cref="CurrentBuffer"/>.
+        /// </summary>
         int CurrentBufferLength { get; }
 
+        /// <summary>
+        /// Gets the current position in <see cref="CurrentBuffer"/>.
+        /// </summary>
         int CurrentBufferPosition { get; }
 
+        /// <summary>
+        /// Gets the current position in source stream.
+        /// </summary>
         int CurrentSequenceNumber { get; }
 
         IEncodingConfig EncodingConfig { get; }
 
         Encoding Encoding { get; }
 
+        /// <summary>
+        /// Advances source stream to position <paramref name="bufferPosition"/>.
+        /// </summary>
         bool AdvanceBuffer(int bufferPosition);
 
-        void SeekForwardUntil(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition);
+        /// <summary>
+        /// Seeks source stream until <paramref name="match"/> is found.
+        /// </summary>
+        /// <param name="match">The token to find.</param>
+        /// <param name="bufferLength">The length of the buffer after the token is found.</param>
+        /// <param name="currentBufferPosition">The position in the buffer after the token is found.</param>
+        /// <param name="consumeToken">True if token should be seeked through.</param>
+        void SeekSourceForwardUntil(ITokenTrie match, ref int bufferLength, ref int currentBufferPosition, bool consumeToken = false);
 
-        void SeekForwardThrough(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition);
+        /// <summary>
+        /// Seeks source stream while <paramref name="match"/> is found.
+        /// </summary>
+        void SeekSourceForwardWhile(ITokenTrie match, ref int bufferLength, ref int currentBufferPosition);
 
-        void SeekForwardWhile(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition);
+        /// <summary>
+        /// Seeks target stream backwards until <paramref name="match"/> is found.
+        /// </summary>
+        /// <param name="match">The token to find.</param>
+        /// <param name="consumeToken">True if token should be seeked through.</param>
+        void SeekTargetBackUntil(ITokenTrie match, bool consumeToken = false);
 
-        void SeekBackUntil(ITokenTrie match);
+        /// <summary>
+        /// Seeks target stream backwards while <paramref name="match"/> is found.
+        /// </summary>
+        void SeekTargetBackWhile(ITokenTrie match);
 
-        void SeekBackUntil(ITokenTrie match, bool consume);
-
-        void SeekBackWhile(ITokenTrie match);
-
-        void Write(byte[] buffer, int offset, int count);
+        /// <summary>
+        /// Writes <paramref name="buffer"/> to target stream.
+        /// </summary>
+        /// <param name="buffer">The buffer to write.</param>
+        /// <param name="offset">The start position in the buffer to write.</param>
+        /// <param name="count">The count of bytes to write.</param>
+        void WriteToTarget(byte[] buffer, int offset, int count);
 
         void Inject(Stream staged);
     }

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IToken.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IToken.cs
@@ -5,12 +5,24 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 {
     public interface IToken
     {
+        /// <summary>
+        /// The value to match.
+        /// </summary>
         byte[] Value { get; }
 
+        /// <summary>
+        /// Start of actual token. May be not 0, when look arounds are used.
+        /// </summary>
         int Start { get; }
 
+        /// <summary>
+        /// Start of actual token. May be not Value.Length, when look arounds are used.
+        /// </summary>
         int End { get; }
 
+        /// <summary>
+        /// The length of the actual token.
+        /// </summary>
         int Length { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Core.Contracts/ITokenTrie.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/ITokenTrie.cs
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateEngine.Core.Contracts
 
         int AddToken(IToken token);
 
-        void AddToken(IToken token, int index);
+        void AddToken(IToken? token, int index);
 
         bool GetOperation(byte[] buffer, int bufferLength, ref int currentBufferPosition, out int token);
 

--- a/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Shipped.txt
@@ -58,10 +58,7 @@ Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.RootVariableCollection.ge
 Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.Special.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<Microsoft.TemplateEngine.Core.Contracts.IPathMatcher!, Microsoft.TemplateEngine.Core.Contracts.IRunSpec!>>!
 Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.TryGetTargetRelPath(string! sourceRelPath, out string! targetRelPath) -> bool
 Microsoft.TemplateEngine.Core.Contracts.IOperation.HandleMatch(Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processor, int bufferLength, ref int currentBufferPosition, int token) -> int
-Microsoft.TemplateEngine.Core.Contracts.IOperation.Id.get -> string!
-Microsoft.TemplateEngine.Core.Contracts.IOperation.Tokens.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IToken!>!
 Microsoft.TemplateEngine.Core.Contracts.IOperationProvider.GetOperation(System.Text.Encoding! encoding, Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processorState) -> Microsoft.TemplateEngine.Core.Contracts.IOperation!
-Microsoft.TemplateEngine.Core.Contracts.IOperationProvider.Id.get -> string!
 Microsoft.TemplateEngine.Core.Contracts.IOrchestrator.GetFileChanges(Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec! spec, Microsoft.TemplateEngine.Abstractions.Mount.IDirectory! sourceDir, string! targetDir) -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.IFileChange2!>!
 Microsoft.TemplateEngine.Core.Contracts.IOrchestrator.GetFileChanges(string! runSpecPath, Microsoft.TemplateEngine.Abstractions.Mount.IDirectory! sourceDir, string! targetDir) -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.IFileChange2!>!
 Microsoft.TemplateEngine.Core.Contracts.IOrchestrator.Run(Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec! spec, Microsoft.TemplateEngine.Abstractions.Mount.IDirectory! sourceDir, string! targetDir) -> void
@@ -77,13 +74,6 @@ Microsoft.TemplateEngine.Core.Contracts.IProcessorState.CurrentBuffer.get -> byt
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.Encoding.get -> System.Text.Encoding!
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.EncodingConfig.get -> Microsoft.TemplateEngine.Core.Contracts.IEncodingConfig!
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.Inject(System.IO.Stream! staged) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, bool consume) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekBackWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekForwardThrough(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekForwardUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekForwardWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
-Microsoft.TemplateEngine.Core.Contracts.IProcessorState.Write(byte[]! buffer, int offset, int count) -> void
 Microsoft.TemplateEngine.Core.Contracts.IReplacementTokens.OriginalValue.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig!
 Microsoft.TemplateEngine.Core.Contracts.IReplacementTokens.VariableName.get -> string!
 Microsoft.TemplateEngine.Core.Contracts.IRunSpec.GetOperations(System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider!>! sourceOperations) -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider!>!
@@ -95,7 +85,6 @@ Microsoft.TemplateEngine.Core.Contracts.ITokenConfig.Before.get -> string!
 Microsoft.TemplateEngine.Core.Contracts.ITokenConfig.ToToken(System.Text.Encoding! encoding) -> Microsoft.TemplateEngine.Core.Contracts.IToken!
 Microsoft.TemplateEngine.Core.Contracts.ITokenConfig.Value.get -> string!
 Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.AddToken(Microsoft.TemplateEngine.Core.Contracts.IToken! token) -> int
-Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.AddToken(Microsoft.TemplateEngine.Core.Contracts.IToken! token, int index) -> void
 Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.Append(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie) -> void
 Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.CreateEvaluator() -> Microsoft.TemplateEngine.Core.Contracts.ITokenTrieEvaluator!
 Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.GetOperation(byte[]! buffer, int bufferLength, ref int currentBufferPosition, bool mustMatchPosition, out int token) -> bool

--- a/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
@@ -1,1 +1,9 @@
-﻿
+﻿Microsoft.TemplateEngine.Core.Contracts.IOperation.Id.get -> string?
+Microsoft.TemplateEngine.Core.Contracts.IOperation.Tokens.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IToken?>!
+Microsoft.TemplateEngine.Core.Contracts.IOperationProvider.Id.get -> string?
+Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekSourceForwardUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, ref int bufferLength, ref int currentBufferPosition, bool consumeToken = false) -> void
+Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekSourceForwardWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, ref int bufferLength, ref int currentBufferPosition) -> void
+Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekTargetBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, bool consumeToken = false) -> void
+Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekTargetBackWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
+Microsoft.TemplateEngine.Core.Contracts.IProcessorState.WriteToTarget(byte[]! buffer, int offset, int count) -> void
+Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.AddToken(Microsoft.TemplateEngine.Core.Contracts.IToken? token, int index) -> void

--- a/src/Microsoft.TemplateEngine.Core/CommonOperations.cs
+++ b/src/Microsoft.TemplateEngine.Core/CommonOperations.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Core
@@ -26,23 +28,22 @@ namespace Microsoft.TemplateEngine.Core
 
         public static void ConsumeWholeLine(this IProcessorState processor, ref int bufferLength, ref int currentBufferPosition)
         {
-            processor.SeekBackWhile(processor.EncodingConfig.Whitespace);
-            processor.SeekForwardThrough(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition);
+            processor.SeekTargetBackWhile(processor.EncodingConfig.Whitespace);
+            processor.SeekSourceForwardUntil(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition, consumeToken: true);
         }
 
         public static void TrimWhitespace(this IProcessorState processor, bool forward, bool backward, ref int bufferLength, ref int currentBufferPosition)
         {
             if (backward)
             {
-                processor.SeekBackWhile(processor.EncodingConfig.Whitespace);
+                processor.SeekTargetBackWhile(processor.EncodingConfig.Whitespace);
             }
 
             if (forward)
             {
-                processor.SeekForwardWhile(processor.EncodingConfig.Whitespace, ref bufferLength, ref currentBufferPosition);
+                processor.SeekSourceForwardWhile(processor.EncodingConfig.Whitespace, ref bufferLength, ref currentBufferPosition);
                 //Consume the trailing line end if possible
-                int tok;
-                processor.EncodingConfig.LineEndings.GetOperation(processor.CurrentBuffer, bufferLength, ref currentBufferPosition, out tok);
+                processor.EncodingConfig.LineEndings.GetOperation(processor.CurrentBuffer, bufferLength, ref currentBufferPosition, out _);
             }
         }
     }

--- a/src/Microsoft.TemplateEngine.Core/Matching/OperationTerminal.cs
+++ b/src/Microsoft.TemplateEngine.Core/Matching/OperationTerminal.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Core.Matching
@@ -14,8 +16,14 @@ namespace Microsoft.TemplateEngine.Core.Matching
             Token = token;
         }
 
+        /// <summary>
+        /// Operation to perform. The tokens that operation matches are part of <see cref="IOperation"/> itself.
+        /// </summary>
         public IOperation Operation { get; }
 
+        /// <summary>
+        /// This is not an actual token to match, but index of token defined in <see cref="IOperation"/>.
+        /// </summary>
         public int Token { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Core/Matching/TerminalBase.cs
+++ b/src/Microsoft.TemplateEngine.Core/Matching/TerminalBase.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace Microsoft.TemplateEngine.Core.Matching
 {
     public abstract class TerminalBase
@@ -12,10 +14,19 @@ namespace Microsoft.TemplateEngine.Core.Matching
             Length = tokenLength;
         }
 
+        /// <summary>
+        /// Start position of the token.
+        /// </summary>
         public int Start { get; protected set; }
 
+        /// <summary>
+        /// End position of the token.
+        /// </summary>
         public int End { get; protected set; }
 
+        /// <summary>
+        /// Length of the token.
+        /// </summary>
         public int Length { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Core/Matching/TerminalLocation.cs
+++ b/src/Microsoft.TemplateEngine.Core/Matching/TerminalLocation.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 namespace Microsoft.TemplateEngine.Core.Matching
 {
     public class TerminalLocation<T>
@@ -12,6 +14,9 @@ namespace Microsoft.TemplateEngine.Core.Matching
             Location = location;
         }
 
+        /// <summary>
+        /// Start position of the terminal. Relative location of matching token is defined in <see cref="TerminalBase"/>.
+        /// </summary>
         public int Location { get; set; }
 
         public T Terminal { get; }

--- a/src/Microsoft.TemplateEngine.Core/Operations/BalancedNesting.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/BalancedNesting.cs
@@ -114,12 +114,12 @@ namespace Microsoft.TemplateEngine.Core.Operations
 
                 if (_depth == 0 && token == PseudoEndTokenIndex)
                 {
-                    processor.Write(_realEndToken.Value, _realEndToken.Start, _realEndToken.Length);
+                    processor.WriteToTarget(_realEndToken.Value, _realEndToken.Start, _realEndToken.Length);
                     return _psuedoEndToken.Length;  // the source buffer needs to skip over this token.
                 }
                 else
                 {
-                    processor.Write(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
+                    processor.WriteToTarget(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
                 }
 
                 return 0;

--- a/src/Microsoft.TemplateEngine.Core/Operations/Conditional.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/Conditional.cs
@@ -158,7 +158,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 bool flag;
                 if (processor.Config.Flags.TryGetValue(OperationName, out flag) && !flag)
                 {
-                    processor.Write(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
+                    processor.WriteToTarget(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
                     return Tokens[token].Length;
                 }
 
@@ -167,7 +167,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 {
                     if (_definition._wholeLine)
                     {
-                        processor.SeekBackUntil(processor.EncodingConfig.LineEndings);
+                        processor.SeekTargetBackUntil(processor.EncodingConfig.LineEndings);
                     }
                     else if (_definition._trimWhitespace)
                     {
@@ -196,7 +196,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                     {
                         if (_definition.WholeLine)
                         {
-                            processor.SeekForwardThrough(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition);
+                            processor.SeekSourceForwardUntil(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition, consumeToken: true);
                         }
 
                         if (IsTokenIndexOfType(token, IfTokenActionableBaseIndex))
@@ -219,7 +219,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 // If we've got an unbalanced statement, emit the token
                 if (_current == null)
                 {
-                    processor.Write(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
+                    processor.WriteToTarget(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
                     return Tokens[token].Length;
                 }
 
@@ -240,7 +240,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
 
                     if (_definition._wholeLine)
                     {
-                        processor.SeekForwardThrough(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition);
+                        processor.SeekSourceForwardUntil(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition, consumeToken: true);
                     }
                     else if (_definition._trimWhitespace)
                     {
@@ -252,7 +252,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
 
                 if (_current.BranchTaken)
                 {
-                    processor.SeekBackUntil(processor.EncodingConfig.LineEndings, true);
+                    processor.SeekTargetBackUntil(processor.EncodingConfig.LineEndings, true);
                     //A previous branch was taken. Skip to the endif token.
                     // NOTE: this can probably use the new method SeekToNextTokenAtSameLevel() - they do almost the same thing.
                     SkipToMatchingEndif(processor, ref bufferLength, ref currentBufferPosition, ref token);
@@ -271,7 +271,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
 
                     if (_definition._wholeLine)
                     {
-                        processor.SeekForwardUntil(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition);
+                        processor.SeekSourceForwardUntil(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition, consumeToken: false);
                     }
                     else if (_definition._trimWhitespace)
                     {
@@ -290,7 +290,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                     {
                         if (_definition.WholeLine)
                         {
-                            processor.SeekForwardThrough(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition);
+                            processor.SeekSourceForwardUntil(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition, consumeToken: true);
                         }
 
                         if (IsTokenIndexOfType(token, ElseIfTokenActionableBaseIndex))
@@ -357,7 +357,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
             {
                 if (_definition.WholeLine)
                 {
-                    processor.SeekForwardThrough(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition);
+                    processor.SeekSourceForwardUntil(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition, consumeToken: true);
                 }
 
                 bool seekSucceeded = SeekToToken(processor, ref bufferLength, ref currentBufferPosition, out token);

--- a/src/Microsoft.TemplateEngine.Core/Operations/ExpandVariables.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/ExpandVariables.cs
@@ -50,7 +50,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 bool flag;
                 if (processor.Config.Flags.TryGetValue("expandVariables", out flag) && !flag)
                 {
-                    processor.Write(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
+                    processor.WriteToTarget(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
                     return Tokens[token].Length;
                 }
 
@@ -58,7 +58,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 string output = result?.ToString() ?? "null";
 
                 byte[] outputBytes = processor.Encoding.GetBytes(output);
-                processor.Write(outputBytes, 0, outputBytes.Length);
+                processor.WriteToTarget(outputBytes, 0, outputBytes.Length);
                 return outputBytes.Length;
             }
         }

--- a/src/Microsoft.TemplateEngine.Core/Operations/Include.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/Include.cs
@@ -70,7 +70,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 bool flag;
                 if (processor.Config.Flags.TryGetValue(OperationName, out flag) && !flag)
                 {
-                    processor.Write(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
+                    processor.WriteToTarget(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
                     return Tokens[token].Length;
                 }
 
@@ -147,7 +147,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                     nBytesToWrite = totalBytesRead - bom.Length;
                 }
 
-                processor.Write(composite, offset, nBytesToWrite);
+                processor.WriteToTarget(composite, offset, nBytesToWrite);
                 return nBytesToWrite;
             }
         }

--- a/src/Microsoft.TemplateEngine.Core/Operations/InlineMarkupConditional.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/InlineMarkupConditional.cs
@@ -106,7 +106,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 bool flag;
                 if (processor.Config.Flags.TryGetValue(Conditional.OperationName, out flag) && !flag)
                 {
-                    processor.Write(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
+                    processor.WriteToTarget(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
                     return Tokens[token].Length;
                 }
 
@@ -123,7 +123,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
 
                 if (faulted)
                 {
-                    processor.Write(Tokens[0].Value, Tokens[0].Start, Tokens[0].Length);
+                    processor.WriteToTarget(Tokens[0].Value, Tokens[0].Start, Tokens[0].Length);
                     MemoryStream fragment = new MemoryStream();
                     fragment.Write(condition, 0, condition.Length);
                     fragment.Write(_closeConditionTrie.Tokens[0].Value, _closeConditionTrie.Tokens[0].Start, _closeConditionTrie.Tokens[0].Length);
@@ -141,7 +141,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                     return 0;
                 }
 
-                processor.SeekBackUntil(_scanBackTrie, true);
+                processor.SeekTargetBackUntil(_scanBackTrie, true);
                 FindEnd(processor, ref bufferLength, ref currentBufferPosition);
                 processor.WhitespaceHandler(ref bufferLength, ref currentBufferPosition, _definition.WholeLine, _definition.TrimWhitespace);
                 return 0;

--- a/src/Microsoft.TemplateEngine.Core/Operations/PhasedOperation.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/PhasedOperation.cs
@@ -118,7 +118,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 if (match != null)
                 {
                     _currentPhase = match.Next.Count > 0 ? match : null;
-                    processor.Write(match.Replacement, 0, match.Replacement.Length);
+                    processor.WriteToTarget(match.Replacement, 0, match.Replacement.Length);
                     return match.Replacement.Length;
                 }
 
@@ -127,7 +127,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                     _currentPhase = null;
                 }
 
-                processor.Write(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
+                processor.WriteToTarget(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
                 return Tokens[token].Length;
             }
         }

--- a/src/Microsoft.TemplateEngine.Core/Operations/Region.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/Region.cs
@@ -74,7 +74,7 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 bool flag;
                 if (processor.Config.Flags.TryGetValue(Region.OperationName, out flag) && !flag)
                 {
-                    processor.Write(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
+                    processor.WriteToTarget(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
                     return Tokens[token].Length;
                 }
 

--- a/src/Microsoft.TemplateEngine.Core/Operations/Replacement.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/Replacement.cs
@@ -67,11 +67,11 @@ namespace Microsoft.TemplateEngine.Core.Operations
                 bool flag;
                 if (processor.Config.Flags.TryGetValue(OperationName, out flag) && !flag)
                 {
-                    processor.Write(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
+                    processor.WriteToTarget(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
                     return Tokens[token].Length;
                 }
 
-                processor.Write(_replacement, 0, _replacement.Length);
+                processor.WriteToTarget(_replacement, 0, _replacement.Length);
                 return _replacement.Length;
             }
         }

--- a/src/Microsoft.TemplateEngine.Core/Operations/SetFlag.cs
+++ b/src/Microsoft.TemplateEngine.Core/Operations/SetFlag.cs
@@ -90,13 +90,13 @@ namespace Microsoft.TemplateEngine.Core.Operations
 
                 if (emit)
                 {
-                    processor.Write(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
+                    processor.WriteToTarget(Tokens[token].Value, Tokens[token].Start, Tokens[token].Length);
                     written = Tokens[token].Length;
                 }
                 else
                 {
                     // consume the entire line when not emitting. Otherwise the newlines on the falg tokens get emitted
-                    processor.SeekForwardThrough(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition);
+                    processor.SeekSourceForwardUntil(processor.EncodingConfig.LineEndings, ref bufferLength, ref currentBufferPosition, consumeToken: true);
                 }
 
                 //Only turn the flag in question back on if it's the "flags" flag.

--- a/src/Microsoft.TemplateEngine.Core/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Core/PublicAPI.Shipped.txt
@@ -333,11 +333,6 @@ override Microsoft.TemplateEngine.Core.TokenConfig.GetHashCode() -> int
 ~Microsoft.TemplateEngine.Core.Expressions.UnaryScope<TOperator>.Parent.set -> void
 ~Microsoft.TemplateEngine.Core.Expressions.UnaryScope<TOperator>.TryAccept(Microsoft.TemplateEngine.Core.Expressions.IEvaluable child) -> bool
 ~Microsoft.TemplateEngine.Core.Expressions.UnaryScope<TOperator>.UnaryScope(Microsoft.TemplateEngine.Core.Expressions.IEvaluable parent, TOperator operator, System.Func<object, object> evaluate) -> void
-~Microsoft.TemplateEngine.Core.Matching.OperationTerminal.Operation.get -> Microsoft.TemplateEngine.Core.Contracts.IOperation
-~Microsoft.TemplateEngine.Core.Matching.OperationTerminal.OperationTerminal(Microsoft.TemplateEngine.Core.Contracts.IOperation operation, int token, int tokenLength, int start = 0, int end = -1) -> void
-~Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>
-~Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>.Terminal.get -> T
-~Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>.TerminalLocation(T terminal, int location) -> void
 ~Microsoft.TemplateEngine.Core.Matching.Trie<T>
 ~Microsoft.TemplateEngine.Core.Matching.Trie<T>.AddPath(byte[] path, T terminal) -> void
 ~Microsoft.TemplateEngine.Core.Matching.Trie<T>.NextNodes.get -> System.Collections.Generic.Dictionary<byte, Microsoft.TemplateEngine.Core.Matching.TrieNode<T>>
@@ -460,12 +455,6 @@ Microsoft.TemplateEngine.Core.Util.ProcessorState.Encoding.get -> System.Text.En
 Microsoft.TemplateEngine.Core.Util.ProcessorState.EncodingConfig.get -> Microsoft.TemplateEngine.Core.Contracts.IEncodingConfig!
 Microsoft.TemplateEngine.Core.Util.ProcessorState.Inject(System.IO.Stream! staged) -> void
 Microsoft.TemplateEngine.Core.Util.ProcessorState.ProcessorState(System.IO.Stream! source, System.IO.Stream! target, int bufferSize, int flushThreshold, Microsoft.TemplateEngine.Core.Contracts.IEngineConfig! config, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider!>! operationProviders) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, bool consume) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekBackWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardThrough(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
 ~Microsoft.TemplateEngine.Core.Util.Token.Token(byte[] token, int index, int start = 0, int end = -1) -> void
 ~Microsoft.TemplateEngine.Core.Util.Token.Value.get -> byte[]
 ~Microsoft.TemplateEngine.Core.Util.TokenTrie.AddToken(byte[] literalToken) -> int
@@ -492,9 +481,6 @@ Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekForwardWhile(Microsoft.Tem
 ~override Microsoft.TemplateEngine.Core.Expressions.VisualBasic.VisualBasicStyleEvaluatorDefintion.GetSymbols(Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor) -> Microsoft.TemplateEngine.Core.Contracts.ITokenTrie
 ~override Microsoft.TemplateEngine.Core.Expressions.VisualBasic.VisualBasicStyleEvaluatorDefintion.NullTokenValue.get -> string
 ~override Microsoft.TemplateEngine.Core.TokenConfig.Equals(object obj) -> bool
-~static Microsoft.TemplateEngine.Core.CommonOperations.ConsumeWholeLine(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor, ref int bufferLength, ref int currentBufferPosition) -> void
-~static Microsoft.TemplateEngine.Core.CommonOperations.TrimWhitespace(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor, bool forward, bool backward, ref int bufferLength, ref int currentBufferPosition) -> void
-~static Microsoft.TemplateEngine.Core.CommonOperations.WhitespaceHandler(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor, ref int bufferLength, ref int currentBufferPosition, bool wholeLine = false, bool trim = false, bool trimForward = false, bool trimBackward = false) -> void
 ~static Microsoft.TemplateEngine.Core.Expressions.Converter.TryConvert<T>(object source, out T result) -> bool
 ~static Microsoft.TemplateEngine.Core.Expressions.Cpp.CppStyleEvaluatorDefinition.Evaluate(Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor, ref int bufferLength, ref int currentBufferPosition, out bool faulted) -> bool
 ~static Microsoft.TemplateEngine.Core.Expressions.ScopeBuilderHelper.ScopeBuilder<TOperator, TToken>(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor, Microsoft.TemplateEngine.Core.Contracts.ITokenTrie tokens, Microsoft.TemplateEngine.Core.Expressions.IOperatorMap<TOperator, TToken> operatorMap, bool dereferenceInLiterals = false) -> Microsoft.TemplateEngine.Core.Expressions.ScopeBuilder<TOperator, TToken>
@@ -533,7 +519,6 @@ Microsoft.TemplateEngine.Core.Util.Orchestrator.GetFileChanges(Microsoft.Templat
 Microsoft.TemplateEngine.Core.Util.Orchestrator.Run(string! runSpecPath, Microsoft.TemplateEngine.Abstractions.Mount.IDirectory! sourceDir, string! targetDir) -> void
 Microsoft.TemplateEngine.Core.Util.Orchestrator.Orchestrator(Microsoft.Extensions.Logging.ILogger! logger, Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem! fileSystem) -> void
 Microsoft.TemplateEngine.Core.Util.Orchestrator.Run(Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec! spec, Microsoft.TemplateEngine.Abstractions.Mount.IDirectory! sourceDir, string! targetDir) -> void
-Microsoft.TemplateEngine.Core.Util.ProcessorState.Write(byte[]! buffer, int offset, int count) -> void
 Microsoft.TemplateEngine.Core.ValueReadEventArgs.Key.get -> string!
 Microsoft.TemplateEngine.Core.ValueReadEventArgs.Value.get -> object!
 Microsoft.TemplateEngine.Core.ValueReadEventArgs.ValueReadEventArgs(string! key, object! value) -> void

--- a/src/Microsoft.TemplateEngine.Core/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,13 @@
+Microsoft.TemplateEngine.Core.Matching.OperationTerminal.Operation.get -> Microsoft.TemplateEngine.Core.Contracts.IOperation!
+Microsoft.TemplateEngine.Core.Matching.OperationTerminal.OperationTerminal(Microsoft.TemplateEngine.Core.Contracts.IOperation! operation, int token, int tokenLength, int start = 0, int end = -1) -> void
+Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>
+Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>.Terminal.get -> T!
+Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>.TerminalLocation(T! terminal, int location) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekSourceForwardUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, ref int bufferLength, ref int currentBufferPosition, bool consumeToken = false) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekSourceForwardWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekTargetBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, bool consume = false) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekTargetBackWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
+Microsoft.TemplateEngine.Core.Util.ProcessorState.WriteToTarget(byte[]! buffer, int offset, int count) -> void
+static Microsoft.TemplateEngine.Core.CommonOperations.ConsumeWholeLine(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processor, ref int bufferLength, ref int currentBufferPosition) -> void
+static Microsoft.TemplateEngine.Core.CommonOperations.TrimWhitespace(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processor, bool forward, bool backward, ref int bufferLength, ref int currentBufferPosition) -> void
+static Microsoft.TemplateEngine.Core.CommonOperations.WhitespaceHandler(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processor, ref int bufferLength, ref int currentBufferPosition, bool wholeLine = false, bool trim = false, bool trimForward = false, bool trimBackward = false) -> void

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/EvaluatorSelector.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/EvaluatorSelector.cs
@@ -3,44 +3,50 @@
 
 #nullable enable
 
-using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Expressions.Cpp;
 using Microsoft.TemplateEngine.Core.Expressions.Cpp2;
 using Microsoft.TemplateEngine.Core.Expressions.MSBuild;
 using Microsoft.TemplateEngine.Core.Expressions.VisualBasic;
 using Microsoft.TemplateEngine.Core.Operations;
+using Microsoft.TemplateEngine.Utils;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
+    internal delegate bool ConditionStringEvaluator(ILogger logger, string text, IVariableCollection variables);
+
     internal static class EvaluatorSelector
     {
+        internal static ConditionStringEvaluator SelectStringEvaluator(string? name, ConditionStringEvaluator? @default = null)
+        {
+            @default ??= CppStyleEvaluatorDefinition.EvaluateFromString;
+            string evaluatorName = name ?? string.Empty;
+            ConditionStringEvaluator evaluator = evaluatorName switch
+            {
+                "" => @default,
+                "C++2" => Cpp2StyleEvaluatorDefinition.EvaluateFromString,
+                "C++" => CppStyleEvaluatorDefinition.EvaluateFromString,
+                "MSBUILD" => MSBuildStyleEvaluatorDefinition.EvaluateFromString,
+                "VB" => VisualBasicStyleEvaluatorDefintion.EvaluateFromString,
+                _ => throw new TemplateAuthoringException($"Unrecognized evaluator: '{evaluatorName}'.", evaluatorName),
+            };
+            return evaluator;
+        }
+
         internal static ConditionEvaluator Select(string? name, ConditionEvaluator? @default = null)
         {
-            @default = @default ?? CppStyleEvaluatorDefinition.Evaluate;
+            @default ??= CppStyleEvaluatorDefinition.Evaluate;
             string evaluatorName = name ?? string.Empty;
-            ConditionEvaluator evaluator;
-
-            switch (evaluatorName)
+            ConditionEvaluator evaluator = evaluatorName switch
             {
-                case "":
-                    evaluator = @default;
-                    break;
-                case "C++2":
-                    evaluator = Cpp2StyleEvaluatorDefinition.Evaluate;
-                    break;
-                case "C++":
-                    evaluator = CppStyleEvaluatorDefinition.Evaluate;
-                    break;
-                case "MSBUILD":
-                    evaluator = MSBuildStyleEvaluatorDefinition.Evaluate;
-                    break;
-                case "VB":
-                    evaluator = VisualBasicStyleEvaluatorDefintion.Evaluate;
-                    break;
-                default:
-                    throw new Exception($"Unrecognized evaluator {evaluatorName}");
-            }
-
+                "" => @default,
+                "C++2" => Cpp2StyleEvaluatorDefinition.Evaluate,
+                "C++" => CppStyleEvaluatorDefinition.Evaluate,
+                "MSBUILD" => MSBuildStyleEvaluatorDefinition.Evaluate,
+                "VB" => VisualBasicStyleEvaluatorDefintion.Evaluate,
+                _ => throw new TemplateAuthoringException($"Unrecognized evaluator: '{evaluatorName}'.", evaluatorName),
+            };
             return evaluator;
         }
     }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
@@ -5,16 +5,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Expressions.Cpp2;
 using Microsoft.TemplateEngine.Core.Operations;
-using Microsoft.TemplateEngine.Core.Util;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig;
@@ -182,78 +179,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             }
 
             return customOperations;
-        }
-
-        internal class ProcessorState : IProcessorState
-        {
-            internal ProcessorState(IEngineEnvironmentSettings environmentSettings, IVariableCollection vars, byte[] buffer, Encoding encoding)
-            {
-                Config = new EngineConfig(environmentSettings.Host.Logger, vars);
-                CurrentBuffer = buffer;
-                CurrentBufferPosition = 0;
-                Encoding = encoding;
-                EncodingConfig = new EncodingConfig(Config, encoding);
-            }
-
-            public IEngineConfig Config { get; }
-
-            public byte[] CurrentBuffer { get; private set; }
-
-            public int CurrentBufferLength => CurrentBuffer.Length;
-
-            public int CurrentBufferPosition { get; }
-
-            public Encoding Encoding { get; set; }
-
-            public IEncodingConfig EncodingConfig { get; }
-
-            public int CurrentSequenceNumber => throw new NotImplementedException();
-
-            public bool AdvanceBuffer(int bufferPosition)
-            {
-                byte[] tmp = new byte[CurrentBufferLength - bufferPosition];
-                Buffer.BlockCopy(CurrentBuffer, bufferPosition, tmp, 0, CurrentBufferLength - bufferPosition);
-                CurrentBuffer = tmp;
-
-                return true;
-            }
-
-            public void SeekBackUntil(ITokenTrie match)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void SeekBackUntil(ITokenTrie match, bool consume)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void SeekBackWhile(ITokenTrie match)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void Write(byte[] buffer, int offset, int count) => throw new NotImplementedException();
-
-            public void SeekForwardUntil(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void SeekForwardThrough(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void SeekForwardWhile(ITokenTrie trie, ref int bufferLength, ref int currentBufferPosition)
-            {
-                throw new NotImplementedException();
-            }
-
-            public void Inject(Stream staged)
-            {
-                throw new NotImplementedException();
-            }
         }
     }
 }


### PR DESCRIPTION
### Problem
naming of some `TemplateEngine.Core` API is confusing

### Solution
Done the renames and documented selected interfaces.