### PR TITLE
2 low prio `TemplateEngine.Core` bugs

### DIFF
--- a/src/Microsoft.TemplateEngine.Core/Util/ProcessorState.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/ProcessorState.cs
@@ -256,9 +256,19 @@ namespace Microsoft.TemplateEngine.Core.Util
                 //Calculate the sequence number at the head of the buffer
                 int headSequenceNumber = CurrentSequenceNumber - CurrentBufferPosition;
 
-                // Calculate the buffer position to advance to. It can not be negative.
-                // Taking a maximum is a workaround for out-of-sync _trie.OldestRequiredSequenceNumber which may appear near EOF.
-                int bufferPositionToAdvanceTo = Math.Max(_trie.OldestRequiredSequenceNumber - headSequenceNumber, 0);
+                int bufferPositionToAdvanceTo;
+                if (headSequenceNumber > _trie.OldestRequiredSequenceNumber)
+                {
+                    // if headSequenceNumber is higher than _trie.OldestRequiredSequenceNumber
+                    // the window is already missed
+                    // we won't be able to continue with current tries anyway
+                    // advance to new chunk of the buffer.
+                    bufferPositionToAdvanceTo = CurrentBufferLength;
+                }
+                else
+                {
+                    bufferPositionToAdvanceTo = _trie.OldestRequiredSequenceNumber - headSequenceNumber;
+                }
                 int numberOfUncommittedBytesBeforeThePositionToAdvanceTo = _trie.OldestRequiredSequenceNumber - nextSequenceNumberThatCouldBeWritten;
 
                 //If we'd advance data out of the buffer that hasn't been

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/ExportOptions.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/ExportOptions.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
 {
-    public struct ExportOptions : IEquatable<ExportOptions>
+    public readonly struct ExportOptions : IEquatable<ExportOptions>
     {
         /// <summary>
         /// Creates an instance of <see cref="ExportOptions"/>.

--- a/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateString.cs
+++ b/src/Microsoft.TemplateEngine.TemplateLocalizer.Core/TemplateString.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TemplateEngine.TemplateLocalizer.Core
     /// <summary>
     /// Represents a string in template.json file that needs to be localized.
     /// </summary>
-    internal struct TemplateString : IEquatable<TemplateString>
+    internal readonly struct TemplateString : IEquatable<TemplateString>
     {
         /// <summary>
         /// Creates an instance of <see cref="TemplateString"/>.

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.CStyleEvaluator.cs
@@ -1644,5 +1644,27 @@ GAGA
             processor.Run(input, output, 999);
             Verify(Encoding.UTF8, output, true, value, expected);
         }
+
+        [Fact]
+        public void VerifyTheScopeAfterLongConditionIsNotLost()
+        {
+            //the buffer size is selected in the way so after processing the condition, the buffer is in the end and should be read
+            //for trie, the last know position is 4 and it misses the buffer window after condition processing.
+            string value = """
+                #ifdef false
+                Long text, long text, long text, long text, long text, long text, long text, long text, long text, long text, long text, long text, long tex
+                #endif
+                Long test after condition, Long test after condition,Long test after condition, Long test after condition,Long test after condition
+                """;
+            string expected = "Long test after condition, Long test after condition,Long test after condition, Long test after condition,Long test after condition";
+            byte[] valueBytes = Encoding.UTF8.GetBytes(value);
+            using MemoryStream input = new(valueBytes);
+            using MemoryStream output = new();
+
+            VariableCollection vc = new();
+            IProcessor processor = SetupCStyleNoCommentsProcessor(vc);
+            processor.Run(input, output, 20);
+            Verify(Encoding.UTF8, output, true, value, expected);
+        }
     }
 }


### PR DESCRIPTION
### Problem
~~`CppStyleEvaluatorDefinition`: if the next token is not a token this means the expression is read; no need to advance the buffer, the evaluation can be started. Previously the code attempted to advance buffer first, leading to other issues.~~ - cannot reproduce anymore

- `ProcessorState` bug: calculating the position to advance to: if `headSequenceNumber` is higher than `_trie.OldestRequiredSequenceNumber`, this means we cannot continue with `_trie.OldestRequiredSequenceNumber` position already as it is left in previous window, the buffer should be advanced to new chunk (`CurrentBufferLength`) instead. In current code processing was stopped at this point (buffer was advanced to 0).

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)