### PR TITLE
`Orchestrator.RunnableProjects`: enable nullable

### DIFF
--- a/src/Microsoft.TemplateEngine.Core.Contracts/IRunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IRunSpec.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TemplateEngine.Core.Contracts
     {
         string VariableFormatString { get; }
 
-        bool TryGetTargetRelPath(string sourceRelPath, out string targetRelPath);
+        bool TryGetTargetRelPath(string sourceRelPath, out string? targetRelPath);
 
         IReadOnlyList<IOperationProvider> GetOperations(IReadOnlyList<IOperationProvider> sourceOperations);
     }

--- a/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Shipped.txt
@@ -77,7 +77,6 @@ Microsoft.TemplateEngine.Core.Contracts.IProcessorState.Inject(System.IO.Stream!
 Microsoft.TemplateEngine.Core.Contracts.IReplacementTokens.OriginalValue.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig!
 Microsoft.TemplateEngine.Core.Contracts.IReplacementTokens.VariableName.get -> string!
 Microsoft.TemplateEngine.Core.Contracts.IRunSpec.GetOperations(System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider!>! sourceOperations) -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider!>!
-Microsoft.TemplateEngine.Core.Contracts.IRunSpec.TryGetTargetRelPath(string! sourceRelPath, out string! targetRelPath) -> bool
 Microsoft.TemplateEngine.Core.Contracts.IRunSpec.VariableFormatString.get -> string!
 Microsoft.TemplateEngine.Core.Contracts.IToken.Value.get -> byte[]!
 Microsoft.TemplateEngine.Core.Contracts.ITokenConfig.After.get -> string!

--- a/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
@@ -6,4 +6,5 @@ Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekSourceForwardWhile(M
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekTargetBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, bool consumeToken = false) -> void
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekTargetBackWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.WriteToTarget(byte[]! buffer, int offset, int count) -> void
+Microsoft.TemplateEngine.Core.Contracts.IRunSpec.TryGetTargetRelPath(string! sourceRelPath, out string? targetRelPath) -> bool
 Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.AddToken(Microsoft.TemplateEngine.Core.Contracts.IToken? token, int index) -> void

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Abstractions/IDeferredMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Abstractions/IDeferredMacro.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Abstractions/IMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Abstractions/IMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Abstractions/IMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Abstractions/IMacroConfig.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions
 {
     /// <summary>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Abstractions/IOperationConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Abstractions/IOperationConfig.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/BindSymbolEvaluator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/BindSymbolEvaluator.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Components.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Components.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BaseReplaceSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BaseReplaceSymbol.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BaseSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BaseSymbol.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BaseValueSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BaseValueSymbol.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Newtonsoft.Json.Linq;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BindSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BindSymbol.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ComputedSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ComputedSymbol.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ConditionedConfigurationElement.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ConditionedConfigurationElement.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Core.Contracts;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/CustomFileGlobModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/CustomFileGlobModel.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Core.Contracts;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/CustomOperationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/CustomOperationModel.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/DerivedSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/DerivedSymbol.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ExtendedFileSource.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ExtendedFileSource.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/GeneratedSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/GeneratedSymbol.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Utils;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ManualInstructionModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ManualInstructionModel.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel
 {
     /// <summary>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ParameterSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ParameterSymbol.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/PostActionModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/PostActionModel.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/PrimaryOutputModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/PrimaryOutputModel.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ReplacementContext.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ReplacementContext.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/SourceModifier.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/SourceModifier.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/SymbolModelConverter.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/SymbolModelConverter.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/SymbolValueFormsModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/SymbolValueFormsModel.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/TemplateConfigModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/TemplateConfigModel.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationEffects.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationEffects.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationPath.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationPath.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationResult.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CreationResult.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CryptoRandom.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/CryptoRandom.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Security.Cryptography;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/EvaluatorSelector.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/EvaluatorSelector.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Expressions.Cpp;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileRenameGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/FileRenameGenerator.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunSpec.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ILocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ILocalizationModel.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IPostActionLocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IPostActionLocalizationModel.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IRunnableProjectConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IRunnableProjectConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ListGlobbingPatternMatcher.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ListGlobbingPatternMatcher.cs
@@ -11,7 +11,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
     {
         private readonly IReadOnlyList<IPathMatcher> _pathMatchers;
 
-        private string _displayPattern;
+        private string? _displayPattern;
 
         internal ListGlobbingPatternMatcher(IList<string> patternList)
         {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/LocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/LocalizationModel.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/ParameterSymbolLocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/ParameterSymbolLocalizationModel.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/PostActionLocalizationModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Localization/PostActionLocalizationModel.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Localization

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizationModelDeserializer.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizationModelDeserializer.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CaseChangeMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CaseChangeMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CoalesceMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CoalesceMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/CaseChangeMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/CaseChangeMacroConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/CoalesceMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/CoalesceMacroConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/ConstantMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/ConstantMacroConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/EvaluateMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/EvaluateMacroConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GeneratePortNumberConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GeneratePortNumberConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GeneratedSymbolDeferredMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GeneratedSymbolDeferredMacroConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GuidMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/GuidMacroConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/JoinMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/JoinMacroConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/NowMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/NowMacroConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/ProcessValueFormMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/ProcessValueFormMacroConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/RandomMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/RandomMacroConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/RegexMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/RegexMacroConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/RegexMatchMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/RegexMatchMacroConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros.Config

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/SwitchMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/Config/SwitchMacroConfig.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ConstantMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ConstantMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/EvaluateMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/EvaluateMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GeneratePortNumberMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GeneratePortNumberMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GuidMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GuidMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/JoinMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/JoinMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/NowMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/NowMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ProcessValueFormMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ProcessValueFormMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RandomMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RandomMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMatchMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMatchMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/SwitchMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/SwitchMacro.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj
@@ -6,6 +6,7 @@
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/BalancedNestingConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/BalancedNestingConfig.cs
@@ -21,11 +21,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
         public IEnumerable<IOperationProvider> ConfigureFromJson(string configuration, IDirectory templateRoot)
         {
             JObject rawConfiguration = JObject.Parse(configuration);
-            string startToken = rawConfiguration.ToString("startToken");
-            string realEndToken = rawConfiguration.ToString("realEndToken");
-            string pseudoEndToken = rawConfiguration.ToString("pseudoEndToken");
-            string id = rawConfiguration.ToString("id");
-            string resetFlag = rawConfiguration.ToString("resetFlag");
+            string? startToken = rawConfiguration.ToString("startToken");
+            string? realEndToken = rawConfiguration.ToString("realEndToken");
+            string? pseudoEndToken = rawConfiguration.ToString("pseudoEndToken");
+            string? id = rawConfiguration.ToString("id");
+            string? resetFlag = rawConfiguration.ToString("resetFlag");
             bool onByDefault = rawConfiguration.ToBool("onByDefault");
 
             yield return new BalancedNesting(startToken.TokenConfig(), realEndToken.TokenConfig(), pseudoEndToken.TokenConfig(), id, resetFlag, onByDefault);

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ConditionalBlockCommentConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ConditionalBlockCommentConfig.cs
@@ -15,8 +15,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
     {
         internal static List<IOperationProvider> ConfigureFromJObject(JObject rawConfiguration)
         {
-            string startToken = rawConfiguration.ToString("startToken");
-            string endToken = rawConfiguration.ToString("endToken");
+            string? startToken = rawConfiguration.ToString("startToken");
+            string? endToken = rawConfiguration.ToString("endToken");
 
             if (string.IsNullOrWhiteSpace(startToken))
             {
@@ -27,7 +27,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
                 throw new TemplateAuthoringException($"Template authoring error. EndToken must be defined", "EndToken");
             }
 
-            string pseudoEndToken = rawConfiguration.ToString("pseudoEndToken");
+            string? pseudoEndToken = rawConfiguration.ToString("pseudoEndToken");
 
             ConditionalKeywords keywords = ConditionalKeywords.FromJObject(rawConfiguration);
             ConditionalOperationOptions options = ConditionalOperationOptions.FromJObject(rawConfiguration);
@@ -47,11 +47,11 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
             return GenerateConditionalSetup(startToken, endToken, new ConditionalKeywords(), new ConditionalOperationOptions());
         }
 
-        internal static List<IOperationProvider> GenerateConditionalSetup(string startToken, string endToken, ConditionalKeywords keywords, ConditionalOperationOptions options)
+        internal static List<IOperationProvider> GenerateConditionalSetup(string? startToken, string? endToken, ConditionalKeywords keywords, ConditionalOperationOptions options)
         {
-            string pseudoEndComment;
+            string? pseudoEndComment;
 
-            if (endToken.Length < 2)
+            if (endToken is null || endToken.Length < 2)
             {
                 // end comment must be at least two characters to have a programmatically determined pseudo-comment
                 pseudoEndComment = null;
@@ -65,12 +65,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
             return GenerateConditionalSetup(startToken, endToken, pseudoEndComment, keywords, options);
         }
 
-        internal static List<IOperationProvider> GenerateConditionalSetup(string startToken, string endToken, string pseudoEndToken)
+        internal static List<IOperationProvider> GenerateConditionalSetup(string? startToken, string? endToken, string? pseudoEndToken)
         {
             return GenerateConditionalSetup(startToken, endToken, pseudoEndToken, new ConditionalKeywords(), new ConditionalOperationOptions());
         }
 
-        internal static List<IOperationProvider> GenerateConditionalSetup(string startToken, string endToken, string pseudoEndToken, ConditionalKeywords keywords, ConditionalOperationOptions options)
+        internal static List<IOperationProvider> GenerateConditionalSetup(string? startToken, string? endToken, string? pseudoEndToken, ConditionalKeywords keywords, ConditionalOperationOptions options)
         {
             ConditionEvaluator evaluator = EvaluatorSelector.Select(options.EvaluatorType);
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ConditionalConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ConditionalConfig.cs
@@ -22,7 +22,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
         public IEnumerable<IOperationProvider> ConfigureFromJson(string configuration, IDirectory templateRoot)
         {
             JObject rawConfiguration = JObject.Parse(configuration);
-            string commentStyle = rawConfiguration.ToString("style");
+            string? commentStyle = rawConfiguration.ToString("style");
             IEnumerable<IOperationProvider> operations = string.IsNullOrEmpty(commentStyle) || string.Equals(commentStyle, "custom", StringComparison.OrdinalIgnoreCase)
                 ? ConditionalCustomConfig.ConfigureFromJObject(rawConfiguration)
                 : string.Equals(commentStyle, "line", StringComparison.OrdinalIgnoreCase)
@@ -36,7 +36,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
             }
         }
 
-        internal static IReadOnlyList<IOperationProvider> ConditionalSetup(ConditionalType style, string evaluatorType, bool wholeLine, bool trimWhiteSpace, string id)
+        internal static IReadOnlyList<IOperationProvider> ConditionalSetup(ConditionalType style, string evaluatorType, bool wholeLine, bool trimWhiteSpace, string? id)
         {
             List<IOperationProvider> setup;
 
@@ -134,7 +134,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
         }
 
         // Nice to have: Generalize this type of setup similarly to Line, Block, & Custom
-        internal static List<IOperationProvider> CStyleNoCommentsConditionalSetup(string evaluatorType, bool wholeLine, bool trimWhiteSpace, string id)
+        internal static List<IOperationProvider> CStyleNoCommentsConditionalSetup(string evaluatorType, bool wholeLine, bool trimWhiteSpace, string? id)
         {
             ConditionalKeywords defaultKeywords = new ConditionalKeywords();
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ConditionalCustomConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ConditionalCustomConfig.cs
@@ -21,12 +21,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
             IReadOnlyList<string> actionableElseIfToken = rawConfiguration.ArrayAsStrings("actionableElseif");
             IReadOnlyList<string> actionsToken = rawConfiguration.ArrayAsStrings("actions");
             IReadOnlyList<string> endIfToken = rawConfiguration.ArrayAsStrings("endif");
-            string id = rawConfiguration.ToString("id");
+            string? id = rawConfiguration.ToString("id");
             bool trim = rawConfiguration.ToBool("trim");
             bool wholeLine = rawConfiguration.ToBool("wholeLine");
             bool onByDefault = rawConfiguration.ToBool("onByDefault");
 
-            string evaluatorName = rawConfiguration.ToString("evaluator");
+            string? evaluatorName = rawConfiguration.ToString("evaluator");
             ConditionEvaluator evaluator = EvaluatorSelector.Select(evaluatorName);
 
             ConditionalTokens tokenVariants = new ConditionalTokens

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ConditionalKeywords.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ConditionalKeywords.cs
@@ -38,31 +38,31 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
         internal static ConditionalKeywords FromJObject(JObject rawConfiguration)
         {
             ConditionalKeywords keywords = new ConditionalKeywords();
-            string ifKeyword = rawConfiguration.ToString("ifKeyword");
+            string? ifKeyword = rawConfiguration.ToString("ifKeyword");
             if (!string.IsNullOrWhiteSpace(ifKeyword))
             {
-                keywords.IfKeywords = new[] { ifKeyword };
+                keywords.IfKeywords = new[] { ifKeyword! };
             }
 
-            string elseIfKeyword = rawConfiguration.ToString("elseIfKeyword");
+            string? elseIfKeyword = rawConfiguration.ToString("elseIfKeyword");
             if (!string.IsNullOrWhiteSpace(elseIfKeyword))
             {
-                keywords.ElseIfKeywords = new[] { elseIfKeyword };
+                keywords.ElseIfKeywords = new[] { elseIfKeyword! };
             }
 
-            string elseKeyword = rawConfiguration.ToString("elseKeyword");
+            string? elseKeyword = rawConfiguration.ToString("elseKeyword");
             if (!string.IsNullOrWhiteSpace(elseKeyword))
             {
-                keywords.ElseKeywords = new[] { elseKeyword };
+                keywords.ElseKeywords = new[] { elseKeyword! };
             }
 
-            string endIfKeyword = rawConfiguration.ToString("endIfKeyword");
+            string? endIfKeyword = rawConfiguration.ToString("endIfKeyword");
             if (!string.IsNullOrWhiteSpace(endIfKeyword))
             {
-                keywords.EndIfKeywords = new[] { endIfKeyword };
+                keywords.EndIfKeywords = new[] { endIfKeyword! };
             }
 
-            string prefixString = rawConfiguration.ToString("keywordPrefix");
+            string? prefixString = rawConfiguration.ToString("keywordPrefix");
             if (prefixString != null)
             {
                 // Empty string is a valid value for keywordPrefix, null is not.

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ConditionalLineCommentConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ConditionalLineCommentConfig.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
     {
         internal static List<IOperationProvider> ConfigureFromJObject(JObject rawConfiguration)
         {
-            string token = rawConfiguration.ToString("token");
+            string? token = rawConfiguration.ToString("token");
 
             if (string.IsNullOrWhiteSpace(token))
             {
@@ -33,7 +33,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
             return GenerateConditionalSetup(token, new ConditionalKeywords(), new ConditionalOperationOptions());
         }
 
-        internal static List<IOperationProvider> GenerateConditionalSetup(string token, ConditionalKeywords keywords, ConditionalOperationOptions options)
+        internal static List<IOperationProvider> GenerateConditionalSetup(string? token, ConditionalKeywords keywords, ConditionalOperationOptions options)
         {
             string uncommentOperationId = $"Uncomment (line): {token} -> ()";
             string reduceCommentOperationId = $"Reduce comment (line): ({token}{token}) -> ({token})";

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ConditionalOperationOptions.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ConditionalOperationOptions.cs
@@ -10,14 +10,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
         private const string DefaultEvaluatorType = "C++";
         private const bool DefaultWholeLine = true;
         private const bool DefaultTrimWhitespace = true;
-        private static readonly string DefaultId;
 
         internal ConditionalOperationOptions()
         {
             EvaluatorType = DefaultEvaluatorType;
             WholeLine = DefaultWholeLine;
             TrimWhitespace = DefaultTrimWhitespace;
-            Id = DefaultId;
         }
 
         internal string EvaluatorType { get; set; }
@@ -26,7 +24,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
 
         internal bool TrimWhitespace { get; set; }
 
-        internal string Id { get; set; }
+        internal string? Id { get; set; }
 
         internal bool OnByDefault { get; set; }
 
@@ -34,20 +32,20 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
         {
             ConditionalOperationOptions options = new ConditionalOperationOptions();
 
-            string evaluatorType = rawConfiguration.ToString("evaluator");
+            string? evaluatorType = rawConfiguration.ToString("evaluator");
             if (!string.IsNullOrWhiteSpace(evaluatorType))
             {
-                options.EvaluatorType = evaluatorType;
+                options.EvaluatorType = evaluatorType!;
             }
 
             options.TrimWhitespace = rawConfiguration.ToBool("trim", true);
             options.WholeLine = rawConfiguration.ToBool("wholeLine", true);
             options.OnByDefault = rawConfiguration.ToBool("onByDefault");
 
-            string id = rawConfiguration.ToString("id");
+            string? id = rawConfiguration.ToString("id");
             if (!string.IsNullOrWhiteSpace(id))
             {
-                options.Id = id;
+                options.Id = id!;
             }
 
             return options;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/FlagsConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/FlagsConfig.cs
@@ -28,13 +28,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
         public IEnumerable<IOperationProvider> ConfigureFromJson(string configuration, IDirectory templateRoot)
         {
             JObject rawConfiguration = JObject.Parse(configuration);
-            string flag = rawConfiguration.ToString("name");
+            string? flag = rawConfiguration.ToString("name");
             string on = rawConfiguration.ToString("on") ?? string.Empty;
             string off = rawConfiguration.ToString("off") ?? string.Empty;
             string onNoEmit = rawConfiguration.ToString("onNoEmit") ?? string.Empty;
             string offNoEmit = rawConfiguration.ToString("offNoEmit") ?? string.Empty;
-            string defaultStr = rawConfiguration.ToString("default");
-            string id = rawConfiguration.ToString("id");
+            string? defaultStr = rawConfiguration.ToString("default");
+            string? id = rawConfiguration.ToString("id");
             bool onByDefault = rawConfiguration.ToBool("onByDefault");
             bool? @default = null;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/IncludeConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/IncludeConfig.cs
@@ -22,12 +22,12 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
         public IEnumerable<IOperationProvider> ConfigureFromJson(string configuration, IDirectory templateRoot)
         {
             JObject rawConfiguration = JObject.Parse(configuration);
-            string startToken = rawConfiguration.ToString("start");
-            string endToken = rawConfiguration.ToString("end");
-            string id = rawConfiguration.ToString("id");
+            string? startToken = rawConfiguration.ToString("start");
+            string? endToken = rawConfiguration.ToString("end");
+            string? id = rawConfiguration.ToString("id");
             bool onByDefault = rawConfiguration.ToBool("onByDefault");
 
-            yield return new Include(startToken.TokenConfig(), endToken.TokenConfig(), x => templateRoot.FileInfo(x).OpenRead(), id, onByDefault);
+            yield return new Include(startToken.TokenConfig(), endToken.TokenConfig(), x => templateRoot.FileInfo(x)?.OpenRead(), id, onByDefault);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/MacrosOperationConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/MacrosOperationConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/RegionConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/RegionConfig.cs
@@ -21,9 +21,9 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
         public IEnumerable<IOperationProvider> ConfigureFromJson(string configuration, IDirectory templateRoot)
         {
             JObject rawConfiguration = JObject.Parse(configuration);
-            string id = rawConfiguration.ToString("id");
-            string start = rawConfiguration.ToString("start");
-            string end = rawConfiguration.ToString("end");
+            string? id = rawConfiguration.ToString("id");
+            string? start = rawConfiguration.ToString("start");
+            string? end = rawConfiguration.ToString("end");
             bool include = rawConfiguration.ToBool("include");
             bool regionTrim = rawConfiguration.ToBool("trim");
             bool regionWholeLine = rawConfiguration.ToBool("wholeLine");

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ReplacementConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/ReplacementConfig.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Parameter.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Parameter.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ParameterConverter.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ParameterConverter.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostAction.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostAction.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunSpec.cs
@@ -10,7 +10,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
     {
         private readonly IReadOnlyList<IOperationProvider> _overrides;
 
-        internal RunSpec(IReadOnlyList<IOperationProvider> operationOverrides, string variableFormatString)
+        internal RunSpec(IReadOnlyList<IOperationProvider> operationOverrides, string? variableFormatString)
         {
             _overrides = operationOverrides;
             VariableFormatString = variableFormatString ?? "{0}";
@@ -18,7 +18,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         public string VariableFormatString { get; }
 
-        public bool TryGetTargetRelPath(string sourceRelPath, out string targetRelPath)
+        public bool TryGetTargetRelPath(string sourceRelPath, out string? targetRelPath)
         {
             targetRelPath = null;
             return false;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.ITemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.ITemplateInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModifiers.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/SimpleConfigModifiers.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects;
 
 namespace Microsoft.TemplateEngine.Utils

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/TemplateValidationException.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/TemplateValidationException.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/UnicodeCharacterUtilities.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/UnicodeCharacterUtilities.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Globalization;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Utilities

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueFormRegistry.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueFormRegistry.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ActionableValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ActionableValueFormFactory.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/BaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/BaseValueFormFactory.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ChainValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ChainValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ConfigurableValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ConfigurableValueFormFactory.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNameValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNameValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     internal class DefaultLowerSafeNameValueFormFactory : ActionableValueFormFactory

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNamespaceValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultLowerSafeNamespaceValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     internal class DefaultLowerSafeNamespaceValueFormFactory : ActionableValueFormFactory

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNameValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNameValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Text.RegularExpressions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNamespaceValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DefaultSafeNamespaceValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Text;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Utilities;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DependantValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/DependantValueFormFactory.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstLowerCaseInvariantValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstLowerCaseInvariantValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstLowerCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstLowerCaseValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstUpperCaseInvariantValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstUpperCaseInvariantValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstUpperCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/FirstUpperCaseValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IValueForm.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IValueForm.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IValueFormFactory.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IdentityValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/IdentityValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     internal class IdentityValueFormFactory : ActionableValueFormFactory

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/JsonEncodeValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/JsonEncodeValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using Newtonsoft.Json;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/KebabCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/KebabCaseValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Linq;
 using System.Text.RegularExpressions;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/LowerCaseInvariantValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/LowerCaseInvariantValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     internal class LowerCaseInvariantValueFormFactory : ActionableValueFormFactory

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/LowerCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/LowerCaseValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     internal class LowerCaseValueFormFactory : ActionableValueFormFactory

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ReplacementValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/ReplacementValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/TitleCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/TitleCaseValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Globalization;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/UpperCaseInvariantValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/UpperCaseInvariantValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     internal class UpperCaseInvariantValueFormFactory : ActionableValueFormFactory

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/UpperCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/UpperCaseValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
     internal class UpperCaseValueFormFactory : ActionableValueFormFactory

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/XmlEncodeValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/XmlEncodeValueFormFactory.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Text;
 using System.Xml;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/VariableConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/VariableConfig.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable enable
-
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Core.Contracts;
 


### PR DESCRIPTION
### Problem
Nullable is not enabled in `Orchestrator.RunnableProjects`

### Solution
Enabled nullable project wide, with KISS fixes of remaining failures.
Important commit: https://github.com/dotnet/templating/pull/5298/commits/59373f6edfa596d8ce7b2d488bf638af51d8a702

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)