### PR TITLE
Fix dependabot does not update package versions

### DIFF
--- a/eng/Package.props
+++ b/eng/Package.props
@@ -1,6 +1,36 @@
 <Project>
   <!-- Import references updated by Dependabot. This file is for package references updated manually or by Darc/Maestro. -->
   <Import Project="dependabot\Packages.props" />
+  <!-- Override package versions in dependabot\Packages.props for source build -->
+  <!-- Packages must be set to their package version property if it exists (ex. BenchmarkDotNetVersion) since source-build uses
+  these properties to override package versions if necessary. -->
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <PackageReference Update="System.Diagnostics.Process" Condition="'$(SystemDiagnosticsProcessVersion)' != ''" Version="$(SystemDiagnosticsProcessVersion)" />
+    <PackageReference Update="System.IO.Compression" Condition="'$(SystemIOCompressionVersion)' != ''" Version="$(SystemIOCompressionVersion)" />
+    <PackageReference Update="System.Runtime.Loader" Condition="'$(SystemRuntimeLoaderVersion)' != ''" Version="$(SystemRuntimeLoaderVersion)" />
+    <PackageReference Update="Microsoft.Build.Framework" Condition="'$(MicrosoftBuildFrameworkVersion)' != ''" Version="$(MicrosoftBuildFrameworkVersion)" />
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Condition="'$(MicrosoftBuildUtilitiesCoreVersion)' != ''" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJsonVersion)' != ''" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Update="Wcwidth.Sources" Condition="'$(WcwidthSourcesVersion)' != ''" Version="$(WcwidthSourcesVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Condition="'$(MicrosoftExtensionsLoggingVersion)' != ''" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Console" Condition="'$(MicrosoftExtensionsLoggingConsoleVersion)' != ''" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Condition="'$(MicrosoftExtensionsLoggingAbstractionsVersion)' != ''" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
+    <PackageReference Update="NuGet.Configuration" Condition="'$(NuGetConfigurationVersion)' != ''" Version="$(NuGetConfigurationVersion)" />
+    <PackageReference Update="NuGet.Credentials" Condition="'$(NuGetCredentialsVersion)' != ''" Version="$(NuGetCredentialsVersion)" />
+    <PackageReference Update="NuGet.Protocol" Condition="'$(NuGetProtocolVersion)' != ''" Version="$(NuGetProtocolVersion)" />
+
+    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
+    <PackageReference Update="StyleCop.Analyzers" Condition="'$(StyleCopAnalyzersVersion)' != ''" Version="$(StyleCopAnalyzersVersion)" />
+
+    <PackageReference Update="FakeItEasy" Condition="'$(FakeItEasyVersion)' != ''" Version="$(FakeItEasyVersion)" />
+    <PackageReference Update="FluentAssertions" Condition="'$(FluentAssertionsVersion)' != ''" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Condition="'$(MicrosoftNETTestSdkVersion)' != ''" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Update="xunit.abstractions" Condition="'$(xunitabstractionsVersion)' != ''" Version="$(xunitabstractionsVersion)" />
+    <PackageReference Update="Newtonsoft.Json.Schema" Condition="'$(NewtonsoftJsonSchemaVersion)' != ''" Version="$(NewtonsoftJsonSchemaVersion)" />
+    <PackageReference Update="Verify.XUnit" Condition="'$(VerifyXUnitVersion)' != ''" Version="$(VerifyXUnitVersion)" />
+    <PackageReference Update="Verify.DiffPlex" Condition="'$(VerifyDiffPlexVersion)' != ''" Version="$(VerifyDiffPlexVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Update="System.CommandLine" Version="$(SystemCommandLinePackageVersion)" />
     <!--Analyzer dependencies-->

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -1,9 +1,6 @@
 <Project>
 
-  <!-- Packages in this file have versions updated periodically by Dependabot. Versions managed by Darc/Maestro should be in ..\Package.props.
-
-  Packages must be set to their package version property if it exists (ex. BenchmarkDotNetVersion) since source-build uses
-  these properties to override package versions if necessary. -->
+  <!-- Packages in this file have versions updated periodically by Dependabot. Versions managed by Darc/Maestro should be in ..\Package.props. -->
 
   <ItemGroup>
     <PackageReference Update="System.Diagnostics.Process" Version="4.3.0" />
@@ -32,32 +29,5 @@
     <PackageReference Update="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Update="Verify.XUnit" Version="17.2.1" />
     <PackageReference Update="Verify.DiffPlex" Version="1.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
-    <PackageReference Update="System.Diagnostics.Process" Condition="'$(SystemDiagnosticsProcessVersion)' != ''" Version="$(SystemDiagnosticsProcessVersion)" />
-    <PackageReference Update="System.IO.Compression" Condition="'$(SystemIOCompressionVersion)' != ''" Version="$(SystemIOCompressionVersion)" />
-    <PackageReference Update="System.Runtime.Loader" Condition="'$(SystemRuntimeLoaderVersion)' != ''" Version="$(SystemRuntimeLoaderVersion)" />
-    <PackageReference Update="Microsoft.Build.Framework" Condition="'$(MicrosoftBuildFrameworkVersion)' != ''" Version="$(MicrosoftBuildFrameworkVersion)" />
-    <PackageReference Update="Microsoft.Build.Utilities.Core" Condition="'$(MicrosoftBuildUtilitiesCoreVersion)' != ''" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
-    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJsonVersion)' != ''" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Update="Wcwidth.Sources" Condition="'$(WcwidthSourcesVersion)' != ''" Version="$(WcwidthSourcesVersion)" />
-    <PackageReference Update="Microsoft.Extensions.Logging" Condition="'$(MicrosoftExtensionsLoggingVersion)' != ''" Version="$(MicrosoftExtensionsLoggingVersion)" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Console" Condition="'$(MicrosoftExtensionsLoggingConsoleVersion)' != ''" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Condition="'$(MicrosoftExtensionsLoggingAbstractionsVersion)' != ''" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
-    <PackageReference Update="NuGet.Configuration" Condition="'$(NuGetConfigurationVersion)' != ''" Version="$(NuGetConfigurationVersion)" />
-    <PackageReference Update="NuGet.Credentials" Condition="'$(NuGetCredentialsVersion)' != ''" Version="$(NuGetCredentialsVersion)" />
-    <PackageReference Update="NuGet.Protocol" Condition="'$(NuGetProtocolVersion)' != ''" Version="$(NuGetProtocolVersion)" />
-
-    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
-    <PackageReference Update="StyleCop.Analyzers" Condition="'$(StyleCopAnalyzersVersion)' != ''" Version="$(StyleCopAnalyzersVersion)" />
-
-    <PackageReference Update="FakeItEasy" Condition="'$(FakeItEasyVersion)' != ''" Version="$(FakeItEasyVersion)" />
-    <PackageReference Update="FluentAssertions" Condition="'$(FluentAssertionsVersion)' != ''" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Condition="'$(MicrosoftNETTestSdkVersion)' != ''" Version="$(MicrosoftNETTestSdkVersion)" />
-    <PackageReference Update="xunit.abstractions" Condition="'$(xunitabstractionsVersion)' != ''" Version="$(xunitabstractionsVersion)" />
-    <PackageReference Update="Newtonsoft.Json.Schema" Condition="'$(NewtonsoftJsonSchemaVersion)' != ''" Version="$(NewtonsoftJsonSchemaVersion)" />
-    <PackageReference Update="Verify.XUnit" Condition="'$(VerifyXUnitVersion)' != ''" Version="$(VerifyXUnitVersion)" />
-    <PackageReference Update="Verify.DiffPlex" Condition="'$(VerifyDiffPlexVersion)' != ''" Version="$(VerifyDiffPlexVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Problem
Dependabot doesn't update package version with latest one. From its check log, the latest version is found, but no update needed for the old version. For example, NuGet.Configuration in the check https://github.com/dotnet/templating/network/updates/464268635 

### Solution
Dependabot is not happy with the section overriding package versions for source build. Without that part, Dependabot could work well in my test repo. I guess the version property causes the problem. Hence move the section overriding package versions for source build to `eng/Package.props`

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)