### PR TITLE
[release/6.0.1xx] Update VM images for Windows and Linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,10 +62,11 @@ stages:
       - job: Windows_NT
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            vmImage: windows-2019
+            name: NetCore-Svc-Public
+            vmImage: 1es-windows-2019-open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Svc-Internal
-            demands: ImageOverride -equals build.windows.10.amd64.vs2019
+            demands: ImageOverride -equals windows.vs2019.amd64
 
         variables:
         - _InternalBuildArgs: ''
@@ -150,10 +151,10 @@ stages:
         - job: Linux
           pool:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              vmImage: ubuntu-18.04
+              vmImage: ubuntu-latest
             ${{ if eq(variables['System.TeamProject'], 'internal') }}:
               name: NetCore1ESPool-Svc-Internal
-              demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+              demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
           strategy:
             matrix:
               debug_configuration:

--- a/eng/common/templates/job/source-build.yml
+++ b/eng/common/templates/job/source-build.yml
@@ -47,10 +47,10 @@ jobs:
     pool:
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
         name: NetCore-Svc-Public
-        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64.Open
+        demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
+        demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
   ${{ if ne(parameters.platform.pool, '') }}:
     pool: ${{ parameters.platform.pool }}
 

--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -10,7 +10,8 @@ schedules:
   always: true
 
 pool:
-    name: Hosted Ubuntu 1604
+    name: NetCore1ESPool-Svc-Internal
+    demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
 
 steps:
 - checkout: self


### PR DESCRIPTION
### Problem

- #5002
- ubuntu-18.04 is deprecated.

### Solution
<!-- Describe the solution. -->

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)