### PR TITLE
Output passed parameters/variables for investigating odd CI issue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,8 +45,6 @@ stages:
       parameters:
         MirrorRepo: templating
         LclSource: lclFilesfromPackage
-        MirrorBranch: $(OneLocBuildBranch)
-        LclPackageId: 'LCL-JUNO-PROD-TEMPLATING'
         ${{ if eq(variables['Build.SourceBranch'], format('{0}{1}', 'refs/heads/', variables['OneLocBuildBranch'])) }}:
           MirrorBranch: $(OneLocBuildBranch)
           LclPackageId: 'LCL-JUNO-PROD-TEMPLATING'

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -55,6 +55,10 @@ jobs:
       
 
   steps:
+    - script: echo $(Build.SourceBranch)
+    - script: echo $(OneLocBuildBranch)
+    - script: echo ${{ parameters.MirrorBranch }}
+    - script: echo ${{ parameters.LclPackageId }}
     - task: Powershell@2
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/common/generate-locproject.ps1


### PR DESCRIPTION
### Problem
OneLocBuild for release/7.0.1xx has to force passing the parameter while the conditional parameter logic doesn't get the parameter passed to the job.

### Solution
For investigation output the values of the parameters/variables without force passing the parameters.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)