### PR TITLE
Convert conditional parameters to conditional jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,13 +45,16 @@ stages:
       parameters:
         MirrorRepo: templating
         LclSource: lclFilesfromPackage
-        ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-          LclPackageId: 'LCL-JUNO-PROD-TMPLTNGMAIN'
-          MirrorBranch: 'main'
-        ${{ if eq(variables['Build.SourceBranch'], format('{0}{1}', 'refs/heads/', variables['OneLocBuildBranch'])) }}:
-          LclPackageId: 'LCL-JUNO-PROD-TEMPLATING'
-          MirrorBranch: $(OneLocBuildBranch)
-        condition: or(eq(variables['Build.SourceBranch'], format('{0}{1}', 'refs/heads/', variables['OneLocBuildBranch'] )), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+        LclPackageId: 'LCL-JUNO-PROD-TEMPLATING'
+        MirrorBranch: $(OneLocBuildBranch)
+        condition: eq(variables['Build.SourceBranch'], format('{0}{1}', 'refs/heads/', variables['OneLocBuildBranch'] ))
+    - template: /eng/common/templates/job/onelocbuild.yml
+      parameters:
+        MirrorRepo: templating
+        LclSource: lclFilesfromPackage
+        LclPackageId: 'LCL-JUNO-PROD-TMPLTNGMAIN'
+        MirrorBranch: 'main'
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -55,10 +55,6 @@ jobs:
       
 
   steps:
-    - script: echo $(Build.SourceBranch)
-    - script: echo $(OneLocBuildBranch)
-    - script: echo ${{ parameters.MirrorBranch }}
-    - script: echo ${{ parameters.LclPackageId }}
     - task: Powershell@2
       inputs:
         filePath: $(Build.SourcesDirectory)/eng/common/generate-locproject.ps1


### PR DESCRIPTION
### Problem
#5288 

### Solution
Conditional parameters are not supported in Azure pipelines (https://learn.microsoft.com/en-us/azure/devops/pipelines/process/runtime-parameters?view=azure-devops&tabs=script), so we need to either conver them to conditions on the job execution itself (leads to small duplication in our pipleline steps definition) or we'de need to change the OneLocBuild job to accept variables. Going for the easier (first) solution for now

### Checks: N/A
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)