### PR TITLE
Make InputDataSet params case insensitive again

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Template/InputDataSet.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/InputDataSet.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -43,7 +44,7 @@ public class InputDataSet : IReadOnlyDictionary<ITemplateParameter, InputParamet
     /// <param name="templateInfo"></param>
     /// <param name="inputParameters"></param>
     public InputDataSet(ITemplateInfo templateInfo, IReadOnlyDictionary<string, string?> inputParameters)
-        : this(templateInfo, inputParameters.ToDictionary(p => p.Key, p => (object?)p.Value))
+        : this(templateInfo, inputParameters.ToDictionary(p => p.Key, p => (object?)p.Value, StringComparer.OrdinalIgnoreCase))
     { }
 
     private InputDataSet(ITemplateInfo templateInfo, IReadOnlyDictionary<string, object?>? inputParameters)

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/TemplateCreatorTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/TemplateCreatorTests.cs
@@ -119,6 +119,41 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
                 parameters1: parameters);
         }
 
+        [Theory]
+        [InlineData("paramA", "paramA", true, "Line to be generated")]
+        [InlineData("paramA", "paramA", false, "")]
+        // parameters in content file are case sensitive
+        [InlineData("PARAMa", "paramA", true, "")]
+        [InlineData("PARAMa", "paramA", false, "")]
+        // parameters in param collection are case insensitive
+        [InlineData("paramA", "PARAMa", true, "Line to be generated")]
+        [InlineData("paramA", "PARAMa", false, "")]
+        // but still the content is case sensitive in regards to original template
+        [InlineData("PARAMa", "PARAMa", true, "")]
+        [InlineData("PARAMa", "PARAMa", false, "")]
+        public async void InstantiateAsync_CaseInsesitiveParameters(string parameNameInContent, string paramNameInParamsCollection, bool paramValue, string expectedOutput)
+        {
+            const string conditionalContentFmt = @"
+#if ( {0} )
+Line to be generated
+#endif
+";
+
+            IReadOnlyDictionary<string, string?> parameters = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+            {
+                { paramNameInParamsCollection, paramValue.ToString() }
+            };
+
+            await InstantiateAsyncHelper(
+                TemplateConfigBooleanParam,
+                string.Format(conditionalContentFmt, parameNameInContent),
+                expectedOutput,
+                string.Empty,
+                false,
+                sourceExtension: ".cs",
+                parameters1: parameters);
+        }
+
         private const string TemplateConfigQuotelessLiteralsEnabled = @"
 {
     ""identity"": ""test.template"",


### PR DESCRIPTION
Fixes https://github.com/dotnet/templating/issues/5334

### Description
Fix to TemplateCreator API regression (introduced as part of parameters refactoring work).
The parameter collection passed to API used to be case-insensitive, now it is case-sensitive.

### Customer Impact
This can break `TemplateCreator` API users (e.g. NPD - that's how this issue was discoved by @phenning)
Other 3rd party API users might be possibly affected (Rider? AWS?)
If 3rd party code generators or custom tooling do not ensure proper casing a template instantiotion might appear broken (by not instantiation some of the parameters) - the example is the New Project issue in VS: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1633125 (fixed in VS code now)

### Regression
Yes

### Risk
Very low

### Solution
Making the parameters within `InputDataSet` again case insensitive
Test cases added (same test executed on 6.0.4xx)