### PR TITLE
Fix OneLocBuild conditional logic and naming

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,17 +41,24 @@ stages:
   displayName: Build
   jobs:
   - ${{ if and( ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - template: /eng/common/templates/job/onelocbuild.yml
-      parameters:
-        MirrorRepo: templating
-        LclSource: lclFilesfromPackage
-        ${{ if eq(variables['Build.SourceBranch'], format('{0}{1}', 'refs/heads/', variables['OneLocBuildBranch'])) }}:
-          MirrorBranch: $(OneLocBuildBranch)
+    - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
+      - template: /eng/common/templates/job/onelocbuild.yml
+        parameters:
+          MirrorRepo: templating
+          LclSource: lclFilesfromPackage
           LclPackageId: 'LCL-JUNO-PROD-TEMPLATING'
-        ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
-          MirrorBranch: 'main'
+          MirrorBranch: $(OneLocBuildBranch)
+          JobNameSuffix: '_release'
+          condition: eq(variables['Build.SourceBranch'], format('{0}{1}', 'refs/heads/', variables['OneLocBuildBranch'] ))
+    - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
+      - template: /eng/common/templates/job/onelocbuild.yml
+        parameters:
+          MirrorRepo: templating
+          LclSource: lclFilesfromPackage
           LclPackageId: 'LCL-JUNO-PROD-TMPLTNGMAIN'
-        condition: eq(or(variables['Build.SourceBranch'], format('{0}{1}', 'refs/heads/', variables['OneLocBuildBranch'] )), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+          MirrorBranch: 'main'
+          JobNameSuffix: '_main'
+          condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enableMicrobuild: true

--- a/eng/common/templates/job/onelocbuild.yml
+++ b/eng/common/templates/job/onelocbuild.yml
@@ -22,13 +22,14 @@ parameters:
   MirrorRepo: ''
   MirrorBranch: main
   condition: ''
+  JobNameSuffix: ''
 
 jobs:
-- job: OneLocBuild
+- job: OneLocBuild${{ parameters.JobNameSuffix }}
   
   dependsOn: ${{ parameters.dependsOn }}
 
-  displayName: OneLocBuild
+  displayName: OneLocBuild${{ parameters.JobNameSuffix }}
 
   ${{ if ne(parameters.pool, '') }}:
     pool: ${{ parameters.pool }}


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/5288

### Solution
Improve the conditional logic not to rely on variables (they are resolved on runtime, while the jobs plan on compile time). Plus allow distinctive naming of OneLocBuild job in case multiple job will need to be created.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)