### PR TITLE
Stabilize installing Azure CLI for search cache pipeline

### DIFF
--- a/eng/SearchCache/InstallAzureCLI.sh
+++ b/eng/SearchCache/InstallAzureCLI.sh
@@ -1,0 +1,22 @@
+function retry {
+  local n=0
+  local max=5
+  local delay=60
+  while true; do
+    ((n++))
+    "$@" && {
+      echo "Command succeeded."
+      break
+    } || {
+      if [[ $n -lt $max ]]; then
+        echo "Command failed with the attempt $n/$max."
+        sleep $delay;
+      else
+        echo "The command has failed after $n attempts."
+        break
+      fi
+    }
+  done
+}
+
+retry curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash

--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -78,7 +78,7 @@ steps:
   displayName: Publish Artifacts
 
 - ${{ if eq(parameters.publishToBlob, true) }}:
-  - bash: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+  - script: '$(Build.SourcesDirectory)/eng/SearchCache/InstallAzureCLI.sh'
     displayName: Install Azure CLI
 
   - bash: az config set extension.use_dynamic_install=yes_without_prompt


### PR DESCRIPTION
### Problem
#5344 - Azure CLI installation failed randomly with the error below.
`E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 9016 (unattended-upgr)`
The system automatically installs updates in the background. It needs to wait that to finish. 

### Solution
Stabilize installing Azure CLI using retries with some delay.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)