### PR TITLE
Enable dependabot on the branches: main and release/7.0.2xx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,17 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
+    target-branch: "main"
+    labels:
+      - "dependencies"
+      - "dependabot: main"
+
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    target-branch: "release/7.0.2xx"
+    labels:
+      - "dependencies"
+      - "dependabot: 7.0.2xx"


### PR DESCRIPTION
### Problem
Need to enable dependabot on the branch release/7.0.2xx.

### Solution
Add the entries targeting branches main and release/7.0.2xx respectively.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)