### PR TITLE
Fix the shell script error: command not found

### DIFF
--- a/eng/SearchCache/InstallAzureCLI.sh
+++ b/eng/SearchCache/InstallAzureCLI.sh
@@ -19,4 +19,6 @@ function retry {
   done
 }
 
-retry curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+install_script="/tmp/azurecli_install.sh"
+curl -sL https://aka.ms/InstallAzureCLIDeb -o "$install_script"
+retry sudo bash "$install_script"


### PR DESCRIPTION
### Problem
`eng/SearchCache/InstallAzureCLI.sh` has the error: bash: line 95: Command: command not found.

### Solution
Save the install script locally and then execute.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)