### PR TITLE
Enables CodeQL in build pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,8 @@ variables:
     value: NETDevUX
   - name: _PublishUsingPipelines
     value: true
-
+  - name: Codeql.Enabled
+    value: true
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: Templating-SDLValidation-Params
     


### PR DESCRIPTION
### Problem
#5295

### Solution
This enables CodeQL task in official build pipeline for `main` branch. It uses default settings, so CodeQL will collect data with 72 hours cadence.

### Checks:
We will have to check pipeline logs after merge. It works for MSBuild, I don't expect any problems blocking the build.