### PR TITLE
Publish test log and results in search cache pipeline for the investigation on random test failure

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -24,6 +24,26 @@ steps:
 
 - script: '$(Build.SourcesDirectory)/build.sh'
 
+- task: CopyFiles@2
+  displayName: Gather Test Log and Results
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)/artifacts'
+    Contents: |
+     log/**/*
+     TestResults/**/*
+    TargetFolder: '$(Build.ArtifactStagingDirectory)'
+  continueOnError: true
+  condition: always()
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish Test Log and Results
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+    ArtifactName: Test_LogResults
+    publishLocation: Container
+  continueOnError: true
+  condition: always()
+
 - task: UseDotNet@2
   displayName: 'Use .NET 3.1'
   inputs:


### PR DESCRIPTION
### Problem
Search cache pipeline still has random test failure. It's hard to repro locally.

### Solution
Publish test log and results for the investigation on random test failure in the pipeline.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)