### PR TITLE
Move to -Svc pool providers for COGS reasons

### DIFF
--- a/azure-pipelines-codeql.yml
+++ b/azure-pipelines-codeql.yml
@@ -24,7 +24,7 @@ stages:
       - job: Windows_NT_CSharp
         timeoutInMinutes: 90
         pool:
-          name: NetCore1ESPool-Internal
+          name: NetCore1ESPool-Svc-Internal
           demands: ImageOverride -equals windows.vs2019.amd64
 
         steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,10 +75,10 @@ stages:
         timeoutInMinutes: 90
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCore-Public
+            name: NetCore-Svc-Public
             vmImage: 1es-windows-2019-open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            name: NetCore1ESPool-Internal
+            name: NetCore1ESPool-Svc-Internal
             demands: ImageOverride -equals windows.vs2019.amd64
         variables:
         - _InternalBuildArgs: ''
@@ -165,7 +165,7 @@ stages:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
               vmImage: ubuntu-latest 
             ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-              name: NetCore1ESPool-Internal
+              name: NetCore1ESPool-Svc-Internal
               demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
           strategy:
             matrix:

--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -16,7 +16,7 @@ parameters:
   default: true
 
 pool:
-  name: NetCore1ESPool-Internal
+  name: NetCore1ESPool-Svc-Internal
   demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
 
 steps:


### PR DESCRIPTION
### Problem
Release branches (anything which has shipped) need to be on "-Svc" pools

### Solution
Update to "-Svc"-named pool provider

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)