### PR TITLE
Support multiple scrubbers per file extension

### DIFF
--- a/src/Microsoft.TemplateEngine.Authoring.TemplateVerifier/ScrubbersDefinition.cs
+++ b/src/Microsoft.TemplateEngine.Authoring.TemplateVerifier/ScrubbersDefinition.cs
@@ -38,9 +38,18 @@ public class ScrubbersDefinition
         // This is to get the same behavior as Verify.NET
         else
         {
-            ScrubersByExtension[extension.Trim()] = extension.Trim().StartsWith('.')
-                ? throw new TemplateVerificationException(LocalizableStrings.VerificationEngine_Error_ScrubberExtension, TemplateVerificationErrorCode.InvalidOption)
-                : scrubber;
+            extension = extension.Trim();
+            if (extension.StartsWith('.'))
+            {
+                throw new TemplateVerificationException(LocalizableStrings.VerificationEngine_Error_ScrubberExtension, TemplateVerificationErrorCode.InvalidOption);
+            }
+
+            if (ScrubersByExtension.TryGetValue(extension, out var origScrubber))
+            {
+                scrubber = origScrubber + scrubber;
+            }
+
+            ScrubersByExtension[extension] = scrubber;
         }
 
         return this;

--- a/test/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests/VerificationEngineTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests/VerificationEngineTests.cs
@@ -53,7 +53,9 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests
                         .AddScrubber(sb => sb.Replace("bb", "xx"), "cs")
                         .AddScrubber(sb => sb.Replace("cc", "yy"), "dll")
                         .AddScrubber(sb => sb.Replace("123", "yy"), "dll")
-                        .AddScrubber(sb => sb.Replace("aa", "zz")))
+                        .AddScrubber(sb => sb.Replace("aa", "zz"))
+                        // supports multiple scrubbers per extension
+                        .AddScrubber(sb => sb.Replace("cc", "**"), "cs"))
                 .WithCustomDirectoryVerifier(
                     async (content, contentFetcher) =>
                     {
@@ -66,7 +68,7 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests
             await VerificationEngine.CreateVerificationTask(verifyLocation, "callerLocation", null, options, fileSystem);
 
             resultContents.Keys.Count.Should().Be(2);
-            resultContents["Program.cs"].Should().BeEquivalentTo("zz xx cc");
+            resultContents["Program.cs"].Should().BeEquivalentTo("zz xx **");
             resultContents["Subfolder\\Class.cs"].Should().BeEquivalentTo("123 456 789 zz");
         }
 


### PR DESCRIPTION
### Problem
Multiple scrubbers definitions per single file extension were overwritting each other (only the last one was preserved)

### Solution
Chain multicast delegates

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)