### PR TITLE
[release/6.0.1xx] updated NuGet packages versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,9 +21,9 @@
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
     <SystemCommandLinePackageVersion>2.0.0-beta1.21406.1</SystemCommandLinePackageVersion>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
-    <NuGetCredentialsPackageVersion>6.0.0</NuGetCredentialsPackageVersion>
-    <NuGetConfigurationPackageVersion>6.0.0</NuGetConfigurationPackageVersion>
-    <NuGetProtocolPackageVersion>6.0.0</NuGetProtocolPackageVersion>
+    <NuGetCredentialsPackageVersion>6.0.3-rc.1</NuGetCredentialsPackageVersion>
+    <NuGetConfigurationPackageVersion>6.0.3-rc.1</NuGetConfigurationPackageVersion>
+    <NuGetProtocolPackageVersion>6.0.3-rc.1</NuGetProtocolPackageVersion>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
     <MicrosoftNETCoreAppRefPackageVersion>6.0.10</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>6.0.10</MicrosoftNETCoreAppRuntimewinx64PackageVersion>

--- a/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
+++ b/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
@@ -7,6 +7,7 @@
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DefineConstants Condition="'$(TargetFramework)' == '$(NETFullTargetFramework)'">$(DefineConstants);NETFULL</DefineConstants>
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description 
`NuGet.Protocol` `6.0.0` to `6.0.3-rc.1` version bump, addressing https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-templating/alert/7360925?typeId=10636862
SDK uses `6.0.3-rc.1` already, therefore it is the highest version we can go for.

We are able to use `6.0.3-rc.1` as it is already [available ](https://www.nuget.org/packages/NuGet.Protocol/6.0.3-rc.1 )on NuGet.org, and it won't be a problem for the customers using NuGet [package](https://www.nuget.org/packages/Microsoft.TemplateEngine.Edge/6.0.110) directly.

### Customer Impact 
None

### Regression
No

### Risk
Very-low.
