### PR TITLE
Fix CodeQL errors and hide warning/recommendation from query results

### DIFF
--- a/src/Microsoft.TemplateEngine.Core/Expressions/Cpp/CppStyleEvaluatorDefinition.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/Cpp/CppStyleEvaluatorDefinition.cs
@@ -540,17 +540,17 @@ namespace Microsoft.TemplateEngine.Core.Expressions.Cpp
             //  The character that the string starts with must be one of the supported quote kinds
             if (literal.Length < 2 || literal[0] != literal[literal.Length - 1] || !SupportedQuotes.Contains(literal[0]))
             {
-                if (string.Equals(literal, "true", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(literal, "true", StringComparison.OrdinalIgnoreCase)) //lgtm [cs/campaign/constantine]
                 {
                     return true;
                 }
 
-                if (string.Equals(literal, "false", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(literal, "false", StringComparison.OrdinalIgnoreCase)) //lgtm [cs/campaign/constantine]
                 {
                     return false;
                 }
 
-                if (string.Equals(literal, "null", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(literal, "null", StringComparison.OrdinalIgnoreCase)) //lgtm [cs/campaign/constantine]
                 {
                     return null;
                 }

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
@@ -294,7 +294,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                             // don't fail on value resolution errors, but report them as authoring problems.
                             else
                             {
-                                _logger.LogDebug($"Template {template.Identity} has an invalid DefaultIfOptionWithoutValue value for parameter {inputParam.ParameterDefinition.Name}");
+                                _logger.LogDebug($"Template {template.Identity} has an invalid DefaultIfOptionWithoutValue value for parameter {inputParam.ParameterDefinition.Name}"); //lgtm [cs/privacy/suspicious-logging-arguments]
                             }
                         }
                         else

--- a/src/Microsoft.TemplateEngine.Utils/TemplateMatchInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Utils/TemplateMatchInfoExtensions.cs
@@ -144,7 +144,7 @@ namespace Microsoft.TemplateEngine.Utils
         /// </summary>
         public static bool HasAuthorMatch(this ITemplateMatchInfo templateMatchInfo)
         {
-            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && (x.Kind == MatchKind.Exact || x.Kind == MatchKind.Partial));
+            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && (x.Kind == MatchKind.Exact || x.Kind == MatchKind.Partial)); //lgtm [cs/campaign/constantine]
         }
 
         /// <summary>
@@ -152,7 +152,7 @@ namespace Microsoft.TemplateEngine.Utils
         /// </summary>
         public static bool HasAuthorExactMatch(this ITemplateMatchInfo templateMatchInfo)
         {
-            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && x.Kind == MatchKind.Exact);
+            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && x.Kind == MatchKind.Exact); //lgtm [cs/campaign/constantine]
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace Microsoft.TemplateEngine.Utils
         /// </summary>
         public static bool HasAuthorPartialMatch(this ITemplateMatchInfo templateMatchInfo)
         {
-            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && x.Kind == MatchKind.Partial);
+            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && x.Kind == MatchKind.Partial); //lgtm [cs/campaign/constantine]
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace Microsoft.TemplateEngine.Utils
         /// </summary>
         public static bool HasAuthorMismatch(this ITemplateMatchInfo templateMatchInfo)
         {
-            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && x.Kind == MatchKind.Mismatch);
+            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && x.Kind == MatchKind.Mismatch); //lgtm [cs/campaign/constantine]
         }
     }
 }

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NuGetPackSourceCheckerFactory.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NuGetPackSourceCheckerFactory.cs
@@ -106,6 +106,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
             {
                 HttpClientHandler handler = new HttpClientHandler()
                 {
+                    CheckCertificateRevocationList = true,
                     AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
                 };
                 using (HttpClient client = new HttpClient(handler))

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Nuget/NugetPackProvider.cs
@@ -92,7 +92,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
                 string queryString = string.Format(_searchUriFormat, skip, pageSize);
 
                 Uri queryUri = new Uri(queryString);
-                using (HttpClient client = new HttpClient())
+                using (HttpClient client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
                 using (HttpResponseMessage response = await client.GetAsync(queryUri, token).ConfigureAwait(false))
                 {
                     if (response.IsSuccessStatusCode)
@@ -174,7 +174,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
         {
             string queryString = string.Format(_searchUriFormat, 0, _pageSize);
             Uri queryUri = new Uri(queryString);
-            using (HttpClient client = new HttpClient())
+            using (HttpClient client = new HttpClient(new HttpClientHandler() { CheckCertificateRevocationList = true }))
             using (HttpResponseMessage response = await client.GetAsync(queryUri, token).ConfigureAwait(false))
             {
                 response.EnsureSuccessStatusCode();


### PR DESCRIPTION
### Problem
#5483

### Solution
For error, fix the violations.
For warning/recommendation, hide the query results by adding lgtm comment. Since [hiding query results via configuration file](https://1es.lgtm.microsoft.com/help/lgtm/showing-hiding-query-results) hides the results of rules applying to all source code rather than specific term/file path, there is some risk missing real problem.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)