### PR TITLE
Increase the number of retries to ensure Azure CLI installation succeeds

### DIFF
--- a/eng/SearchCache/InstallAzureCLI.sh
+++ b/eng/SearchCache/InstallAzureCLI.sh
@@ -1,6 +1,6 @@
 function retry {
   local n=0
-  local max=5
+  local max=15
   local delay=60
   while true; do
     ((n++))


### PR DESCRIPTION
### Problem
#5344 - The number of retries is not enough waiting until automatic system update finishes. Then next step `Disable Azure CLI prompts` failed with the error `az: command not found`.

### Solution
Increase the number of retries to ensure Azure CLI installation succeeds.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)