### PR TITLE
[release/7.0.2xx] removed dependency on runtime for 7.0.2xx+

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,14 +4,6 @@
 
   <Import Project="$(RepositoryEngineeringDir)Package.props" />
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(BuildingInsideVisualStudio)' != 'true'">
-    <FrameworkReference
-        Update="Microsoft.NETCore.App"
-        TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
-        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)" />
-  </ItemGroup>
-
-
   <ItemGroup>
     <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true"/>
     <None Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" PackagePath="THIRD-PARTY-NOTICES.txt" Pack="true"/>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,14 +11,6 @@
       <Sha>ddc5b4880b0bf18783fc6808c4d407214f7bdae1</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="7.0.0-rtm.22511.4">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d25158d0dffd699340cedcfd43324c87a809a214</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="7.0.0-rtm.22511.4">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>d25158d0dffd699340cedcfd43324c87a809a214</Sha>
-    </Dependency>
     <Dependency Name="System.CommandLine" Version="2.0.0-beta4.22504.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>c776cd4e906b669b9cce1017fee7d0ba9845d163</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,8 +22,5 @@
     <!-- Maestro-managed Package Versions - Ordered by repo name -->
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
     <SystemCommandLinePackageVersion>2.0.0-beta4.22504.1</SystemCommandLinePackageVersion>
-    <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>7.0.0-rtm.22511.4</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>7.0.0-rtm.22511.4</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,11 +1,6 @@
 {
   "tools": {
-    "dotnet": "7.0.100-rc.2.22477.23",
-    "runtimes": {
-      "dotnet": [
-        "$(MicrosoftNETCoreAppRefPackageVersion)"
-      ]
-    }
+    "dotnet": "7.0.100-rc.2.22477.23"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "7.0.0-beta.22531.4"


### PR DESCRIPTION
### Problem
Dependency on runtime is not needed for the SDK releases. Runtime patch have low to none chances for breaking changes to keep maintaining it.

### Solution
Removed the dependency
