### PR TITLE
Add the justification to CodeQL suppression

### DIFF
--- a/src/Microsoft.TemplateEngine.Core/Expressions/Cpp/CppStyleEvaluatorDefinition.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/Cpp/CppStyleEvaluatorDefinition.cs
@@ -540,17 +540,17 @@ namespace Microsoft.TemplateEngine.Core.Expressions.Cpp
             //  The character that the string starts with must be one of the supported quote kinds
             if (literal.Length < 2 || literal[0] != literal[literal.Length - 1] || !SupportedQuotes.Contains(literal[0]))
             {
-                if (string.Equals(literal, "true", StringComparison.OrdinalIgnoreCase)) //lgtm [cs/campaign/constantine]
+                if (string.Equals(literal, "true", StringComparison.OrdinalIgnoreCase)) // CodeQL [cs/campaign/constantine] False Positive: CodeQL wrongly detected "literal"
                 {
                     return true;
                 }
 
-                if (string.Equals(literal, "false", StringComparison.OrdinalIgnoreCase)) //lgtm [cs/campaign/constantine]
+                if (string.Equals(literal, "false", StringComparison.OrdinalIgnoreCase)) // CodeQL [cs/campaign/constantine] False Positive: CodeQL wrongly detected "literal"
                 {
                     return false;
                 }
 
-                if (string.Equals(literal, "null", StringComparison.OrdinalIgnoreCase)) //lgtm [cs/campaign/constantine]
+                if (string.Equals(literal, "null", StringComparison.OrdinalIgnoreCase)) // CodeQL [cs/campaign/constantine] False Positive: CodeQL wrongly detected "literal"
                 {
                     return null;
                 }

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
@@ -294,7 +294,7 @@ namespace Microsoft.TemplateEngine.Edge.Template
                             // don't fail on value resolution errors, but report them as authoring problems.
                             else
                             {
-                                _logger.LogDebug($"Template {template.Identity} has an invalid DefaultIfOptionWithoutValue value for parameter {inputParam.ParameterDefinition.Name}"); //lgtm [cs/privacy/suspicious-logging-arguments]
+                                _logger.LogDebug($"Template {template.Identity} has an invalid DefaultIfOptionWithoutValue value for parameter {inputParam.ParameterDefinition.Name}"); // CodeQL [cs/privacy/suspicious-logging-arguments] False Positive: CodeQL wrongly detected "Identity"
                             }
                         }
                         else

--- a/src/Microsoft.TemplateEngine.Utils/TemplateMatchInfoExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Utils/TemplateMatchInfoExtensions.cs
@@ -144,7 +144,7 @@ namespace Microsoft.TemplateEngine.Utils
         /// </summary>
         public static bool HasAuthorMatch(this ITemplateMatchInfo templateMatchInfo)
         {
-            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && (x.Kind == MatchKind.Exact || x.Kind == MatchKind.Partial)); //lgtm [cs/campaign/constantine]
+            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && (x.Kind == MatchKind.Exact || x.Kind == MatchKind.Partial)); // CodeQL [cs/campaign/constantine] False Positive: CodeQL wrongly detected "Author"
         }
 
         /// <summary>
@@ -152,7 +152,7 @@ namespace Microsoft.TemplateEngine.Utils
         /// </summary>
         public static bool HasAuthorExactMatch(this ITemplateMatchInfo templateMatchInfo)
         {
-            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && x.Kind == MatchKind.Exact); //lgtm [cs/campaign/constantine]
+            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && x.Kind == MatchKind.Exact); // CodeQL [cs/campaign/constantine] False Positive: CodeQL wrongly detected "Author"
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace Microsoft.TemplateEngine.Utils
         /// </summary>
         public static bool HasAuthorPartialMatch(this ITemplateMatchInfo templateMatchInfo)
         {
-            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && x.Kind == MatchKind.Partial); //lgtm [cs/campaign/constantine]
+            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && x.Kind == MatchKind.Partial); // CodeQL [cs/campaign/constantine] False Positive: CodeQL wrongly detected "Author"
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace Microsoft.TemplateEngine.Utils
         /// </summary>
         public static bool HasAuthorMismatch(this ITemplateMatchInfo templateMatchInfo)
         {
-            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && x.Kind == MatchKind.Mismatch); //lgtm [cs/campaign/constantine]
+            return templateMatchInfo.MatchDisposition.Any(x => x.Name == MatchInfo.BuiltIn.Author && x.Kind == MatchKind.Mismatch); // CodeQL [cs/campaign/constantine] False Positive: CodeQL wrongly detected "Author"
         }
     }
 }


### PR DESCRIPTION
### Problem
#5483 - For the added comment `// lgtm [<query id>]` that hides query result, CodeQL has the warning `A Suppression for [<query id>] does not have a justifictaion.`

### Solution
CodeQL suppression needs a justification referring to https://1es.lgtm.microsoft.com/rules/1001308/.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)