### PR TITLE
Use -svc pools for release/ branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,7 @@ stages:
             name: NetCore-Svc-Public
             demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            name: NetCore1ESPool-Internal
+            name: NetCore1ESPool-Svc-Internal
             demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
         strategy:
           matrix:


### PR DESCRIPTION
### Problem
For billing purposes, we need to use the "-Svc-" named pools for release branches

### Solution
Flip over to using -Svc pools in these builds

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)