### PR TITLE
Update System.Drawing.Common transitive dependency

### DIFF
--- a/test/Microsoft.TemplateEngine.Cli.TestHelper/Microsoft.TemplateEngine.Cli.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.Cli.TestHelper/Microsoft.TemplateEngine.Cli.TestHelper.csproj
@@ -9,6 +9,8 @@
     <PackageReference Include="xunit.abstractions" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" />
+    <!-- Bumping transitive dependency pulled with Microsoft.DotNet.Cli.Utils -->
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
### Problem
System.Drawing.Common 4.7.0 bump to 4.7.2
Addressing https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-templating/alert/7408013?typeId=10630754
The reference is transitive from Microsoft.DotNet.Cli.Utils, but let's update explicitly not to wait for Microsoft.DotNet.Cli.Utils fix

### Customer Impact 
None - only test code is involved

### Regression
No - only test code is involved

### Risk
Very-low - only test code is involved