### PR TITLE
Revert dotnet/runtime update by maestro

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,13 +11,13 @@
       <Sha>dab1b0db4f4937b9213c5aecc5a5279d88180741</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="8.0.0-alpha.1.22556.2">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="8.0.0-alpha.1.22530.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>94cbc49cd9084b1256cc9b90b425336676228599</Sha>
+      <Sha>e6700ea21bbb17ca5058801259bc2d05957814d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-alpha.1.22556.2">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-alpha.1.22530.1">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>94cbc49cd9084b1256cc9b90b425336676228599</Sha>
+      <Sha>e6700ea21bbb17ca5058801259bc2d05957814d4</Sha>
     </Dependency>
     <Dependency Name="System.CommandLine" Version="2.0.0-beta4.22504.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,7 +18,7 @@
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
     <SystemCommandLinePackageVersion>2.0.0-beta4.22504.1</SystemCommandLinePackageVersion>
     <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-alpha.1.22556.2</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>8.0.0-alpha.1.22556.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-alpha.1.22530.1</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>8.0.0-alpha.1.22530.1</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
### Problem
Failed runtime update in sdk (https://github.com/dotnet/sdk/pull/28865) is preventing us from updating dotnet/templating reference in sdk (and hence it blocks onboarding of template verifier tests)

### Solution
Temporarily reverting most recent runtime update - this will enable us to update templating dependecy in sdk. After that we can merge next maestro PR and be on latest runtime version again.

### Checks: N/A
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)