### PR TITLE
Fix ByPath scrubber

### DIFF
--- a/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/ScrubbersDefinition.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/ScrubbersDefinition.cs
@@ -57,6 +57,11 @@ public class ScrubbersDefinition
 
     public ScrubbersDefinition AddScrubber(ScrubFileByPath fileScrubber)
     {
+        if (ReferenceEquals(this, Empty))
+        {
+            return new ScrubbersDefinition().AddScrubber(fileScrubber);
+        }
+
         ByPathScrubbers.Add(fileScrubber);
         return this;
     }


### PR DESCRIPTION
### Problem
ByPath scrubber might change and return `ScrubbersDefinition.Empty`, this will then prevent adding additional scrubbers by extension.

### Solution
Return new scrubber if `ScrubbersDefinition.Empty` is passed to chaining `AddScrubber` function.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)