### PR TITLE
[release/7.0.1xx] packages updates

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -16,9 +16,9 @@
     <PackageReference Update="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-    <PackageReference Update="NuGet.Configuration" Version="6.2.1" />
-    <PackageReference Update="NuGet.Credentials" Version="6.2.1" />
-    <PackageReference Update="NuGet.Protocol" Version="6.2.1" />
+    <PackageReference Update="NuGet.Configuration" Version="6.3.1" />
+    <PackageReference Update="NuGet.Credentials" Version="6.3.1" />
+    <PackageReference Update="NuGet.Protocol" Version="6.3.1" />
 
     <!--Analyzers-->
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.2.0" />

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.CommandLine" />
-    <PackageReference Include="Microsoft.DotNet.Cli.Utils" />
     <PackageReference Include="FluentAssertions" />
   </ItemGroup>
 

--- a/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
@@ -25,6 +25,8 @@
 
   <ItemGroup Condition="$(TargetFramework) == $(NETCoreTargetFramework)">
     <PackageReference Include="Microsoft.DotNet.Cli.Utils" />
+    <!-- Bumping transitive dependency pulled with Microsoft.DotNet.Cli.Utils -->
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description

- Updated NuGet packages version to `6.3.1` (related to the [issue](https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-templating/alert/7334971?action=ContributedHub&controller=Apps&typeId=13404799))
- pinned `System.Drawing.Common` to `4.7.2` (related to the [issue](https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-templating/alert/7408013?typeId=12612499)).  

Already done and approved for previous versions: 
https://github.com/dotnet/templating/pull/5569
https://github.com/dotnet/templating/pull/5568 
https://github.com/dotnet/templating/pull/5567

## Customer Impact
None

## Regression
No

## Risk
Very-low (none)