### PR TITLE
addressed API documentation generation issues

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/ITemplateParameter.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ITemplateParameter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.TemplateEngine.Abstractions
 
         /// <summary>
         /// Gets parameter type.
-        /// In Orchestrator.RunnableProjects the following types are used: parameter, generated, combined, derived, bind (same as symbol types).
+        /// In Orchestrator.RunnableProjects the type is always 'parameter'.
         /// </summary>
         string Type { get; }
 

--- a/src/Microsoft.TemplateEngine.Abstractions/IVariableCollection.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/IVariableCollection.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Microsoft.TemplateEngine.Abstractions
+{
+    /// <summary>
+    /// Defines an interface for generic variable collection.
+    /// The variable collection may have a parent.
+    /// The parenet collection is used when the value is not found in current collection.
+    /// </summary>
+    public interface IVariableCollection : IDictionary<string, object>
+    {
+        /// <summary>
+        /// Gets the parent collection for the instance.
+        /// </summary>
+        IVariableCollection? Parent { get; set; }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Abstractions/Installer/InstallerConstants.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Installer/InstallerConstants.cs
@@ -11,13 +11,13 @@ namespace Microsoft.TemplateEngine.Abstractions.Installer
         /// <summary>
         /// Defines the key for <see cref="InstallRequest.Details"/> to specify additional NuGet sources to be used on installation. Supported by NuGet installer.
         /// </summary>
-        /// <remarks><seealso cref="NuGetSourcesSeparator"/></remarks>
+        /// <remarks><see cref="NuGetSourcesSeparator"/> defines the separator to use when multiple sources are required.</remarks>
         public const string NuGetSourcesKey = "NuGetSources";
 
         /// <summary>
         /// Defines the separator to be used when specifying multiple additional NuGet sources to be used on installation. Supported by NuGet installer.
         /// </summary>
-        /// <remarks><seealso cref="NuGetSourcesKey"/></remarks>
+        /// <remarks>Used together with <see cref="NuGetSourcesKey"/>.</remarks>
         public const char NuGetSourcesSeparator = ';';
 
         /// <summary>

--- a/src/Microsoft.TemplateEngine.Abstractions/Installer/InstallerOperationResult.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Installer/InstallerOperationResult.cs
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateEngine.Abstractions.Installer
         }
 
         /// <summary>
-        /// Error code, <seealso cref="InstallerErrorCode"/>.
+        /// Gets result error code.
         /// <see cref="InstallerErrorCode.Success"/> if the operation completed successfully.
         /// </summary>
         public InstallerErrorCode Error { get; }

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
 ﻿Microsoft.TemplateEngine.Abstractions.ITemplate.TemplateSourceRoot.get -> Microsoft.TemplateEngine.Abstractions.Mount.IDirectory!
+Microsoft.TemplateEngine.Abstractions.IVariableCollection
+Microsoft.TemplateEngine.Abstractions.IVariableCollection.Parent.get -> Microsoft.TemplateEngine.Abstractions.IVariableCollection?
+Microsoft.TemplateEngine.Abstractions.IVariableCollection.Parent.set -> void

--- a/src/Microsoft.TemplateEngine.Abstractions/TemplatePackage/ITemplatePackage.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/TemplatePackage/ITemplatePackage.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TemplateEngine.Abstractions.TemplatePackage
     /// <summary>
     /// Represents the template package.
     /// Template package is a folder, .nupkg or other container that can contain single or multiple templates.
-    /// <seealso cref="ITemplatePackageProvider"/> for more information.
+    /// See <see cref="ITemplatePackageProvider"/> for more information.
     /// </summary>
     public interface ITemplatePackage
     {

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IEngineConfig.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IEngineConfig.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Core.Contracts
 {

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IGlobalRunSpec.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IGlobalRunSpec.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Core.Contracts
 {

--- a/src/Microsoft.TemplateEngine.Core.Contracts/IVariableCollection.cs
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/IVariableCollection.cs
@@ -1,16 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
 
 namespace Microsoft.TemplateEngine.Core.Contracts
 {
-    public interface IVariableCollection : IDictionary<string, object>
+    /// <summary>
+    /// Extends <see cref="IVariableCollection"/> with the events raised when collection is being read or changed.
+    /// </summary>
+    public interface IMonitoredVariableCollection : IVariableCollection
     {
         event KeysChangedEventHander KeysChanged;
 
         event ValueReadEventHander ValueRead;
-
-        IVariableCollection? Parent { get; set; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Shipped.txt
@@ -30,7 +30,6 @@ Microsoft.TemplateEngine.Core.Contracts.ITokenTrieEvaluator.Accept(byte data, re
 Microsoft.TemplateEngine.Core.Contracts.ITokenTrieEvaluator.BytesToKeepInBuffer.get -> int
 Microsoft.TemplateEngine.Core.Contracts.ITokenTrieEvaluator.TryFinalizeMatchesInProgress(ref int bufferPosition, out int token) -> bool
 Microsoft.TemplateEngine.Core.Contracts.IValueReadEventArgs
-Microsoft.TemplateEngine.Core.Contracts.IVariableCollection
 Microsoft.TemplateEngine.Core.Contracts.IVariableConfig
 Microsoft.TemplateEngine.Core.Contracts.IVariableConfig.Expand.get -> bool
 Microsoft.TemplateEngine.Core.Contracts.KeysChangedEventHander
@@ -47,14 +46,12 @@ Microsoft.TemplateEngine.Core.Contracts.IEngineConfig.Flags.get -> System.Collec
 Microsoft.TemplateEngine.Core.Contracts.IEngineConfig.LineEndings.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateEngine.Core.Contracts.IEngineConfig.Logger.get -> Microsoft.Extensions.Logging.ILogger!
 Microsoft.TemplateEngine.Core.Contracts.IEngineConfig.VariableFormatString.get -> string!
-Microsoft.TemplateEngine.Core.Contracts.IEngineConfig.Variables.get -> Microsoft.TemplateEngine.Core.Contracts.IVariableCollection!
 Microsoft.TemplateEngine.Core.Contracts.IEngineConfig.Whitespaces.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.CopyOnly.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IPathMatcher!>!
 Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.Exclude.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IPathMatcher!>!
 Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.IgnoreFileNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.Include.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IPathMatcher!>!
 Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.Operations.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider!>!
-Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.RootVariableCollection.get -> Microsoft.TemplateEngine.Core.Contracts.IVariableCollection!
 Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.Special.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<Microsoft.TemplateEngine.Core.Contracts.IPathMatcher!, Microsoft.TemplateEngine.Core.Contracts.IRunSpec!>>!
 Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.TryGetTargetRelPath(string! sourceRelPath, out string! targetRelPath) -> bool
 Microsoft.TemplateEngine.Core.Contracts.IOperation.HandleMatch(Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processor, int bufferLength, ref int currentBufferPosition, int token) -> int
@@ -92,10 +89,6 @@ Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.TokenLength.get -> System.Col
 Microsoft.TemplateEngine.Core.Contracts.ITokenTrie.Tokens.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IToken!>!
 Microsoft.TemplateEngine.Core.Contracts.IValueReadEventArgs.Key.get -> string!
 Microsoft.TemplateEngine.Core.Contracts.IValueReadEventArgs.Value.get -> object!
-Microsoft.TemplateEngine.Core.Contracts.IVariableCollection.KeysChanged -> Microsoft.TemplateEngine.Core.Contracts.KeysChangedEventHander!
-Microsoft.TemplateEngine.Core.Contracts.IVariableCollection.Parent.get -> Microsoft.TemplateEngine.Core.Contracts.IVariableCollection?
-Microsoft.TemplateEngine.Core.Contracts.IVariableCollection.Parent.set -> void
-Microsoft.TemplateEngine.Core.Contracts.IVariableCollection.ValueRead -> Microsoft.TemplateEngine.Core.Contracts.ValueReadEventHander!
 Microsoft.TemplateEngine.Core.Contracts.IVariableConfig.FallbackFormat.get -> string?
 Microsoft.TemplateEngine.Core.Contracts.IVariableConfig.Order.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateEngine.Core.Contracts.IVariableConfig.Sources.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!

--- a/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/PublicAPI.Unshipped.txt
@@ -1,4 +1,9 @@
-﻿Microsoft.TemplateEngine.Core.Contracts.IOperation.Id.get -> string?
+﻿Microsoft.TemplateEngine.Core.Contracts.IEngineConfig.Variables.get -> Microsoft.TemplateEngine.Abstractions.IVariableCollection!
+Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec.RootVariableCollection.get -> Microsoft.TemplateEngine.Abstractions.IVariableCollection!
+Microsoft.TemplateEngine.Core.Contracts.IMonitoredVariableCollection
+Microsoft.TemplateEngine.Core.Contracts.IMonitoredVariableCollection.KeysChanged -> Microsoft.TemplateEngine.Core.Contracts.KeysChangedEventHander!
+Microsoft.TemplateEngine.Core.Contracts.IMonitoredVariableCollection.ValueRead -> Microsoft.TemplateEngine.Core.Contracts.ValueReadEventHander!
+Microsoft.TemplateEngine.Core.Contracts.IOperation.Id.get -> string?
 Microsoft.TemplateEngine.Core.Contracts.IOperation.Tokens.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IToken?>!
 Microsoft.TemplateEngine.Core.Contracts.IOperationProvider.Id.get -> string?
 Microsoft.TemplateEngine.Core.Contracts.IProcessorState.SeekSourceForwardUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, ref int bufferLength, ref int currentBufferPosition, bool consumeToken = false) -> void

--- a/src/Microsoft.TemplateEngine.Core/Expressions/Cpp/CppStyleEvaluatorDefinition.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/Cpp/CppStyleEvaluatorDefinition.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Util;
 using Microsoft.TemplateEngine.Utils;

--- a/src/Microsoft.TemplateEngine.Core/Expressions/Shared/SharedEvaluatorDefinition.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/Shared/SharedEvaluatorDefinition.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Util;
 using Microsoft.TemplateEngine.Utils;

--- a/src/Microsoft.TemplateEngine.Core/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Core/PublicAPI.Shipped.txt
@@ -422,14 +422,10 @@ Microsoft.TemplateEngine.Core.Operations.MarkupTokens.OpenOpenElementToken.get -
 ~Microsoft.TemplateEngine.Core.Util.EncodingConfig.VariableValues.get -> System.Collections.Generic.IReadOnlyList<System.Func<object>>
 ~Microsoft.TemplateEngine.Core.Util.EncodingConfig.Whitespace.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenTrie
 ~Microsoft.TemplateEngine.Core.Util.EncodingConfig.WhitespaceOrLineEnding.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenTrie
-Microsoft.TemplateEngine.Core.Util.EngineConfig.EngineConfig(Microsoft.Extensions.Logging.ILogger! logger, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection! variables) -> void
-Microsoft.TemplateEngine.Core.Util.EngineConfig.EngineConfig(Microsoft.Extensions.Logging.ILogger! logger, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection! variables, string! variableFormatString) -> void
-Microsoft.TemplateEngine.Core.Util.EngineConfig.EngineConfig(Microsoft.Extensions.Logging.ILogger! logger, System.Collections.Generic.IReadOnlyList<string!>! whitespaces, System.Collections.Generic.IReadOnlyList<string!>! lineEndings, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection! variables, string! variableFormatString = "{0}") -> void
 Microsoft.TemplateEngine.Core.Util.EngineConfig.Flags.get -> System.Collections.Generic.IDictionary<string!, bool>!
 Microsoft.TemplateEngine.Core.Util.EngineConfig.LineEndings.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateEngine.Core.Util.EngineConfig.Logger.get -> Microsoft.Extensions.Logging.ILogger!
 Microsoft.TemplateEngine.Core.Util.EngineConfig.VariableFormatString.get -> string!
-Microsoft.TemplateEngine.Core.Util.EngineConfig.Variables.get -> Microsoft.TemplateEngine.Core.Contracts.IVariableCollection!
 Microsoft.TemplateEngine.Core.Util.EngineConfig.Whitespaces.get -> System.Collections.Generic.IReadOnlyList<string!>!
 ~Microsoft.TemplateEngine.Core.Util.Processor.CloneAndAppendOperations(System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Core.Contracts.IOperationProvider> tempOperations) -> Microsoft.TemplateEngine.Core.Contracts.IProcessor
 ~Microsoft.TemplateEngine.Core.Util.Processor.Config.get -> Microsoft.TemplateEngine.Core.Util.EngineConfig
@@ -517,8 +513,6 @@ Microsoft.TemplateEngine.Core.VariableCollection.CopyTo(System.Collections.Gener
 Microsoft.TemplateEngine.Core.VariableCollection.GetEnumerator() -> System.Collections.Generic.IEnumerator<System.Collections.Generic.KeyValuePair<string!, object!>>!
 Microsoft.TemplateEngine.Core.VariableCollection.Keys.get -> System.Collections.Generic.ICollection<string!>!
 Microsoft.TemplateEngine.Core.VariableCollection.KeysChanged -> Microsoft.TemplateEngine.Core.Contracts.KeysChangedEventHander?
-Microsoft.TemplateEngine.Core.VariableCollection.Parent.get -> Microsoft.TemplateEngine.Core.Contracts.IVariableCollection?
-Microsoft.TemplateEngine.Core.VariableCollection.Parent.set -> void
 Microsoft.TemplateEngine.Core.VariableCollection.Remove(string! key) -> bool
 Microsoft.TemplateEngine.Core.VariableCollection.Remove(System.Collections.Generic.KeyValuePair<string!, object!> item) -> bool
 Microsoft.TemplateEngine.Core.VariableCollection.this[string! key].get -> object!
@@ -526,9 +520,7 @@ Microsoft.TemplateEngine.Core.VariableCollection.this[string! key].set -> void
 Microsoft.TemplateEngine.Core.VariableCollection.TryGetValue(string! key, out object! value) -> bool
 Microsoft.TemplateEngine.Core.VariableCollection.ValueRead -> Microsoft.TemplateEngine.Core.Contracts.ValueReadEventHander?
 Microsoft.TemplateEngine.Core.VariableCollection.Values.get -> System.Collections.Generic.ICollection<object!>!
-Microsoft.TemplateEngine.Core.VariableCollection.VariableCollection(Microsoft.TemplateEngine.Core.Contracts.IVariableCollection? parent, System.Collections.Generic.IDictionary<string!, object!>! values) -> void
 Microsoft.TemplateEngine.Core.VariableCollection.VariableCollection(Microsoft.TemplateEngine.Core.VariableCollection? parent) -> void
-static Microsoft.TemplateEngine.Core.Expressions.Cpp.CppStyleEvaluatorDefinition.EvaluateFromString(Microsoft.Extensions.Logging.ILogger! logger, string! text, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection! variables) -> bool
 static Microsoft.TemplateEngine.Core.Expressions.Cpp.CppStyleEvaluatorDefinition.Evaluate(Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processor, ref int bufferLength, ref int currentBufferPosition, out bool faulted) -> bool
 static Microsoft.TemplateEngine.Core.Util.EngineConfig.DefaultLineEndings.get -> System.Collections.Generic.IReadOnlyList<string!>!
 static Microsoft.TemplateEngine.Core.Util.EngineConfig.DefaultLineEndings.set -> void
@@ -536,7 +528,6 @@ static Microsoft.TemplateEngine.Core.Util.EngineConfig.DefaultWhitespaces.get ->
 static Microsoft.TemplateEngine.Core.Util.EngineConfig.DefaultWhitespaces.set -> void
 static Microsoft.TemplateEngine.Core.VariableCollection.Root() -> Microsoft.TemplateEngine.Core.VariableCollection!
 static Microsoft.TemplateEngine.Core.VariableCollection.Root(System.Collections.Generic.IDictionary<string!, object!>! values) -> Microsoft.TemplateEngine.Core.VariableCollection!
-static Microsoft.TemplateEngine.Core.VariableCollection.SetupVariables(Microsoft.TemplateEngine.Abstractions.Parameters.IParameterSetData! parameters, Microsoft.TemplateEngine.Core.Contracts.IVariableConfig! variableConfig) -> Microsoft.TemplateEngine.Core.Contracts.IVariableCollection!
 virtual Microsoft.TemplateEngine.Core.Util.Orchestrator.RunSpecLoader(System.IO.Stream! runSpec) -> Microsoft.TemplateEngine.Core.Contracts.IGlobalRunSpec!
 virtual Microsoft.TemplateEngine.Core.Util.Orchestrator.TryGetBufferSize(Microsoft.TemplateEngine.Abstractions.Mount.IFile! sourceFile, out int bufferSize) -> bool
 virtual Microsoft.TemplateEngine.Core.Util.Orchestrator.TryGetFlushThreshold(Microsoft.TemplateEngine.Abstractions.Mount.IFile! sourceFile, out int threshold) -> bool
@@ -548,5 +539,3 @@ Microsoft.TemplateEngine.Core.Operations.MarkupTokens.MarkupTokens(Microsoft.Tem
 Microsoft.TemplateEngine.Core.Operations.MarkupTokens.SelfClosingElementEndToken.get -> Microsoft.TemplateEngine.Core.Contracts.ITokenConfig!
 ~static Microsoft.TemplateEngine.Core.Expressions.Shared.SharedEvaluatorDefinition<TSelf, TTokens>.Evaluate(Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor, ref int bufferLength, ref int currentBufferPosition, out bool faulted) -> bool
 ~static Microsoft.TemplateEngine.Core.Expressions.Shared.SharedEvaluatorDefinition<TSelf, TTokens>.Evaluate(Microsoft.TemplateEngine.Core.Contracts.IProcessorState processor, ref int bufferLength, ref int currentBufferPosition, out string faultedMessage, System.Collections.Generic.HashSet<string> referencedVariablesKeys) -> bool
-~static Microsoft.TemplateEngine.Core.Expressions.Shared.SharedEvaluatorDefinition<TSelf, TTokens>.EvaluateFromString(Microsoft.Extensions.Logging.ILogger logger, string text, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection variables) -> bool
-~static Microsoft.TemplateEngine.Core.Expressions.Shared.SharedEvaluatorDefinition<TSelf, TTokens>.EvaluateFromString(Microsoft.Extensions.Logging.ILogger logger, string text, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection variables, out string faultedMessage, System.Collections.Generic.HashSet<string> referencedVariablesKeys = null) -> bool

--- a/src/Microsoft.TemplateEngine.Core/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Core/PublicAPI.Unshipped.txt
@@ -3,11 +3,22 @@ Microsoft.TemplateEngine.Core.Matching.OperationTerminal.OperationTerminal(Micro
 Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>
 Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>.Terminal.get -> T!
 Microsoft.TemplateEngine.Core.Matching.TerminalLocation<T>.TerminalLocation(T! terminal, int location) -> void
+Microsoft.TemplateEngine.Core.Util.EngineConfig.EngineConfig(Microsoft.Extensions.Logging.ILogger! logger, Microsoft.TemplateEngine.Abstractions.IVariableCollection! variables) -> void
+Microsoft.TemplateEngine.Core.Util.EngineConfig.EngineConfig(Microsoft.Extensions.Logging.ILogger! logger, Microsoft.TemplateEngine.Abstractions.IVariableCollection! variables, string! variableFormatString) -> void
+Microsoft.TemplateEngine.Core.Util.EngineConfig.EngineConfig(Microsoft.Extensions.Logging.ILogger! logger, System.Collections.Generic.IReadOnlyList<string!>! whitespaces, System.Collections.Generic.IReadOnlyList<string!>! lineEndings, Microsoft.TemplateEngine.Abstractions.IVariableCollection! variables, string! variableFormatString = "{0}") -> void
+Microsoft.TemplateEngine.Core.Util.EngineConfig.Variables.get -> Microsoft.TemplateEngine.Abstractions.IVariableCollection!
 Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekSourceForwardUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, ref int bufferLength, ref int currentBufferPosition, bool consumeToken = false) -> void
 Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekSourceForwardWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! trie, ref int bufferLength, ref int currentBufferPosition) -> void
 Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekTargetBackUntil(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match, bool consume = false) -> void
 Microsoft.TemplateEngine.Core.Util.ProcessorState.SeekTargetBackWhile(Microsoft.TemplateEngine.Core.Contracts.ITokenTrie! match) -> void
 Microsoft.TemplateEngine.Core.Util.ProcessorState.WriteToTarget(byte[]! buffer, int offset, int count) -> void
+Microsoft.TemplateEngine.Core.VariableCollection.Parent.get -> Microsoft.TemplateEngine.Abstractions.IVariableCollection?
+Microsoft.TemplateEngine.Core.VariableCollection.Parent.set -> void
+Microsoft.TemplateEngine.Core.VariableCollection.VariableCollection(Microsoft.TemplateEngine.Abstractions.IVariableCollection? parent, System.Collections.Generic.IDictionary<string!, object!>! values) -> void
 static Microsoft.TemplateEngine.Core.CommonOperations.ConsumeWholeLine(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processor, ref int bufferLength, ref int currentBufferPosition) -> void
 static Microsoft.TemplateEngine.Core.CommonOperations.TrimWhitespace(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processor, bool forward, bool backward, ref int bufferLength, ref int currentBufferPosition) -> void
 static Microsoft.TemplateEngine.Core.CommonOperations.WhitespaceHandler(this Microsoft.TemplateEngine.Core.Contracts.IProcessorState! processor, ref int bufferLength, ref int currentBufferPosition, bool wholeLine = false, bool trim = false, bool trimForward = false, bool trimBackward = false) -> void
+static Microsoft.TemplateEngine.Core.Expressions.Cpp.CppStyleEvaluatorDefinition.EvaluateFromString(Microsoft.Extensions.Logging.ILogger! logger, string! text, Microsoft.TemplateEngine.Abstractions.IVariableCollection! variables) -> bool
+static Microsoft.TemplateEngine.Core.VariableCollection.SetupVariables(Microsoft.TemplateEngine.Abstractions.Parameters.IParameterSetData! parameters, Microsoft.TemplateEngine.Core.Contracts.IVariableConfig! variableConfig) -> Microsoft.TemplateEngine.Abstractions.IVariableCollection!
+~static Microsoft.TemplateEngine.Core.Expressions.Shared.SharedEvaluatorDefinition<TSelf, TTokens>.EvaluateFromString(Microsoft.Extensions.Logging.ILogger logger, string text, Microsoft.TemplateEngine.Abstractions.IVariableCollection variables) -> bool
+~static Microsoft.TemplateEngine.Core.Expressions.Shared.SharedEvaluatorDefinition<TSelf, TTokens>.EvaluateFromString(Microsoft.Extensions.Logging.ILogger logger, string text, Microsoft.TemplateEngine.Abstractions.IVariableCollection variables, out string faultedMessage, System.Collections.Generic.HashSet<string> referencedVariablesKeys = null) -> bool

--- a/src/Microsoft.TemplateEngine.Core/Util/EngineConfig.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/EngineConfig.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Core.Util

--- a/src/Microsoft.TemplateEngine.Core/VariableCollection.cs
+++ b/src/Microsoft.TemplateEngine.Core/VariableCollection.cs
@@ -13,7 +13,7 @@ using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Core
 {
-    public class VariableCollection : IVariableCollection
+    public class VariableCollection : IVariableCollection, IMonitoredVariableCollection
     {
         private static readonly IEnumerable<string> NoKeys = Array.Empty<string>();
         private readonly IDictionary<string, object> _values;
@@ -42,9 +42,9 @@ namespace Microsoft.TemplateEngine.Core
             _parent = parent;
             _values = values ?? new Dictionary<string, object>();
 
-            if (_parent != null)
+            if (_parent is not null and IMonitoredVariableCollection monitored)
             {
-                _parent.KeysChanged += RelayKeysChanged;
+                monitored.KeysChanged += RelayKeysChanged;
             }
         }
 

--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Shipped.txt
@@ -50,7 +50,6 @@ Microsoft.TemplateEngine.Edge.Settings.FilteredTemplateInfo.IsPartialMatch.get -
 Microsoft.TemplateEngine.Edge.Settings.InstallationScope
 Microsoft.TemplateEngine.Edge.Settings.InstallationScope.Global = 0 -> Microsoft.TemplateEngine.Edge.Settings.InstallationScope
 Microsoft.TemplateEngine.Edge.Settings.ITemplateInfoHostJsonCache
-Microsoft.TemplateEngine.Edge.Settings.ITemplateInfoHostJsonCache.HostData.get -> Newtonsoft.Json.Linq.JObject?
 Microsoft.TemplateEngine.Edge.Settings.Scanner
 Microsoft.TemplateEngine.Edge.Settings.Scanner.Scan(string! mountPointUri) -> Microsoft.TemplateEngine.Edge.Settings.ScanResult!
 Microsoft.TemplateEngine.Edge.Settings.Scanner.Scan(string! mountPointUri, bool scanForComponents) -> Microsoft.TemplateEngine.Edge.Settings.ScanResult!

--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Microsoft.TemplateEngine.Edge.Settings.ITemplateInfoHostJsonCache.HostData.get -> string?

--- a/src/Microsoft.TemplateEngine.Edge/Settings/ITemplateInfoHostJsonCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/ITemplateInfoHostJsonCache.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.TemplateEngine.Abstractions;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Edge.Settings
 {
@@ -12,8 +11,8 @@ namespace Microsoft.TemplateEngine.Edge.Settings
     public interface ITemplateInfoHostJsonCache
     {
         /// <summary>
-        /// Full content of .host.json file.
+        /// Full content of .host.json file in JSON format.
         /// </summary>
-        JObject? HostData { get; }
+        string? HostData { get; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfo.cs
@@ -117,7 +117,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     using (var sr = new StreamReader(hostFile.OpenRead()))
                     using (var jsonTextReader = new JsonTextReader(sr))
                     {
-                        HostData = JObject.Load(jsonTextReader);
+                        HostData = JObject.Load(jsonTextReader).ToString(Formatting.None);
                     }
                 }
                 catch (Exception ex)
@@ -260,7 +260,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         [JsonIgnore]
         bool ITemplateInfo.HasScriptRunningPostActions { get; set; }
 
-        public JObject? HostData { get; private set; }
+        public string? HostData { get; private set; }
 
         [JsonProperty]
         public IReadOnlyList<Guid> PostActions { get; private set; } = Array.Empty<Guid>();

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateInfoReader.cs
@@ -98,7 +98,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
                     info.TagsCollection = tags;
                 }
 
-                info.HostData = entry.Get<JObject>(nameof(info.HostData));
+                info.HostData = entry.Get<JObject>(nameof(info.HostData))?.ToString(Newtonsoft.Json.Formatting.None);
                 JArray? postActionsArray = entry.Get<JArray>(nameof(info.PostActions));
                 if (postActionsArray != null)
                 {

--- a/src/Microsoft.TemplateEngine.Edge/Template/InputParameterData.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/InputParameterData.cs
@@ -50,6 +50,5 @@ public class InputParameterData
     /// </summary>
     public InputDataState InputDataState { get; }
 
-    /// <inheritdoc/>
     public override string ToString() => $"{ParameterDefinition}: {Value?.ToString() ?? "<null>"}";
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Abstractions/IDeterministicModeMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Abstractions/IDeterministicModeMacro.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions
 {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Abstractions/IMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Abstractions/IMacro.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions
 {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/BindSymbolEvaluator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/BindSymbolEvaluator.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Components;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel;
 using Microsoft.TemplateEngine.Utils;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BaseValueSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BaseValueSymbol.cs
@@ -69,7 +69,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel
         /// </summary>
         public string? DataType { get; internal init; }
 
-        protected bool TryGetIsRequiredField(JToken token, out bool result)
+        private protected bool TryGetIsRequiredField(JToken token, out bool result)
         {
             result = false;
             return (token.Type == JTokenType.Boolean || token.Type == JTokenType.String)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ConditionedConfigurationElement.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ConditionedConfigurationElement.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Expressions.Cpp2;
-using Newtonsoft.Json;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel
 {
@@ -27,7 +26,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel
         /// Stores the result of condition evaluation. <see cref="EvaluateCondition(ILogger, IVariableCollection)"/> should be done before accessting this property.
         /// </summary>
         /// <exception cref="InvalidOperationException">when the property is accessed prior to <see cref="EvaluateCondition(ILogger, IVariableCollection)"/> method is called.</exception>
-        [JsonIgnore]
         public bool ConditionResult
         {
             get

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ConditionedConfigurationElement.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ConditionedConfigurationElement.cs
@@ -3,7 +3,7 @@
 
 using System;
 using Microsoft.Extensions.Logging;
-using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Expressions.Cpp2;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/CustomFileGlobModel.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/CustomFileGlobModel.cs
@@ -30,14 +30,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel
         public IReadOnlyList<CustomOperationModel> Operations { get; }
 
         /// <summary>
-        /// Gets the variable configuration format.
-        /// </summary>
-        public IVariableConfig VariableFormat { get; } = VariableConfig.DefaultVariableSetup();
-
-        /// <summary>
         /// Gets the prefix that is used in flags.
         /// </summary>
         public string? FlagPrefix { get; internal init; }
+
+        /// <summary>
+        /// Gets the variable configuration format.
+        /// </summary>
+        internal IVariableConfig VariableFormat { get; } = VariableConfig.Default;
 
         internal static CustomFileGlobModel FromJObject(JObject globData, string globName)
         {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/EvaluatorSelector.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/EvaluatorSelector.cs
@@ -3,7 +3,7 @@
 
 using System;
 using Microsoft.Extensions.Logging;
-using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Expressions.Cpp;
 using Microsoft.TemplateEngine.Core.Expressions.Cpp2;
 using Microsoft.TemplateEngine.Core.Expressions.MSBuild;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunConfig.cs
@@ -14,7 +14,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
     {
         public IReadOnlyList<IOperationProvider> Operations { get; init; } = Array.Empty<IOperationProvider>();
 
-        public IVariableConfig VariableSetup { get; init; } = VariableConfig.DefaultVariableSetup();
+        public IVariableConfig VariableSetup { get; init; } = VariableConfig.Default;
 
         public IReadOnlyList<IGeneratedSymbolConfig> GeneratedSymbolMacros { get; init; } = Array.Empty<IGeneratedSymbolConfig>();
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IRunnableProjectConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/IRunnableProjectConfig.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/MacroProcessor.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/MacroProcessor.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros;
 using Microsoft.TemplateEngine.Utils;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/BaseGeneratedSymbolMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/BaseGeneratedSymbolMacro.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/BaseMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/BaseMacro.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/BaseMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/BaseMacroConfig.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Text.RegularExpressions;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json.Linq;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CaseChangeMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CaseChangeMacro.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CoalesceMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/CoalesceMacro.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ConstantMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ConstantMacro.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/EvaluateMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/EvaluateMacro.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GeneratePortNumberMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GeneratePortNumberMacro.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GuidMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/GuidMacro.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/JoinMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/JoinMacro.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 using Microsoft.TemplateEngine.Utils;
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/NowMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/NowMacro.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ProcessValueFormMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/ProcessValueFormMacro.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
 {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RandomMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RandomMacro.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMacro.cs
@@ -5,7 +5,6 @@ using System;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMatchMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/RegexMatchMacro.cs
@@ -5,7 +5,6 @@ using System;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/SwitchMacro.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/SwitchMacro.cs
@@ -4,7 +4,6 @@
 using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostAction.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostAction.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Shipped.txt
@@ -36,7 +36,6 @@ Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.CustomFileGlo
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.CustomFileGlobModel.FlagPrefix.get -> string?
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.CustomFileGlobModel.Glob.get -> string!
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.CustomFileGlobModel.Operations.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.CustomOperationModel!>!
-Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.CustomFileGlobModel.VariableFormat.get -> Microsoft.TemplateEngine.Core.Contracts.IVariableConfig!
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.CustomOperationModel
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.CustomOperationModel.Configuration.get -> string?
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.CustomOperationModel.Type.get -> string?

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Shipped.txt
@@ -6,7 +6,6 @@ Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Components
 static Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Components.AllComponents.get -> System.Collections.Generic.IReadOnlyList<(System.Type! Type, Microsoft.TemplateEngine.Abstractions.IIdentifiedComponent! Instance)>!
 abstract Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.BaseSymbol.Type.get -> string!
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IDeferredMacro.CreateConfig(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! environmentSettings, Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacroConfig! rawConfig) -> Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacroConfig!
-Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro.EvaluateConfig(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! environmentSettings, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection! vars, Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacroConfig! config) -> void
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacroConfig
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacroConfig.Type.get -> string!
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacroConfig.VariableName.get -> string!
@@ -31,7 +30,6 @@ Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.ConditionedCo
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.ConditionedConfigurationElement.Condition.get -> string?
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.ConditionedConfigurationElement.ConditionedConfigurationElement() -> void
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.ConditionedConfigurationElement.ConditionResult.get -> bool
-Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.ConditionedConfigurationElement.EvaluateCondition(Microsoft.Extensions.Logging.ILogger! logger, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection! variables) -> bool
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.CustomFileGlobModel
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.CustomFileGlobModel.FlagPrefix.get -> string?
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.CustomFileGlobModel.Glob.get -> string!

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Unshipped.txt
@@ -2,6 +2,8 @@
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IGeneratedSymbolConfig.DataType.get -> string!
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IGeneratedSymbolConfig.Parameters.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IGeneratedSymbolMacro
+Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro.EvaluateConfig(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! environmentSettings, Microsoft.TemplateEngine.Abstractions.IVariableCollection! vars, Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacroConfig! config) -> void
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro<T>
-Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro<T>.Evaluate(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! environmentSettings, Microsoft.TemplateEngine.Core.Contracts.IVariableCollection! variables, T config) -> void
+Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro<T>.Evaluate(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! environmentSettings, Microsoft.TemplateEngine.Abstractions.IVariableCollection! variables, T config) -> void
+Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.ConditionedConfigurationElement.EvaluateCondition(Microsoft.Extensions.Logging.ILogger! logger, Microsoft.TemplateEngine.Abstractions.IVariableCollection! variables) -> bool
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.TemplateConfigModel.Identity.get -> string!

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
@@ -462,7 +462,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 operations.AddRange(FlagsConfig.FlagsDefaultSetup(customGlobModel.FlagPrefix!));
             }
 
-            IVariableConfig variableConfig = customGlobModel != null ? customGlobModel.VariableFormat : VariableConfig.DefaultVariableSetup();
+            IVariableConfig variableConfig = customGlobModel != null ? customGlobModel.VariableFormat : VariableConfig.Default;
             List<IGeneratedSymbolConfig> generatedSymbolMacros = new();
             List<BaseMacroConfig> computedMacros = new();
             List<IReplacementTokens> macroGeneratedReplacements = new();

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/VariableConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/VariableConfig.cs
@@ -28,15 +28,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         public bool Expand { get; private init; }
 
-        internal static IVariableConfig DefaultVariableSetup()
-        {
-            return new VariableConfig(
+        internal static IVariableConfig Default { get; } =
+                new VariableConfig(
                 new Dictionary<string, string>
                 {
                     { "user", "{0}" }
                 },
                 new[] { "user" },
                 null);
-        }
     }
 }

--- a/src/Microsoft.TemplateEngine.Utils/ExactVersionSpecification.cs
+++ b/src/Microsoft.TemplateEngine.Utils/ExactVersionSpecification.cs
@@ -30,7 +30,6 @@ namespace Microsoft.TemplateEngine.Utils
             return result.HasValue && result.Value == 0;
         }
 
-        /// <inheritdoc/>
         public override string ToString() => RequiredVersion;
     }
 }

--- a/src/Microsoft.TemplateEngine.Utils/MultiValueParameter.cs
+++ b/src/Microsoft.TemplateEngine.Utils/MultiValueParameter.cs
@@ -67,10 +67,8 @@ namespace Microsoft.TemplateEngine.Utils
             return true;
         }
 
-        /// <inheritdoc/>
         public override string ToString() => string.Join(MultiValueSeparator.ToString(), Values);
 
-        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is null)
@@ -91,7 +89,6 @@ namespace Microsoft.TemplateEngine.Utils
             return Equals((MultiValueParameter)obj);
         }
 
-        /// <inheritdoc/>
         public override int GetHashCode() => Values.OrderBy(v => v).ToCsvString().GetHashCode();
 
         protected bool Equals(MultiValueParameter other)

--- a/src/Microsoft.TemplateEngine.Utils/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Utils/PublicAPI.Shipped.txt
@@ -109,9 +109,7 @@ Microsoft.TemplateEngine.Utils.TemplateMatchInfoExtensions
 Microsoft.TemplateEngine.Utils.TemplateParameter
 Microsoft.TemplateEngine.Utils.TemplateParameter.Choices.get -> System.Collections.Generic.IReadOnlyDictionary<string!, Microsoft.TemplateEngine.Abstractions.ParameterChoice!>?
 Microsoft.TemplateEngine.Utils.TemplateParameter.DataType.get -> string!
-Microsoft.TemplateEngine.Utils.TemplateParameter.DataType.set -> void
 Microsoft.TemplateEngine.Utils.TemplateParameter.DefaultIfOptionWithoutValue.get -> string?
-Microsoft.TemplateEngine.Utils.TemplateParameter.DefaultIfOptionWithoutValue.set -> void
 Microsoft.TemplateEngine.Utils.TemplateParameter.DefaultValue.get -> string?
 Microsoft.TemplateEngine.Utils.TemplateParameter.Description.get -> string?
 Microsoft.TemplateEngine.Utils.TemplateParameter.DisplayName.get -> string?
@@ -119,7 +117,6 @@ Microsoft.TemplateEngine.Utils.TemplateParameter.Documentation.get -> string?
 Microsoft.TemplateEngine.Utils.TemplateParameter.IsName.get -> bool
 Microsoft.TemplateEngine.Utils.TemplateParameter.Name.get -> string!
 Microsoft.TemplateEngine.Utils.TemplateParameter.Priority.get -> Microsoft.TemplateEngine.Abstractions.TemplateParameterPriority
-Microsoft.TemplateEngine.Utils.TemplateParameter.TemplateParameter(Newtonsoft.Json.Linq.JObject! jObject) -> void
 Microsoft.TemplateEngine.Utils.TemplateParameter.Type.get -> string!
 Microsoft.TemplateEngine.Utils.TemplateParameterExtensions
 Microsoft.TemplateEngine.Utils.Timing

--- a/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Utils/PublicAPI.Unshipped.txt
@@ -11,5 +11,13 @@ Microsoft.TemplateEngine.Utils.DictionaryExtensions.ConflictingKeysResolution.Pr
 Microsoft.TemplateEngine.Utils.DictionaryExtensions.ConflictingKeysResolution.Throw = 2 -> Microsoft.TemplateEngine.Utils.DictionaryExtensions.ConflictingKeysResolution
 Microsoft.TemplateEngine.Utils.IPatternMatcher
 Microsoft.TemplateEngine.Utils.IPatternMatcher.IsMatch(string! test) -> bool
+Microsoft.TemplateEngine.Utils.TemplateParameter.AllowMultipleValues.init -> void
+Microsoft.TemplateEngine.Utils.TemplateParameter.Choices.init -> void
+Microsoft.TemplateEngine.Utils.TemplateParameter.DefaultIfOptionWithoutValue.init -> void
+Microsoft.TemplateEngine.Utils.TemplateParameter.DefaultValue.init -> void
+Microsoft.TemplateEngine.Utils.TemplateParameter.Description.init -> void
+Microsoft.TemplateEngine.Utils.TemplateParameter.DisplayName.init -> void
+Microsoft.TemplateEngine.Utils.TemplateParameter.IsName.init -> void
+Microsoft.TemplateEngine.Utils.TemplateParameter.Precedence.init -> void
 static Microsoft.TemplateEngine.Utils.DictionaryExtensions.Merge<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue>! dict, System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>! another, Microsoft.TemplateEngine.Utils.DictionaryExtensions.ConflictingKeysResolution conflictingKeysResolution = Microsoft.TemplateEngine.Utils.DictionaryExtensions.ConflictingKeysResolution.Overwrite) -> void
 static readonly Microsoft.TemplateEngine.Utils.Glob.MatchAll -> Microsoft.TemplateEngine.Utils.IPatternMatcher!

--- a/src/Microsoft.TemplateEngine.Utils/RangeVersionSpecification.cs
+++ b/src/Microsoft.TemplateEngine.Utils/RangeVersionSpecification.cs
@@ -116,7 +116,6 @@ namespace Microsoft.TemplateEngine.Utils
             return isStartValid && isEndValid;
         }
 
-        /// <inheritdoc/>
         public override string ToString()
         {
             return $"{(IsStartInclusive ? "[" : "(")}{MinVersion}-{MaxVersion}{(IsEndInclusive ? "]" : ")")}";

--- a/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/BlobStorageTemplateInfo.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/BlobStorageTemplateInfo.cs
@@ -78,7 +78,7 @@ namespace Microsoft.TemplateSearch.Common
 
         [JsonProperty(nameof(Parameters))]
         //reading manually now to support old format
-        public IParameterDefinitionSet ParameterDefinitions { get; private set; } = TemplateEngine.Abstractions.Parameters.ParameterDefinitionSet.Empty;
+        public IParameterDefinitionSet ParameterDefinitions { get; private set; } = ParameterDefinitionSet.Empty;
 
         [JsonIgnore]
         [Obsolete("Use ParameterDefinitionSet instead.")]

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.InlineMarkup.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/ConditionalTests.InlineMarkup.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Expressions.MSBuild;
 using Microsoft.TemplateEngine.Core.Operations;

--- a/test/Microsoft.TemplateEngine.Core.UnitTests/PhasedOperationTests.cs
+++ b/test/Microsoft.TemplateEngine.Core.UnitTests/PhasedOperationTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Operations;
 using Microsoft.TemplateEngine.Core.Util;

--- a/test/Microsoft.TemplateEngine.Mocks/MockGlobalRunSpec.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockGlobalRunSpec.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core.Contracts;
 
 namespace Microsoft.TemplateEngine.Mocks

--- a/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
@@ -136,9 +136,7 @@ namespace Microsoft.TemplateEngine.Mocks
         {
             foreach (var param in parameters)
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                _parameters[param] = new TemplateParameter(param, "parameter", "string", priority: TemplateParameterPriority.Optional);
-#pragma warning restore CS0618 // Type or member is obsolete
+                _parameters[param] = new TemplateParameter(param, "parameter", "string", precedence: new TemplateParameterPrecedence(PrecedenceDefinition.Optional));
             }
             return this;
         }
@@ -151,46 +149,40 @@ namespace Microsoft.TemplateEngine.Mocks
 
         public MockTemplateInfo WithChoiceParameter(string name, params string[] values)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             _parameters.Add(name, new TemplateParameter(
                 name,
                 type: "parameter",
                 datatype: "choice",
-                priority: TemplateParameterPriority.Optional,
+                precedence: new TemplateParameterPrecedence(PrecedenceDefinition.Optional),
                 choices: values.ToDictionary(v => v, v => new ParameterChoice(null, null))));
-#pragma warning restore CS0618 // Type or member is obsolete
             return this;
         }
 
         public MockTemplateInfo WithMultiChoiceParameter(string name, params string[] values)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             _parameters.Add(name, new TemplateParameter(
                 name,
                 type: "parameter",
                 datatype: "choice",
-                priority: TemplateParameterPriority.Optional,
+                precedence: new TemplateParameterPrecedence(PrecedenceDefinition.Optional),
                 allowMultipleValues: true,
                 choices: values.ToDictionary(v => v, v => new ParameterChoice(null, null))));
-#pragma warning restore CS0618 // Type or member is obsolete
             return this;
         }
 
         public MockTemplateInfo WithChoiceParameter(string name, string[] values, bool isRequired = false, string? defaultValue = null, string? defaultIfNoOptionValue = null, string? description = null, bool allowMultipleValues = false)
         {
 #pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
             _parameters.Add(name, new TemplateParameter(
                 name,
                 type: "parameter",
                 datatype: "choice",
                 description: description,
-                priority: isRequired ? TemplateParameterPriority.Required : TemplateParameterPriority.Optional,
+                precedence: (isRequired ? TemplateParameterPriority.Required : TemplateParameterPriority.Optional).ToTemplateParameterPrecedence(),
                 defaultValue: defaultValue,
                 defaultIfOptionWithoutValue: defaultIfNoOptionValue,
                 allowMultipleValues: allowMultipleValues,
                 choices: values.ToDictionary(v => v, v => new ParameterChoice(null, null))));
-#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0618 // Type or member is obsolete
             return this;
         }
@@ -216,16 +208,14 @@ namespace Microsoft.TemplateEngine.Mocks
         public MockTemplateInfo WithParameter(string paramName, string paramType = "string", bool isRequired = false, string? defaultValue = null, string? defaultIfNoOptionValue = null, string? description = null)
         {
 #pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
             _parameters[paramName] = new TemplateParameter(
                 paramName,
                 "parameter",
                 paramType,
-                isRequired ? TemplateParameterPriority.Required : TemplateParameterPriority.Optional,
+                (isRequired ? TemplateParameterPriority.Required : TemplateParameterPriority.Optional).ToTemplateParameterPrecedence(),
                 description: description,
                 defaultValue: defaultValue,
                 defaultIfOptionWithoutValue: defaultIfNoOptionValue);
-#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0618 // Type or member is obsolete
             return this;
         }
@@ -315,104 +305,6 @@ namespace Microsoft.TemplateEngine.Mocks
         }
 
         #endregion XUnitSerializable implementation
-
-        private class TemplateParameter : ITemplateParameter
-        {
-            [JsonConstructor]
-            internal TemplateParameter(
-                string name,
-                string type,
-                string datatype,
-#pragma warning disable CS0618 // Type or member is obsolete
-                TemplateParameterPriority priority = default,
-#pragma warning restore CS0618 // Type or member is obsolete
-                bool isName = false,
-                string? defaultValue = null,
-                string? defaultIfOptionWithoutValue = null,
-                string? description = null,
-                string? displayName = null,
-                IReadOnlyDictionary<string, ParameterChoice>? choices = null,
-                bool allowMultipleValues = false)
-            {
-                Name = name;
-                Type = type;
-                DataType = datatype;
-                Priority = priority;
-                IsName = isName;
-                DefaultValue = defaultValue;
-                DefaultIfOptionWithoutValue = defaultIfOptionWithoutValue;
-                Description = description;
-                DisplayName = displayName;
-                AllowMultipleValues = allowMultipleValues;
-#pragma warning disable CS0618 // Type or member is obsolete
-                Precedence = priority.ToTemplateParameterPrecedence();
-#pragma warning restore CS0618 // Type or member is obsolete
-
-                if (this.IsChoice())
-                {
-                    Choices = choices ?? new Dictionary<string, ParameterChoice>();
-                }
-            }
-
-            [Obsolete("Use Description instead.")]
-            public string? Documentation => Description;
-
-            [JsonProperty]
-            public string Name { get; }
-
-            [JsonProperty]
-#pragma warning disable CS0618 // Type or member is obsolete
-            public TemplateParameterPriority Priority { get; }
-#pragma warning restore CS0618 // Type or member is obsolete
-
-            public TemplateParameterPrecedence Precedence { get; }
-
-            [JsonProperty]
-            public string Type { get; }
-
-            [JsonProperty]
-            public bool IsName { get; }
-
-            [JsonProperty]
-            public string? DefaultValue { get; }
-
-            [JsonProperty]
-            public string DataType { get; set; }
-
-            [JsonProperty]
-            public string? DefaultIfOptionWithoutValue { get; set; }
-
-            [JsonProperty]
-            public IReadOnlyDictionary<string, ParameterChoice>? Choices { get; }
-
-            [JsonProperty]
-            public string? Description { get; }
-
-            [JsonProperty]
-            public string? DisplayName { get; }
-
-            [JsonProperty]
-            public bool AllowMultipleValues { get; }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(this, obj))
-                {
-                    return true;
-                }
-
-                if (obj is ITemplateParameter parameter)
-                {
-                    return Equals(parameter);
-                }
-
-                return false;
-            }
-
-            public override int GetHashCode() => Name.GetHashCode();
-
-            public bool Equals(ITemplateParameter other) => !string.IsNullOrEmpty(Name) && !string.IsNullOrEmpty(other.Name) && Name == other.Name;
-        }
     }
 
 }

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/AdditionalData/CliHostTemplateDataLoader.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/AdditionalData/CliHostTemplateDataLoader.cs
@@ -23,11 +23,15 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.AdditionalData
         {
             IMountPoint? mountPoint = null;
 
-            if (templateInfo is ITemplateInfoHostJsonCache { HostData: JObject hostData })
+            if (templateInfo is ITemplateInfoHostJsonCache { HostData: string hostData })
             {
                 try
                 {
-                    return new CliHostTemplateData(hostData);
+                    if (!string.IsNullOrWhiteSpace(hostData))
+                    {
+                        JObject jObject = JObject.Parse(hostData);
+                        return new CliHostTemplateData(jObject);
+                    }
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
### Problem
fixes: https://github.com/dotnet/templating/issues/5478

### Solution
- `ITemplateInfoHostJsonCache` had exposed `JObject` - replaced with `string`
- removed usage of `seealso`
- removed `inheritdoc` from overridden members
- removed obsolete `Newtonsoft.Json` attributes
- removed public reference to `IVariableConfig`
- moved `IVariableCollection` to `Abstractions`
- refactored `TemplateParameter` to address the doc concerns (removed references to `Newtonsoft.Json`)

Suggested for 7.0.2xx - only minor changes
- https://github.com/dotnet/templating/pull/5672/commits/50e99efc389d7d2ffb231bc31cab2214e5e46dac
- https://github.com/dotnet/templating/pull/5672/commits/ca52ed26dca89d47ee388a62d9efba3db597c706
- https://github.com/dotnet/templating/pull/5672/commits/969fa8b2f14415952133fae446b84e61023efa93

### Checks:
- [ ] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)