### PR TITLE
add string value transform sample

### DIFF
--- a/dotnet-template-samples/17-string-value-transform/MyProject.Con/.template.config/template.json
+++ b/dotnet-template-samples/17-string-value-transform/MyProject.Con/.template.config/template.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Milan Jaros",
+  "classifications": [ "Console" ],
+  "name": "Contoso Sample 17",
+  "identity": "MyProject.17.Sample.CSharp",
+  "groupIdentity":"MyProject.17.Sample",
+  "shortName": "sample17",
+  "tags": {
+    "language": "C#",
+    "type":"project"
+  },
+  "sourceName": "MyProject.Con",
+  "preferNameDirectory": true,
+  "symbols":{
+    "ownername":{
+      "type": "parameter",
+      "datatype":"text",
+      "replaces": "John Smith (original)",
+      "defaultValue": "John Doe"
+    },
+    "pascalCasedName": {
+      "type": "derived",
+      "valueSource": "ownername",
+      "replaces": "John Smith (PascalCase)",
+      "valueTransform": "pascalCase"
+    },
+    "camelCasedName": {
+      "type": "derived",
+      "valueSource": "pascalCasedName",
+      "replaces": "John Smith (camelCase)",
+      "valueTransform": "firtstLowerCase"
+    },
+    "kebabCasedName": {
+      "type": "derived",
+      "valueSource": "pascalCasedName",
+      "replaces": "John Smith (kebab-case)",
+      "valueTransform": "kebabCase"
+    }
+  },
+  "forms" :{
+    "titleCase": {
+      "identifier": "titleCase"
+    },
+    "invalidChars": {
+      "identifier": "replace",
+      "pattern": "([\\-_\\.\\ ])",
+      "replacement": ""
+    },
+    "pascalCase": {
+      "identifier": "chain",
+      "steps": [
+        "titleCase",
+        "invalidChars"
+      ]
+    },
+    "kebabCase": {
+      "identifier": "kebabCase"
+    },
+    "firtstLowerCase": {
+      "identifier": "firstLowerCaseInvariant"
+    }
+  }
+}

--- a/dotnet-template-samples/17-string-value-transform/MyProject.Con/MyProject.Con.csproj
+++ b/dotnet-template-samples/17-string-value-transform/MyProject.Con/MyProject.Con.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/dotnet-template-samples/17-string-value-transform/MyProject.Con/MyProject.Con.csproj
+++ b/dotnet-template-samples/17-string-value-transform/MyProject.Con/MyProject.Con.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/dotnet-template-samples/17-string-value-transform/MyProject.Con/Program.cs
+++ b/dotnet-template-samples/17-string-value-transform/MyProject.Con/Program.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace MyProject.Con
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine(@"
+Name:                 John Smith (original)
+Name PascalCase:      John Smith (PascalCase)
+Name camelCase:       John Smith (camelCase)
+Name kebab-case:      John Smith (kebab-case)");
+        }
+    }
+}

--- a/dotnet-template-samples/17-string-value-transform/README.md
+++ b/dotnet-template-samples/17-string-value-transform/README.md
@@ -1,0 +1,21 @@
+The sample in this folder demonstrates:
+
+ - PascalCasing a parameter value.
+ - camelCasing a parameter value.
+ - kebab-casing a paremeter value.
+ - Regex replace a parameter value.
+ - Chaining of value forms.
+
+See
+
+ - [`template.json`](./MyProject.Con/.template.config/template.json)
+ - [`Program.cs`](./MyProject.Con/Program.cs)
+
+Details
+
+ - A `derived` `type` with a value transformation is performed using `forms` (`ValueForms` type).
+ - The sample uses `replace`, `titleCase`, `kebabCase`, `firstLowerCaseInvariant` and `chain` value forms.
+ - More value forms can be found in [the source code](https://github.com/dotnet/templating/tree/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms).
+
+Related
+ - [Change String Casing](../11-change-string-casing/README.md)

--- a/dotnet-template-samples/17-string-value-transform/README.md
+++ b/dotnet-template-samples/17-string-value-transform/README.md
@@ -1,10 +1,10 @@
-The sample in this folder demonstrates:
+The sample in this folder demonstrates using `derived` parameter to:
 
- - PascalCasing a parameter value.
- - camelCasing a parameter value.
- - kebab-casing a paremeter value.
+ - PascalCase a parameter value.
+ - camelCase a parameter value.
+ - kebab-case a paremeter value.
  - Regex replace a parameter value.
- - Chaining of value forms.
+ - Chain value forms.
 
 See
 
@@ -13,7 +13,7 @@ See
 
 Details
 
- - A `derived` `type` with a value transformation is performed using `forms` (`ValueForms` type).
+ - A `derived` `type` with a value transformation is performed using [value forms](https://github.com/dotnet/templating/blob/main/docs/Value-Forms.md) (`ValueForms` type).
  - The sample uses `replace`, `titleCase`, `kebabCase`, `firstLowerCaseInvariant` and `chain` value forms.
  - More value forms can be found in [the source code](https://github.com/dotnet/templating/tree/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms).
 


### PR DESCRIPTION
### Problem
#5651: add string value transform sample

### Solution
The sample demonstrates the usage of a `derived` `type` with `valueTransform` set using `forms` (`ValueForms`) to generate PascalCase, camelCase and kebab-case value. There is also the usage of Regex replacing and chaining of value forms.

### Checks:
- [ ] Added unit tests
  - I have not found any unit tests and end-to-end tests for existing samples.
  - Tested by:
    - Create custom `MyProject.Templates.csproj`
    - Run `dotnet pack MyProject.Templates.csproj ; dotnet new -i bin/Debug/MyProject.Templates.1.0.0.nupkg ; dotnet new sample17`
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)
  - Not needed