### PR TITLE
[release/7.0.2xx] addressed API documentation generation issues

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/Installer/InstallerConstants.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Installer/InstallerConstants.cs
@@ -11,13 +11,13 @@ namespace Microsoft.TemplateEngine.Abstractions.Installer
         /// <summary>
         /// Defines the key for <see cref="InstallRequest.Details"/> to specify additional NuGet sources to be used on installation. Supported by NuGet installer.
         /// </summary>
-        /// <remarks><seealso cref="NuGetSourcesSeparator"/></remarks>
+        /// <remarks><see cref="NuGetSourcesSeparator"/> defines the separator to use when multiple sources are required.</remarks>
         public const string NuGetSourcesKey = "NuGetSources";
 
         /// <summary>
         /// Defines the separator to be used when specifying multiple additional NuGet sources to be used on installation. Supported by NuGet installer.
         /// </summary>
-        /// <remarks><seealso cref="NuGetSourcesKey"/></remarks>
+        /// <remarks>Used together with <see cref="NuGetSourcesKey"/>.</remarks>
         public const char NuGetSourcesSeparator = ';';
 
         /// <summary>

--- a/src/Microsoft.TemplateEngine.Abstractions/Installer/InstallerOperationResult.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Installer/InstallerOperationResult.cs
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateEngine.Abstractions.Installer
         }
 
         /// <summary>
-        /// Error code, <seealso cref="InstallerErrorCode"/>.
+        /// Gets result error code.
         /// <see cref="InstallerErrorCode.Success"/> if the operation completed successfully.
         /// </summary>
         public InstallerErrorCode Error { get; }

--- a/src/Microsoft.TemplateEngine.Abstractions/TemplatePackage/ITemplatePackage.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/TemplatePackage/ITemplatePackage.cs
@@ -9,7 +9,7 @@ namespace Microsoft.TemplateEngine.Abstractions.TemplatePackage
     /// <summary>
     /// Represents the template package.
     /// Template package is a folder, .nupkg or other container that can contain single or multiple templates.
-    /// <seealso cref="ITemplatePackageProvider"/> for more information.
+    /// See <see cref="ITemplatePackageProvider"/> for more information.
     /// </summary>
     public interface ITemplatePackage
     {

--- a/src/Microsoft.TemplateEngine.Edge/Template/InputParameterData.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/InputParameterData.cs
@@ -50,6 +50,5 @@ public class InputParameterData
     /// </summary>
     public InputDataState InputDataState { get; }
 
-    /// <inheritdoc/>
     public override string ToString() => $"{ParameterDefinition}: {Value?.ToString() ?? "<null>"}";
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BaseValueSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BaseValueSymbol.cs
@@ -69,7 +69,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel
         /// </summary>
         public string? DataType { get; internal init; }
 
-        protected bool TryGetIsRequiredField(JToken token, out bool result)
+        private protected bool TryGetIsRequiredField(JToken token, out bool result)
         {
             result = false;
             return (token.Type == JTokenType.Boolean || token.Type == JTokenType.String)

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ConditionedConfigurationElement.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/ConditionedConfigurationElement.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Core.Expressions.Cpp2;
-using Newtonsoft.Json;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel
 {
@@ -27,7 +26,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel
         /// Stores the result of condition evaluation. <see cref="EvaluateCondition(ILogger, IVariableCollection)"/> should be done before accessting this property.
         /// </summary>
         /// <exception cref="InvalidOperationException">when the property is accessed prior to <see cref="EvaluateCondition(ILogger, IVariableCollection)"/> method is called.</exception>
-        [JsonIgnore]
         public bool ConditionResult
         {
             get

--- a/src/Microsoft.TemplateEngine.Utils/ExactVersionSpecification.cs
+++ b/src/Microsoft.TemplateEngine.Utils/ExactVersionSpecification.cs
@@ -30,7 +30,6 @@ namespace Microsoft.TemplateEngine.Utils
             return result.HasValue && result.Value == 0;
         }
 
-        /// <inheritdoc/>
         public override string ToString() => RequiredVersion;
     }
 }

--- a/src/Microsoft.TemplateEngine.Utils/MultiValueParameter.cs
+++ b/src/Microsoft.TemplateEngine.Utils/MultiValueParameter.cs
@@ -67,10 +67,8 @@ namespace Microsoft.TemplateEngine.Utils
             return true;
         }
 
-        /// <inheritdoc/>
         public override string ToString() => string.Join(MultiValueSeparator.ToString(), Values);
 
-        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is null)
@@ -91,7 +89,6 @@ namespace Microsoft.TemplateEngine.Utils
             return Equals((MultiValueParameter)obj);
         }
 
-        /// <inheritdoc/>
         public override int GetHashCode() => Values.OrderBy(v => v).ToCsvString().GetHashCode();
 
         protected bool Equals(MultiValueParameter other)

--- a/src/Microsoft.TemplateEngine.Utils/RangeVersionSpecification.cs
+++ b/src/Microsoft.TemplateEngine.Utils/RangeVersionSpecification.cs
@@ -116,7 +116,6 @@ namespace Microsoft.TemplateEngine.Utils
             return isStartValid && isEndValid;
         }
 
-        /// <inheritdoc/>
         public override string ToString()
         {
             return $"{(IsStartInclusive ? "[" : "(")}{MinVersion}-{MaxVersion}{(IsEndInclusive ? "]" : ")")}";


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/pull/5672 to release/7.0.2xx (non-destructive changes only)

### Solution
- removed usage of `seealso`
- removed `inheritdoc` from overridden members
- removed obsolete `Newtonsoft.Json` attributes

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)