### PR TITLE
`TemplateParameter` fixes

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/TemplateParameterPrecedenceExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/TemplateParameterPrecedenceExtensions.cs
@@ -51,10 +51,7 @@ public static class TemplateParameterPrecedenceExtensions
             PrecedenceDefinition.Required => TemplateParameterPriority.Required,
             PrecedenceDefinition.Optional => TemplateParameterPriority.Optional,
             PrecedenceDefinition.Implicit => TemplateParameterPriority.Implicit,
-            PrecedenceDefinition.ConditionalyRequired => throw new ArgumentOutOfRangeException(nameof(precedenceDefinition), precedenceDefinition, "Conversion to obsolete TemplateParameterPriority is not defined for current value"),
-            PrecedenceDefinition.ConditionalyDisabled => throw new ArgumentOutOfRangeException(nameof(precedenceDefinition), precedenceDefinition, "Conversion to obsolete TemplateParameterPriority is not defined for current value"),
-            PrecedenceDefinition.Disabled => throw new ArgumentOutOfRangeException(nameof(precedenceDefinition), precedenceDefinition, "Conversion to obsolete TemplateParameterPriority is not defined for current value"),
-            _ => throw new ArgumentOutOfRangeException(nameof(precedenceDefinition), precedenceDefinition, "Conversion to obsolete TemplateParameterPriority is not defined for current value"),
+            _ => TemplateParameterPriority.Optional,
         };
     }
 }


### PR DESCRIPTION
### Problem
- `TemplateParameter.Priority` throws when `TemplateParameterPrecedence` is conditional
- obsolete members from `TemplateParameter` are serialized to template cache

### Solution
- unsupported values of `TemplateParameterPrecedence` are converted to `TemplateParameterPriority.Optional`
- created an overload for `ITemplateParameter` controlling JSON serialization settings for template cache. Thus JSON serialization attributes are only used internally. 

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)