### PR TITLE
Change conditions determining which pool to use for Windows

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,12 +39,10 @@ stages:
       jobs:
       - job: Windows_NT
         pool:
-          # For public or PR jobs, use the hosted pool.  For internal jobs use the internal pool.
-          # Will eventually change this to two BYOC pools.
-          ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
+          ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore-Svc-Public
             vmImage: 1es-windows-2019-open
-          ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Svc-Internal
             demands: ImageOverride -equals 1es-windows-2019
           


### PR DESCRIPTION
### Problem
For internal PR, the conditions determining which pool to use for Windows are not right.

### Solution
Change it to be:
- Use public pool when running public project.
- User internal pool when running internal project.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)