### PR TITLE
Enable internal publishing of Microsoft.TemplateSearch.TemplateDiscovery

### DIFF
--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -4,6 +4,8 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
     <ImplicitUsings>enable</ImplicitUsings>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>


### PR DESCRIPTION
### Problem
#5086 - Moving the test of  Microsoft.TemplateSearch.TemplateDiscovery to SDK needs the assembly.

### Solution
Enable internal publishing of Microsoft.TemplateSearch.TemplateDiscovery and then use its package reference.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)