### PR TITLE
Add issue templates and configure template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,38 @@
+name: Bug Report
+description: Create a report to help us improve
+#labels: ["bug", "untriaged"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce the behavior.
+      value: |
+        Steps:
+        1. 
+        2. 
+        3. 
+    validations:
+      required: true
+  - type: textarea
+    id: dotnet-version
+    attributes:
+      label: dotnet info
+      description: Provide the output of **`dotnet --info`** to understand what the dotnet version is.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Provide any details that could help with the investigation.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,23 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Issue with Common project and item templates
+    url: https://github.com/dotnet/sdk
+    about: Please open issues related to Common project and item templates in dotnet/sdk.
+  - name: Issue with ASP.NET and Blazor templates
+    url:  https://github.com/dotnet/aspnetcore
+    about: Please open issues relating to ASP.NET and Blazor templates in dotnet/aspnetcore.
+  - name: Issue with ASP.NET Single Page Application templates
+    url:  https://github.com/dotnet/spa-templates
+    about: Please open issues relating to ASP.NET Single Page Application templates in dotnet/spa-templates.
+  - name: Issue with WPF templates
+    url:  https://github.com/dotnet/wpf
+    about: Please open issues relating to WPF templates in dotnet/wpf.
+  - name: Issue with Windows Forms templates
+    url:  https://github.com/dotnet/winforms
+    about: Please open issues relating to Windows Forms templates in dotnet/winforms.
+  - name: Issue with Test templates
+    url:  https://github.com/dotnet/test-templates
+    about: Please open issues relating to Test templates in dotnet/test-templates.
+  - name: Issue with MAUI templates
+    url:  https://github.com/dotnet/maui
+    about: Please open issues relating to MAUI templates in dotnet/maui.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature Request
+description: Suggest an idea for this project
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      placeholder: "A clear and concise description of what the problem is. Example: I am trying to do [...] but [...]"
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like.
+      placeholder: A clear and concise description of what you want to happen. Include any alternative solutions you've considered.
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      placeholder: Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
### Problem
The number of issues created without proper description is raising.

### Solution
- Add issue templates to guide what is needed for creating an issue. 
- Configure template chooser including the locations of .NET default templates.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)