### PR TITLE
Update newtonsoft.json

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -8,7 +8,8 @@
     <PackageReference Update="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Update="Microsoft.Build.Framework" Version="17.4.0" />
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="17.4.0" />
-    <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Update="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJsonVersion)' != ''" Version="$(NewtonsoftJsonVersion)" />
     <PackageReference Update="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -7,6 +7,5 @@
   <ItemGroup>
     <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="System.Security.Cryptography.X509Certificates" Version="4.3.0" /> 
-    <PackageReference Condition="'$(IsTestProject)' == 'true'" Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Problem
Templating referencing old, vulnerable, version of newtonsoft.json, while simple update would break integration into sdk

### Solution
Update newtonsoft.json, but let it be overidden by explicitly set version in sdk build - so that we are not blocked and flaged until sdk is updated (https://github.com/dotnet/sdk/issues/29269)

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)