### PR TITLE
Multiple generators support PoC

### DIFF
--- a/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs
+++ b/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateEngine.IDE
     {
         private readonly ITemplateEngineHost _host;
         private readonly TemplateCreator _templateCreator;
-        private readonly Edge.Settings.TemplatePackageManager _templatePackagesManager;
+        private readonly TemplatePackageManager _templatePackagesManager;
         private readonly EngineEnvironmentSettings _engineEnvironmentSettings;
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Microsoft.TemplateEngine.IDE
             }
 
             _templateCreator = new TemplateCreator(_engineEnvironmentSettings);
-            _templatePackagesManager = new Edge.Settings.TemplatePackageManager(_engineEnvironmentSettings);
+            _templatePackagesManager = new TemplatePackageManager(_engineEnvironmentSettings);
             if (loadDefaultComponents)
             {
                 LoadDefaultComponents();
@@ -73,7 +73,7 @@ namespace Microsoft.TemplateEngine.IDE
             {
                 AddComponent(component.Type, component.Instance);
             }
-            foreach ((Type Type, IIdentifiedComponent Instance) component in Edge.Components.AllComponents)
+            foreach ((Type Type, IIdentifiedComponent Instance) component in Components.AllComponents)
             {
                 AddComponent(component.Type, component.Instance);
             }

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/GeneratorTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/GeneratorTests.cs
@@ -1,0 +1,239 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Constraints;
+using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.Abstractions.Parameters;
+using Microsoft.TemplateEngine.Edge.Settings;
+using Microsoft.TemplateEngine.Edge.Template;
+using Microsoft.TemplateEngine.TestHelper;
+using Microsoft.TemplateEngine.Tests;
+using Xunit;
+using ITemplateMatchInfo = Microsoft.TemplateEngine.Abstractions.TemplateFiltering.ITemplateMatchInfo;
+using WellKnownSearchFilters = Microsoft.TemplateEngine.Utils.WellKnownSearchFilters;
+
+namespace Microsoft.TemplateEngine.Edge.UnitTests
+{
+    public class GeneratorTests : TestBase
+    {
+        [Fact]
+        public async Task CanUseCustomGenerator()
+        {
+            var builtIns = new List<(Type, IIdentifiedComponent)>()
+            {
+                (typeof(IGenerator), new CustomGenerator())
+            };
+            builtIns.AddRange(BuiltInTemplatePackagesProviderFactory.GetComponents(TestTemplatesLocation));
+            builtIns.AddRange(Orchestrator.RunnableProjects.Components.AllComponents);
+            builtIns.AddRange(Components.AllComponents);
+
+            using ITemplateEngineHost testHost = TestHost.GetVirtualHost("generatorTest", additionalComponents: builtIns);
+            using IEngineEnvironmentSettings engineEnvironmentSettings = new EngineEnvironmentSettings(testHost);
+            TemplateCreator templateCreator = new(engineEnvironmentSettings);
+            TemplatePackageManager templatePackagesManager = new(engineEnvironmentSettings);
+
+            IReadOnlyList<ITemplateMatchInfo> foundTemplates = await templatePackagesManager.GetTemplatesAsync(
+                matchFilter: WellKnownSearchFilters.MatchesAllCriteria,
+                filters: new[] { WellKnownSearchFilters.NameFilter("test-template") },
+                cancellationToken: default).ConfigureAwait(false);
+            ITemplateMatchInfo template = Assert.Single(foundTemplates);
+
+            string output = TestUtils.CreateTemporaryFolder();
+            ITemplateCreationResult dryRunResult = await templateCreator.InstantiateAsync(
+                template.Info,
+                "MyProject",
+                fallbackName: null,
+                outputPath: output,
+                inputParameters: new Dictionary<string, string?>(),
+                forceCreation: true,
+                dryRun: true).ConfigureAwait(false);
+
+            Assert.Equal(CreationResultStatus.Success, dryRunResult.Status);
+            Assert.Equal((ICreationEffects)CustomGenerator.CreationEffects.Instance, dryRunResult.CreationEffects);
+
+            ITemplateCreationResult runResult = await templateCreator.InstantiateAsync(
+                template.Info,
+                "MyProject",
+                fallbackName: null,
+                outputPath: output,
+                inputParameters: new Dictionary<string, string?>(),
+                forceCreation: true,
+                dryRun: false).ConfigureAwait(false);
+
+            Assert.Equal(CreationResultStatus.Success, runResult.Status);
+            Assert.Equal(CustomGenerator.SimpleCreationResult.Instance, runResult.CreationResult);
+
+            string targetFile = Path.Combine(output, "success.txt");
+            Assert.True(File.Exists(targetFile));
+        }
+
+        private class CustomGenerator : IGenerator
+        {
+            public Guid Id { get; } = new Guid("{AB083D9D-857A-419E-8394-113F97FFBD6B}");
+
+            public object? ConvertParameterValueToType(IEngineEnvironmentSettings environmentSettings, ITemplateParameter parameter, string untypedValue, out bool valueResolutionError) => throw new NotImplementedException();
+
+            [Obsolete]
+            public Task<ICreationResult> CreateAsync(IEngineEnvironmentSettings environmentSettings, ITemplate template, IParameterSet parameters, string targetDirectory, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+            public Task<ICreationResult> CreateAsync(IEngineEnvironmentSettings environmentSettings, ITemplate template, IParameterSetData parameters, string targetDirectory, CancellationToken cancellationToken)
+            {
+                if (!environmentSettings.Host.FileSystem.DirectoryExists(targetDirectory))
+                {
+                    environmentSettings.Host.FileSystem.CreateDirectory(targetDirectory);
+                }
+                environmentSettings.Host.FileSystem.WriteAllText(Path.Combine(targetDirectory, "success.txt"), string.Empty);
+
+                return Task.FromResult(SimpleCreationResult.Instance);
+            }
+
+            [Obsolete]
+            public Task<ICreationEffects> GetCreationEffectsAsync(IEngineEnvironmentSettings environmentSettings, ITemplate template, IParameterSet parameters, string targetDirectory, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+            public Task<ICreationEffects> GetCreationEffectsAsync(IEngineEnvironmentSettings environmentSettings, ITemplate template, IParameterSetData parameters, string targetDirectory, CancellationToken cancellationToken)
+            {
+                return Task.FromResult((ICreationEffects)CreationEffects.Instance);
+            }
+
+            [Obsolete]
+            public IParameterSet GetParametersForTemplate(IEngineEnvironmentSettings environmentSettings, ITemplate template) => throw new NotImplementedException();
+
+            public IList<ITemplate> GetTemplatesAndLangpacksFromDir(IMountPoint source, out IList<ILocalizationLocator> localizations)
+            {
+                localizations = new List<ILocalizationLocator>();
+                return new List<ITemplate>() { new Template(this, source) };
+            }
+
+            public bool TryEvaluateFromString(ILogger logger, string text, IDictionary<string, object> variables, out bool result, out string evaluationError, HashSet<string>? referencedVariablesKeys = null) => throw new NotImplementedException();
+
+            public bool TryGetTemplateFromConfigInfo(IFileSystemInfo config, out ITemplate? template, IFileSystemInfo? localeConfig, IFile? hostTemplateConfigFile, string? baselineName = null)
+            {
+                template = new Template(this, config.MountPoint);
+                return true;
+            }
+
+            internal class Template : ITemplate
+            {
+                private readonly IMountPoint _mountPoint;
+
+                public Template(IGenerator generator, IMountPoint mountPoint)
+                {
+                    Generator = generator;
+                    _mountPoint = mountPoint;
+                }
+
+                public IGenerator Generator { get; }
+
+                public IFileSystemInfo Configuration => _mountPoint.Root;
+
+                public IFileSystemInfo? LocaleConfiguration => null;
+
+                public IDirectory TemplateSourceRoot => _mountPoint.Root;
+
+                public bool IsNameAgreementWithFolderPreferred => false;
+
+                public string? Author => "Microsoft";
+
+                public string? Description => "This is the description";
+
+                public IReadOnlyList<string> Classifications => Array.Empty<string>();
+
+                public string? DefaultName => null;
+
+                public string Identity => "Static.Test.Template";
+
+                public Guid GeneratorId => Generator.Id;
+
+                public string? GroupIdentity => null;
+
+                public int Precedence => 0;
+
+                public string Name => "Test template";
+
+                public string ShortName => "test-template";
+
+                [Obsolete]
+                public IReadOnlyDictionary<string, ICacheTag> Tags => throw new NotImplementedException();
+
+                public IReadOnlyDictionary<string, string> TagsCollection { get; } = new Dictionary<string, string>();
+
+                [Obsolete]
+                public IReadOnlyDictionary<string, ICacheParameter> CacheParameters => throw new NotImplementedException();
+
+                public IParameterDefinitionSet ParameterDefinitions => ParameterDefinitionSet.Empty;
+
+                public IReadOnlyList<ITemplateParameter> Parameters => ParameterDefinitions;
+
+                public string MountPointUri => _mountPoint.MountPointUri;
+
+                public string ConfigPlace => ".";
+
+                public string? LocaleConfigPlace => null;
+
+                public string? HostConfigPlace => null;
+
+                public string? ThirdPartyNotices => null;
+
+                public IReadOnlyDictionary<string, IBaselineInfo> BaselineInfo { get; } = new Dictionary<string, IBaselineInfo>();
+
+                public bool HasScriptRunningPostActions { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+                public IReadOnlyList<string> ShortNameList => new[] { ShortName };
+
+                public IReadOnlyList<Guid> PostActions => Array.Empty<Guid>();
+
+                public IReadOnlyList<TemplateConstraintInfo> Constraints => Array.Empty<TemplateConstraintInfo>();
+            }
+
+            internal class CreationEffects : ICreationEffects2, ICreationEffects
+            {
+                private CreationEffects() { }
+
+                public static ICreationEffects2 Instance { get; } = new CreationEffects();
+
+                public IReadOnlyList<IFileChange2> FileChanges => new[] { FileChange.Instance };
+
+                public ICreationResult CreationResult => SimpleCreationResult.Instance;
+
+                IReadOnlyList<IFileChange> ICreationEffects.FileChanges => new[] { FileChange.Instance };
+
+                private class FileChange : IFileChange2, IFileChange
+                {
+                    private FileChange() { }
+
+                    public static FileChange Instance { get; } = new FileChange();
+
+                    public string SourceRelativePath => "success.txt";
+
+                    public string TargetRelativePath => "success.txt";
+
+                    public ChangeKind ChangeKind => ChangeKind.Create;
+
+                    public byte[] Contents => throw new NotImplementedException();
+                }
+            }
+
+            internal class SimpleCreationResult : ICreationResult
+            {
+                private SimpleCreationResult() { }
+
+                public static ICreationResult Instance { get; } = new SimpleCreationResult();
+
+                public IReadOnlyList<IPostAction> PostActions { get; } = Array.Empty<IPostAction>();
+
+                public IReadOnlyList<ICreationPath> PrimaryOutputs => new[] { CreationPath.Instance };
+
+                private class CreationPath : ICreationPath
+                {
+                    private CreationPath() { }
+
+                    public string Path => "success.txt";
+
+                    public static CreationPath Instance { get; } = new CreationPath();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Problem
Multiple generators support investigation

### Solution
Added test showcasing usage of multiple generators.
All works as expected.

Couple of concerns:
- no good solution for discovering the static generator. Static generator now returns its template(s) for each scanned package and then it got dedupped. If there is no packages available, static generator won't return the template.
- no basic implementations for `IGenerator` return classes - worth consider adding them to Utils

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - NA