### PR TITLE
Update Verify.Diffplex

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -27,6 +27,6 @@
     <PackageReference Update="xunit.abstractions" Version="2.0.3" />
     <PackageReference Update="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Update="Verify.XUnit" Version="19.5.0" />
-    <PackageReference Update="Verify.DiffPlex" Version="1.3.0" />
+    <PackageReference Update="Verify.DiffPlex" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/VerifySettingsFixture.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/VerifySettingsFixture.cs
@@ -7,8 +7,15 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 {
     public class VerifySettingsFixture : IDisposable
     {
+        private static bool s_called;
+
         public VerifySettingsFixture()
         {
+            if (s_called)
+            {
+                return;
+            }
+            s_called = true;
             DerivePathInfo(
                 (_, _, type, method) => new(
                     directory: "Approvals",

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/VerifySettingsFixture.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/VerifySettingsFixture.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using VerifyTests.DiffPlex;
+
 namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 {
     public class VerifySettingsFixture : IDisposable

--- a/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/VerificationEngine.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/VerificationEngine.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.TemplateEngine.Authoring.TemplateVerifier.Commands;
 using Microsoft.TemplateEngine.CommandUtils;
 using Microsoft.TemplateEngine.Utils;
+using VerifyTests.DiffPlex;
 
 namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier
 {


### PR DESCRIPTION
### Problem
Verify.Diffple 1.3.0 have some flaws in reporting diff outputs (e.g. nonactionable output for whitespace only changes)

### Solution
Updating manually now - as it needs usings adjust as well

### Checks: N/A
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)