### PR TITLE
Lowered conditions error logging level

### DIFF
--- a/src/Microsoft.TemplateEngine.Core/Expressions/Shared/SharedEvaluatorDefinition.cs
+++ b/src/Microsoft.TemplateEngine.Core/Expressions/Shared/SharedEvaluatorDefinition.cs
@@ -151,7 +151,7 @@ namespace Microsoft.TemplateEngine.Core.Expressions.Shared
 
             if (!string.IsNullOrEmpty(faultedMessage))
             {
-                processor.Config.Logger.LogInformation(LocalizableStrings.Error_Evaluation_Expression + faultedMessage);
+                processor.Config.Logger.LogDebug(LocalizableStrings.Error_Evaluation_Expression + faultedMessage);
             }
             return result;
         }


### PR DESCRIPTION
### Problem
LogInformation goes to console - so some existing sdk templates counting on weird logical evaluation (string casting leading to errors, trnaslated as false) would have extra console output

### Solution
Change log level to Debug

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)