### PR TITLE
Pack Microsoft.TemplateSearch.TemplateDiscovery as tool for moving corresponding test to SDK repo

### DIFF
--- a/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
@@ -21,20 +21,15 @@ namespace Microsoft.TemplateEngine.TestHelper
     {
         private const string NuGetOrgFeed = "https://api.nuget.org/v3/index.json";
         private static readonly SemaphoreSlim Semaphore = new SemaphoreSlim(1, 1);
-        private string _packageLocation = TestUtils.CreateTemporaryFolder("packages");
+        private readonly string _packageLocation = TestUtils.CreateTemporaryFolder("packages");
         private readonly ConcurrentDictionary<string, string> _installedPackages = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private static readonly Mutex PackMutex = new Mutex(false, "TemplateEngineTestPackMutex");
 
-        public string PackageLocation
-        {
-            get => _packageLocation;
-            set => _packageLocation = value;
-        }
-
-        public async Task<string> GetNuGetPackage(string templatePackName, string? version = null, NuGetVersion? minimumVersion = null, ILogger? logger = null)
+        public async Task<string> GetNuGetPackage(string templatePackName, string? version = null, NuGetVersion? minimumVersion = null, ILogger? logger = null, string? downloadDirectory = null)
         {
             logger ??= NullLogger.Instance;
-            NuGetHelper nuGetHelper = new NuGetHelper(_packageLocation, logger);
+            string downloadDir = downloadDirectory ?? _packageLocation;
+            NuGetHelper nuGetHelper = new NuGetHelper(downloadDir, logger);
             try
             {
                 logger.LogDebug($"[NuGet Package Manager] Trying to get semaphore.");

--- a/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
@@ -21,9 +21,15 @@ namespace Microsoft.TemplateEngine.TestHelper
     {
         private const string NuGetOrgFeed = "https://api.nuget.org/v3/index.json";
         private static readonly SemaphoreSlim Semaphore = new SemaphoreSlim(1, 1);
-        private readonly string _packageLocation = TestUtils.CreateTemporaryFolder("packages");
+        private string _packageLocation = TestUtils.CreateTemporaryFolder("packages");
         private readonly ConcurrentDictionary<string, string> _installedPackages = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private static readonly Mutex PackMutex = new Mutex(false, "TemplateEngineTestPackMutex");
+
+        public string PackageLocation
+        {
+            get => _packageLocation;
+            set => _packageLocation = value;
+        }
 
         public async Task<string> GetNuGetPackage(string templatePackName, string? version = null, NuGetVersion? minimumVersion = null, ILogger? logger = null)
         {

--- a/test/Microsoft.TemplateEngine.TestHelper/PublicAPI.Unshipped.txt
+++ b/test/Microsoft.TemplateEngine.TestHelper/PublicAPI.Unshipped.txt
@@ -57,6 +57,8 @@ Microsoft.TemplateEngine.TestHelper.MonitoredFileSystem.WriteAllText(string! pat
 Microsoft.TemplateEngine.TestHelper.PackageManager
 Microsoft.TemplateEngine.TestHelper.PackageManager.Dispose() -> void
 Microsoft.TemplateEngine.TestHelper.PackageManager.GetNuGetPackage(string! templatePackName, string? version = null, NuGet.Versioning.NuGetVersion? minimumVersion = null, NuGet.Common.ILogger? logger = null) -> System.Threading.Tasks.Task<string!>!
+Microsoft.TemplateEngine.TestHelper.PackageManager.PackageLocation.get -> string!
+Microsoft.TemplateEngine.TestHelper.PackageManager.PackageLocation.set -> void
 Microsoft.TemplateEngine.TestHelper.PackageManager.PackageManager() -> void
 Microsoft.TemplateEngine.TestHelper.PackageManager.PackNuGetPackage(string! projectPath, NuGet.Common.ILogger? logger = null) -> string!
 Microsoft.TemplateEngine.TestHelper.SharedTestOutputHelper

--- a/test/Microsoft.TemplateEngine.TestHelper/PublicAPI.Unshipped.txt
+++ b/test/Microsoft.TemplateEngine.TestHelper/PublicAPI.Unshipped.txt
@@ -56,9 +56,7 @@ Microsoft.TemplateEngine.TestHelper.MonitoredFileSystem.WatchFileChanges(string!
 Microsoft.TemplateEngine.TestHelper.MonitoredFileSystem.WriteAllText(string! path, string! value) -> void
 Microsoft.TemplateEngine.TestHelper.PackageManager
 Microsoft.TemplateEngine.TestHelper.PackageManager.Dispose() -> void
-Microsoft.TemplateEngine.TestHelper.PackageManager.GetNuGetPackage(string! templatePackName, string? version = null, NuGet.Versioning.NuGetVersion? minimumVersion = null, NuGet.Common.ILogger? logger = null) -> System.Threading.Tasks.Task<string!>!
-Microsoft.TemplateEngine.TestHelper.PackageManager.PackageLocation.get -> string!
-Microsoft.TemplateEngine.TestHelper.PackageManager.PackageLocation.set -> void
+Microsoft.TemplateEngine.TestHelper.PackageManager.GetNuGetPackage(string! templatePackName, string? version = null, NuGet.Versioning.NuGetVersion? minimumVersion = null, NuGet.Common.ILogger? logger = null, string? downloadDirectory = null) -> System.Threading.Tasks.Task<string!>!
 Microsoft.TemplateEngine.TestHelper.PackageManager.PackageManager() -> void
 Microsoft.TemplateEngine.TestHelper.PackageManager.PackNuGetPackage(string! projectPath, NuGet.Common.ILogger? logger = null) -> string!
 Microsoft.TemplateEngine.TestHelper.SharedTestOutputHelper

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
+    <PackAsTool>true</PackAsTool>
     <ImplicitUsings>enable</ImplicitUsings>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>


### PR DESCRIPTION
### Problem
#5086

- Need to pack Microsoft.TemplateSearch.TemplateDiscovery as tool. Then run this tool in the moved template discovery integration test in dotnet/sdk.
- Change the package location of PackageManager. So that the test moved to dotnet/sdk can output package in test execution directory.

### Solution

- Add packastool in the project
- Make the package location of PackageManager alterable. Refer to https://github.com/dotnet/sdk/pull/29628#discussion_r1053993027

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)