### PR TITLE
Adjust the place of overriding packages with version properties used in source build for Dependabot

### DIFF
--- a/eng/Package.props
+++ b/eng/Package.props
@@ -1,6 +1,37 @@
 <Project>
   <!-- Import references updated by Dependabot. This file is for package references updated manually or by Darc/Maestro. -->
   <Import Project="dependabot\Packages.props" />
+  <!-- Override package versions in dependabot\Packages.props for source build -->
+  <!-- Packages must be set to their package version property if it exists (ex. BenchmarkDotNetVersion) since source-build uses
+  these properties to override package versions if necessary. -->
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
+    <PackageReference Update="System.Diagnostics.Process" Condition="'$(SystemDiagnosticsProcessVersion)' != ''" Version="$(SystemDiagnosticsProcessVersion)" />
+    <PackageReference Update="System.IO.Compression" Condition="'$(SystemIOCompressionVersion)' != ''" Version="$(SystemIOCompressionVersion)" />
+    <PackageReference Update="System.Runtime.Loader" Condition="'$(SystemRuntimeLoaderVersion)' != ''" Version="$(SystemRuntimeLoaderVersion)" />
+    <PackageReference Update="Microsoft.Build.Framework" Condition="'$(MicrosoftBuildFrameworkVersion)' != ''" Version="$(MicrosoftBuildFrameworkVersion)" />
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Condition="'$(MicrosoftBuildUtilitiesCoreVersion)' != ''" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
+    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJsonVersion)' != ''" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging" Condition="'$(MicrosoftExtensionsLoggingVersion)' != ''" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Console" Condition="'$(MicrosoftExtensionsLoggingConsoleVersion)' != ''" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Condition="'$(MicrosoftExtensionsLoggingAbstractionsVersion)' != ''" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
+    <PackageReference Update="NuGet.Configuration" Condition="'$(NuGetConfigurationVersion)' != ''" Version="$(NuGetConfigurationVersion)" />
+    <PackageReference Update="NuGet.Credentials" Condition="'$(NuGetCredentialsVersion)' != ''" Version="$(NuGetCredentialsVersion)" />
+    <PackageReference Update="NuGet.Protocol" Condition="'$(NuGetProtocolVersion)' != ''" Version="$(NuGetProtocolVersion)" />
+
+    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Condition="'$(MicrosoftNetCompilersToolsetVersion)' != ''" Version="$(MicrosoftNetCompilersToolsetVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Condition="'$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)' != ''" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" />
+    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
+    <PackageReference Update="StyleCop.Analyzers" Condition="'$(StyleCopAnalyzersVersion)' != ''" Version="$(StyleCopAnalyzersVersion)" />
+
+    <PackageReference Update="FakeItEasy" Condition="'$(FakeItEasyVersion)' != ''" Version="$(FakeItEasyVersion)" />
+    <PackageReference Update="FluentAssertions" Condition="'$(FluentAssertionsVersion)' != ''" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Condition="'$(MicrosoftNETTestSdkVersion)' != ''" Version="$(MicrosoftNETTestSdkVersion)" />
+    <PackageReference Update="xunit.abstractions" Condition="'$(xunitabstractionsVersion)' != ''" Version="$(xunitabstractionsVersion)" />
+    <PackageReference Update="Newtonsoft.Json.Schema" Condition="'$(NewtonsoftJsonSchemaVersion)' != ''" Version="$(NewtonsoftJsonSchemaVersion)" />
+    <PackageReference Update="Verify.XUnit" Condition="'$(VerifyXUnitVersion)' != ''" Version="$(VerifyXUnitVersion)" />
+    <PackageReference Update="Verify.DiffPlex" Condition="'$(VerifyDiffPlexVersion)' != ''" Version="$(VerifyDiffPlexVersion)" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Update="System.CommandLine" Version="$(SystemCommandLinePackageVersion)" />
     <!--Analyzer dependencies-->

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -1,9 +1,6 @@
 <Project>
 
-  <!-- Packages in this file have versions updated periodically by Dependabot. Versions managed by Darc/Maestro should be in ..\Package.props.
-
-  Packages must be set to their package version property if it exists (ex. BenchmarkDotNetVersion) since source-build uses
-  these properties to override package versions if necessary. -->
+  <!-- Packages in this file have versions updated periodically by Dependabot. Versions managed by Darc/Maestro should be in ..\Package.props. -->
 
   <ItemGroup>
     <PackageReference Update="System.Diagnostics.Process" Version="4.3.0" />
@@ -12,7 +9,6 @@
     <PackageReference Update="Microsoft.Build.Framework" Version="17.2.0" />
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="17.2.0" />
     <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Update="Wcwidth.Sources" Version="0.6.0" />
     <PackageReference Update="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
@@ -33,34 +29,5 @@
     <PackageReference Update="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Update="Verify.XUnit" Version="17.2.1" />
     <PackageReference Update="Verify.DiffPlex" Version="1.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' == 'true'">
-    <PackageReference Update="System.Diagnostics.Process" Condition="'$(SystemDiagnosticsProcessVersion)' != ''" Version="$(SystemDiagnosticsProcessVersion)" />
-    <PackageReference Update="System.IO.Compression" Condition="'$(SystemIOCompressionVersion)' != ''" Version="$(SystemIOCompressionVersion)" />
-    <PackageReference Update="System.Runtime.Loader" Condition="'$(SystemRuntimeLoaderVersion)' != ''" Version="$(SystemRuntimeLoaderVersion)" />
-    <PackageReference Update="Microsoft.Build.Framework" Condition="'$(MicrosoftBuildFrameworkVersion)' != ''" Version="$(MicrosoftBuildFrameworkVersion)" />
-    <PackageReference Update="Microsoft.Build.Utilities.Core" Condition="'$(MicrosoftBuildUtilitiesCoreVersion)' != ''" Version="$(MicrosoftBuildUtilitiesCoreVersion)" />
-    <PackageReference Update="Newtonsoft.Json" Condition="'$(NewtonsoftJsonVersion)' != ''" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Update="Wcwidth.Sources" Condition="'$(WcwidthSourcesVersion)' != ''" Version="$(WcwidthSourcesVersion)" />
-    <PackageReference Update="Microsoft.Extensions.Logging" Condition="'$(MicrosoftExtensionsLoggingVersion)' != ''" Version="$(MicrosoftExtensionsLoggingVersion)" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Console" Condition="'$(MicrosoftExtensionsLoggingConsoleVersion)' != ''" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Condition="'$(MicrosoftExtensionsLoggingAbstractionsVersion)' != ''" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
-    <PackageReference Update="NuGet.Configuration" Condition="'$(NuGetConfigurationVersion)' != ''" Version="$(NuGetConfigurationVersion)" />
-    <PackageReference Update="NuGet.Credentials" Condition="'$(NuGetCredentialsVersion)' != ''" Version="$(NuGetCredentialsVersion)" />
-    <PackageReference Update="NuGet.Protocol" Condition="'$(NuGetProtocolVersion)' != ''" Version="$(NuGetProtocolVersion)" />
-
-    <PackageReference Update="Microsoft.Net.Compilers.Toolset" Condition="'$(MicrosoftNetCompilersToolsetVersion)' != ''" Version="$(MicrosoftNetCompilersToolsetVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Condition="'$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)' != ''" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" />
-    <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
-    <PackageReference Update="StyleCop.Analyzers" Condition="'$(StyleCopAnalyzersVersion)' != ''" Version="$(StyleCopAnalyzersVersion)" />
-
-    <PackageReference Update="FakeItEasy" Condition="'$(FakeItEasyVersion)' != ''" Version="$(FakeItEasyVersion)" />
-    <PackageReference Update="FluentAssertions" Condition="'$(FluentAssertionsVersion)' != ''" Version="$(FluentAssertionsVersion)" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Condition="'$(MicrosoftNETTestSdkVersion)' != ''" Version="$(MicrosoftNETTestSdkVersion)" />
-    <PackageReference Update="xunit.abstractions" Condition="'$(xunitabstractionsVersion)' != ''" Version="$(xunitabstractionsVersion)" />
-    <PackageReference Update="Newtonsoft.Json.Schema" Condition="'$(NewtonsoftJsonSchemaVersion)' != ''" Version="$(NewtonsoftJsonSchemaVersion)" />
-    <PackageReference Update="Verify.XUnit" Condition="'$(VerifyXUnitVersion)' != ''" Version="$(VerifyXUnitVersion)" />
-    <PackageReference Update="Verify.DiffPlex" Condition="'$(VerifyDiffPlexVersion)' != ''" Version="$(VerifyDiffPlexVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Problem
#5804

### Solution

1. Fix dependabot in release/7.0.1xx.
2. Then add the entry for release/7.0.1xx in the workflow of default branch `main`. (Another PR #5810 merging change to main)

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)