### PR TITLE
Enable Dependabot for branch release/7.0.1xx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,13 @@ updates:
     labels:
       - "dependencies"
       - "dependabot: 7.0.2xx"
+  
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    target-branch: "release/7.0.1xx"
+    labels:
+      - "dependencies"
+      - "dependabot: 7.0.1xx"


### PR DESCRIPTION
### Problem
#5804

### Solution
Enable Dependabot for branch release/7.0.1xx. This requires to create the label `dependabot: 7.0.1xx` before merging into main.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)