### PR TITLE
[release/6.0.1xx]  inverted language version conditions in console / classlib templates

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   ],
   "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project for creating a class library that targets .NET or .NET Standard",
+  "description": "A project for creating a class library that targets .NET Standard or .NET Core",
   "groupIdentity": "Microsoft.Common.Library",
   "precedence": "8000",
   "identity": "Microsoft.Common.Library.CSharp.6.0",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ClassLibrary-CSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   ],
   "name": "Class Library",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project for creating a class library that targets .NET Standard or .NET Core",
+  "description": "A project for creating a class library that targets .NET or .NET Standard",
   "groupIdentity": "Microsoft.Common.Library",
   "precedence": "8000",
   "identity": "Microsoft.Common.Library.CSharp.6.0",
@@ -85,23 +85,31 @@
       "defaultValue": "false",
       "displayName": "Skip restore"
     },
-    "csharp10orLater": {
+    "csharp9orOlder": {
       "type": "generated",
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|10\\.0|10|preview|latest|default|latestMajor)$",
+        "pattern": "^(ISO-1|ISO-2|[1-7]|[8-9]|[8-9]\\.0|7\\.[0-3])$",
         "source": "langVersion"
       }
     },
-    "csharp8orLater": {
+    "csharp7orOlder": {
       "type": "generated",
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|8|8\\.0|9|9\\.0|10\\.0|10|preview|latest|default|latestMajor)$",
+        "pattern": "^(ISO-1|ISO-2|[1-7]|7\\.[0-3])$",
         "source": "langVersion"
       }
+    },
+    "csharp10orLater": {
+      "type": "computed",
+      "value": "!csharp9orOlder"
+    },
+    "csharp8orLater": {
+      "type": "computed",
+      "value": "!csharp7orOlder"
     },
     "csharpFeature_ImplicitUsings": {
       "type": "computed",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -61,6 +61,13 @@
       "defaultValue": "false",
       "displayName": "Skip restore"
     },
+    "UseProgramMain": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
+      "displayName": "Do not use top-level statements"
+    },
     "csharp9orOlder": {
       "type": "generated",
       "generator": "regexMatch",

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   ],
   "name": "Console App",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS",
+  "description": "A project for creating a command-line application that can run on .NET on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Common.Console",
   "precedence": "8000",
   "identity": "Microsoft.Common.Console.CSharp.6.0",
@@ -61,32 +61,44 @@
       "defaultValue": "false",
       "displayName": "Skip restore"
     },
-    "csharp10orLater": {
+    "csharp9orOlder": {
       "type": "generated",
       "generator": "regexMatch",
       "datatype": "bool",
       "parameters": {
-        "pattern": "^(|10\\.0|10|preview|latest|default|latestMajor)$",
+        "pattern": "^(ISO-1|ISO-2|[1-7]|[8-9]|[8-9]\\.0|7\\.[0-3])$",
         "source": "langVersion"
       }
+    },
+    "csharp8orOlder": {
+      "type": "generated",
+      "generator": "regexMatch",
+      "datatype": "bool",
+      "parameters": {
+        "pattern": "^(ISO-1|ISO-2|[1-7]|8|8\\.0|7\\.[0-3])$",
+        "source": "langVersion"
+      }
+    },
+    "csharp7orOlder": {
+      "type": "generated",
+      "generator": "regexMatch",
+      "datatype": "bool",
+      "parameters": {
+        "pattern": "^(ISO-1|ISO-2|[1-7]|7\\.[0-3])$",
+        "source": "langVersion"
+      }
+    },
+    "csharp10orLater": {
+      "type": "computed",
+      "value": "!csharp9orOlder"
     },
     "csharp9orLater": {
-      "type": "generated",
-      "generator": "regexMatch",
-      "datatype": "bool",
-      "parameters": {
-        "pattern": "^(|9|9\\.0|10\\.0|10|preview|latest|default|latestMajor)$",
-        "source": "langVersion"
-      }
+      "type": "computed",
+      "value": "!csharp8orOlder"
     },
     "csharp8orLater": {
-      "type": "generated",
-      "generator": "regexMatch",
-      "datatype": "bool",
-      "parameters": {
-        "pattern": "^(|8|8\\.0|9|9\\.0|10\\.0|10|preview|latest|default|latestMajor)$",
-        "source": "langVersion"
-      }
+      "type": "computed",
+      "value": "!csharp7orOlder"
     },
     "csharpFeature_ImplicitUsings": {
       "type": "computed",
@@ -98,7 +110,11 @@
     },
     "csharpFeature_TopLevelProgram": {
       "type": "computed",
-      "value": "csharp9orLater == \"true\""
+      "value": "(csharp9orLater == \"true\" && UseProgramMain != \"true\")"
+    },
+    "csharpFeature_FileScopedNamespaces": {
+      "type": "computed",
+      "value": "csharp10orLater == \"true\""
     }
   },
   "primaryOutputs": [

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -61,13 +61,6 @@
       "defaultValue": "false",
       "displayName": "Skip restore"
     },
-    "UseProgramMain": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "false",
-      "description": "Whether to generate an explicit Program class and Main method instead of top-level statements.",
-      "displayName": "Do not use top-level statements"
-    },
     "csharp9orOlder": {
       "type": "generated",
       "generator": "regexMatch",
@@ -117,7 +110,7 @@
     },
     "csharpFeature_TopLevelProgram": {
       "type": "computed",
-      "value": "(csharp9orLater == \"true\" && UseProgramMain != \"true\")"
+      "value": "csharp9orLater == \"true\""
     }
   },
   "primaryOutputs": [

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -111,10 +111,6 @@
     "csharpFeature_TopLevelProgram": {
       "type": "computed",
       "value": "(csharp9orLater == \"true\" && UseProgramMain != \"true\")"
-    },
-    "csharpFeature_FileScopedNamespaces": {
-      "type": "computed",
-      "value": "csharp10orLater == \"true\""
     }
   },
   "primaryOutputs": [

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.6.0/content/ConsoleApplication-CSharp/.template.config/template.json
@@ -7,7 +7,7 @@
   ],
   "name": "Console App",
   "generatorVersions": "[1.0.0.0-*)",
-  "description": "A project for creating a command-line application that can run on .NET on Windows, Linux and macOS",
+  "description": "A project for creating a command-line application that can run on .NET Core on Windows, Linux and macOS",
   "groupIdentity": "Microsoft.Common.Console",
   "precedence": "8000",
   "identity": "Microsoft.Common.Console.CSharp.6.0",

--- a/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
@@ -100,8 +100,11 @@ Options\:
 
   \-\-no\-restore    If specified, skips the automatic restore of the project on create\.
                   bool \- Optional                                                    
-                  Default\: false                                                     
+                  Default\: false
 
+  \-U\|\-\-UseProgramMain  Whether to generate an explicit Program class and Main method instead of top-level statements.
+                       bool - Optional                                                                               
+                       Default: false  
 
 To see help for other template languages \(F#\, VB\)\, use \-\-language option\:
    dotnet new3 classlib \-h \-\-language (F#|VB)";
@@ -340,6 +343,9 @@ Options\:
                   bool \- Optional                                                    
                   Default\: false                                                     
 
+  \-U\|\-\-UseProgramMain  Whether to generate an explicit Program class and Main method instead of top-level statements.
+                       bool - Optional                                                                               
+                       Default: false  
 
 To see help for other template languages \(F#\, VB\)\, use \-\-language option\:
    dotnet new3 console \-h \-\-language (F#|VB)";

--- a/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewHelp.cs
@@ -100,11 +100,8 @@ Options\:
 
   \-\-no\-restore    If specified, skips the automatic restore of the project on create\.
                   bool \- Optional                                                    
-                  Default\: false
+                  Default\: false                                                     
 
-  \-U\|\-\-UseProgramMain  Whether to generate an explicit Program class and Main method instead of top-level statements.
-                       bool - Optional                                                                               
-                       Default: false  
 
 To see help for other template languages \(F#\, VB\)\, use \-\-language option\:
    dotnet new3 classlib \-h \-\-language (F#|VB)";
@@ -343,24 +340,21 @@ Options\:
                   bool \- Optional                                                    
                   Default\: false                                                     
 
-  \-U\|\-\-UseProgramMain  Whether to generate an explicit Program class and Main method instead of top-level statements.
-                       bool - Optional                                                                               
-                       Default: false  
 
 To see help for other template languages \(F#\, VB\)\, use \-\-language option\:
    dotnet new3 console \-h \-\-language (F#|VB)";
 
-        string home = TestUtils.CreateTemporaryFolder("Home");
-        string workingDirectory = TestUtils.CreateTemporaryFolder();
+            string home = TestUtils.CreateTemporaryFolder("Home");
+            string workingDirectory = TestUtils.CreateTemporaryFolder();
 
-        new DotnetNewCommand(_log, "console", "--help", "--langVersion", "8.0")
-                .WithCustomHive(home)
-                .WithWorkingDirectory(workingDirectory)
-                .Execute()
-                .Should().Pass()
-                .And.NotHaveStdErr()
-                .And.HaveStdOutMatching(ConsoleHelp)
-                .And.NotHaveStdOutContaining(HelpOutput);
+            new DotnetNewCommand(_log, "console", "--help", "--langVersion", "8.0")
+                    .WithCustomHive(home)
+                    .WithWorkingDirectory(workingDirectory)
+                    .Execute()
+                    .Should().Pass()
+                    .And.NotHaveStdErr()
+                    .And.HaveStdOutMatching(ConsoleHelp)
+                    .And.NotHaveStdOutContaining(HelpOutput);
         }
 
         [Fact]


### PR DESCRIPTION
## Problem
fixes https://github.com/dotnet/templating/issues/5668

## Description
The net6.0 templates doesn't support C# 11 (and later) at the moment. In case C# 11 is requested via --langVersion the template that uses old syntax will be created.
In the fix the condition on language version was reverted, so the default behavior is new syntax and that the C#11 and further language versions will use new syntax.

## Customer Impact
when executing dotnet new console --framework net6.0 --langVersion 11.0 or dotnet new classlib --framework net6.0 --langVersion 11.0 the template that uses old syntax is created.
After the fix, the template that uses latest language features (top-level statements, file-scoped namespaces etc) will be used

## Testing
Automated

## Risk
Very low
Those conditions are already used in .NET 8 templates and passing the tests

## Checks:
 Added unit tests - existing tests cover the change
 Added #nullable enable to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style) - NA
