### PR TITLE
added support for 'dataType' for 'bind' symbols

### DIFF
--- a/src/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
+++ b/src/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
@@ -272,12 +272,8 @@ namespace Microsoft.TemplateEngine.Core.Util
 
         private void ProcessFile(IFile sourceFile, string sourceRel, string targetDir, IGlobalRunSpec spec, IProcessor fallback, IEnumerable<KeyValuePair<IPathMatcher, IProcessor>> fileGlobProcessors)
         {
-            IProcessor runner = fileGlobProcessors.FirstOrDefault(x => x.Key.IsMatch(sourceRel)).Value ?? fallback;
-            if (runner == null)
-            {
-                throw new InvalidOperationException("At least one of [runner] or [fallback] cannot be null");
-            }
-
+            IProcessor runner = (fileGlobProcessors.FirstOrDefault(x => x.Key.IsMatch(sourceRel)).Value ?? fallback)
+                ?? throw new InvalidOperationException("At least one of [runner] or [fallback] cannot be null");
             if (!spec.TryGetTargetRelPath(sourceRel, out string targetRel))
             {
                 targetRel = sourceRel;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BindSymbol.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ConfigModel/BindSymbol.cs
@@ -34,6 +34,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel
 
             Binding = binding!;
             DefaultValue = jObject.ToString(nameof(DefaultValue));
+            DataType = jObject.ToString(nameof(DataType));
         }
 
         /// <summary>
@@ -44,6 +45,16 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel
         /// <inheritdoc />
         public override string Type => TypeName;
 
+        /// <summary>
+        /// Gets default value of the symbol.
+        /// Corresponds to "defaultValue" JSON property.
+        /// </summary>
         public string? DefaultValue { get; internal init; }
+
+        /// <summary>
+        /// Gets the data type of the symbol.
+        /// Corresponds to "datatype" JSON property.
+        /// </summary>
+        public string? DataType { get; internal init; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
@@ -224,6 +224,24 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Bind symbol &apos;{0}&apos;: failed to convert value &apos;{1}&apos; to datatype &apos;{2}&apos;. The symbol processing is skipped..
+        /// </summary>
+        internal static string BindSymbolEvaluator_Warning_ConversionFailure {
+            get {
+                return ResourceManager.GetString("BindSymbolEvaluator_Warning_ConversionFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Bind symbol &apos;{0}&apos;: failed to convert default value &apos;{1}&apos; to datatype &apos;{2}&apos;. The default value is skipped..
+        /// </summary>
+        internal static string BindSymbolEvaluator_Warning_DefaultValueConversionFailure {
+            get {
+                return ResourceManager.GetString("BindSymbolEvaluator_Warning_DefaultValueConversionFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to evaluate bind symbol &apos;{0}&apos;, it will be skipped..
         /// </summary>
         internal static string BindSymbolEvaluator_Warning_EvaluationError {

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
@@ -185,6 +185,14 @@ Details: {1}</value>
   <data name="Authoring_TemplateRootOutsideInstallSource" xml:space="preserve">
     <value>The template root is outside the specified install source location.</value>
   </data>
+  <data name="BindSymbolEvaluator_Warning_ConversionFailure" xml:space="preserve">
+    <value>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</value>
+    <comment>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</comment>
+  </data>
+  <data name="BindSymbolEvaluator_Warning_DefaultValueConversionFailure" xml:space="preserve">
+    <value>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</value>
+    <comment>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</comment>
+  </data>
   <data name="BindSymbolEvaluator_Warning_EvaluationError" xml:space="preserve">
     <value>Failed to evaluate bind symbol '{0}', it will be skipped.</value>
     <comment>{0} - name of the symbol in configuration that cannot be evaluated</comment>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/JoinMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/JoinMacroConfig.cs
@@ -40,11 +40,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
                     throw new TemplateAuthoringException(string.Format(LocalizableStrings.MacroConfig_Exception_ArrayShouldContainObjects, generatedSymbolConfig.VariableName, SymbolsPropertyName), generatedSymbolConfig.VariableName);
                 }
                 JoinType type = jobj.ToEnum(SymbolsTypePropertyName, JoinType.Const, ignoreCase: true);
-                string? value = jobj.ToString(SymbolsValuePropertyName);
-                if (value == null)
-                {
-                    throw new TemplateAuthoringException(string.Format(LocalizableStrings.MacroConfig_Exception_MissingValueProperty, generatedSymbolConfig.VariableName, SymbolsPropertyName, SymbolsValuePropertyName), generatedSymbolConfig.VariableName);
-                }
+                string? value = jobj.ToString(SymbolsValuePropertyName)
+                    ?? throw new TemplateAuthoringException(
+                        string.Format(
+                            LocalizableStrings.MacroConfig_Exception_MissingValueProperty,
+                            generatedSymbolConfig.VariableName,
+                            SymbolsPropertyName,
+                            SymbolsValuePropertyName),
+                        generatedSymbolConfig.VariableName);
                 if (type == JoinType.Ref && string.IsNullOrWhiteSpace(value))
                 {
                     throw new TemplateAuthoringException(

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/SwitchMacroConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Macros/SwitchMacroConfig.cs
@@ -40,11 +40,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Macros
                     throw new TemplateAuthoringException(string.Format(LocalizableStrings.MacroConfig_Exception_ArrayShouldContainObjects, generatedSymbolConfig.VariableName, CasesPropertyName), generatedSymbolConfig.VariableName);
                 }
                 string? condition = jobj.ToString(CasesConditionPropertyName);
-                string? value = jobj.ToString(CasesValuePropertyName);
-                if (value == null)
-                {
-                    throw new TemplateAuthoringException(string.Format(LocalizableStrings.MacroConfig_Exception_MissingValueProperty, generatedSymbolConfig.VariableName, CasesPropertyName, CasesValuePropertyName), generatedSymbolConfig.VariableName);
-                }
+                string? value = jobj.ToString(CasesValuePropertyName)
+                    ?? throw new TemplateAuthoringException(
+                        string.Format(
+                            LocalizableStrings.MacroConfig_Exception_MissingValueProperty,
+                            generatedSymbolConfig.VariableName,
+                            CasesPropertyName,
+                            CasesValuePropertyName),
+                        generatedSymbolConfig.VariableName);
                 cases.Add((condition, value));
             }
             Cases = cases;

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Unshipped.txt
@@ -5,5 +5,6 @@ Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IGeneratedSy
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro.EvaluateConfig(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! environmentSettings, Microsoft.TemplateEngine.Abstractions.IVariableCollection! vars, Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacroConfig! config) -> void
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro<T>
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro<T>.Evaluate(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! environmentSettings, Microsoft.TemplateEngine.Abstractions.IVariableCollection! variables, T config) -> void
+Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.BindSymbol.DataType.get -> string?
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.ConditionedConfigurationElement.EvaluateCondition(Microsoft.Extensions.Logging.ILogger! logger, Microsoft.TemplateEngine.Abstractions.IVariableCollection! variables) -> bool
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.TemplateConfigModel.Identity.get -> string!

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
@@ -255,7 +255,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             }
             BindSymbolEvaluator bindSymbolEvaluator = new BindSymbolEvaluator(settings);
 
-            return bindSymbolEvaluator.EvaluateBindedSymbolsAsync(bindSymbols, variableCollection, cancellationToken);
+            return bindSymbolEvaluator.EvaluateBindSymbolsAsync(bindSymbols, variableCollection, cancellationToken);
         }
 
         /// <summary>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
@@ -359,13 +359,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     throw new TemplateAuthoringException(string.Format(LocalizableStrings.SimpleConfigModel_AuthoringException_MergeConfiguration_InvalidFileName, partialConfigFileName, RunnableProjectGenerator.TemplateConfigFileName), partialConfigFileName);
                 }
 
-                IFile? partialConfigFile = primarySourceConfig.Parent?.EnumerateFiles(partialConfigFileName, SearchOption.TopDirectoryOnly).FirstOrDefault(x => string.Equals(x.Name, partialConfigFileName));
-
-                if (partialConfigFile == null)
-                {
-                    throw new TemplateAuthoringException(string.Format(LocalizableStrings.SimpleConfigModel_AuthoringException_MergeConfiguration_FileNotFound, partialConfigFileName), partialConfigFileName);
-                }
-
+                IFile? partialConfigFile = (primarySourceConfig.Parent?.EnumerateFiles(partialConfigFileName, SearchOption.TopDirectoryOnly)
+                    .FirstOrDefault(x => string.Equals(x.Name, partialConfigFileName)))
+                    ?? throw new TemplateAuthoringException(
+                        string.Format(
+                            LocalizableStrings.SimpleConfigModel_AuthoringException_MergeConfiguration_FileNotFound,
+                            partialConfigFileName),
+                        partialConfigFileName);
                 JObject partialConfigJson = partialConfigFile.ReadJObjectFromIFile();
                 combinedSource.Merge(partialConfigJson);
             }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
@@ -98,6 +98,16 @@ Podrobnosti: {1}</target>
         <target state="translated">Kořen šablony je mimo zadané umístění zdroje instalace.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">Nepovedlo se vyhodnotit symbol vazby {0}, přeskočí se.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
@@ -98,6 +98,16 @@ Details: {1}</target>
         <target state="translated">Der Vorlagenstamm liegt außerhalb des angegebenen Speicherorts der Installationsquelle.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">Fehler beim Auswerten des Bindungssymbols "{0}". Es wird übersprungen.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
@@ -98,6 +98,16 @@ Detalles: {1}</target>
         <target state="translated">La raíz de la plantilla está fuera de la ubicación de origen de instalación especificada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">No se pudo evaluar el símbolo de enlace '{0}', se omitirá.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
@@ -98,6 +98,16 @@ détails : {1}</target>
         <target state="translated">La racine du modèle se trouve en dehors de l’emplacement source d’installation spécifié.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">Échec de l’évaluation du symbole de liaison « {0} ». Il sera ignoré.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
@@ -98,6 +98,16 @@ Dettagli: {1}</target>
         <target state="translated">La radice del modello non è compresa nella località di origine di installazione specificata.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">Non è stato possibile valutare il simbolo di associazione '{0}'. Verrà ignorato.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
@@ -98,6 +98,16 @@ Details: {1}</source>
         <target state="translated">テンプレート ルートは、指定されたインストール ソースの場所外です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">バインド シンボル '{0}' を評価できませんでした。スキップされます。</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
@@ -98,6 +98,16 @@ Details: {1}</source>
         <target state="translated">템플릿 루트가 지정된 설치 원본 위치 외부에 있습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">바인딩 기호 '{0}'을(를) 평가하지 못했습니다. 기호를 건너뜁니다.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
@@ -98,6 +98,16 @@ Szczegóły: {1}</target>
         <target state="translated">Katalog główny szablonu znajduje się poza określoną lokalizacją źródła instalacji.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">Nie można ocenić symbolu powiązania „{0}”, zostanie on pominięty.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
@@ -98,6 +98,16 @@ Detalhes: {1}</target>
         <target state="translated">A raiz do modelo está fora do local de origem da instalação especificada.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">Falha ao avaliar o símbolo de associação '{0}', ele será ignorado.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
@@ -98,6 +98,16 @@ Details: {1}</source>
         <target state="translated">Корень шаблона находится за пределами указанного расположения источника установки.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">Не удалось вычислить символ привязки "{0}". Он будет пропущен.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
@@ -98,6 +98,16 @@ Ayrıntılar: {1}</target>
         <target state="translated">Şablon kökü belirtilen yükleme kaynağı konumunun dışında.</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">'{0}' bağlama sembolü değerlendirilemedi, sembol atlanacak.</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
@@ -98,6 +98,16 @@ Details: {1}</source>
         <target state="translated">模板根位于指定的安装源位置之外。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">无法计算绑定符号“{0}”，将跳过它。</target>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
@@ -98,6 +98,16 @@ Details: {1}</source>
         <target state="translated">範本根目錄超出指定的安裝來源位置。</target>
         <note />
       </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_ConversionFailure">
+        <source>Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert value '{1}' to datatype '{2}'. The symbol processing is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - obtained value for a symbol, {2} - defined datatype for a symbol</note>
+      </trans-unit>
+      <trans-unit id="BindSymbolEvaluator_Warning_DefaultValueConversionFailure">
+        <source>Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</source>
+        <target state="new">Bind symbol '{0}': failed to convert default value '{1}' to datatype '{2}'. The default value is skipped.</target>
+        <note>{0} - the name of symbol in configuration, {1} - default value in configuraion, {2} - defined datatype for a symbol</note>
+      </trans-unit>
       <trans-unit id="BindSymbolEvaluator_Warning_EvaluationError">
         <source>Failed to evaluate bind symbol '{0}', it will be skipped.</source>
         <target state="translated">無法評估繫結符號 '{0}'，將略過該符號。</target>

--- a/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/LegacySearchCacheReader.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/LegacySearchCacheReader.cs
@@ -169,11 +169,7 @@ namespace Microsoft.TemplateSearch.Common
                             && entryValue.TryGetValue(nameof(PackToTemplateEntry.TemplateIdentificationEntry), StringComparison.OrdinalIgnoreCase, out JToken? identificationToken)
                             && identificationToken is JArray identificationArray)
                         {
-                            string? version = versionToken.Value<string>();
-                            if (version == null)
-                            {
-                                throw new Exception("Version value is null.");
-                            }
+                            string? version = versionToken.Value<string>() ?? throw new Exception("Version value is null.");
                             List<TemplateIdentificationEntry> templatesInPack = new List<TemplateIdentificationEntry>();
 
                             foreach (JToken templateIdentityInfo in identificationArray)

--- a/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplatePackageSearchData.Json.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplatePackageSearchData.Json.cs
@@ -36,11 +36,8 @@ namespace Microsoft.TemplateSearch.Common
             Description = jObject.ToString(nameof(Description));
             IconUrl = jObject.ToString(nameof(IconUrl));
 
-            JArray? templatesData = jObject.Get<JArray>(nameof(Templates));
-            if (templatesData == null)
-            {
-                throw new ArgumentException($"{nameof(jObject)} doesn't have {nameof(Templates)} property or it is not an array.", nameof(jObject));
-            }
+            JArray? templatesData = jObject.Get<JArray>(nameof(Templates))
+                ?? throw new ArgumentException($"{nameof(jObject)} doesn't have {nameof(Templates)} property or it is not an array.", nameof(jObject));
             List<TemplateSearchData> templates = new List<TemplateSearchData>();
             foreach (JToken template in templatesData)
             {

--- a/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplateSearchCache.Json.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplateSearchCache.Json.cs
@@ -49,11 +49,8 @@ namespace Microsoft.TemplateSearch.Common
 
             }
 
-            JArray? data = cacheObject.Get<JArray>(nameof(TemplatePackages));
-            if (data == null)
-            {
-                throw new Exception(LocalizableStrings.TemplateSearchCache_Exception_NotValid);
-            }
+            JArray? data = cacheObject.Get<JArray>(nameof(TemplatePackages))
+                ?? throw new Exception(LocalizableStrings.TemplateSearchCache_Exception_NotValid);
             List<TemplatePackageSearchData> templatePackages = new();
             foreach (JToken templatePackage in data)
             {


### PR DESCRIPTION
### Problem
This blocks adding "class" item template.
Now the type for bind symbols is inferred.  For language version, in some cases it is incorrectly inferred to double.
Conditions as `"langVersion == \"\""` therefore won't work.

### Solution
Added support for configuring `dataType` for `bind`  symbols
If `dataType` is configured in json configuration for `bind` symbol, this data type is forced to be used.

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)