### PR TITLE
bind symbols: no warning when no value for binding was found and default value is set

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/BindSymbolEvaluator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/BindSymbolEvaluator.cs
@@ -62,14 +62,17 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 }
             }
 
-            var bindSymbols = symbols.Where(bs => !string.IsNullOrWhiteSpace(bs.Binding));
+            IEnumerable<BindSymbol> bindSymbols = symbols.Where(bs => !string.IsNullOrWhiteSpace(bs.Binding));
             if (!bindSymbols.Any())
             {
                 _logger.LogDebug("No bind symbols has '{0}' defined.", nameof(BindSymbol.Binding).ToLowerInvariant());
                 return;
             }
 
-            var tasksToRun = bindSymbols.Select(s => new { Symbol = s, Task = GetBoundValueAsync(s.Binding, cancellationToken) }).ToList();
+            IReadOnlyList<(BindSymbol Symbol, Task<string?> Task)> tasksToRun = bindSymbols
+                .Select(s => (s, GetBoundValueAsync(s.Binding, cancellationToken)))
+                .ToList();
+
             try
             {
                 await Task.WhenAll(tasksToRun.Select(t => t.Task)).ConfigureAwait(false);
@@ -80,32 +83,62 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 //errors are handled below
             }
             cancellationToken.ThrowIfCancellationRequested();
+            ProcessEvaluationResults(variableCollection, tasksToRun);
+        }
 
-            foreach (var task in tasksToRun.Where(t => t.Task.IsFaulted || (t.Task.IsCompleted && t.Task.Result == null)))
+        private void ProcessEvaluationResults(IVariableCollection variableCollection, IReadOnlyList<(BindSymbol Symbol, Task<string?> Task)> completedTasks)
+        {
+            foreach ((BindSymbol currentSymbol, Task<string?> currentTask) in completedTasks)
             {
-                _logger.LogWarning(LocalizableStrings.BindSymbolEvaluator_Warning_EvaluationError, task.Symbol.Name);
-            }
+                if (!currentTask.IsCompleted)
+                {
+                    throw new InvalidOperationException("The method should be used only after the tasks are completed.");
+                }
+                if (currentTask.IsFaulted || currentTask.IsCanceled)
+                {
+                    _logger.LogWarning(LocalizableStrings.BindSymbolEvaluator_Warning_EvaluationError, currentSymbol.Name);
+                    _logger.LogDebug(currentTask.Exception, "The evaluation task has failed: {0}", currentTask.Exception.Message);
+                    continue;
+                }
 
-            var successfulTasks = tasksToRun.Where(t => t.Task.IsCompleted && t.Task.Result != null);
-            foreach (var task in successfulTasks)
-            {
-                string obtainedValue = task.Task.Result!;
-                BindSymbol currentSymbol = task.Symbol;
+                if (currentTask.Result is null)
+                {
+                    if (currentSymbol.DefaultValue != null)
+                    {
+                        _logger.LogDebug(
+                            "Failed to evaluate bind symbol '{0}', the returned value is null. The default value '{1}' is used instead.",
+                            currentSymbol.Name,
+                            currentSymbol.DefaultValue);
+                    }
+                    else
+                    {
+                        _logger.LogWarning(LocalizableStrings.BindSymbolEvaluator_Warning_EvaluationError, currentSymbol.Name);
+                    }
+                    continue;
+                }
 
-                bool result = ParameterConverter.TryConvertLiteralToDatatype(obtainedValue, currentSymbol.DataType, out object? value);
-                if (result && value != null)
+                string obtainedValue = currentTask.Result!;
+                bool result = ParameterConverter.TryConvertLiteralToDatatype(obtainedValue, currentSymbol.DataType, out object? convertedValue);
+                if (result && convertedValue != null)
                 {
-                    variableCollection[currentSymbol.Name] = value;
-                    _logger.LogDebug("Variable '{0}' was set to '{1}'.", currentSymbol.Name, value);
+                    variableCollection[currentSymbol.Name] = convertedValue;
+                    _logger.LogDebug("Variable '{0}' was set to '{1}'.", currentSymbol.Name, convertedValue);
+                    continue;
                 }
-                if (!result && !string.IsNullOrWhiteSpace(currentSymbol.DataType))
+                if (!result)
                 {
-                    _logger.LogWarning(LocalizableStrings.BindSymbolEvaluator_Warning_ConversionFailure, currentSymbol.Name, obtainedValue, currentSymbol.DataType);
+                    _logger.LogWarning(
+                        LocalizableStrings.BindSymbolEvaluator_Warning_ConversionFailure,
+                        currentSymbol.Name,
+                        obtainedValue,
+                        currentSymbol.DataType ?? "<null>");
+                    continue;
                 }
-                else
-                {
-                    _logger.LogDebug("Variable '{0}' was not set due to its value is null.", currentSymbol.Name);
-                }
+                _logger.LogDebug(
+                    "Variable '{0}' was not set: the value '{1}' after conversion to datatype '{2}' is null.",
+                    currentSymbol.Name,
+                    obtainedValue,
+                    currentSymbol.DataType ?? "<null>");
             }
         }
 


### PR DESCRIPTION
### Problem
MSBuild properties that may be bound to symbols sometimes are not set. This result to warning as:
`
﻿Warning: Failed to evaluate bind symbol 'ImplicitUsings', it will be skipped.
`
In most of the cases it's valid scenario that the property is not set, and the warning (currently appearing twice) is confusing to final user.

### Solution
Changed logging strategy:
- if evaluation task faulted - show the warning
- if value was not found and default value is set - do not show the warning, just debug message
- if value was not found and default value is not set - show the warning

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)