### PR TITLE
removed `ITemplateEngineHost.OnParameterError` and other obsolete methods

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/ITemplateEngineHost.cs
@@ -67,30 +67,6 @@ namespace Microsoft.TemplateEngine.Abstractions
 
         #region Obsolete
 
-        [Obsolete("Use " + nameof(Logger) + " instead.")]
-        void LogTiming(string label, TimeSpan duration, int depth);
-
-        [Obsolete("Use " + nameof(Logger) + " instead.")]
-        void LogMessage(string message);
-
-        [Obsolete("Use " + nameof(Logger) + " instead.")]
-        void OnCriticalError(string code, string message, string currentFile, long currentPosition);
-
-        [Obsolete("Use " + nameof(Logger) + " instead.")]
-        bool OnNonCriticalError(string code, string message, string currentFile, long currentPosition);
-
-        [Obsolete("The method is deprecated.")]
-        bool OnParameterError(ITemplateParameter parameter, string receivedValue, string message, out string? newValue);
-
-        [Obsolete("The method is deprecated.")]
-        void OnSymbolUsed(string symbol, object value);
-
-        [Obsolete("Use " + nameof(Logger) + " instead.")]
-        void LogDiagnosticMessage(string message, string category, params string[] details);
-
-        [Obsolete("The method is deprecated.")]
-        bool OnConfirmPartialMatch(string name);
-
         /// <summary>
         /// Action to be done when potentially destructive changes on template instantiation are detected.
         /// The host can implement it as needed: prompt user, show error, etc.

--- a/src/Microsoft.TemplateEngine.Abstractions/Parameters/DataSource.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Parameters/DataSource.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+
 namespace Microsoft.TemplateEngine.Abstractions.Parameters
 {
     public enum DataSource
@@ -21,8 +23,9 @@ namespace Microsoft.TemplateEngine.Abstractions.Parameters
         HostDefault,
 
         /// <summary>
-        /// Value obtained via <see cref="ITemplateEngineHost.OnParameterError"/>.
+        /// Value obtained via ITemplateEngineHost.OnParameterError.
         /// </summary>
+        [Obsolete("The value is not used anymore due to ITemplateEngineHost.OnParameterError was removed.")]
         HostOnError,
 
         /// <summary>

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Shipped.txt
@@ -120,16 +120,9 @@ Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.BuiltInComponents.get 
 Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.FallbackHostTemplateConfigNames.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.FileSystem.get -> Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem.IPhysicalFileSystem!
 Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.HostIdentifier.get -> string!
-Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.LogDiagnosticMessage(string! message, string! category, params string![]! details) -> void
 Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.Logger.get -> Microsoft.Extensions.Logging.ILogger!
 Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.LoggerFactory.get -> Microsoft.Extensions.Logging.ILoggerFactory!
-Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.LogMessage(string! message) -> void
-Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.LogTiming(string! label, System.TimeSpan duration, int depth) -> void
-Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.OnConfirmPartialMatch(string! name) -> bool
-Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.OnCriticalError(string! code, string! message, string! currentFile, long currentPosition) -> void
-Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.OnNonCriticalError(string! code, string! message, string! currentFile, long currentPosition) -> bool
 Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.OnPotentiallyDestructiveChangesDetected(System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.IFileChange!>! changes, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.IFileChange!>! destructiveChanges) -> bool
-Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.OnSymbolUsed(string! symbol, object! value) -> void
 Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.TryGetHostParamDefault(string! paramName, out string? value) -> bool
 Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.Version.get -> string!
 Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.VirtualizeDirectory(string! path) -> void
@@ -437,7 +430,6 @@ Microsoft.TemplateEngine.Abstractions.ISimpleConfigModifiers.BaselineName.get ->
 Microsoft.TemplateEngine.Abstractions.ITemplate.Configuration.get -> Microsoft.TemplateEngine.Abstractions.Mount.IFileSystemInfo!
 Microsoft.TemplateEngine.Abstractions.ITemplate.Generator.get -> Microsoft.TemplateEngine.Abstractions.IGenerator!
 Microsoft.TemplateEngine.Abstractions.ITemplate.LocaleConfiguration.get -> Microsoft.TemplateEngine.Abstractions.Mount.IFileSystemInfo?
-Microsoft.TemplateEngine.Abstractions.ITemplateEngineHost.OnParameterError(Microsoft.TemplateEngine.Abstractions.ITemplateParameter! parameter, string! receivedValue, string! message, out string? newValue) -> bool
 Microsoft.TemplateEngine.Abstractions.ITemplateParameter.AllowMultipleValues.get -> bool
 Microsoft.TemplateEngine.Abstractions.ITemplateInfo.Constraints.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.Constraints.TemplateConstraintInfo!>!
 Microsoft.TemplateEngine.Abstractions.ITemplateInfo.PostActions.get -> System.Collections.Generic.IReadOnlyList<System.Guid>!

--- a/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs
@@ -16,8 +16,6 @@ namespace Microsoft.TemplateEngine.Edge
         private static readonly IReadOnlyList<(Type, IIdentifiedComponent)> NoComponents = Array.Empty<(Type, IIdentifiedComponent)>();
         private readonly IReadOnlyDictionary<string, string> _hostDefaults;
         private readonly IReadOnlyList<(Type InterfaceType, IIdentifiedComponent Instance)> _hostBuiltInComponents;
-        [Obsolete]
-        private readonly Dictionary<string, Action<string, string[]>> _diagnosticLoggers = new Dictionary<string, Action<string, string[]>>();
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger _logger;
 
@@ -78,70 +76,7 @@ namespace Microsoft.TemplateEngine.Edge
             _loggerFactory?.Dispose();
         }
 
-        #region Obsolete
-
-#pragma warning disable SA1201 // Elements should appear in the correct order
-        [Obsolete("Use " + nameof(Logger) + " instead")]
-        public Action<string, TimeSpan, int>? OnLogTiming { get; set; }
-#pragma warning restore SA1201 // Elements should appear in the correct order
-
-        [Obsolete("The method is deprecated.")]
-        bool ITemplateEngineHost.OnConfirmPartialMatch(string name)
-        {
-            return true;
-        }
-
-        [Obsolete("The method is deprecated.")]
-        void ITemplateEngineHost.OnSymbolUsed(string symbol, object value)
-        {
-        }
-
-        [Obsolete("The method is deprecated.")]
-        bool ITemplateEngineHost.OnParameterError(ITemplateParameter parameter, string receivedValue, string message, out string newValue)
-        {
-            newValue = receivedValue;
-            return false;
-        }
-
-        [Obsolete("Use " + nameof(Logger) + " instead")]
-        public void RegisterDiagnosticLogger(string category, Action<string, string[]> messageHandler)
-        {
-            _diagnosticLoggers[category] = messageHandler;
-        }
-
-        [Obsolete("Use " + nameof(Logger) + " instead")]
-        void ITemplateEngineHost.LogDiagnosticMessage(string message, string category, params string[] details)
-        {
-            if (_diagnosticLoggers.TryGetValue(category, out Action<string, string[]> messageHandler))
-            {
-                messageHandler(message, details);
-            }
-        }
-
-        [Obsolete("Use " + nameof(Logger) + " instead")]
-        void ITemplateEngineHost.LogTiming(string label, TimeSpan duration, int depth)
-        {
-            OnLogTiming?.Invoke(label, duration, depth);
-        }
-
-        [Obsolete("Use " + nameof(Logger) + " instead")]
-        void ITemplateEngineHost.LogMessage(string message)
-        {
-            Console.WriteLine(message);
-        }
-
-        [Obsolete("Use " + nameof(Logger) + " instead")]
-        void ITemplateEngineHost.OnCriticalError(string code, string message, string currentFile, long currentPosition)
-        {
-        }
-
-        [Obsolete("Use " + nameof(Logger) + " instead")]
-        bool ITemplateEngineHost.OnNonCriticalError(string code, string message, string currentFile, long currentPosition)
-        {
-            ((ITemplateEngineHost)this).LogMessage(string.Format($"Error: {message}"));
-            return false;
-        }
-
+        #region Obsoleted
         [Obsolete]
         bool ITemplateEngineHost.OnPotentiallyDestructiveChangesDetected(IReadOnlyList<IFileChange> changes, IReadOnlyList<IFileChange> destructiveChanges)
         {

--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Shipped.txt
@@ -20,9 +20,6 @@ Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.FileSystem.get -> Micros
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.HostIdentifier.get -> string!
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.Logger.get -> Microsoft.Extensions.Logging.ILogger!
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.LoggerFactory.get -> Microsoft.Extensions.Logging.ILoggerFactory!
-Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.OnLogTiming.get -> System.Action<string!, System.TimeSpan, int>?
-Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.OnLogTiming.set -> void
-Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.RegisterDiagnosticLogger(string! category, System.Action<string!, string![]!>! messageHandler) -> void
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.Version.get -> string!
 Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.VirtualizeDirectory(string! path) -> void
 Microsoft.TemplateEngine.Edge.EngineEnvironmentSettings

--- a/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Template/TemplateCreator.cs
@@ -378,48 +378,6 @@ namespace Microsoft.TemplateEngine.Edge.Template
             }
         }
 
-        /// <summary>
-        /// Checks that all required parameters are provided. If a missing one is found, a value may be provided via host.OnParameterError
-        /// but it's up to the caller / UI to decide how to act.
-        /// Returns true if there are any missing params, false otherwise.
-        /// </summary>
-        /// <param name="templateParams"></param>
-        /// <param name="parametersBuilder"></param>
-        /// <param name="missingParamNames"></param>
-        /// <returns></returns>
-        private bool CheckForMissingRequiredParameters(InputDataSet templateParams, IParameterSetBuilder parametersBuilder, out IList<string> missingParamNames)
-        {
-            ITemplateEngineHost host = _environmentSettings.Host;
-            bool anyMissingParams = false;
-            missingParamNames = new List<string>();
-
-            foreach (InputParameterData evaluatedParameterData in templateParams.Values.Where(v => v.GetEvaluatedPrecedence() == EvaluatedPrecedence.Required && v.InputDataState == InputDataState.Unset))
-            {
-                string? newParamValue;
-                const int _MAX_RETRIES = 3;
-                int retries = 0;
-#pragma warning disable CS0618 // Type or member is obsolete - for backward compatibility
-                while (host.OnParameterError(evaluatedParameterData.ParameterDefinition, string.Empty, "Missing required parameter", out newParamValue)
-#pragma warning restore CS0618 // Type or member is obsolete
-                       && string.IsNullOrEmpty(newParamValue)
-                       && ++retries < _MAX_RETRIES)
-                {
-                }
-
-                if (!string.IsNullOrEmpty(newParamValue))
-                {
-                    parametersBuilder.SetParameterValue(evaluatedParameterData.ParameterDefinition, newParamValue!, DataSource.HostOnError);
-                }
-                else
-                {
-                    missingParamNames.Add(evaluatedParameterData.ParameterDefinition.Name);
-                    anyMissingParams = true;
-                }
-            }
-
-            return anyMissingParams;
-        }
-
         private InputDataSet? EvaluateConditionalParameters(
             IParameterSetBuilder parametersBuilder,
             InputDataSet inputParameters,
@@ -503,11 +461,13 @@ namespace Microsoft.TemplateEngine.Edge.Template
                 return false;
             }
 
-            bool missingParams = CheckForMissingRequiredParameters(evaluatedParams!, parameterSetBuilder, out IList<string> missingParamNames);
+            IEnumerable<string> missingParams = evaluatedParams!.Values
+                .Where(v => v.GetEvaluatedPrecedence() == EvaluatedPrecedence.Required && v.InputDataState == InputDataState.Unset)
+                .Select(v => v.ParameterDefinition.Name);
 
-            if (missingParams)
+            if (missingParams.Any())
             {
-                failureResult = new TemplateCreationResult(CreationResultStatus.MissingMandatoryParam, template.Name, string.Join(", ", missingParamNames));
+                failureResult = new TemplateCreationResult(CreationResultStatus.MissingMandatoryParam, template.Name, string.Join(", ", missingParams));
                 templateParams = null;
                 return false;
             }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -37,7 +37,8 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         /// </summary>
         object? IGenerator.ConvertParameterValueToType(IEngineEnvironmentSettings environmentSettings, ITemplateParameter parameter, string untypedValue, out bool valueResolutionError)
         {
-            return ParameterConverter.ConvertParameterValueToType(environmentSettings.Host, parameter, untypedValue, out valueResolutionError);
+            valueResolutionError = !ParameterConverter.TryConvertParameterValueToType(parameter, untypedValue, out object? convertedValue);
+            return convertedValue;
         }
 
         bool IGenerator.TryEvaluateFromString(ILogger logger, string text, IDictionary<string, object> variables, out bool result, out string evaluationError, HashSet<string>? referencedVariablesKeys)

--- a/test/Microsoft.TemplateEngine.TestHelper/TestHost.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/TestHost.cs
@@ -108,62 +108,10 @@ namespace Microsoft.TemplateEngine.TestHelper
         }
 
         [Obsolete]
-        void ITemplateEngineHost.OnSymbolUsed(string symbol, object value)
-        {
-            //do nothing
-        }
-
-        [Obsolete]
-        bool ITemplateEngineHost.OnParameterError(ITemplateParameter parameter, string receivedValue, string message, out string newValue)
-        {
-            //do nothing
-            newValue = receivedValue;
-            return false;
-        }
-
-        [Obsolete]
-        bool ITemplateEngineHost.OnNonCriticalError(string code, string message, string currentFile, long currentPosition)
-        {
-            //do nothing
-            return false;
-        }
-
-        [Obsolete]
-        void ITemplateEngineHost.OnCriticalError(string code, string message, string currentFile, long currentPosition)
-        {
-            //do nothing
-        }
-
-        [Obsolete]
-        void ITemplateEngineHost.LogMessage(string message)
-        {
-            //do nothing
-        }
-
-        [Obsolete]
         bool ITemplateEngineHost.OnPotentiallyDestructiveChangesDetected(IReadOnlyList<IFileChange> changes, IReadOnlyList<IFileChange> destructiveChanges)
         {
             //do nothing
             return false;
-        }
-
-        [Obsolete]
-        bool ITemplateEngineHost.OnConfirmPartialMatch(string name)
-        {
-            //do nothing
-            return false;
-        }
-
-        [Obsolete]
-        void ITemplateEngineHost.LogDiagnosticMessage(string message, string category, params string[] details)
-        {
-            //do nothing
-        }
-
-        [Obsolete]
-        void ITemplateEngineHost.LogTiming(string label, TimeSpan duration, int depth)
-        {
-            //do nothing
         }
     }
 }


### PR DESCRIPTION
This is main only as the it is a breaking change

### Problem
`ITemplateEngineHost.OnParameterError` is obsolete and keeps the logic in `ParameterConverter` complicated.

### Solution
- removed `ITemplateEngineHost.OnParameterError` and other obsolete methods; they are obsolete for 2+ major releases
- `ParameterConverter` simplification

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)