### PR TITLE
Pin console logging to 6.0 to workaround dispose issue in 7.0

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -10,7 +10,7 @@
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="17.4.0" />
     <PackageReference Update="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Update="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Update="NuGet.Configuration" Version="6.4.0" />
     <PackageReference Update="NuGet.Credentials" Version="6.4.0" />


### PR DESCRIPTION
### Problem
Console Logger in 7.0 misses messages upon dispose (https://github.com/dotnet/runtime/issues/79812)

### Solution
Let's move to 6.0 of console logging for the time being to unblock our CI

### Checks: N/A
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)