### PR TITLE
`validate` CLI command

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿Microsoft.TemplateEngine.Edge.DefaultEnvironment.DefaultEnvironment(System.Collections.Generic.IReadOnlyDictionary<string!, string!>! environmentVariables) -> void
+Microsoft.TemplateEngine.Edge.Settings.Scanner.ScanAsync(string! mountPointUri, bool logValidationResults = true, bool returnInvalidTemplates = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.TemplateEngine.Edge.Settings.ScanResult!>!
 Microsoft.TemplateEngine.Edge.Settings.Scanner.ScanAsync(string! mountPointUri, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.TemplateEngine.Edge.Settings.ScanResult!>!
 Microsoft.TemplateEngine.Edge.Settings.ScanResult.Templates.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.IScanTemplateInfo!>!
 Microsoft.TemplateEngine.Edge.Settings.ITemplateInfoHostJsonCache.HostData.get -> string?

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests.csproj
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests.csproj
@@ -15,5 +15,12 @@
   <ItemGroup>
     <Compile Include="..\Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Snapshots\**\*" />
+    <Content Include="Snapshots\**\*" />
+    <None Include="Snapshots\**\*" CopyToOutputDirectory="Never" />
+  </ItemGroup>
+
   
 </Project>

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.Linux.verified.txt
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.Linux.verified.txt
@@ -1,0 +1,60 @@
+﻿StdErr:
+
+StdOut:
+info: validate[0]
+      Scanning location '{SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid' for the templates...
+fail: Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator[0]
+      Failed to load template from {SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/MissingIdentity/.template.config/template.json.
+      Details: 'identity' is missing or is an empty string.
+warn: Template Engine[0]
+      Failed to read or parse localization file {SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/Localization/InvalidFormat/.template.config/localize/templatestrings.de-DE.json, it will be skipped from further processing.
+warn: Template Engine[0]
+      [{SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/Localization/ValidationFailure/.template.config/template.json]: id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
+info: validate[0]
+      Scanning completed
+info: validate[0]
+      Location '{SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid': found 6 templates.
+info: validate[0]
+      Found template 'TestAssets.Invalid.InvalidHostData' (TestAssets.Invalid.InvalidHostData):
+         [Info][MV011] One or more postActions have a malformed or missing manualInstructions value.
+      Template 'TestAssets.Invalid.InvalidHostData' (TestAssets.Invalid.InvalidHostData): the template is valid.
+      
+info: validate[0]
+      Found template '<no name>' (MissingConfigTest):
+         [Error][MV002] Missing 'name'.
+         [Error][MV003] Missing 'shortName'.
+         [Info][MV005] Missing 'sourceName'.
+         [Info][MV006] Missing 'author'.
+         [Info][MV007] Missing 'groupIdentity'.
+         [Info][MV008] Missing 'generatorVersions'.
+         [Info][MV009] Missing 'precedence'.
+         [Info][MV010] Missing 'classifications'.
+      Template '<no name>' (MissingConfigTest): the template is not valid.
+      
+info: validate[0]
+      Found template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat):
+         <no entries>
+      Template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat): the template is valid.
+      
+info: validate[0]
+      Found template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         <no entries>
+      Found localization de-DE for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         [Error][LOC001] In localization file under the post action with id 'pa1', there are localized strings for manual instruction(s) with ids 'do-not-exist'. These manual instructions do not exist in the template.json file and should be removed from localization file.
+         [Error][LOC002] Post action(s) with id(s) 'pa0' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
+      Found localization tr for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         [Error][LOC002] Post action(s) with id(s) 'pa6' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
+      Template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the template is valid.
+      'de-DE' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
+      'tr' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
+      
+info: validate[0]
+      Found template 'Invalid.SameShortName.TemplateA' (Invalid.SameShortName.TemplateA):
+         <no entries>
+      Template 'Invalid.SameShortName.TemplateA' (Invalid.SameShortName.TemplateA): the template is valid.
+      
+info: validate[0]
+      Found template 'Invalid.SameShortName.TemplateB' (Invalid.SameShortName.TemplateB):
+         <no entries>
+      Template 'Invalid.SameShortName.TemplateB' (Invalid.SameShortName.TemplateB): the template is valid.
+      

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.Linux.verified.txt
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.Linux.verified.txt
@@ -2,23 +2,18 @@
 
 StdOut:
 info: validate[0]
-      Scanning location '{SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid' for the templates...
+      Scanning location '%TEMPLATE_LOCATION%' for the templates..
 fail: Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator[0]
-      Failed to load template from {SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/MissingIdentity/.template.config/template.json.
+      Failed to load template from %TEMPLATE_LOCATION%/MissingIdentity/.template.config/template.json.
       Details: 'identity' is missing or is an empty string.
 warn: Template Engine[0]
-      Failed to read or parse localization file {SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/Localization/InvalidFormat/.template.config/localize/templatestrings.de-DE.json, it will be skipped from further processing.
+      [%TEMPLATE_LOCATION%/Localization/ValidationFailure/.template.config/template.json]: id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
 warn: Template Engine[0]
-      [{SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/Localization/ValidationFailure/.template.config/template.json]: id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
+      Failed to read or parse localization file %TEMPLATE_LOCATION%/Localization/InvalidFormat/.template.config/localize/templatestrings.de-DE.json, it will be skipped from further processing.
 info: validate[0]
       Scanning completed
 info: validate[0]
-      Location '{SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid': found 6 templates.
-info: validate[0]
-      Found template 'TestAssets.Invalid.InvalidHostData' (TestAssets.Invalid.InvalidHostData):
-         [Info][MV011] One or more postActions have a malformed or missing manualInstructions value.
-      Template 'TestAssets.Invalid.InvalidHostData' (TestAssets.Invalid.InvalidHostData): the template is valid.
-      
+      Location '%TEMPLATE_LOCATION%': found 6 templates.
 info: validate[0]
       Found template '<no name>' (MissingConfigTest):
          [Error][MV002] Missing 'name'.
@@ -32,21 +27,9 @@ info: validate[0]
       Template '<no name>' (MissingConfigTest): the template is not valid.
       
 info: validate[0]
-      Found template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat):
-         <no entries>
-      Template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat): the template is valid.
-      
-info: validate[0]
-      Found template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
-         <no entries>
-      Found localization de-DE for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
-         [Error][LOC001] In localization file under the post action with id 'pa1', there are localized strings for manual instruction(s) with ids 'do-not-exist'. These manual instructions do not exist in the template.json file and should be removed from localization file.
-         [Error][LOC002] Post action(s) with id(s) 'pa0' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
-      Found localization tr for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
-         [Error][LOC002] Post action(s) with id(s) 'pa6' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
-      Template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the template is valid.
-      'de-DE' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
-      'tr' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
+      Found template 'TestAssets.Invalid.InvalidHostData' (TestAssets.Invalid.InvalidHostData):
+         [Info][MV011] One or more postActions have a malformed or missing manualInstructions value.
+      Template 'TestAssets.Invalid.InvalidHostData' (TestAssets.Invalid.InvalidHostData): the template is valid.
       
 info: validate[0]
       Found template 'Invalid.SameShortName.TemplateA' (Invalid.SameShortName.TemplateA):
@@ -57,4 +40,21 @@ info: validate[0]
       Found template 'Invalid.SameShortName.TemplateB' (Invalid.SameShortName.TemplateB):
          <no entries>
       Template 'Invalid.SameShortName.TemplateB' (Invalid.SameShortName.TemplateB): the template is valid.
+      
+info: validate[0]
+      Found template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         <no entries>
+      Found localization 'de-DE' for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         [Error][LOC001] In localization file under the post action with id 'pa1', there are localized strings for manual instruction(s) with ids 'do-not-exist'. These manual instructions do not exist in the template.json file and should be removed from localization file.
+         [Error][LOC002] Post action(s) with id(s) 'pa0' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
+      Found localization 'tr' for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         [Error][LOC002] Post action(s) with id(s) 'pa6' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
+      Template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the template is valid.
+      'de-DE' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
+      'tr' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
+      
+info: validate[0]
+      Found template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat):
+         <no entries>
+      Template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat): the template is valid.
       

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.OSX.verified.txt
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.OSX.verified.txt
@@ -1,0 +1,60 @@
+﻿StdErr:
+
+StdOut:
+info: validate[0]
+      Scanning location '{SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid' for the templates...
+fail: Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator[0]
+      Failed to load template from {SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/MissingIdentity/.template.config/template.json.
+      Details: 'identity' is missing or is an empty string.
+warn: Template Engine[0]
+      Failed to read or parse localization file {SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/Localization/InvalidFormat/.template.config/localize/templatestrings.de-DE.json, it will be skipped from further processing.
+warn: Template Engine[0]
+      [{SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/Localization/ValidationFailure/.template.config/template.json]: id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
+info: validate[0]
+      Scanning completed
+info: validate[0]
+      Location '{SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid': found 6 templates.
+info: validate[0]
+      Found template 'TestAssets.Invalid.InvalidHostData' (TestAssets.Invalid.InvalidHostData):
+         [Info][MV011] One or more postActions have a malformed or missing manualInstructions value.
+      Template 'TestAssets.Invalid.InvalidHostData' (TestAssets.Invalid.InvalidHostData): the template is valid.
+      
+info: validate[0]
+      Found template '<no name>' (MissingConfigTest):
+         [Error][MV002] Missing 'name'.
+         [Error][MV003] Missing 'shortName'.
+         [Info][MV005] Missing 'sourceName'.
+         [Info][MV006] Missing 'author'.
+         [Info][MV007] Missing 'groupIdentity'.
+         [Info][MV008] Missing 'generatorVersions'.
+         [Info][MV009] Missing 'precedence'.
+         [Info][MV010] Missing 'classifications'.
+      Template '<no name>' (MissingConfigTest): the template is not valid.
+      
+info: validate[0]
+      Found template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat):
+         <no entries>
+      Template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat): the template is valid.
+      
+info: validate[0]
+      Found template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         <no entries>
+      Found localization de-DE for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         [Error][LOC001] In localization file under the post action with id 'pa1', there are localized strings for manual instruction(s) with ids 'do-not-exist'. These manual instructions do not exist in the template.json file and should be removed from localization file.
+         [Error][LOC002] Post action(s) with id(s) 'pa0' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
+      Found localization tr for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         [Error][LOC002] Post action(s) with id(s) 'pa6' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
+      Template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the template is valid.
+      'de-DE' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
+      'tr' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
+      
+info: validate[0]
+      Found template 'Invalid.SameShortName.TemplateA' (Invalid.SameShortName.TemplateA):
+         <no entries>
+      Template 'Invalid.SameShortName.TemplateA' (Invalid.SameShortName.TemplateA): the template is valid.
+      
+info: validate[0]
+      Found template 'Invalid.SameShortName.TemplateB' (Invalid.SameShortName.TemplateB):
+         <no entries>
+      Template 'Invalid.SameShortName.TemplateB' (Invalid.SameShortName.TemplateB): the template is valid.
+      

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.OSX.verified.txt
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.OSX.verified.txt
@@ -2,18 +2,18 @@
 
 StdOut:
 info: validate[0]
-      Scanning location '{SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid' for the templates...
+      Scanning location '%TEMPLATE_LOCATION%' for the templates..
 fail: Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator[0]
-      Failed to load template from {SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/MissingIdentity/.template.config/template.json.
+      Failed to load template from %TEMPLATE_LOCATION%/MissingIdentity/.template.config/template.json.
       Details: 'identity' is missing or is an empty string.
 warn: Template Engine[0]
-      Failed to read or parse localization file {SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/Localization/InvalidFormat/.template.config/localize/templatestrings.de-DE.json, it will be skipped from further processing.
+      [%TEMPLATE_LOCATION%/Localization/ValidationFailure/.template.config/template.json]: id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
 warn: Template Engine[0]
-      [{SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid/Localization/ValidationFailure/.template.config/template.json]: id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
+      Failed to read or parse localization file %TEMPLATE_LOCATION%/Localization/InvalidFormat/.template.config/localize/templatestrings.de-DE.json, it will be skipped from further processing.
 info: validate[0]
       Scanning completed
 info: validate[0]
-      Location '{SolutionDirectory}test/Microsoft.TemplateEngine.TestTemplates/test_templates/Invalid': found 6 templates.
+      Location '%TEMPLATE_LOCATION%': found 6 templates.
 info: validate[0]
       Found template 'TestAssets.Invalid.InvalidHostData' (TestAssets.Invalid.InvalidHostData):
          [Info][MV011] One or more postActions have a malformed or missing manualInstructions value.
@@ -32,21 +32,9 @@ info: validate[0]
       Template '<no name>' (MissingConfigTest): the template is not valid.
       
 info: validate[0]
-      Found template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat):
+      Found template 'Invalid.SameShortName.TemplateB' (Invalid.SameShortName.TemplateB):
          <no entries>
-      Template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat): the template is valid.
-      
-info: validate[0]
-      Found template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
-         <no entries>
-      Found localization de-DE for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
-         [Error][LOC001] In localization file under the post action with id 'pa1', there are localized strings for manual instruction(s) with ids 'do-not-exist'. These manual instructions do not exist in the template.json file and should be removed from localization file.
-         [Error][LOC002] Post action(s) with id(s) 'pa0' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
-      Found localization tr for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
-         [Error][LOC002] Post action(s) with id(s) 'pa6' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
-      Template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the template is valid.
-      'de-DE' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
-      'tr' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
+      Template 'Invalid.SameShortName.TemplateB' (Invalid.SameShortName.TemplateB): the template is valid.
       
 info: validate[0]
       Found template 'Invalid.SameShortName.TemplateA' (Invalid.SameShortName.TemplateA):
@@ -54,7 +42,19 @@ info: validate[0]
       Template 'Invalid.SameShortName.TemplateA' (Invalid.SameShortName.TemplateA): the template is valid.
       
 info: validate[0]
-      Found template 'Invalid.SameShortName.TemplateB' (Invalid.SameShortName.TemplateB):
+      Found template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
          <no entries>
-      Template 'Invalid.SameShortName.TemplateB' (Invalid.SameShortName.TemplateB): the template is valid.
+      Found localization 'de-DE' for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         [Error][LOC001] In localization file under the post action with id 'pa1', there are localized strings for manual instruction(s) with ids 'do-not-exist'. These manual instructions do not exist in the template.json file and should be removed from localization file.
+         [Error][LOC002] Post action(s) with id(s) 'pa0' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
+      Found localization 'tr' for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         [Error][LOC002] Post action(s) with id(s) 'pa6' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
+      Template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the template is valid.
+      'de-DE' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
+      'tr' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
+      
+info: validate[0]
+      Found template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat):
+         <no entries>
+      Template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat): the template is valid.
       

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.Windows.verified.txt
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.Windows.verified.txt
@@ -1,0 +1,60 @@
+﻿StdErr:
+
+StdOut:
+info: validate[0]
+      Scanning location '{SolutionDirectory}test\Microsoft.TemplateEngine.TestTemplates\test_templates\Invalid' for the templates...
+fail: Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator[0]
+      Failed to load template from {SolutionDirectory}test\Microsoft.TemplateEngine.TestTemplates\test_templates\Invalid\MissingIdentity/.template.config/template.json.
+      Details: 'identity' is missing or is an empty string.
+warn: Template Engine[0]
+      Failed to read or parse localization file {SolutionDirectory}test\Microsoft.TemplateEngine.TestTemplates\test_templates\Invalid\Localization/InvalidFormat/.template.config/localize/templatestrings.de-DE.json, it will be skipped from further processing.
+warn: Template Engine[0]
+      [{SolutionDirectory}test\Microsoft.TemplateEngine.TestTemplates\test_templates\Invalid\Localization/ValidationFailure/.template.config/template.json]: id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
+info: validate[0]
+      Scanning completed
+info: validate[0]
+      Location '{SolutionDirectory}test\Microsoft.TemplateEngine.TestTemplates\test_templates\Invalid': found 6 templates.
+info: validate[0]
+      Found template 'TestAssets.Invalid.InvalidHostData' (TestAssets.Invalid.InvalidHostData):
+         [Info][MV011] One or more postActions have a malformed or missing manualInstructions value.
+      Template 'TestAssets.Invalid.InvalidHostData' (TestAssets.Invalid.InvalidHostData): the template is valid.
+      
+info: validate[0]
+      Found template '<no name>' (MissingConfigTest):
+         [Error][MV002] Missing 'name'.
+         [Error][MV003] Missing 'shortName'.
+         [Info][MV005] Missing 'sourceName'.
+         [Info][MV006] Missing 'author'.
+         [Info][MV007] Missing 'groupIdentity'.
+         [Info][MV008] Missing 'generatorVersions'.
+         [Info][MV009] Missing 'precedence'.
+         [Info][MV010] Missing 'classifications'.
+      Template '<no name>' (MissingConfigTest): the template is not valid.
+      
+info: validate[0]
+      Found template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat):
+         <no entries>
+      Template 'name in base configuration' (TestAssets.Invalid.Localization.InvalidFormat): the template is valid.
+      
+info: validate[0]
+      Found template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         <no entries>
+      Found localization de-DE for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         [Error][LOC001] In localization file under the post action with id 'pa1', there are localized strings for manual instruction(s) with ids 'do-not-exist'. These manual instructions do not exist in the template.json file and should be removed from localization file.
+         [Error][LOC002] Post action(s) with id(s) 'pa0' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
+      Found localization tr for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+         [Error][LOC002] Post action(s) with id(s) 'pa6' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
+      Template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the template is valid.
+      'de-DE' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
+      'tr' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.
+      
+info: validate[0]
+      Found template 'Invalid.SameShortName.TemplateA' (Invalid.SameShortName.TemplateA):
+         <no entries>
+      Template 'Invalid.SameShortName.TemplateA' (Invalid.SameShortName.TemplateA): the template is valid.
+      
+info: validate[0]
+      Found template 'Invalid.SameShortName.TemplateB' (Invalid.SameShortName.TemplateB):
+         <no entries>
+      Template 'Invalid.SameShortName.TemplateB' (Invalid.SameShortName.TemplateB): the template is valid.
+      

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.Windows.verified.txt
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.Windows.verified.txt
@@ -2,18 +2,18 @@
 
 StdOut:
 info: validate[0]
-      Scanning location '{SolutionDirectory}test\Microsoft.TemplateEngine.TestTemplates\test_templates\Invalid' for the templates...
+      Scanning location '%TEMPLATE_LOCATION%' for the templates..
 fail: Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator[0]
-      Failed to load template from {SolutionDirectory}test\Microsoft.TemplateEngine.TestTemplates\test_templates\Invalid\MissingIdentity/.template.config/template.json.
+      Failed to load template from %TEMPLATE_LOCATION%\MissingIdentity/.template.config/template.json.
       Details: 'identity' is missing or is an empty string.
 warn: Template Engine[0]
-      Failed to read or parse localization file {SolutionDirectory}test\Microsoft.TemplateEngine.TestTemplates\test_templates\Invalid\Localization/InvalidFormat/.template.config/localize/templatestrings.de-DE.json, it will be skipped from further processing.
+      Failed to read or parse localization file %TEMPLATE_LOCATION%\Localization/InvalidFormat/.template.config/localize/templatestrings.de-DE.json, it will be skipped from further processing.
 warn: Template Engine[0]
-      [{SolutionDirectory}test\Microsoft.TemplateEngine.TestTemplates\test_templates\Invalid\Localization/ValidationFailure/.template.config/template.json]: id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
+      [%TEMPLATE_LOCATION%\Localization/ValidationFailure/.template.config/template.json]: id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
 info: validate[0]
       Scanning completed
 info: validate[0]
-      Location '{SolutionDirectory}test\Microsoft.TemplateEngine.TestTemplates\test_templates\Invalid': found 6 templates.
+      Location '%TEMPLATE_LOCATION%': found 6 templates.
 info: validate[0]
       Found template 'TestAssets.Invalid.InvalidHostData' (TestAssets.Invalid.InvalidHostData):
          [Info][MV011] One or more postActions have a malformed or missing manualInstructions value.
@@ -39,10 +39,10 @@ info: validate[0]
 info: validate[0]
       Found template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
          <no entries>
-      Found localization de-DE for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+      Found localization 'de-DE' for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
          [Error][LOC001] In localization file under the post action with id 'pa1', there are localized strings for manual instruction(s) with ids 'do-not-exist'. These manual instructions do not exist in the template.json file and should be removed from localization file.
          [Error][LOC002] Post action(s) with id(s) 'pa0' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
-      Found localization tr for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
+      Found localization 'tr' for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
          [Error][LOC002] Post action(s) with id(s) 'pa6' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.
       Template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the template is valid.
       'de-DE' localization for the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ValidateCommandTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ValidateCommandTests.cs
@@ -31,10 +31,11 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
 
             commandResult
                 .Should()
-                .Pass();
+                .Fail();
 
             return Verify(FormatOutputStreams(commandResult))
-               .UniqueForOSPlatform();
+               .UniqueForOSPlatform()
+               .AddScrubber(text => text.Replace(Path.Combine(TestTemplatesLocation, "Invalid"), "%TEMPLATE_LOCATION%"));
         }
 
         private static string FormatOutputStreams(CommandResult commandResult)

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ValidateCommandTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ValidateCommandTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.TemplateEngine.CommandUtils;
+using Microsoft.TemplateEngine.Tests;
+using Xunit.Abstractions;
+
+namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
+{
+    [UsesVerify]
+    [Collection("Verify Tests")]
+    public class ValidateCommandTests : TestBase
+    {
+        private readonly ITestOutputHelper _log;
+
+        public ValidateCommandTests(ITestOutputHelper log)
+        {
+            _log = log;
+        }
+
+        [Fact]
+        public Task ValidateCommand_BasicTest()
+        {
+            CommandResult commandResult = new BasicCommand(
+                          _log,
+                          "dotnet",
+                          Path.GetFullPath("Microsoft.TemplateEngine.Authoring.CLI.dll"),
+                          "validate",
+                          Path.Combine(TestTemplatesLocation, "Invalid"))
+                .Execute();
+
+            commandResult
+                .Should()
+                .Pass();
+
+            return Verify(FormatOutputStreams(commandResult))
+               .UniqueForOSPlatform();
+        }
+
+        private static string FormatOutputStreams(CommandResult commandResult)
+        {
+            return "StdErr:" + Environment.NewLine + commandResult.StdErr + Environment.NewLine + "StdOut:" + Environment.NewLine + commandResult.StdOut;
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/VerifySettingsFixture.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/VerifySettingsFixture.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using VerifyTests.DiffPlex;
+
+namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
+{
+    public class VerifySettingsFixture : IDisposable
+    {
+        private static bool s_called;
+
+        public VerifySettingsFixture()
+        {
+            if (s_called)
+            {
+                return;
+            }
+            s_called = true;
+            DerivePathInfo(
+                (_, _, type, method) => new(
+                    directory: "Snapshots",
+                    typeName: type.Name,
+                    methodName: method.Name));
+
+            // Customize diff output of verifier
+            VerifyDiffPlex.Initialize(OutputType.Compact);
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/VerifyTestCollection.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/VerifyTestCollection.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
+{
+    [CollectionDefinition("Verify Tests")]
+    public class VerifyTestCollection : IClassFixture<VerifySettingsFixture>
+    {
+        //intentionally empty
+        //defines test class collection to share the fixture
+        //usage [Collection("Verify Tests")] on the test class.
+    }
+}

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/Microsoft.TemplateEngine.Authoring.CLI.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/Microsoft.TemplateEngine.Authoring.CLI.UnitTests.csproj
@@ -10,5 +10,9 @@
     <ProjectReference Include="$(ToolsDir)Microsoft.TemplateEngine.Authoring.CLI\Microsoft.TemplateEngine.Authoring.CLI.csproj" />
     <ProjectReference Include="$(TestDir)Microsoft.TemplateEngine.TestHelper\Microsoft.TemplateEngine.TestHelper.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\**\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
   
 </Project>

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/ValidateCommandTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/ValidateCommandTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.UnitTests
     public class ValidateCommandTests : TestBase
     {
         [Fact]
-        public async Task ValidateCommand_BasicTest()
+        public async Task ValidateCommand_BasicTest_InvalidTemplate()
         {
             RootCommand root = new()
             {
@@ -19,6 +19,20 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.UnitTests
             };
 
             int result = await root.Parse("validate", Path.Combine(TestTemplatesLocation, "Invalid")).InvokeAsync();
+
+            //there are some invalid templates in location "Invalid"
+            Assert.Equal(1, result);
+        }
+
+        [Fact]
+        public async Task ValidateCommand_BasicTest_ValidTemplate()
+        {
+            RootCommand root = new()
+            {
+                new ValidateCommand()
+            };
+
+            int result = await root.Parse("validate", Path.Combine(TestTemplatesLocation, "TemplateWithSourceName")).InvokeAsync();
 
             Assert.Equal(0, result);
         }

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/ValidateCommandTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/ValidateCommandTests.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Microsoft.TemplateEngine.Authoring.CLI.Commands;
+using Microsoft.TemplateEngine.Tests;
+
+namespace Microsoft.TemplateEngine.Authoring.CLI.UnitTests
+{
+    public class ValidateCommandTests : TestBase
+    {
+        [Fact]
+        public async Task ValidateCommand_BasicTest()
+        {
+            RootCommand root = new()
+            {
+                new ValidateCommand()
+            };
+
+            int result = await root.Parse("validate", Path.Combine(TestTemplatesLocation, "Invalid")).InvokeAsync();
+
+            Assert.Equal(0, result);
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/VerifyCommandTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/VerifyCommandTests.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using System.CommandLine;
 using FluentAssertions;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.TemplateEngine.Authoring.CLI.Commands.Verify;
 using Microsoft.TemplateEngine.Authoring.TemplateVerifier;
 

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/Commands/validate/ValidateCommand.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/Commands/validate/ValidateCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.Commands
             Arity = new ArgumentArity(1, 1)
         };
 
-        public ValidateCommand() : base(CommandName, "Validates the templates at given location.")
+        public ValidateCommand() : base(CommandName, LocalizableStrings.command_validate_help_locationArg_description)
         {
             AddArgument(_templateLocationArg);
         }
@@ -38,7 +38,7 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.Commands
             using IEngineEnvironmentSettings settings = SetupSettings(loggerFactory);
             Scanner scanner = new(settings);
 
-            logger.LogInformation("Scanning location '{0}' for the templates...", args.TemplateLocation);
+            logger.LogInformation(LocalizableStrings.command_validate_info_scanning_in_progress, args.TemplateLocation);
 
             ScanResult scanResult = await scanner.ScanAsync(
                 args.TemplateLocation,
@@ -66,7 +66,7 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.Commands
         private void PrintResults(ILogger logger, ScanResult scanResult)
         {
             using var scope = logger.BeginScope("Results");
-            logger.LogInformation("Location '{0}': found {1} templates.", scanResult.MountPoint.MountPointUri, scanResult.Templates.Count);
+            logger.LogInformation(LocalizableStrings.command_validate_info_scanning_completed, scanResult.MountPoint.MountPointUri, scanResult.Templates.Count);
             foreach (IScanTemplateInfo template in scanResult.Templates)
             {
                 string templateDisplayName = GetTemplateDisplayName(template);
@@ -74,7 +74,7 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.Commands
 
                 LogValidationEntries(
                     sb,
-                    string.Format("Found template {0}:", templateDisplayName),
+                    string.Format(LocalizableStrings.command_validate_info_template_header, templateDisplayName),
                     template.ValidationErrors);
                 foreach (KeyValuePair<string, ILocalizationLocator> locator in template.Localizations)
                 {
@@ -82,28 +82,28 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.Commands
 
                     LogValidationEntries(
                         sb,
-                        string.Format("Found localization {0} for template {1}:", localizationInfo.Locale, templateDisplayName),
+                        string.Format(LocalizableStrings.command_validate_info_template_loc_header, localizationInfo.Locale, templateDisplayName),
                         localizationInfo.ValidationErrors);
                 }
 
                 if (!template.IsValid)
                 {
-                    sb.AppendFormat("Template {0}: the template is not valid.", templateDisplayName);
+                    sb.AppendFormat(LocalizableStrings.command_validate_info_summary_invalid, templateDisplayName);
                 }
                 else
                 {
-                    sb.AppendFormat("Template {0}: the template is valid.", templateDisplayName);
+                    sb.AppendFormat(LocalizableStrings.command_validate_info_summary_valid, templateDisplayName);
                 }
                 sb.AppendLine();
                 foreach (ILocalizationLocator loc in template.Localizations.Values)
                 {
                     if (loc.IsValid)
                     {
-                        sb.AppendFormat("'{0}' localization for the template {1}: the localization file is valid.", loc.Locale, templateDisplayName);
+                        sb.AppendFormat(LocalizableStrings.command_validate_info_summary_loc_valid, loc.Locale, templateDisplayName);
                     }
                     else
                     {
-                        sb.AppendFormat("'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.", loc.Locale, templateDisplayName);
+                        sb.AppendFormat(LocalizableStrings.command_validate_info_summary_loc_invalid, loc.Locale, templateDisplayName);
                     }
                     sb.AppendLine();
                 }
@@ -123,7 +123,7 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.Commands
                 sb.AppendLine(header);
                 if (!errors.Any())
                 {
-                    sb.AppendLine("   <no entries>");
+                    sb.AppendLine("   " + LocalizableStrings.command_validate_info_no_entries);
                 }
                 else
                 {

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/Commands/validate/ValidateCommand.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/Commands/validate/ValidateCommand.cs
@@ -16,8 +16,7 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.Commands
 
         private readonly Argument<string> _templateLocationArg = new("template-location")
         {
-            Description = "The location of template(s) to validate",
-            // 0 for case where only path is specified
+            Description = LocalizableStrings.command_validate_help_description,
             Arity = new ArgumentArity(1, 1)
         };
 
@@ -49,7 +48,7 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.Commands
             cancellationToken.ThrowIfCancellationRequested();
             logger.LogInformation("Scanning completed");
             PrintResults(logger, scanResult);
-            return 0;
+            return scanResult.Templates.Any(t => !t.IsValid) ? 1 : 0;
         }
 
         private IEngineEnvironmentSettings SetupSettings(ILoggerFactory loggerFactory)

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/Commands/validate/ValidateCommand.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/Commands/validate/ValidateCommand.cs
@@ -1,0 +1,140 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Edge;
+using Microsoft.TemplateEngine.Edge.Settings;
+
+namespace Microsoft.TemplateEngine.Authoring.CLI.Commands
+{
+    internal class ValidateCommand : ExecutableCommand<ValidateCommandArgs>
+    {
+        private const string CommandName = "validate";
+
+        private readonly Argument<string> _templateLocationArg = new("template-location")
+        {
+            Description = "The location of template(s) to validate",
+            // 0 for case where only path is specified
+            Arity = new ArgumentArity(1, 1)
+        };
+
+        public ValidateCommand() : base(CommandName, "Validates the templates at given location.")
+        {
+            AddArgument(_templateLocationArg);
+        }
+
+        protected internal override ValidateCommandArgs ParseContext(ParseResult parseResult)
+        {
+            return new ValidateCommandArgs(parseResult.GetValue(_templateLocationArg));
+        }
+
+        protected override async Task<int> ExecuteAsync(ValidateCommandArgs args, ILoggerFactory loggerFactory, CancellationToken cancellationToken)
+        {
+            ILogger logger = loggerFactory.CreateLogger(CommandName);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using IEngineEnvironmentSettings settings = SetupSettings(loggerFactory);
+            Scanner scanner = new(settings);
+
+            logger.LogInformation("Scanning location '{0}' for the templates...", args.TemplateLocation);
+
+            ScanResult scanResult = await scanner.ScanAsync(
+                args.TemplateLocation,
+                logValidationResults: false,
+                returnInvalidTemplates: true,
+                cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            logger.LogInformation("Scanning completed");
+            PrintResults(logger, scanResult);
+            return 0;
+        }
+
+        private IEngineEnvironmentSettings SetupSettings(ILoggerFactory loggerFactory)
+        {
+            var builtIns = new List<(Type InterfaceType, IIdentifiedComponent Instance)>();
+            builtIns.AddRange(Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Components.AllComponents);
+            builtIns.AddRange(Microsoft.TemplateEngine.Edge.Components.AllComponents);
+
+            ITemplateEngineHost host = new DefaultTemplateEngineHost("template-validator", "1.0", builtIns: builtIns, loggerFactory: loggerFactory);
+            IEngineEnvironmentSettings engineEnvironmentSettings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+
+            return engineEnvironmentSettings;
+        }
+
+        private void PrintResults(ILogger logger, ScanResult scanResult)
+        {
+            using var scope = logger.BeginScope("Results");
+            logger.LogInformation("Location '{0}': found {1} templates.", scanResult.MountPoint.MountPointUri, scanResult.Templates.Count);
+            foreach (IScanTemplateInfo template in scanResult.Templates)
+            {
+                string templateDisplayName = GetTemplateDisplayName(template);
+                StringBuilder sb = new();
+
+                LogValidationEntries(
+                    sb,
+                    string.Format("Found template {0}:", templateDisplayName),
+                    template.ValidationErrors);
+                foreach (KeyValuePair<string, ILocalizationLocator> locator in template.Localizations)
+                {
+                    ILocalizationLocator localizationInfo = locator.Value;
+
+                    LogValidationEntries(
+                        sb,
+                        string.Format("Found localization {0} for template {1}:", localizationInfo.Locale, templateDisplayName),
+                        localizationInfo.ValidationErrors);
+                }
+
+                if (!template.IsValid)
+                {
+                    sb.AppendFormat("Template {0}: the template is not valid.", templateDisplayName);
+                }
+                else
+                {
+                    sb.AppendFormat("Template {0}: the template is valid.", templateDisplayName);
+                }
+                sb.AppendLine();
+                foreach (ILocalizationLocator loc in template.Localizations.Values)
+                {
+                    if (loc.IsValid)
+                    {
+                        sb.AppendFormat("'{0}' localization for the template {1}: the localization file is valid.", loc.Locale, templateDisplayName);
+                    }
+                    else
+                    {
+                        sb.AppendFormat("'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.", loc.Locale, templateDisplayName);
+                    }
+                    sb.AppendLine();
+                }
+                logger.LogInformation(sb.ToString());
+            }
+
+            static string GetTemplateDisplayName(IScanTemplateInfo template)
+            {
+                string templateName = string.IsNullOrEmpty(template.Name) ? "<no name>" : template.Name;
+                return $"'{templateName}' ({template.Identity})";
+            }
+
+            static string PrintError(IValidationEntry error) => $"   [{error.Severity}][{error.Code}] {error.ErrorMessage}";
+
+            static void LogValidationEntries(StringBuilder sb, string header, IReadOnlyList<IValidationEntry> errors)
+            {
+                sb.AppendLine(header);
+                if (!errors.Any())
+                {
+                    sb.AppendLine("   <no entries>");
+                }
+                else
+                {
+                    foreach (IValidationEntry error in errors.OrderByDescending(e => e.Severity))
+                    {
+                        sb.AppendLine(PrintError(error));
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/Commands/validate/ValidateCommandArgs.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/Commands/validate/ValidateCommandArgs.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.TemplateEngine.Authoring.CLI.Commands
+{
+    internal class ValidateCommandArgs
+    {
+        public ValidateCommandArgs(string templateLocation)
+        {
+            TemplateLocation = templateLocation;
+        }
+
+        public string TemplateLocation { get; }
+    }
+}

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/LocalizableStrings.Designer.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/LocalizableStrings.Designer.cs
@@ -162,6 +162,105 @@ namespace Microsoft.TemplateEngine.Authoring.CLI {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Validates the templates at given location..
+        /// </summary>
+        internal static string command_validate_help_description {
+            get {
+                return ResourceManager.GetString("command_validate_help_description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The location of template(s) to validate..
+        /// </summary>
+        internal static string command_validate_help_locationArg_description {
+            get {
+                return ResourceManager.GetString("command_validate_help_locationArg_description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;no entries&gt;.
+        /// </summary>
+        internal static string command_validate_info_no_entries {
+            get {
+                return ResourceManager.GetString("command_validate_info_no entries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Location &apos;{0}&apos;: found {1} templates..
+        /// </summary>
+        internal static string command_validate_info_scanning_completed {
+            get {
+                return ResourceManager.GetString("command_validate_info_scanning_completed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Scanning location &apos;{0}&apos; for the templates...
+        /// </summary>
+        internal static string command_validate_info_scanning_in_progress {
+            get {
+                return ResourceManager.GetString("command_validate_info_scanning_in_progress", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Template {0}: the template is not valid..
+        /// </summary>
+        internal static string command_validate_info_summary_invalid {
+            get {
+                return ResourceManager.GetString("command_validate_info_summary_invalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; localization for the template {1}: the localization file is not valid. The localization will be skipped..
+        /// </summary>
+        internal static string command_validate_info_summary_loc_invalid {
+            get {
+                return ResourceManager.GetString("command_validate_info_summary_loc_invalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; localization for the template {1}: the localization file is valid..
+        /// </summary>
+        internal static string command_validate_info_summary_loc_valid {
+            get {
+                return ResourceManager.GetString("command_validate_info_summary_loc_valid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Template {0}: the template is valid..
+        /// </summary>
+        internal static string command_validate_info_summary_valid {
+            get {
+                return ResourceManager.GetString("command_validate_info_summary_valid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found template {0}:.
+        /// </summary>
+        internal static string command_validate_info_template_header {
+            get {
+                return ResourceManager.GetString("command_validate_info_template_header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Found localization &apos;{0}&apos; for template {1}:.
+        /// </summary>
+        internal static string command_validate_info_template_loc_header {
+            get {
+                return ResourceManager.GetString("command_validate_info_template_loc_header", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Verification Failed..
         /// </summary>
         internal static string command_verify_error_failed {

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/LocalizableStrings.resx
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/LocalizableStrings.resx
@@ -161,6 +161,48 @@ Do not localize: "template.json"</comment>
     <value>Failed to find "template.json" file under the path "{0}".</value>
     <comment>Do not localize: "template.json"</comment>
   </data>
+  <data name="command_validate_help_description" xml:space="preserve">
+    <value>Validates the templates at given location.</value>
+  </data>
+  <data name="command_validate_help_locationArg_description" xml:space="preserve">
+    <value>The location of template(s) to validate.</value>
+  </data>
+  <data name="command_validate_info_no entries" xml:space="preserve">
+    <value>&lt;no entries&gt;</value>
+    <comment>used when there is no entries in the list</comment>
+  </data>
+  <data name="command_validate_info_scanning_completed" xml:space="preserve">
+    <value>Location '{0}': found {1} templates.</value>
+    <comment>{0} - file path to templates to scan; {1} - count of templates found.</comment>
+  </data>
+  <data name="command_validate_info_scanning_in_progress" xml:space="preserve">
+    <value>Scanning location '{0}' for the templates..</value>
+    <comment>{0} - file path to templates to scan</comment>
+  </data>
+  <data name="command_validate_info_summary_invalid" xml:space="preserve">
+    <value>Template {0}: the template is not valid.</value>
+    <comment>{0} - template name and identity in format name (identity)</comment>
+  </data>
+  <data name="command_validate_info_summary_loc_invalid" xml:space="preserve">
+    <value>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</value>
+    <comment>{1} - template name and identity in format name (identity), {0} - locale in format en-US</comment>
+  </data>
+  <data name="command_validate_info_summary_loc_valid" xml:space="preserve">
+    <value>'{0}' localization for the template {1}: the localization file is valid.</value>
+    <comment>{1} - template name and identity in format name (identity), {0} - locale in format en-US</comment>
+  </data>
+  <data name="command_validate_info_summary_valid" xml:space="preserve">
+    <value>Template {0}: the template is valid.</value>
+    <comment>{0} - template name and identity in format name (identity)</comment>
+  </data>
+  <data name="command_validate_info_template_header" xml:space="preserve">
+    <value>Found template {0}:</value>
+    <comment>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</comment>
+  </data>
+  <data name="command_validate_info_template_loc_header" xml:space="preserve">
+    <value>Found localization '{0}' for template {1}:</value>
+    <comment>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</comment>
+  </data>
   <data name="command_verify_error_failed" xml:space="preserve">
     <value>Verification Failed.</value>
   </data>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/Microsoft.TemplateEngine.Authoring.CLI.csproj
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/Microsoft.TemplateEngine.Authoring.CLI.csproj
@@ -23,7 +23,9 @@
   <ItemGroup>
     <ProjectReference Include="$(ToolsDir)Microsoft.TemplateEngine.TemplateLocalizer.Core\Microsoft.TemplateEngine.TemplateLocalizer.Core.csproj" />
     <ProjectReference Include="$(ToolsDir)Microsoft.TemplateEngine.Authoring.TemplateVerifier\Microsoft.TemplateEngine.Authoring.TemplateVerifier.csproj" />
+    <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Orchestrator.RunnableProjects\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj" />
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
+    <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Edge\Microsoft.TemplateEngine.Edge.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/Program.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/Program.cs
@@ -15,6 +15,7 @@ namespace Microsoft.TemplateEngine.Authoring.CLI
             RootCommand rootCommand = new("dotnet-template-authoring");
             rootCommand.AddCommand(new LocalizeCommand());
             rootCommand.AddCommand(new VerifyCommand());
+            rootCommand.AddCommand(new ValidateCommand());
 
             return CreateParser(rootCommand).Parse(args).InvokeAsync();
         }

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.cs.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.cs.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">Soubor „template.json“ se v cestě „{0}“ nepodařilo najít.</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">Ověření se nezdařilo.</target>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.de.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.de.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">Die Datei "template.json" konnte unter dem Pfad "{0}" nicht gefunden werden.</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">Fehler bei der Überprüfung.</target>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.es.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.es.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">No se pudo encontrar el archivo "template.json" bajo la ruta "{0}".</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">Error de comprobación.</target>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.fr.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.fr.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">Échec de la recherche du fichier « template.jssur » sous le chemin d’accès «0{0} ».</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">Échec de la vérification.</target>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.it.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.it.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">Non è stato possibile trovare il file "template.json" nel percorso "{0}".</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">La verifica non è riuscita.</target>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.ja.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.ja.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">パス "{0}" の下に "template.json" ファイルが見つかりません。</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">検証に失敗しました。</target>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.ko.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.ko.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">"{0}” 경로에서 "template.json" 파일을 찾지 못했습니다.</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">확인에 실패했습니다.</target>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.pl.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.pl.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">Nie można odnaleźć pliku „template.json” pod ścieżką „{0}”.</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">Weryfikacja nie powiodła się.</target>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.pt-BR.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.pt-BR.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">Falhou em localizar o arquivo "template.json" no o caminho "{0}".</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">Falha na Verificação.</target>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.ru.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.ru.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">Не удалось найти файл template.json в пути "{0}".</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">Проверка не пройдена.</target>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.tr.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.tr.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">"{0}" yolunda "template.json" dosyası bulunamadı.</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">Doğrulama Başarısız Oldu.</target>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.zh-Hans.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">在路径“{0}”下未找到“template.json”文件。</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">验证失败。</target>

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/xlf/LocalizableStrings.zh-Hant.xlf
@@ -63,6 +63,61 @@ Do not localize: "template.json"</note>
         <target state="translated">在路徑 "{0}" 下找不到 "template.json" 檔案。</target>
         <note>Do not localize: "template.json"</note>
       </trans-unit>
+      <trans-unit id="command_validate_help_description">
+        <source>Validates the templates at given location.</source>
+        <target state="new">Validates the templates at given location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_help_locationArg_description">
+        <source>The location of template(s) to validate.</source>
+        <target state="new">The location of template(s) to validate.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="command_validate_info_no entries">
+        <source>&lt;no entries&gt;</source>
+        <target state="new">&lt;no entries&gt;</target>
+        <note>used when there is no entries in the list</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_completed">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - file path to templates to scan; {1} - count of templates found.</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_scanning_in_progress">
+        <source>Scanning location '{0}' for the templates..</source>
+        <target state="new">Scanning location '{0}' for the templates..</target>
+        <note>{0} - file path to templates to scan</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_invalid">
+        <source>Template {0}: the template is not valid.</source>
+        <target state="new">Template {0}: the template is not valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_invalid">
+        <source>'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is not valid. The localization will be skipped.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_loc_valid">
+        <source>'{0}' localization for the template {1}: the localization file is valid.</source>
+        <target state="new">'{0}' localization for the template {1}: the localization file is valid.</target>
+        <note>{1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_summary_valid">
+        <source>Template {0}: the template is valid.</source>
+        <target state="new">Template {0}: the template is valid.</target>
+        <note>{0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_header">
+        <source>Found template {0}:</source>
+        <target state="new">Found template {0}:</target>
+        <note>The header is followed by list of issues found in the template. {0} - template name and identity in format name (identity)</note>
+      </trans-unit>
+      <trans-unit id="command_validate_info_template_loc_header">
+        <source>Found localization '{0}' for template {1}:</source>
+        <target state="new">Found localization '{0}' for template {1}:</target>
+        <note>The header is followed by list of issues found in the template localization. {1} - template name and identity in format name (identity), {0} - locale in format en-US</note>
+      </trans-unit>
       <trans-unit id="command_verify_error_failed">
         <source>Verification Failed.</source>
         <target state="translated">驗證失敗。</target>


### PR DESCRIPTION
### Problem
template validation

### Solution
follow up for https://github.com/dotnet/templating/pull/5838
usage of new validation from CLI authoring tools

TODO: 
- [x] extract localization strings (once the approach is approved)

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)