### PR TITLE
MSBuild `ValidateTemplates` task PoC

### DIFF
--- a/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Resources/InvalidTemplatePackage_MissingName/TemplatePackage.csproj
+++ b/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Resources/InvalidTemplatePackage_MissingName/TemplatePackage.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <PackageType>Template</PackageType>
+    <PackageId>TemplatePackage</PackageId>
+    <Authors>Microsoft</Authors>
+    <Description>TemplatePackage</Description>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+    <LocalizeTemplates>true</LocalizeTemplates>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="**\*" />
+    <Content Include="content\**\*" Exclude="content\**\bin\**;content\**\obj\**" />
+  </ItemGroup>
+</Project>

--- a/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Resources/InvalidTemplatePackage_MissingName/content/TemplateWithSourceName/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Resources/InvalidTemplatePackage_MissingName/content/TemplateWithSourceName/.template.config/template.json
@@ -1,0 +1,10 @@
+{
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "description":  "Test description",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateWithSourceName",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateWithSourceName",
+  "sourceName": "bar"
+}

--- a/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Resources/InvalidTemplatePackage_MissingName/content/TemplateWithSourceName/foo.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Resources/InvalidTemplatePackage_MissingName/content/TemplateWithSourceName/foo.cs
@@ -1,0 +1,6 @@
+﻿namespace TemplateWithSourceName
+{
+    internal class Foo
+    {
+    }
+}

--- a/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Resources/InvalidTemplatePackage_MissingOptionalData/TemplatePackage.csproj
+++ b/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Resources/InvalidTemplatePackage_MissingOptionalData/TemplatePackage.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <PackageType>Template</PackageType>
+    <PackageId>TemplatePackage</PackageId>
+    <Authors>Microsoft</Authors>
+    <Description>TemplatePackage</Description>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+    <LocalizeTemplates>true</LocalizeTemplates>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="**\*" />
+    <Content Include="content\**\*" Exclude="content\**\bin\**;content\**\obj\**" />
+  </ItemGroup>
+</Project>

--- a/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Resources/InvalidTemplatePackage_MissingOptionalData/content/TemplateWithSourceName/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Resources/InvalidTemplatePackage_MissingOptionalData/content/TemplateWithSourceName/.template.config/template.json
@@ -1,0 +1,10 @@
+{
+  "name": "TemplateWithSourceName",
+  "description":  "Test description",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateWithSourceName",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateWithSourceName",
+  "shortName": "TestAssets.TemplateWithSourceName",
+  "sourceName": "bar"
+}

--- a/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Resources/InvalidTemplatePackage_MissingOptionalData/content/TemplateWithSourceName/foo.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Resources/InvalidTemplatePackage_MissingOptionalData/content/TemplateWithSourceName/foo.cs
@@ -1,0 +1,6 @@
+﻿namespace TemplateWithSourceName
+{
+    internal class Foo
+    {
+    }
+}

--- a/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/ValidateTemplatesTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/ValidateTemplatesTests.cs
@@ -1,0 +1,70 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using FluentAssertions;
+using Microsoft.TemplateEngine.CommandUtils;
+using Microsoft.TemplateEngine.TestHelper;
+using Microsoft.TemplateEngine.Tests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests
+{
+    public class ValidateTemplatesTests : TestBase
+    {
+        private readonly ITestOutputHelper _log;
+
+        public ValidateTemplatesTests(ITestOutputHelper log)
+        {
+            _log = log;
+        }
+
+        [Fact]
+        public void CanRunValidateTask_OnError()
+        {
+            string tmpDir = TestUtils.CreateTemporaryFolder();
+            TestUtils.DirectoryCopy("Resources/InvalidTemplatePackage_MissingName", tmpDir, true);
+            TestUtils.SetupNuGetConfigForPackagesLocation(tmpDir, ShippingPackagesLocation);
+
+            new DotnetCommand(_log, "add", "TemplatePackage.csproj", "package", "Microsoft.TemplateEngine.Authoring.Tasks", "--prerelease")
+                .WithoutTelemetry()
+                .WithWorkingDirectory(tmpDir)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new DotnetCommand(_log, "build")
+                .WithoutTelemetry()
+                .WithWorkingDirectory(tmpDir)
+                .Execute()
+                .Should()
+                .Fail()
+                .And.HaveStdOutContaining("Template configuration error MV002: Missing 'name'.")
+                .And.HaveStdOutContaining("Template configuration error MV003: Missing 'shortName'.");
+        }
+
+        [Fact]
+        public void CanRunValidateTask_OnInfo()
+        {
+            string tmpDir = TestUtils.CreateTemporaryFolder();
+            TestUtils.DirectoryCopy("Resources/InvalidTemplatePackage_MissingOptionalData", tmpDir, true);
+            TestUtils.SetupNuGetConfigForPackagesLocation(tmpDir, ShippingPackagesLocation);
+
+            new DotnetCommand(_log, "add", "TemplatePackage.csproj", "package", "Microsoft.TemplateEngine.Authoring.Tasks", "--prerelease")
+                .WithoutTelemetry()
+                .WithWorkingDirectory(tmpDir)
+                .Execute()
+                .Should()
+                .Pass();
+
+            new DotnetCommand(_log, "build")
+                .WithoutTelemetry()
+                .WithWorkingDirectory(tmpDir)
+                .Execute()
+                .Should()
+                .Pass()
+                .And.HaveStdOutContaining("Template configuration message MV006: Missing 'author'.")
+                .And.HaveStdOutContaining("Template configuration message MV010: Missing 'classifications'.");
+        }
+    }
+}

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/LocalizableStrings.Designer.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/LocalizableStrings.Designer.cs
@@ -63,36 +63,63 @@ namespace Microsoft.TemplateEngine.Authoring.Tasks {
         /// <summary>
         ///   Looks up a localized string similar to Failed to export localization files for &apos;template.json&apos; file under the path &apos;{0}&apos;: {1}..
         /// </summary>
-        internal static string Command_Localize_Log_ExportTaskFailed {
+        internal static string Localize_Log_ExportTaskFailed {
             get {
-                return ResourceManager.GetString("Command_Localize_Log_ExportTaskFailed", resourceCulture);
+                return ResourceManager.GetString("Localize_Log_ExportTaskFailed", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to &apos;LocalizeTemplates&apos; stopped processing the following file, because the operation was cancelled: {0}.
         /// </summary>
-        internal static string Command_Localize_Log_FileProcessingCancelled {
+        internal static string Localize_Log_FileProcessingCancelled {
             get {
-                return ResourceManager.GetString("Command_Localize_Log_FileProcessingCancelled", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The property &apos;TemplateFolder&apos; should be set for &apos;LocalizeTemplates&apos; target..
-        /// </summary>
-        internal static string Command_Localize_Log_TemplateFolderNotSet {
-            get {
-                return ResourceManager.GetString("Command_Localize_Log_TemplateFolderNotSet", resourceCulture);
+                return ResourceManager.GetString("Localize_Log_FileProcessingCancelled", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Failed to find &apos;template.json&apos; file under the path &apos;{0}&apos;..
         /// </summary>
-        internal static string Command_Localize_Log_TemplateJsonNotFound {
+        internal static string Localize_Log_TemplateJsonNotFound {
             get {
-                return ResourceManager.GetString("Command_Localize_Log_TemplateJsonNotFound", resourceCulture);
+                return ResourceManager.GetString("Localize_Log_TemplateJsonNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The property &apos;{0}&apos; should be set for &apos;{1}&apos; target..
+        /// </summary>
+        internal static string Log_Error_MissingRequiredProperty {
+            get {
+                return ResourceManager.GetString("Log_Error_MissingRequiredProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Location &apos;{0}&apos;: found {1} templates..
+        /// </summary>
+        internal static string Validate_Log_FoundTemplate {
+            get {
+                return ResourceManager.GetString("Validate_Log_FoundTemplate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Template configuration.
+        /// </summary>
+        internal static string Validate_Log_TemplateConfiguration_Subcategory {
+            get {
+                return ResourceManager.GetString("Validate_Log_TemplateConfiguration_Subcategory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Template localization.
+        /// </summary>
+        internal static string Validate_Log_TemplateLocalization_Subcategory {
+            get {
+                return ResourceManager.GetString("Validate_Log_TemplateLocalization_Subcategory", resourceCulture);
             }
         }
     }

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/LocalizableStrings.resx
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/LocalizableStrings.resx
@@ -117,24 +117,33 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Command_Localize_Log_ExportTaskFailed" xml:space="preserve">
+  <data name="Localize_Log_ExportTaskFailed" xml:space="preserve">
     <value>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</value>
     <comment>Do not localize: 'template.json'</comment>
   </data>
-  <data name="Command_Localize_Log_FileProcessingCancelled" xml:space="preserve">
+  <data name="Localize_Log_FileProcessingCancelled" xml:space="preserve">
     <value>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</value>
     <comment>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</comment>
   </data>
-  <data name="Command_Localize_Log_TemplateFolderNotSet" xml:space="preserve">
-    <value>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</value>
-    <comment>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</comment>
-  </data>
-  <data name="Command_Localize_Log_TemplateJsonNotFound" xml:space="preserve">
+  <data name="Localize_Log_TemplateJsonNotFound" xml:space="preserve">
     <value>Failed to find 'template.json' file under the path '{0}'.</value>
     <comment>Do not localize: 'template.json'</comment>
+  </data>
+  <data name="Log_Error_MissingRequiredProperty" xml:space="preserve">
+    <value>The property '{0}' should be set for '{1}' target.</value>
+    <comment>'Target' and 'property' are referring to MSBuild concepts with the same names.</comment>
+  </data>
+  <data name="Validate_Log_FoundTemplate" xml:space="preserve">
+    <value>Location '{0}': found {1} templates.</value>
+    <comment>{0} - path configured for scanning the templates, {1} - the number of templates found.</comment>
+  </data>
+  <data name="Validate_Log_TemplateConfiguration_Subcategory" xml:space="preserve">
+    <value>Template configuration</value>
+    <comment>this is subcategory of the error message displayed after build</comment>
+  </data>
+  <data name="Validate_Log_TemplateLocalization_Subcategory" xml:space="preserve">
+    <value>Template localization</value>
+    <comment>this is subcategory of the error message displayed after build</comment>
   </data>
 </root>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/Microsoft.TemplateEngine.Authoring.Tasks.csproj
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/Microsoft.TemplateEngine.Authoring.Tasks.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Update="@(PackageReference)" PrivateAssets="All" />
     <ProjectReference Include="$(ToolsDir)\Microsoft.TemplateEngine.TemplateLocalizer.Core\Microsoft.TemplateEngine.TemplateLocalizer.Core.csproj" />
+    <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Edge\Microsoft.TemplateEngine.Edge.csproj" />
+    <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Orchestrator.RunnableProjects\Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj" />
     <ProjectReference Update="@(ProjectReference)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/Tasks/LocalizeTemplates.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/Tasks/LocalizeTemplates.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Authoring.Tasks.Tasks;
 using Microsoft.TemplateEngine.Authoring.Tasks.Utilities;
 using Microsoft.TemplateEngine.TemplateLocalizer.Core;
 
@@ -45,7 +46,7 @@ namespace Microsoft.TemplateEngine.Authoring.Tasks
         {
             if (string.IsNullOrWhiteSpace(TemplateFolder))
             {
-                Log.LogError(LocalizableStrings.Command_Localize_Log_TemplateFolderNotSet);
+                Log.LogError(LocalizableStrings.Log_Error_MissingRequiredProperty, nameof(TemplateFolder), nameof(LocalizeTemplates));
                 return false;
             }
 
@@ -53,7 +54,7 @@ namespace Microsoft.TemplateEngine.Authoring.Tasks
 
             if (templateJsonFiles.Count == 0)
             {
-                Log.LogError(LocalizableStrings.Command_Localize_Log_TemplateJsonNotFound, TemplateFolder);
+                Log.LogError(LocalizableStrings.Localize_Log_TemplateJsonNotFound, TemplateFolder);
                 return false;
             }
 
@@ -86,7 +87,7 @@ namespace Microsoft.TemplateEngine.Authoring.Tasks
             {
                 if (pathTaskPair.Task.IsCanceled)
                 {
-                    Log.LogError(LocalizableStrings.Command_Localize_Log_FileProcessingCancelled, pathTaskPair.TemplateJsonPath);
+                    Log.LogError(LocalizableStrings.Localize_Log_FileProcessingCancelled, pathTaskPair.TemplateJsonPath);
                 }
                 else if (pathTaskPair.Task.IsFaulted)
                 {
@@ -101,7 +102,7 @@ namespace Microsoft.TemplateEngine.Authoring.Tasks
                     {
                         if (!string.IsNullOrWhiteSpace(result.ErrorMessage))
                         {
-                            Log.LogError(LocalizableStrings.Command_Localize_Log_ExportTaskFailed, result.TemplateJsonPath, result.ErrorMessage);
+                            Log.LogError(LocalizableStrings.Localize_Log_ExportTaskFailed, result.TemplateJsonPath, result.ErrorMessage);
                         }
                         else if (result.InnerException != null)
                         {

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/Tasks/ValidateTemplates.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/Tasks/ValidateTemplates.cs
@@ -35,7 +35,7 @@ namespace Microsoft.TemplateEngine.Authoring.Tasks.Tasks
         {
             if (string.IsNullOrWhiteSpace(TemplateLocation))
             {
-                Log.LogError("The property 'TemplateLocation' should be set for 'ValidateTemplates' target.");
+                Log.LogError(LocalizableStrings.Log_Error_MissingRequiredProperty, nameof(TemplateLocation), nameof(ValidateTemplates));
                 return false;
             }
 
@@ -67,7 +67,9 @@ namespace Microsoft.TemplateEngine.Authoring.Tasks.Tasks
             }
         }
 
-        public void Cancel() => GetOrCreateCancellationTokenSource().Cancel();
+        public void Cancel() => _cancellationTokenSource.Cancel();
+
+        public void Dispose() => _cancellationTokenSource.Dispose();
 
         private IEngineEnvironmentSettings SetupSettings(ILoggerFactory loggerFactory)
         {
@@ -83,17 +85,17 @@ namespace Microsoft.TemplateEngine.Authoring.Tasks.Tasks
 
         private void LogResults(ScanResult scanResult)
         {
-            Log.LogMessage("Location '{0}': found {1} templates.", scanResult.MountPoint.MountPointUri, scanResult.Templates.Count);
+            Log.LogMessage(LocalizableStrings.Validate_Log_FoundTemplate, scanResult.MountPoint.MountPointUri, scanResult.Templates.Count);
             foreach (IScanTemplateInfo template in scanResult.Templates)
             {
                 string templateDisplayName = GetTemplateDisplayName(template);
                 StringBuilder sb = new();
 
-                LogValidationEntries("Template configuration", template.ValidationErrors);
+                LogValidationEntries(LocalizableStrings.Validate_Log_TemplateConfiguration_Subcategory, template.ValidationErrors);
                 foreach (KeyValuePair<string, ILocalizationLocator> locator in template.Localizations)
                 {
                     ILocalizationLocator localizationInfo = locator.Value;
-                    LogValidationEntries("Localization", localizationInfo.ValidationErrors);
+                    LogValidationEntries(LocalizableStrings.Validate_Log_TemplateLocalization_Subcategory, localizationInfo.ValidationErrors);
                 }
             }
 

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/Tasks/ValidateTemplates.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/Tasks/ValidateTemplates.cs
@@ -1,0 +1,174 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Extensions.Logging;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Authoring.Tasks.Utilities;
+using Microsoft.TemplateEngine.Edge;
+using Microsoft.TemplateEngine.Edge.Settings;
+
+namespace Microsoft.TemplateEngine.Authoring.Tasks.Tasks
+{
+    /// <summary>
+    /// A task that exposes template localization functionality of
+    /// Microsoft.TemplateEngine.TemplateLocalizer through MSBuild.
+    /// </summary>
+    public sealed class ValidateTemplates : Build.Utilities.Task, ICancelableTask
+    {
+        private volatile CancellationTokenSource? _cancellationTokenSource;
+
+        /// <summary>
+        /// Gets or sets the path to the template(s) to be validated.
+        /// </summary>
+        [Required]
+        public string? TemplateLocation { get; set; }
+
+        public override bool Execute()
+        {
+            if (string.IsNullOrWhiteSpace(TemplateLocation))
+            {
+                Log.LogError("The property 'TemplateLocation' should be set for 'ValidateTemplates' target.");
+                return false;
+            }
+
+            string templateLocation = Path.GetFullPath(TemplateLocation);
+
+            using var loggerProvider = new MSBuildLoggerProvider(Log);
+            ILoggerFactory msbuildLoggerFactory = new LoggerFactory(new[] { loggerProvider });
+
+            using CancellationTokenSource cancellationTokenSource = GetOrCreateCancellationTokenSource();
+            CancellationToken cancellationToken = cancellationTokenSource.Token;
+
+            try
+            {
+                using IEngineEnvironmentSettings settings = SetupSettings(msbuildLoggerFactory);
+                Scanner scanner = new(settings);
+                ScanResult scanResult = Task.Run(async () => await scanner.ScanAsync(
+                    templateLocation!,
+                    logValidationResults: false,
+                    returnInvalidTemplates: true,
+                    cancellationToken).ConfigureAwait(false)).GetAwaiter().GetResult();
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                LogResults(scanResult);
+                return !Log.HasLoggedErrors && !cancellationToken.IsCancellationRequested;
+            }
+            catch (Exception ex)
+            {
+                Log.LogErrorFromException(ex);
+                return false;
+            }
+        }
+
+        public void Cancel() => GetOrCreateCancellationTokenSource().Cancel();
+
+        private IEngineEnvironmentSettings SetupSettings(ILoggerFactory loggerFactory)
+        {
+            var builtIns = new List<(Type InterfaceType, IIdentifiedComponent Instance)>();
+            builtIns.AddRange(Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Components.AllComponents);
+            builtIns.AddRange(Microsoft.TemplateEngine.Edge.Components.AllComponents);
+
+            ITemplateEngineHost host = new DefaultTemplateEngineHost("template-validator", "1.0", builtIns: builtIns, loggerFactory: loggerFactory);
+            IEngineEnvironmentSettings engineEnvironmentSettings = new EngineEnvironmentSettings(host, virtualizeSettings: true);
+
+            return engineEnvironmentSettings;
+        }
+
+        private void LogResults(ScanResult scanResult)
+        {
+            Log.LogMessage("Location '{0}': found {1} templates.", scanResult.MountPoint.MountPointUri, scanResult.Templates.Count);
+            foreach (IScanTemplateInfo template in scanResult.Templates)
+            {
+                string templateDisplayName = GetTemplateDisplayName(template);
+                StringBuilder sb = new();
+
+                LogValidationEntries("Template configuration", template.ValidationErrors);
+                foreach (KeyValuePair<string, ILocalizationLocator> locator in template.Localizations)
+                {
+                    ILocalizationLocator localizationInfo = locator.Value;
+                    LogValidationEntries("Localization", localizationInfo.ValidationErrors);
+                }
+            }
+
+            static string GetTemplateDisplayName(IScanTemplateInfo template)
+            {
+                string templateName = string.IsNullOrEmpty(template.Name) ? "<no name>" : template.Name;
+                return $"'{templateName}' ({template.Identity})";
+            }
+
+            void LogValidationEntries(string subCategory, IReadOnlyList<IValidationEntry> errors)
+            {
+                foreach (IValidationEntry error in errors.OrderByDescending(e => e.Severity))
+                {
+                    switch (error.Severity)
+                    {
+                        case IValidationEntry.SeverityLevel.Error:
+                            Log.LogError(
+                                subcategory: subCategory,
+                                errorCode: error.Code,
+                                helpKeyword: string.Empty,
+                                file: error.Location?.Filename ?? string.Empty,
+                                lineNumber: error.Location?.LineNumber ?? 0,
+                                columnNumber: error.Location?.Position ?? 0,
+                                endLineNumber: 0,
+                                endColumnNumber: 0,
+                                message: error.ErrorMessage);
+                            break;
+                        case IValidationEntry.SeverityLevel.Warning:
+                            Log.LogWarning(
+                                subcategory: subCategory,
+                                warningCode: error.Code,
+                                helpKeyword: string.Empty,
+                                file: error.Location?.Filename ?? string.Empty,
+                                lineNumber: error.Location?.LineNumber ?? 0,
+                                columnNumber: error.Location?.Position ?? 0,
+                                endLineNumber: 0,
+                                endColumnNumber: 0,
+                                message: error.ErrorMessage);
+                            break;
+                        case IValidationEntry.SeverityLevel.Info:
+                            Log.LogMessage(
+                                subcategory: subCategory,
+                                code: error.Code,
+                                helpKeyword: string.Empty,
+                                file: error.Location?.Filename ?? string.Empty,
+                                lineNumber: error.Location?.LineNumber ?? 0,
+                                columnNumber: error.Location?.Position ?? 0,
+                                endLineNumber: 0,
+                                endColumnNumber: 0,
+                                MessageImportance.High,
+                                message: error.ErrorMessage);
+                            break;
+                    }
+                }
+            }
+
+        }
+
+        private CancellationTokenSource GetOrCreateCancellationTokenSource()
+        {
+            if (_cancellationTokenSource != null)
+            {
+                return _cancellationTokenSource;
+            }
+
+            CancellationTokenSource cts = new();
+            if (Interlocked.CompareExchange(ref _cancellationTokenSource, cts, null) != null)
+            {
+                // Reference was already set. This instance is not needed.
+                cts.Dispose();
+            }
+
+            return _cancellationTokenSource;
+        }
+    }
+}

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/build/Microsoft.TemplateEngine.Authoring.Tasks.props
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/build/Microsoft.TemplateEngine.Authoring.Tasks.props
@@ -1,6 +1,16 @@
 ﻿<Project>
   <PropertyGroup>
 
+    <ValidateTemplates Condition="'$(ValidateTemplates)' == ''">true</ValidateTemplates>
+
+    <!-- 
+      The directory containing your templates to be validated.
+      All the folders under this directory will be searched for "/.template.config/template.json" files.
+      If not provided, the directory from which the build was initiated will be used.
+    -->
+    
+    <ValidateTemplatesPath Condition="'$(ValidateTemplatesPath)' == ''">.</ValidateTemplatesPath>
+
     <!-- 
       Set this to true to create and update your templatestrings.xx.json files based on the content of your templates.json files. 
       If the value is not true, the rest of the properties related to localization are ignored.

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/build/Microsoft.TemplateEngine.Authoring.Tasks.targets
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/build/Microsoft.TemplateEngine.Authoring.Tasks.targets
@@ -9,4 +9,11 @@
   <Target Name="LocalizeTemplatesAfterBuild" Condition="'$(LocalizeTemplates)' == 'true'" BeforeTargets="AfterBuild">
     <LocalizeTemplates TemplateFolder="$(LocalizableTemplatesPath)" SearchSubfolders="true" Languages="$(TemplateLanguages)"/>
   </Target>
+
+  <UsingTask TaskName="ValidateTemplates" AssemblyFile="$(TemplatingTasksAssembly)" Condition="'$(MSBuildRuntimeType)' != 'Full'" />
+  <UsingTask TaskName="ValidateTemplates" AssemblyFile="$(TemplatingTasksAssembly)" Condition="'$(MSBuildRuntimeType)' == 'Full'" TaskFactory="TaskHostFactory"/>
+
+  <Target Name="ValidateTemplatesAfterBuild" Condition="'$(ValidateTemplates)' == 'true'" BeforeTargets="AfterBuild" AfterTargets="LocalizeTemplatesAfterBuild">
+    <ValidateTemplates TemplateLocation="$(ValidateTemplatesPath)"/>
+  </Target>
 </Project>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.cs.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.cs.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">Nepovedlo se exportovat lokalizační soubory pro soubor template.json v cestě {0}: {1}.</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">LocalizeTemplates zastavil zpracování následujícího souboru, protože operace byla zrušena: {0}</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">Pro cíl LocalizeTemplates by měla být nastavena vlastnost TemplateFolder.</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">Soubor template.json se v cestě {0} nepodařilo najít.</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.de.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.de.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">Fehler beim Exportieren der Lokalisierungsdateien für die Datei \"template.json\" unter dem Pfad “{0}”: {1}.</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">\"LocalizeTemplates\" hat die Verarbeitung der folgenden Datei beendet, da der Vorgang abgebrochen wurde: {0}</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">Die Eigenschaft \"TemplateFolder\" muss für das Ziel \"LocalizeTemplates\" festgelegt werden.</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">Die Datei \"template.json\" konnte unter dem Pfad \"{0}\" wurde nicht gefunden.</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.es.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.es.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">No se pudieron exportar los archivos de localización del archivo 'template.json' en la ruta de acceso '{0}': {1}.</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">'LocalizeTemplates' dejó de procesar el siguiente archivo porque se canceló la operación: {0}</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">La propiedad 'TemplateFolder' debe establecerse para el destino 'LocalizeTemplates'.</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">No se pudo encontrar el archivo 'template.json' bajo la ruta de acceso '{0}'.</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.fr.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.fr.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">Échec de l’exportation des fichiers de localisation pour le fichier 'template.json' sous le chemin d’accès '{0}' : {1}</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">« LocalizeTemplates » a arrêté le traitement du fichier suivant, car l’opération a été annulée : {0}</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">La propriété « TemplateFolder » doit être définie pour la cible « LocalizeTemplates ».</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">Impossible de trouver le fichier 'template.json' dans le chemin '{0}'</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.it.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.it.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">Non è stato possibile esportare i file di localizzazione per il file 'template.json' nel percorso '{0}': {1}.</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">'LocalizeTemplates' ha interrotto l'elaborazione del file seguente perché l'operazione è stata annullata: {0}</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">La proprietà 'TemplateFolder' deve essere impostata per la destinazione 'LocalizeTemplates'.</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">Non è stato possibile trovare il file ‘template.json’ nel percorso ‘{0}’.</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.ja.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.ja.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">パス '{0}' の下にある 'template.json' ファイルのローカライズ ファイルをエクスポートできませんでした。{1}。</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">操作がキャンセルされたため、'LocalizeTemplates' は次のファイルの処理を停止しました: {0}</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">プロパティ 'TemplateFolder' を 'LocalizeTemplates' ターゲットに設定する必要があります。</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">パス '{0}' の下に \"template.json\" ファイルが見つかりません。</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.ko.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.ko.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">'{0}' 경로의 'template.json' 파일에 대한 지역화 파일을 내보내지 못했습니다. {1}.</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">작업이 취소되었기 때문에 'LocalizeTemplates'가 {0} 파일 처리를 중지했습니다.</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">'TemplateFolder' 속성은 'LocalizeTemplates' 대상에 대해 설정해야 합니다.</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">‘{0}’ 경로에서 ‘template.json’ 파일을 찾지 못했습니다.</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.pl.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.pl.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">Nie można wyeksportować plików lokalizacji dla pliku „template.json” w ścieżce „{0}”: {1}.</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">Element „LocalizeTemplates” zatrzymał przetwarzanie następującego pliku, ponieważ operacja została anulowana: {0}</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">Właściwość „TemplateFolder” powinna być ustawiona dla elementu docelowego „LocalizeTemplates”.</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">Nie można odnaleźć pliku „template.json” w ścieżce „{0}”.</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.pt-BR.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">Falha ao exportar os arquivos de localização para o arquivo 'template.json' no caminho '{0}': {1}.</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">A operação foi cancelada porque 'LocalizeTemplates' parou de processar o seguinte arquivo: {0}</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">A propriedade 'TemplateFolder' deve ser definida para ao destino 'LocalizeTemplates'.</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">Falha ao encontrar o arquivo 'template.json' no caminho '{0}'.</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.ru.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.ru.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">Не удалось экспортировать файлы локализации для файла \"template.json\" по пути \"{0}\": {1}.</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">Обработка следующего файла в \"LocalizeTemplates\" остановлена, поскольку операция была отменена: {0}</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">Свойство \"TemplateFolder\" должно быть задано для целевого объекта \"LocalizeTemplates\".</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">Не удалось найти файл \"template.json\" по пути \"{0}\".</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.tr.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.tr.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">'{0}' yolundaki 'template.json' dosyası için şu yerelleştirme dosyaları dışarı aktarılamadı: {1}.</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">'LocalizeTemplates', işlem iptal edildiği için şu dosyayı işlemeyi durdurdu: {0}</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">'LocalizeTemplates' hedefi için 'TemplateFolder' özelliği ayarlanmalıdır.</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">'{0}' yolunda 'template.json' dosyası bulunamadı.</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">无法在路径“{0}”下导出“template.json”文件的本地化文件: {1}。</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">“LocalizeTemplates”已停止处理以下文件，因为操作被取消: {0}</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">应为“LocalizeTemplates”目标设置属性“TemplateFolder”。</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">在路径“{0}”下未找到“template.json”文件。</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>

--- a/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/tools/Microsoft.TemplateEngine.Authoring.Tasks/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,29 +2,41 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="Command_Localize_Log_ExportTaskFailed">
+      <trans-unit id="Localize_Log_ExportTaskFailed">
         <source>Failed to export localization files for 'template.json' file under the path '{0}': {1}.</source>
-        <target state="translated">無法在路徑 '{0}': {1} 下匯出 'template.json' 檔案的當地語系化檔案。</target>
+        <target state="new">Failed to export localization files for 'template.json' file under the path '{0}': {1}.</target>
         <note>Do not localize: 'template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_FileProcessingCancelled">
+      <trans-unit id="Localize_Log_FileProcessingCancelled">
         <source>'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</source>
-        <target state="translated">'LocalizeTemplates' 已停止處理下列檔案，因為作業已取消: {0}</target>
+        <target state="new">'LocalizeTemplates' stopped processing the following file, because the operation was cancelled: {0}</target>
         <note>Do not localize: 'LocalizeTemplates'.
 {0} is the full path to a file, such as 'C:/Users/someguy/Desktop/template.json'</note>
       </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateFolderNotSet">
-        <source>The property 'TemplateFolder' should be set for 'LocalizeTemplates' target.</source>
-        <target state="translated">應該為 'LocalizeTemplates' 目標設定屬性 'TemplateFolder'。</target>
-        <note>Do not localize: 
-- 'TemplateFolder'
-- 'LocalizeTemplates'
-'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
-      </trans-unit>
-      <trans-unit id="Command_Localize_Log_TemplateJsonNotFound">
+      <trans-unit id="Localize_Log_TemplateJsonNotFound">
         <source>Failed to find 'template.json' file under the path '{0}'.</source>
-        <target state="translated">在路徑 ‘{0}’ 下找不到 ‘template.json’ 檔案。</target>
+        <target state="new">Failed to find 'template.json' file under the path '{0}'.</target>
         <note>Do not localize: 'template.json'</note>
+      </trans-unit>
+      <trans-unit id="Log_Error_MissingRequiredProperty">
+        <source>The property '{0}' should be set for '{1}' target.</source>
+        <target state="new">The property '{0}' should be set for '{1}' target.</target>
+        <note>'Target' and 'property' are referring to MSBuild concepts with the same names.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_FoundTemplate">
+        <source>Location '{0}': found {1} templates.</source>
+        <target state="new">Location '{0}': found {1} templates.</target>
+        <note>{0} - path configured for scanning the templates, {1} - the number of templates found.</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateConfiguration_Subcategory">
+        <source>Template configuration</source>
+        <target state="new">Template configuration</target>
+        <note>this is subcategory of the error message displayed after build</note>
+      </trans-unit>
+      <trans-unit id="Validate_Log_TemplateLocalization_Subcategory">
+        <source>Template localization</source>
+        <target state="new">Template localization</target>
+        <note>this is subcategory of the error message displayed after build</note>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
### Problem
Template validation

### Solution
follow up for https://github.com/dotnet/templating/pull/5838
usage of new validation from MSBuild authoring tasks

TODO: 
- [x] extract localization strings (once the approach is approved)
- [ ] better location reporting (separate PR)
- [ ] info messages are not reported in MS in Error list

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)