### PR TITLE
Disable signing validation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -205,7 +205,7 @@ stages:
       enableSourceLinkValidation: false
       # disabling temporarily signing validation
       # causes error NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported.
-      enableSigningValidation: false   
+      enableSigningValidation: false     
       publishDependsOn:
       - Validate
       # This is to enable SDL runs part of Post-Build Validation Stage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,8 @@ variables:
     value: NETDevUX
   - name: _PublishUsingPipelines
     value: true
-
+  - name: Codeql.Enabled
+    value: true
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: Templating-SDLValidation-Params
     
@@ -74,10 +75,10 @@ stages:
         timeoutInMinutes: 90
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCore-Svc-Public
+            name: NetCore-Public
             vmImage: 1es-windows-2019-open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-            name: NetCore1ESPool-Svc-Internal
+            name: NetCore1ESPool-Internal
             demands: ImageOverride -equals windows.vs2019.amd64
         variables:
         - _InternalBuildArgs: ''
@@ -164,7 +165,7 @@ stages:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
               vmImage: ubuntu-latest 
             ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-              name: NetCore1ESPool-Svc-Internal
+              name: NetCore1ESPool-Internal
               demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
           strategy:
             matrix:
@@ -202,6 +203,9 @@ stages:
       # Sourcelink validation isn't passing for Arcade due to some regressions. This should be
       # enabled back once this issue is resolved: https://github.com/dotnet/arcade/issues/2912
       enableSourceLinkValidation: false
+      # disabling temporarily signing validation
+      # causes error NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported.
+      enableSigningValidation: false   
       publishDependsOn:
       - Validate
       # This is to enable SDL runs part of Post-Build Validation Stage


### PR DESCRIPTION
Disable signing validation-  it still causes error NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported.

### Problem
The internal pipeline fails on this step 
https://dev.azure.com/dnceng/internal/_build/results?buildId=2080415&view=results

### Solution
Undo enabling

### Checks:
- [N/A ] Added unit tests
- [ N/A] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)