### PR TITLE
Downgrade verify versions due to problems with compatibility

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -26,7 +26,7 @@
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Update="xunit.abstractions" Version="2.0.3" />
     <PackageReference Update="Newtonsoft.Json.Schema" Version="3.0.14" />
-    <PackageReference Update="Verify.XUnit" Version="19.5.0" />
-    <PackageReference Update="Verify.DiffPlex" Version="2.0.1" />
+    <PackageReference Update="Verify.Xunit" Version="19.3.0" />
+    <PackageReference Update="Verify.DiffPlex" Version="1.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Problem
After getting recent updates for packages Verify.Xunit, Verify.DiffPlex we have started facing test failure due to VerifyTests.InnerVerifier.ThrowIfVerifyHasBeenRun()  invoke

### Solution
Downgrade package version and contact VerifyTests repo owner

### Checks:
- [N/A] Added unit tests
- [N/A] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)