### PR TITLE
Revert "Bump FluentAssertions from 6.7.0 to 6.8.0 in /eng/dependabot" due to cascading updates

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -23,7 +23,7 @@
 
     <!--Test dependencies-->
     <PackageReference Update="FakeItEasy" Version="7.3.1" />
-    <PackageReference Update="FluentAssertions" Version="6.8.0" />
+    <PackageReference Update="FluentAssertions" Version="6.7.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageReference Update="xunit.abstractions" Version="2.0.3" />
     <PackageReference Update="Newtonsoft.Json.Schema" Version="3.0.14" />


### PR DESCRIPTION
Revert "Bump FluentAssertions from 6.7.0 to 6.8.0 in /eng/dependabot" due to cascading updates
Reverts dotnet/templating#5892