### PR TITLE
Re-enable signing validation after upgrading dotnet/arcade with the fix working with .NET 7.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,9 +203,6 @@ stages:
       # Sourcelink validation isn't passing for Arcade due to some regressions. This should be
       # enabled back once this issue is resolved: https://github.com/dotnet/arcade/issues/2912
       enableSourceLinkValidation: false
-      # disabling temporarily signing validation
-      # causes error NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported.
-      enableSigningValidation: false     
       publishDependsOn:
       - Validate
       # This is to enable SDL runs part of Post-Build Validation Stage


### PR DESCRIPTION
### Problem
#5661 - Previously re-enabling signing validation still hit the error NETSDK1192: Targeting .NET 7.0 or higher in Visual Studio 2022 17.3 is not supported. It's because dotnet/arcade was not updated with the fix yet.

### Solution
Currently the version of dotnet/arcade should be updated with the fix by #5876. Then re-enable signing validation again.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)