### PR TITLE
revert NuGet.Credentials/Protocols/Configuration pakage updates

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -13,7 +13,7 @@
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Update="NuGet.Configuration" Version="6.4.0" />
-    <PackageReference Update="NuGet.Credentials" Version="6.4.0" />
+    <PackageReference Update="NuGet.Credentials" Version="6.3.1" />
     <PackageReference Update="NuGet.Protocol" Version="6.4.0" />
 
     <!--Analyzers-->

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -12,9 +12,9 @@
     <PackageReference Update="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-    <PackageReference Update="NuGet.Configuration" Version="6.4.0" />
+    <PackageReference Update="NuGet.Configuration" Version="6.3.1" />
     <PackageReference Update="NuGet.Credentials" Version="6.3.1" />
-    <PackageReference Update="NuGet.Protocol" Version="6.4.0" />
+    <PackageReference Update="NuGet.Protocol" Version="6.3.1" />
 
     <!--Analyzers-->
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.4.0" />

--- a/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
+++ b/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
@@ -21,7 +21,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="NuGet.Configuration" />
     <PackageReference Include="NuGet.Credentials" />
+    <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="System.IO.Compression" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Runtime.Loader" Condition="'$(TargetFramework)' != '$(NETFullTargetFramework)'" />

--- a/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/src/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -13,6 +13,8 @@
     <ProjectReference Include="$(TestDir)Microsoft.TemplateEngine.TestHelper\Microsoft.TemplateEngine.TestHelper.csproj" />
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateSearch.Common\Microsoft.TemplateSearch.Common.csproj" />
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NuGet.Configuration" />
+    <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="FluentAssertions" />
   </ItemGroup>

--- a/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Credentials" />
+    <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging" />


### PR DESCRIPTION
### Problem
NuGet.Credentials/Protocols/Configuration package update causes cascading updates in sdk

### Solution
Revert package bumping

### Checks:
- [ N/A ] Added unit tests
- [ N/A ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)