### PR TITLE
[Bug template] add collapsed section for dotnet --info output as default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,7 +43,9 @@ body:
         <details>
           <summary>output</summary>
           <!-- provide the output here -->
- 
+          
+          
+          
         </details>
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -39,6 +39,12 @@ body:
     attributes:
       label: dotnet Info
       description: Provide the output of **`dotnet --info`** to understand what the dotnet version is.
+      value: |
+        <details>
+          <summary>output</summary>
+          <!-- provide the output here -->
+ 
+        </details>
     validations:
       required: true
   - type: input


### PR DESCRIPTION
### Problem
The bug templates instructs to paste the output of `dotnet --info`, which is often very long. So a reader has to scroll past a long block of text which also is not always interesting

### Solution
So this adds a collapsed details section as default content to the textarea for dotnet --info with instructions to paste the output inside

### Checks:
tested on fork, you can test here as well: https://github.com/Mrxx99/templating/issues/new/choose