### PR TITLE
add WithNoUpdateCheck argument

### DIFF
--- a/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/VerificationEngine.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/VerificationEngine.cs
@@ -341,7 +341,8 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier
                 .WithCustomOrVirtualHive(customHiveLocation)
                 .WithCustomExecutablePath(options.DotnetExecutablePath)
                 .WithEnvironmentVariables(options.Environment)
-                .WithWorkingDirectory(workingDir);
+                .WithWorkingDirectory(workingDir)
+                .WithNoUpdateCheck();
 
             var result = commandRunner.RunCommand(command);
             // Cleanup, unless the settings dir was externally passed

--- a/tools/Shared/Microsoft.TemplateEngine.CommandUtils/DotnetNewCommand.cs
+++ b/tools/Shared/Microsoft.TemplateEngine.CommandUtils/DotnetNewCommand.cs
@@ -33,7 +33,7 @@ namespace Microsoft.TemplateEngine.CommandUtils
             return this;
         }
 
-        internal DotnetNewCommand WithNoUpdateCheck(s)
+        internal DotnetNewCommand WithNoUpdateCheck()
         {
             Arguments.Add("--no-update-check");
             return this;

--- a/tools/Shared/Microsoft.TemplateEngine.CommandUtils/DotnetNewCommand.cs
+++ b/tools/Shared/Microsoft.TemplateEngine.CommandUtils/DotnetNewCommand.cs
@@ -33,6 +33,12 @@ namespace Microsoft.TemplateEngine.CommandUtils
             return this;
         }
 
+        internal DotnetNewCommand WithNoUpdateCheck(s)
+        {
+            Arguments.Add("--no-update-check");
+            return this;
+        }
+
         internal DotnetNewCommand WithCustomOrVirtualHive(string? path)
         {
             return string.IsNullOrEmpty(path) ? WithVirtualHive() : WithCustomHive(path);

--- a/tools/Shared/Microsoft.TemplateEngine.CommandUtils/DotnetNewCommand.cs
+++ b/tools/Shared/Microsoft.TemplateEngine.CommandUtils/DotnetNewCommand.cs
@@ -33,12 +33,6 @@ namespace Microsoft.TemplateEngine.CommandUtils
             return this;
         }
 
-        internal DotnetNewCommand WithNoUpdateCheck()
-        {
-            Arguments.Add("--no-update-check");
-            return this;
-        }
-
         internal DotnetNewCommand WithCustomOrVirtualHive(string? path)
         {
             return string.IsNullOrEmpty(path) ? WithVirtualHive() : WithCustomHive(path);

--- a/tools/Shared/Microsoft.TemplateEngine.CommandUtils/TestCommand.cs
+++ b/tools/Shared/Microsoft.TemplateEngine.CommandUtils/TestCommand.cs
@@ -56,7 +56,7 @@ namespace Microsoft.TemplateEngine.CommandUtils
             return this;
         }
 
-        internal DotnetNewCommand WithNoUpdateCheck()
+        internal TestCommand WithNoUpdateCheck()
         {
             Arguments.Add("--no-update-check");
             return this;

--- a/tools/Shared/Microsoft.TemplateEngine.CommandUtils/TestCommand.cs
+++ b/tools/Shared/Microsoft.TemplateEngine.CommandUtils/TestCommand.cs
@@ -56,6 +56,12 @@ namespace Microsoft.TemplateEngine.CommandUtils
             return this;
         }
 
+        internal DotnetNewCommand WithNoUpdateCheck()
+        {
+            Arguments.Add("--no-update-check");
+            return this;
+        }
+
         internal ProcessStartInfo GetProcessStartInfo(params string[] args)
         {
             SdkCommandSpec commandSpec = CreateCommandSpec(args);


### PR DESCRIPTION
### Problem
Sometimes the tests fail because the template samples package was installed but then later when instantiating the templates, the update checks detected a newer templates sample package being available in the feeds:
https://github.com/dotnet/sdk/pull/29966
```
 The template "Contoso Sample 06" was created successfully.
      + 
      + An update for template package 'Microsoft.TemplateEngine.Samples::8.0.100-alpha.1.23066.9' is available.
      + To update the package use:
      +    dotnet new install Microsoft.TemplateEngine.Samples::8.0.100-alpha.1.23067.1
```

### Solution
Use option` --no-update-check`

### Checks:
- [ N/A ] Added unit tests
- [ N/A ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)