### PR TITLE
Fix the tool's path after target framework was upgraded to net8.0

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -81,7 +81,7 @@ steps:
   displayName: Install latest daily .NET version 
 
 - bash: >
-    $(Build.SourcesDirectory)/.dotnet/dotnet $(Build.SourcesDirectory)/artifacts/bin/Microsoft.TemplateSearch.TemplateDiscovery/Debug/net7.0/Microsoft.TemplateSearch.TemplateDiscovery.dll
+    $(Build.SourcesDirectory)/.dotnet/dotnet $(Build.SourcesDirectory)/artifacts/bin/Microsoft.TemplateSearch.TemplateDiscovery/Debug/net8.0/Microsoft.TemplateSearch.TemplateDiscovery.dll
     --basePath $(System.DefaultWorkingDirectory)/NugetDownloadDirectory --allowPreviewPacks -v --test --diff $(EnableDiffMode)
   displayName: Run Cache Updater
 


### PR DESCRIPTION
### Problem
After target framework was upgraded to net 8.0, the path of the tool `Microsoft.TemplateSearch.TemplateDiscovery.dll` in search cache needs to change.

### Solution
Change the path from net7.0 to net8.0.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)