### PR TITLE
Update latest .NET to 8.0 and add tests for 7.0

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -70,11 +70,18 @@ steps:
   inputs:
     packageType: sdk
     version: 6.0.100
-    installa6ionPath: $(Build.SourcesDirectory)/.dotnet
+    installationPath: $(Build.SourcesDirectory)/.dotnet
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 7.0.100'
+  inputs:
+    packageType: sdk
+    version: 7.0.100
+    installationPath: $(Build.SourcesDirectory)/.dotnet
 
 - bash: >
     curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
-    -Channel 7.0.1xx
+    -Channel 8.0.1xx
     -Quality daily
     -InstallDir $(Build.SourcesDirectory)/.dotnet
     -SkipNonVersionedFiles

--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -59,10 +59,10 @@ steps:
     installationPath: $(Build.SourcesDirectory)/.dotnet
 
 - task: UseDotNet@2
-  displayName: 'Use .NET 5.0.300'
+  displayName: 'Use .NET 5.0.400'
   inputs:
     packageType: sdk
-    version: 5.0.300
+    version: 5.0.400
     installationPath: $(Build.SourcesDirectory)/.dotnet
 
 - task: UseDotNet@2
@@ -73,10 +73,31 @@ steps:
     installationPath: $(Build.SourcesDirectory)/.dotnet
 
 - task: UseDotNet@2
+  displayName: 'Use .NET 6.0.300'
+  inputs:
+    packageType: sdk
+    version: 6.0.300
+    installationPath: $(Build.SourcesDirectory)/.dotnet
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 6.0.400'
+  inputs:
+    packageType: sdk
+    version: 6.0.400
+    installationPath: $(Build.SourcesDirectory)/.dotnet
+
+- task: UseDotNet@2
   displayName: 'Use .NET 7.0.100'
   inputs:
     packageType: sdk
     version: 7.0.100
+    installationPath: $(Build.SourcesDirectory)/.dotnet
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 7.0.200'
+  inputs:
+    packageType: sdk
+    version: 7.0.200
     installationPath: $(Build.SourcesDirectory)/.dotnet
 
 - bash: >

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Program.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Program.cs
@@ -7,10 +7,10 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery
 {
     internal class Program
     {
-        private static async Task Main(string[] args)
+        private static async Task<int> Main(string[] args)
         {
             Command rootCommand = new TemplateDiscoveryCommand();
-            await rootCommand.InvokeAsync(args).ConfigureAwait(false);
+            return await rootCommand.InvokeAsync(args).ConfigureAwait(false);
         }
     }
 }

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
             sdkVersion = "5.0.100";
             Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
             workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
-            UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "5.0.", rollForward: "latestFeature");
+            UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "5.0.1", rollForward: "latestPatch");
             CanSearchWhileInstantiating(workingDirectory, legacyMetadataPath);
             CanCheckUpdates(workingDirectory, legacyMetadataPath);
             CanUpdate(workingDirectory, legacyMetadataPath);
@@ -33,7 +33,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
             sdkVersion = "5.0.400";
             Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
             workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
-            UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "5.0.", rollForward: "latestFeature");
+            UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "5.0.4", rollForward: "latestPatch");
             CanSearch(workingDirectory, legacyMetadataPath);
             CanCheckUpdates(workingDirectory, legacyMetadataPath);
             CanUpdate(workingDirectory, legacyMetadataPath);
@@ -41,7 +41,25 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
             //6.0.100
             sdkVersion = "6.0.100";
             workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
-            UseSdkVersion(workingDirectory, requestedSdkVersion: "6.0.100", resolvedVersionPattern: "6.0.", rollForward: "latestFeature");
+            UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "6.0.1", rollForward: "latestPatch");
+            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
+            CanSearch(workingDirectory, legacyMetadataPath);
+            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
+            CanSearch(workingDirectory, metadataPath);
+
+            //6.0.300
+            sdkVersion = "6.0.300";
+            workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
+            UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "6.0.3", rollForward: "latestPatch");
+            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
+            CanSearch(workingDirectory, legacyMetadataPath);
+            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
+            CanSearch(workingDirectory, metadataPath);
+
+            //6.0.400
+            sdkVersion = "6.0.400";
+            workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
+            UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "6.0.4", rollForward: "latestPatch");
             Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
             CanSearch(workingDirectory, legacyMetadataPath);
             Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
@@ -50,7 +68,16 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
             //7.0.100
             sdkVersion = "7.0.100";
             workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
-            UseSdkVersion(workingDirectory, requestedSdkVersion: "7.0.100", resolvedVersionPattern: "7.0.", rollForward: "latestFeature");
+            UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "7.0.1", rollForward: "latestPatch");
+            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
+            CanSearch(workingDirectory, legacyMetadataPath);
+            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
+            CanSearch(workingDirectory, metadataPath);
+
+            //7.0.200
+            sdkVersion = "7.0.200";
+            workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
+            UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "7.0.2", rollForward: "latestPatch");
             Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
             CanSearch(workingDirectory, legacyMetadataPath);
             Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
@@ -173,6 +200,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
 
         private static void CreateGlobalJson(string directory, string sdkVersion, string rollForward = "latestMinor", bool allowPrerelease = false)
         {
+            Console.WriteLine($"set {sdkVersion} in global.json under {directory}.");
             string prereleaseSection = allowPrerelease ? @", ""allowPrerelease"": ""true""" : string.Empty;
             string jsonContent = $@"{{ ""sdk"": {{ ""version"": ""{sdkVersion}"", ""rollForward"": ""{rollForward}"" {prereleaseSection}}} }}";
             File.WriteAllText(Path.Combine(directory, "global.json"), jsonContent);

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
@@ -89,7 +89,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
         private static void CanSearchWhileInstantiating(string workingDirectory, string cacheFilePath)
         {
             var settingsPath = TestUtils.CreateTemporaryFolder();
-            new DotnetNewCommand(TestOutputLogger.Instance, "func", "--debug:custom-hive", settingsPath)
+            new DotnetNewCommand(TestOutputLogger.Instance, "func")
+                .WithCustomHive(settingsPath)
                 .WithoutTelemetry()
                 .WithWorkingDirectory(workingDirectory)
                 .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
@@ -103,7 +104,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
         private static void CanCheckUpdates(string workingDirectory, string cacheFilePath)
         {
             var settingsPath = TestUtils.CreateTemporaryFolder();
-            new DotnetNewCommand(TestOutputLogger.Instance, "--install", "Microsoft.Azure.WebJobs.ItemTemplates::2.1.1785", "--debug:custom-hive", settingsPath)
+            new DotnetNewCommand(TestOutputLogger.Instance, "--install", "Microsoft.Azure.WebJobs.ItemTemplates::2.1.1785")
+                .WithCustomHive(settingsPath)
               .WithoutTelemetry()
               .WithWorkingDirectory(workingDirectory)
               .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
@@ -112,7 +114,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
               .ExitWith(0)
               .And.NotHaveStdErr();
 
-            new DotnetNewCommand(TestOutputLogger.Instance, "--update-check", "--debug:custom-hive", settingsPath)
+            new DotnetNewCommand(TestOutputLogger.Instance, "--update-check")
+                .WithCustomHive(settingsPath)
                 .WithoutTelemetry()
                 .WithWorkingDirectory(workingDirectory)
                 .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
@@ -128,7 +131,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
         private static void CanUpdate(string workingDirectory, string cacheFilePath)
         {
             var settingsPath = TestUtils.CreateTemporaryFolder();
-            new DotnetNewCommand(TestOutputLogger.Instance, "--install", "Microsoft.Azure.WebJobs.ItemTemplates::2.1.1785", "--debug:custom-hive", settingsPath)
+            new DotnetNewCommand(TestOutputLogger.Instance, "--install", "Microsoft.Azure.WebJobs.ItemTemplates::2.1.1785")
+                .WithCustomHive(settingsPath)
                 .WithoutTelemetry()
                 .WithWorkingDirectory(workingDirectory)
                 .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
@@ -137,7 +141,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
                 .ExitWith(0)
                 .And.NotHaveStdErr();
 
-            new DotnetNewCommand(TestOutputLogger.Instance, "--update-apply", "--debug:custom-hive", settingsPath)
+            new DotnetNewCommand(TestOutputLogger.Instance, "--update-apply")
+                .WithCustomHive(settingsPath)
                 .WithoutTelemetry()
                 .WithWorkingDirectory(workingDirectory)
                 .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
@@ -153,7 +158,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
         private static void CanSearch(string workingDirectory, string cacheFilePath)
         {
             var settingsPath = TestUtils.CreateTemporaryFolder();
-            new DotnetNewCommand(TestOutputLogger.Instance, "func", "--search", "--debug:custom-hive", settingsPath)
+            new DotnetNewCommand(TestOutputLogger.Instance, "func", "--search")
+                .WithCustomHive(settingsPath)
                 .WithoutTelemetry()
                 .WithWorkingDirectory(workingDirectory)
                 .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
@@ -47,6 +47,15 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
             Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
             CanSearch(workingDirectory, metadataPath);
 
+            //7.0.100
+            sdkVersion = "7.0.100";
+            workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
+            UseSdkVersion(workingDirectory, requestedSdkVersion: "7.0.100", resolvedVersionPattern: "7.0.", rollForward: "latestFeature");
+            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
+            CanSearch(workingDirectory, legacyMetadataPath);
+            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
+            CanSearch(workingDirectory, metadataPath);
+
             //latest
             workingDirectory = TestUtils.CreateTemporaryFolder("latest");
             //print the version


### PR DESCRIPTION
### Problem

- Search cache needs updating latest .NET to 8.0 and add tests for 7.0.

- #5956 

### Solution

- Fix the tests
- Update latest .NET to 8.0
- Add supported .NET versions

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)