### PR TITLE
[release/7.0.3xx] Pack Microsoft.TemplateSearch.TemplateDiscovery as tool for moving corresponding test to SDK repo

### DIFF
--- a/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/PackageManager.cs
@@ -25,10 +25,11 @@ namespace Microsoft.TemplateEngine.TestHelper
         private readonly ConcurrentDictionary<string, string> _installedPackages = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private static readonly Mutex PackMutex = new Mutex(false, "TemplateEngineTestPackMutex");
 
-        public async Task<string> GetNuGetPackage(string templatePackName, string? version = null, NuGetVersion? minimumVersion = null, ILogger? logger = null)
+        public async Task<string> GetNuGetPackage(string templatePackName, string? version = null, NuGetVersion? minimumVersion = null, ILogger? logger = null, string? downloadDirectory = null)
         {
             logger ??= NullLogger.Instance;
-            NuGetHelper nuGetHelper = new NuGetHelper(_packageLocation, logger);
+            string downloadDir = downloadDirectory ?? _packageLocation;
+            NuGetHelper nuGetHelper = new NuGetHelper(downloadDir, logger);
             try
             {
                 logger.LogDebug($"[NuGet Package Manager] Trying to get semaphore.");

--- a/test/Microsoft.TemplateEngine.TestHelper/PublicAPI.Unshipped.txt
+++ b/test/Microsoft.TemplateEngine.TestHelper/PublicAPI.Unshipped.txt
@@ -56,7 +56,7 @@ Microsoft.TemplateEngine.TestHelper.MonitoredFileSystem.WatchFileChanges(string!
 Microsoft.TemplateEngine.TestHelper.MonitoredFileSystem.WriteAllText(string! path, string! value) -> void
 Microsoft.TemplateEngine.TestHelper.PackageManager
 Microsoft.TemplateEngine.TestHelper.PackageManager.Dispose() -> void
-Microsoft.TemplateEngine.TestHelper.PackageManager.GetNuGetPackage(string! templatePackName, string? version = null, NuGet.Versioning.NuGetVersion? minimumVersion = null, NuGet.Common.ILogger? logger = null) -> System.Threading.Tasks.Task<string!>!
+Microsoft.TemplateEngine.TestHelper.PackageManager.GetNuGetPackage(string! templatePackName, string? version = null, NuGet.Versioning.NuGetVersion? minimumVersion = null, NuGet.Common.ILogger? logger = null, string? downloadDirectory = null) -> System.Threading.Tasks.Task<string!>!
 Microsoft.TemplateEngine.TestHelper.PackageManager.PackageManager() -> void
 Microsoft.TemplateEngine.TestHelper.PackageManager.PackNuGetPackage(string! projectPath, NuGet.Common.ILogger? logger = null) -> string!
 Microsoft.TemplateEngine.TestHelper.SharedTestOutputHelper

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -4,6 +4,9 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>$(NETCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <IsShipping>false</IsShipping>
+    <PackAsTool>true</PackAsTool>
     <ImplicitUsings>enable</ImplicitUsings>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>


### PR DESCRIPTION
### Problem
Port #5808 to release/7.0.3xx
- Pack Microsoft.TemplateSearch.TemplateDiscovery as tool for moving corresponding test to SDK repo

- Downloaded package can use custom directory

### Solution


### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)