### PR TITLE
Test with all .NET versions for CacheFileTests

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -70,11 +70,18 @@ steps:
   inputs:
     packageType: sdk
     version: 6.0.100
-    installa6ionPath: $(Build.SourcesDirectory)/.dotnet
+    installationPath: $(Build.SourcesDirectory)/.dotnet
+
+- task: UseDotNet@2
+  displayName: 'Use .NET 7.0.100'
+  inputs:
+    packageType: sdk
+    version: 7.0.100
+    installationPath: $(Build.SourcesDirectory)/.dotnet
 
 - bash: >
     curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
-    -Channel 7.0.1xx
+    -Channel 8.0.1xx
     -Quality daily
     -InstallDir $(Build.SourcesDirectory)/.dotnet
     -SkipNonVersionedFiles

--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -1,13 +1,13 @@
-# Don't trigger for CI events: push, PR created etc.
-trigger: none
-# Trigger periodically instead.
-schedules:
-- cron: 0 * * * *
-  displayName: Run every hour
+trigger:
+  batch: true
   branches:
     include:
     - main
-  always: true # Trigger even when there are no code changes.
+
+pr:
+  branches:
+    include:
+    - main
 
 parameters:
 - name: publishToBlob

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
@@ -89,7 +89,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
         private static void CanSearchWhileInstantiating(string workingDirectory, string cacheFilePath)
         {
             var settingsPath = TestUtils.CreateTemporaryFolder();
-            new DotnetNewCommand(TestOutputLogger.Instance, "func", "--debug:custom-hive", settingsPath)
+            new DotnetNewCommand(TestOutputLogger.Instance, "func")
+                .WithCustomHive(settingsPath)
                 .WithoutTelemetry()
                 .WithWorkingDirectory(workingDirectory)
                 .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
@@ -103,7 +104,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
         private static void CanCheckUpdates(string workingDirectory, string cacheFilePath)
         {
             var settingsPath = TestUtils.CreateTemporaryFolder();
-            new DotnetNewCommand(TestOutputLogger.Instance, "--install", "Microsoft.Azure.WebJobs.ItemTemplates::2.1.1785", "--debug:custom-hive", settingsPath)
+            new DotnetNewCommand(TestOutputLogger.Instance, "--install", "Microsoft.Azure.WebJobs.ItemTemplates::2.1.1785")
+                .WithCustomHive(settingsPath)
               .WithoutTelemetry()
               .WithWorkingDirectory(workingDirectory)
               .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
@@ -112,7 +114,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
               .ExitWith(0)
               .And.NotHaveStdErr();
 
-            new DotnetNewCommand(TestOutputLogger.Instance, "--update-check", "--debug:custom-hive", settingsPath)
+            new DotnetNewCommand(TestOutputLogger.Instance, "--update-check")
+                .WithCustomHive(settingsPath)
                 .WithoutTelemetry()
                 .WithWorkingDirectory(workingDirectory)
                 .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
@@ -128,7 +131,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
         private static void CanUpdate(string workingDirectory, string cacheFilePath)
         {
             var settingsPath = TestUtils.CreateTemporaryFolder();
-            new DotnetNewCommand(TestOutputLogger.Instance, "--install", "Microsoft.Azure.WebJobs.ItemTemplates::2.1.1785", "--debug:custom-hive", settingsPath)
+            new DotnetNewCommand(TestOutputLogger.Instance, "--install", "Microsoft.Azure.WebJobs.ItemTemplates::2.1.1785")
+                .WithCustomHive(settingsPath)
                 .WithoutTelemetry()
                 .WithWorkingDirectory(workingDirectory)
                 .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
@@ -137,7 +141,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
                 .ExitWith(0)
                 .And.NotHaveStdErr();
 
-            new DotnetNewCommand(TestOutputLogger.Instance, "--update-apply", "--debug:custom-hive", settingsPath)
+            new DotnetNewCommand(TestOutputLogger.Instance, "--update-apply")
+                .WithCustomHive(settingsPath)
                 .WithoutTelemetry()
                 .WithWorkingDirectory(workingDirectory)
                 .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)
@@ -153,7 +158,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
         private static void CanSearch(string workingDirectory, string cacheFilePath)
         {
             var settingsPath = TestUtils.CreateTemporaryFolder();
-            new DotnetNewCommand(TestOutputLogger.Instance, "func", "--search", "--debug:custom-hive", settingsPath)
+            new DotnetNewCommand(TestOutputLogger.Instance, "func", "--search")
+                .WithCustomHive(settingsPath)
                 .WithoutTelemetry()
                 .WithWorkingDirectory(workingDirectory)
                 .WithEnvironmentVariable("DOTNET_NEW_SEARCH_FILE_OVERRIDE", cacheFilePath)

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
@@ -47,6 +47,15 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
             Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
             CanSearch(workingDirectory, metadataPath);
 
+            //7.0.100
+            sdkVersion = "7.0.100";
+            workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
+            UseSdkVersion(workingDirectory, requestedSdkVersion: "7.0.100", resolvedVersionPattern: "7.0.", rollForward: "latestFeature");
+            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
+            CanSearch(workingDirectory, legacyMetadataPath);
+            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
+            CanSearch(workingDirectory, metadataPath);
+
             //latest
             workingDirectory = TestUtils.CreateTemporaryFolder("latest");
             //print the version


### PR DESCRIPTION
### Problem
CacheFileTests haven't worked for all .NET versions for a long time.

### Solution
Enable pull request triggers search cache pipeline to verify the tests.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)