### PR TITLE
Prevent editors from auto-trimming trailing whitespaces in test approval or snapshot files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -649,3 +649,6 @@ dotnet_analyzer_diagnostic.severity = none
 
 [*.txt]
 insert_final_newline = false
+
+[test/**/{Approvals,Snapshots}/**]
+trim_trailing_whitespace = false


### PR DESCRIPTION
### Problem
#5805

### Solution
Disable trimming trailing whitespaces in .editorconfig for test approval or snapshot files.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)