### PR TITLE
Enable Dependabot for branch release/7.0.3xx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,16 +9,6 @@ updates:
     labels:
       - "dependencies"
       - "dependabot: main"
-
-  - package-ecosystem: "nuget"
-    directory: "/eng/dependabot"
-    open-pull-requests-limit: 10
-    schedule:
-      interval: "weekly"
-    target-branch: "release/7.0.2xx"
-    labels:
-      - "dependencies"
-      - "dependabot: 7.0.2xx"
   
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot"
@@ -29,6 +19,16 @@ updates:
     labels:
       - "dependencies"
       - "dependabot: 7.0.1xx"
+
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    target-branch: "release/7.0.2xx"
+    labels:
+      - "dependencies"
+      - "dependabot: 7.0.2xx"
 
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,13 @@ updates:
     labels:
       - "dependencies"
       - "dependabot: 7.0.1xx"
+
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    target-branch: "release/7.0.3xx"
+    labels:
+      - "dependencies"
+      - "dependabot: 7.0.3xx"


### PR DESCRIPTION
### Problem
Branch release/7.0.3xx needs to enable Dependabot.

### Solution
Enable Dependabot for branch release/7.0.3xx.
This requires to create the label dependabot: 7.0.3xx before merging into main. I created it.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)