### PR TITLE
Install .NET 7.0.2xx and 7.0.3xx using dotnet-install.sh

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -93,12 +93,21 @@ steps:
     version: 7.0.100
     installationPath: $(Build.SourcesDirectory)/.dotnet
 
-- task: UseDotNet@2
-  displayName: 'Use .NET 7.0.200'
-  inputs:
-    packageType: sdk
-    version: 7.0.200
-    installationPath: $(Build.SourcesDirectory)/.dotnet
+- bash: >
+    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
+    -Channel 7.0.2xx
+    -Quality daily
+    -InstallDir $(Build.SourcesDirectory)/.dotnet
+    -SkipNonVersionedFiles
+  displayName: Install daily .NET 7.0.2xx
+
+- bash: >
+    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
+    -Channel 7.0.3xx
+    -Quality daily
+    -InstallDir $(Build.SourcesDirectory)/.dotnet
+    -SkipNonVersionedFiles
+  displayName: Install daily .NET 7.0.3xx
 
 - bash: >
     curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
@@ -83,6 +83,15 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
             Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
             CanSearch(workingDirectory, metadataPath);
 
+            //7.0.300
+            sdkVersion = "7.0.300";
+            workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
+            UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "7.0.3", rollForward: "latestPatch");
+            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
+            CanSearch(workingDirectory, legacyMetadataPath);
+            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
+            CanSearch(workingDirectory, metadataPath);
+
             //latest
             workingDirectory = TestUtils.CreateTemporaryFolder("latest");
             //print the version


### PR DESCRIPTION
### Problem
In search cache pipeline, the task `UseDotNet@2` can't install 7.0.200 currently as it's not released yet.

### Solution
Install using https://dot.net/v1/dotnet-install.sh  for .NET 7.0.2xx and add 7.0.3xx.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)