### PR TITLE
disable cache test for 7.0.3 

### DIFF
--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
             CanSearch(workingDirectory, metadataPath);
 
             //7.0.300
-            sdkVersion = "7.0.300";
+            sdkVersion = "7.0.300-preview.23068.14";
             workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
             UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "7.0.3", rollForward: "latestPatch");
             Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/CacheFileTests.cs
@@ -83,14 +83,15 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
             Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
             CanSearch(workingDirectory, metadataPath);
 
+            // TODO enable then stable version is available
             //7.0.300
-            sdkVersion = "7.0.300-preview.23068.14";
-            workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
-            UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "7.0.3", rollForward: "latestPatch");
-            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
-            CanSearch(workingDirectory, legacyMetadataPath);
-            Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
-            CanSearch(workingDirectory, metadataPath);
+            //sdkVersion = "7.0.300";
+            //workingDirectory = TestUtils.CreateTemporaryFolder(sdkVersion);
+            //UseSdkVersion(workingDirectory, requestedSdkVersion: sdkVersion, resolvedVersionPattern: "7.0.3", rollForward: "latestPatch");
+            //Console.WriteLine($"Running tests on .NET {sdkVersion} for: {legacyMetadataPath}.");
+            //CanSearch(workingDirectory, legacyMetadataPath);
+            //Console.WriteLine($"Running tests on .NET {sdkVersion} for: {metadataPath}.");
+            //CanSearch(workingDirectory, metadataPath);
 
             //latest
             workingDirectory = TestUtils.CreateTemporaryFolder("latest");


### PR DESCRIPTION
### Problem
Adding 7.0.300 version to the test caused caching pipeline failure because preview only is available now

### Solution
Temporarily disable the cache test for 7.0.300 version

### Checks:
- [ N/A] Added unit tests
- [ N/A] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)