### PR TITLE
changed image for search cache pipeline

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -17,7 +17,7 @@ parameters:
 
 pool:
   name: NetCore1ESPool-Internal
-  demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
+  demands: ImageOverride -equals 1es-ubuntu-2004
 
 steps:
 - checkout: self


### PR DESCRIPTION
### Problem
search cache pipeline is not working for last 2 days.

### Solution
applied workaround suggested by engineering - change image for the job.
This has helped: https://dev.azure.com/dnceng/internal/_build/results?buildId=2110149&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=356bb04c-cb4a-5f04-82ca-d3b102917eba