### PR TITLE
Fix typo in Introduction

### DIFF
--- a/docs/Conditional-processing-and-comment-syntax.md
+++ b/docs/Conditional-processing-and-comment-syntax.md
@@ -40,7 +40,7 @@
 
 ## Introduction
 
-To add conditional, or dynamic, content you can add Template Enging expressions in your source files. The conditional expression let you to include or exclude part of the file according to a specified condition, and to do this you can use the familiar conditional expressions like **#if**, **#else**, **#elseif**, **#endif**.
+To add conditional, or dynamic, content you can add Template Engine expressions in your source files. The conditional expression let you to include or exclude part of the file according to a specified condition, and to do this you can use the familiar conditional expressions like **#if**, **#else**, **#elseif**, **#endif**.
 
 To learn more about conditional expressions evaluation go to [Conditions](Conditions.md) description.
 


### PR DESCRIPTION

### Problem
There is a typo in the Introduction on the conditional processing and comment syntax doc.

### Solution
Fixed the typo! : "you can add Template Enging" -> "you can add Template Engine"

### Checks:
N/A