### PR TITLE
Check the availability of global settings file

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/Installer/InstallerErrorCode.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Installer/InstallerErrorCode.cs
@@ -51,6 +51,16 @@ namespace Microsoft.TemplateEngine.Abstractions.Installer
         /// <summary>
         /// The requested package is invalid and cannot be processed.
         /// </summary>
-        InvalidPackage = 8
+        InvalidPackage = 8,
+
+        /// <summary>
+        /// Global settings file is unavailable due to some reason.
+        /// </summary>
+        UnavailableGlobalSettings = 9,
+
+        /// <summary>
+        /// Global settings file is corrupted after the operation including install, uninstall and update.
+        /// </summary>
+        CorruptedGlobalSettings = 10
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Shipped.txt
@@ -66,12 +66,14 @@ Microsoft.TemplateEngine.Abstractions.Installer.IInstallerFactory
 Microsoft.TemplateEngine.Abstractions.Installer.InstallerConstants
 Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
 Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode.AlreadyInstalled = 6 -> Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
+Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode.CorruptedGlobalSettings = 10 -> Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
 Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode.DownloadFailed = 3 -> Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
 Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode.GenericError = 5 -> Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
 Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode.InvalidPackage = 8 -> Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
 Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode.InvalidSource = 2 -> Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
 Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode.PackageNotFound = 1 -> Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
 Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode.Success = 0 -> Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
+Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode.UnavailableGlobalSettings = 9 -> Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
 Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode.UnsupportedRequest = 4 -> Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
 Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode.UpdateUninstallFailed = 7 -> Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
 Microsoft.TemplateEngine.Abstractions.Installer.InstallerOperationResult

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
@@ -241,6 +241,24 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Global settings file {0} was corrupted after the operation..
+        /// </summary>
+        internal static string GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings {
+            get {
+                return ResourceManager.GetString("GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Global settings file {0} is unavailable due to some reason..
+        /// </summary>
+        internal static string GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings {
+            get {
+                return ResourceManager.GetString("GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} can be installed by several installers. Specify the installer name to be used..
         /// </summary>
         internal static string GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed {

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -395,4 +395,10 @@ Template cache will be recreated on the next run.</value>
     <value>'IWorkloadsInfoProvider' component provided by host provided some duplicated workloads (duplicates: {0}). Duplicates will be skipped.</value>
     <comment>{0} is the list of duplicates</comment>
   </data>
+  <data name="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings" xml:space="preserve">
+    <value>Global settings file {0} was corrupted after the operation.</value>
+  </data>
+  <data name="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings" xml:space="preserve">
+    <value>Global settings file {0} is unavailable due to some reason.</value>
+  </data>
 </root>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -105,6 +105,16 @@
         <target state="translated">verze {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">Balíček {0} může nainstalovat několik různých instalačních programů. Určete název instalačního programu, který se má použít.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -105,6 +105,16 @@
         <target state="translated">Version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">\"{0}\" kann von mehreren Installern installiert werden. Geben Sie den Namen des zu verwendenden Installers an.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -105,6 +105,16 @@
         <target state="translated">versión {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">Se puede instalar {0} con varios instaladores. Especifique el nombre del instalador que va a usar.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -105,6 +105,16 @@
         <target state="translated">version {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">{0} peut être installé par plusieurs programmes d’installation. Spécifiez le nom du programme d’installation à utiliser.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -105,6 +105,16 @@
         <target state="translated">versione {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">{0} può essere installato da diversi programmi di installazione. Specificare il nome del programma di installazione da utilizzare.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -105,6 +105,16 @@
         <target state="translated">バージョン {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">{0} は複数のインストーラーでインストールできます。使用するインストーラー名を指定します。</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -105,6 +105,16 @@
         <target state="translated">버전 {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">{0}은(는) 여러 설치 관리자가 설치할 수 있습니다. 사용할 설치 관리자 이름을 지정합니다.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -105,6 +105,16 @@
         <target state="translated">wersja: {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">{0} mogą być instalowane przez kilka instalatorów. Określ nazwę instalatora, która ma być używana.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -105,6 +105,16 @@
         <target state="translated">versão {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">{0} pode ser instalado por vários instaladores. Especifique o nome do instalador a ser utilizado.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -105,6 +105,16 @@
         <target state="translated">версия {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">{0} можно установить с помощью нескольких установщиков. Укажите имя используемого установщика.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -105,6 +105,16 @@
         <target state="translated">sürüm {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">{0}, birkaç yükleyiciyle yüklenebilir. Kullanılacak yükleyici adını belirtin.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -105,6 +105,16 @@
         <target state="translated">版本 {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">可由多个安装程序安装 {0}。请指定要使用的安装程序名称。</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -105,6 +105,16 @@
         <target state="translated">版本 {0}</target>
         <note>small letters, string is used in the sentence</note>
       </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_CorruptedGlobalSettings">
+        <source>Global settings file {0} was corrupted after the operation.</source>
+        <target state="new">Global settings file {0} was corrupted after the operation.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="GlobalSettingsTemplatePackageProvider_GlobalSettings_Error_UnavailableGlobalSettings">
+        <source>Global settings file {0} is unavailable due to some reason.</source>
+        <target state="new">Global settings file {0} is unavailable due to some reason.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed">
         <source>{0} can be installed by several installers. Specify the installer name to be used.</source>
         <target state="translated">{0} 可由多個安裝程式安裝。指定要使用的安裝程式名稱。</target>


### PR DESCRIPTION
### Problem
#5972

### Solution
1. Check the availability of global settings file before and after the operations to detect any corruption and return the error in operation result.
2. Report the error according to the error in operation result. (Pending to do in another PR in SDK repo)

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)