### PR TITLE
Improve the message for corrupted global settings file

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Installer;
 using Microsoft.TemplateEngine.Edge.Settings;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
@@ -98,6 +99,11 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
                     }
 
                     return packages;
+                }
+                catch (JsonReaderException ex)
+                {
+                    var wrappedEx = new JsonReaderException(string.Format(LocalizableStrings.GlobalSettings_Error_CorruptedSettings, _globalSettingsFile, ex.Message), ex);
+                    throw wrappedEx;
                 }
                 catch (Exception)
                 {

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
@@ -241,6 +241,15 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}..
+        /// </summary>
+        internal static string GlobalSettings_Error_CorruptedSettings {
+            get {
+                return ResourceManager.GetString("GlobalSettings_Error_CorruptedSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} can be installed by several installers. Specify the installer name to be used..
         /// </summary>
         internal static string GlobalSettingsTemplatePackageProvider_InstallResult_Error_MultipleInstallersCanBeUsed {

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -410,5 +410,8 @@ The template from 'PACKAGE_ID' will be used. To resolve this conflict, uninstall
     <value>  {0} '{1}' from '{2}'</value>
     <comment>* 'TEMPLATE' from 'PACKAGE_ID'</comment>
   </data>
+  <data name="GlobalSettings_Error_CorruptedSettings" xml:space="preserve">
+    <value>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</value>
+  </data>
 </root>
 

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -130,6 +130,11 @@
         <target state="translated">Balíček {0} se úspěšně odinstaloval.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">{0} nemá povinnou vlastnost {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -130,6 +130,11 @@
         <target state="translated">\"{0}\" wurde erfolgreich deinstalliert.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">„{0}“ weist keine obligatorische Eigenschaft „{1}“ auf.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -130,6 +130,11 @@
         <target state="translated">{0} se desinstaló correctamente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">'{0}' no tiene la propiedad obligatoria '{1}'.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -130,6 +130,11 @@
         <target state="translated">{0} a été désinstallé.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">'{0}' n’a pas de propriété obligatoire '{1}'.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -130,6 +130,11 @@
         <target state="translated">{0} è stato disinstallato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">'{0}' non ha la proprietà obbligatoria '{1}'.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -130,6 +130,11 @@
         <target state="translated">{0} が正常にアンインストールされました。</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">'{0}' には必須のプロパティ '{1}' がありません。</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -130,6 +130,11 @@
         <target state="translated">{0}이(가) 성공적으로 제거되었습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">'{0}'에 '{1}' 필수 속성이 없습니다.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -130,6 +130,11 @@
         <target state="translated">Pomyślnie odinstalowano pakiet {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">Element „{0}” nie ma obowiązkowej właściwości „{1}”.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -130,6 +130,11 @@
         <target state="translated">{0} foi desinstalado com sucesso.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">'{0}' não tem propriedade obrigatória '{1}'.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -130,6 +130,11 @@
         <target state="translated">Выполнено удаление {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">«{0}» не имеет обязательного свойства «{1}».</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -130,6 +130,11 @@
         <target state="translated">{0} başarıyla kaldırıldı.</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">'{0}', zorunlu '{1}' özelliğine sahip değil.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -130,6 +130,11 @@
         <target state="translated">已成功卸载 {0}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">\"{0}\" 没有必需属性 \"{1}\" 。</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -130,6 +130,11 @@
         <target state="translated">{0} 已成功解除安裝。</target>
         <note />
       </trans-unit>
+      <trans-unit id="GlobalSettings_Error_CorruptedSettings">
+        <source>Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</source>
+        <target state="new">Failed to read installed template packages list at {0}. It might be due to the file is corrupted. Please review this file manually and fix the errors in JSON structure, or remove the file to clear up the list of list installed packages and reinstall them again. Details of the error: {1}.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostConstraint_Error_MissingMandatoryProperty">
         <source>'{0}' does not have mandatory property '{1}'.</source>
         <target state="translated">'{0}' 沒有強制屬性 '{1}'。</target>


### PR DESCRIPTION
### Problem
#5972

### Solution
Improve the error message with details and the guide how to resolve manually.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)