### PR TITLE
Trim away netframework targets in source-build

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <GitHubRepositoryName>templating</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+    <SourceBuildTrimNetFrameworkTargets>true</SourceBuildTrimNetFrameworkTargets>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
# Trim away netframework targets in source-build

This is part of the source-build work to enable trimming of net4* targets. Parent repos (`installer` and `sdk`) have been updated, so the next step is to update dependencies, like `templating`.

## Description

Trim away netframework targets in source-build

Fixes: https://github.com/dotnet/templating/issues/5192