### PR TITLE
file renames in post action arguments PoC

### DIFF
--- a/docs/Post-Action-Registry.md
+++ b/docs/Post-Action-Registry.md
@@ -20,6 +20,8 @@ The standard properties are listed below.
    - `configFile` (string) (optional): Additional configuration for the associated post action. The structure & content will vary based on the post action.
    - <a name="continueOnError"></a>`continueOnError` (bool) (optional): If this action fails, the value of continueOnError indicates whether to process the next action, or stop processing the post actions. Should be set to true when subsequent actions rely on the result of the current action. The default value is false.
    - `manualInstructions` (array) (optional): An ordered list of possible instructions to display if the action cannot be performed. Each element in the list must contain a key named "text", whose value contains the instructions. Each element may also optionally provide a key named "condition" - a boolean expression. The first instruction with blank condition is considered a default. If true conditions are present, the last one of them will be considered valid, all other ignored. It is recommended not to have more than one true condition at the time.
+   - `applyFileRenamesToArgs` (array) (optional): A list of arguments names from 'args' to which the file renames configured in symbols should be applied. By default, the file renames are not applied. Available since .NET SDK 8.0.100.
+   - `applyFileRenamesToManualInstructions` (boolean) (optional): If set to true, the file renames configured in symbols should be applied to manual instructions. By default, the file renames are not applied. Available since .NET SDK 8.0.100.
 
 # Restore NuGet packages
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/DirectoryBasedTemplate.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/DirectoryBasedTemplate.cs
@@ -58,8 +58,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             ConfigurationModel = TemplateConfigModel.FromJObject(
                 MergeAdditionalConfiguration(templateFile.ReadJObjectFromIFile(), templateFile),
                 Logger,
-                baselineName,
-                filename: templateFile.GetDisplayPath());
+                baselineName);
             CheckGeneratorVersionRequiredByTemplate();
         }
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.Designer.cs
@@ -61,6 +61,42 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Id of the post action &apos;{0}&apos; at index &apos;{1}&apos; is not unique. Only the first post action that uses this id will be localized..
+        /// </summary>
+        internal static string Authoring_CONFIG0201_PostActionIdIsNotUnique {
+            get {
+                return ResourceManager.GetString("Authoring_CONFIG0201_PostActionIdIsNotUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Post action at index &apos;{0}&apos; should have an &apos;actionId&apos; to declare the action to be executed..
+        /// </summary>
+        internal static string Authoring_CONFIG0202_PostActionMustHaveActionId {
+            get {
+                return ResourceManager.GetString("Authoring_CONFIG0202_PostActionMustHaveActionId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;id&apos; of the manual instruction &apos;{0}&apos; at index {1} is not unique. Only the first manual instruction that uses this id will be localized..
+        /// </summary>
+        internal static string Authoring_CONFIG0203_ManualInstructionIdIsNotUnique {
+            get {
+                return ResourceManager.GetString("Authoring_CONFIG0203_ManualInstructionIdIsNotUnique", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The argument &apos;{0}&apos; configured in &apos;{1}&apos; is not listed in &apos;{2}&apos; and will be skipped for processing..
+        /// </summary>
+        internal static string Authoring_CONFIG0204_UnknownArgumentForReplace {
+            get {
+                return ResourceManager.GetString("Authoring_CONFIG0204_UnknownArgumentForReplace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Localization file should only contain elements with type &apos;string&apos;. Remove elements that are not strings..
         /// </summary>
         internal static string Authoring_InvalidJsonElementInLocalizationFile {
@@ -115,15 +151,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;id&apos; of the manual instruction &apos;{0}&apos; at index {1} is not unique. Only the first manual instruction that uses this id will be localized..
-        /// </summary>
-        internal static string Authoring_ManualInstructionIdIsNotUnique {
-            get {
-                return ResourceManager.GetString("Authoring_ManualInstructionIdIsNotUnique", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Missing &apos;{0}&apos;..
         /// </summary>
         internal static string Authoring_MissingValue {
@@ -138,24 +165,6 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects {
         internal static string Authoring_NonBoolDataTypeForRegexMatch {
             get {
                 return ResourceManager.GetString("Authoring_NonBoolDataTypeForRegexMatch", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to [{0}]: id of the post action &apos;{1}&apos; at index &apos;{2}&apos; is not unique. Only the first post action that uses this id will be localized..
-        /// </summary>
-        internal static string Authoring_PostActionIdIsNotUnique {
-            get {
-                return ResourceManager.GetString("Authoring_PostActionIdIsNotUnique", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to [{0}]: Post action at index &apos;{1}&apos; should have an &apos;actionId&apos; to declare the action to be executed..
-        /// </summary>
-        internal static string Authoring_PostActionMustHaveActionId {
-            get {
-                return ResourceManager.GetString("Authoring_PostActionMustHaveActionId", resourceCulture);
             }
         }
         

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizableStrings.resx
@@ -117,6 +117,24 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Authoring_CONFIG0201_PostActionIdIsNotUnique" xml:space="preserve">
+    <value>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</value>
+    <comment>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</comment>
+  </data>
+  <data name="Authoring_CONFIG0202_PostActionMustHaveActionId" xml:space="preserve">
+    <value>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</value>
+    <comment>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</comment>
+  </data>
+  <data name="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique" xml:space="preserve">
+    <value>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</value>
+    <comment>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</comment>
+  </data>
+  <data name="Authoring_CONFIG0204_UnknownArgumentForReplace" xml:space="preserve">
+    <value>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</value>
+  </data>
   <data name="Authoring_InvalidJsonElementInLocalizationFile" xml:space="preserve">
     <value>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</value>
   </data>
@@ -139,26 +157,11 @@
   <data name="Authoring_MalformedPostActionManualInstructions" xml:space="preserve">
     <value>One or more postActions have a malformed or missing manualInstructions value.</value>
   </data>
-  <data name="Authoring_ManualInstructionIdIsNotUnique" xml:space="preserve">
-    <value>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</value>
-    <comment>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</comment>
-  </data>
   <data name="Authoring_MissingValue" xml:space="preserve">
     <value>Missing '{0}'.</value>
   </data>
   <data name="Authoring_NonBoolDataTypeForRegexMatch" xml:space="preserve">
     <value>A non-bool DataType was specified for a regexMatch type symbol</value>
-  </data>
-  <data name="Authoring_PostActionIdIsNotUnique" xml:space="preserve">
-    <value>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</value>
-    <comment>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</comment>
-  </data>
-  <data name="Authoring_PostActionMustHaveActionId" xml:space="preserve">
-    <value>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</value>
-    <comment>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</comment>
   </data>
   <data name="Authoring_SourceDoesNotExist" xml:space="preserve">
     <value>Source '{0}' in template does not exist.</value>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostAction.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PostAction.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core;
@@ -31,8 +32,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
         public IReadOnlyDictionary<string, string> Args { get; } = new Dictionary<string, string>();
 
-        internal static List<IPostAction> Evaluate(ILogger logger, IReadOnlyList<PostActionModel> modelList, IVariableCollection rootVariableCollection)
+        internal static List<IPostAction> Evaluate(
+            IEngineEnvironmentSettings environmentSettings,
+            IReadOnlyList<PostActionModel> modelList,
+            IVariableCollection rootVariableCollection,
+            FileRenameGenerator renameGenerator)
         {
+            ILogger logger = environmentSettings.Host.Logger;
             List<IPostAction> actionList = new();
 
             rootVariableCollection ??= new VariableCollection();
@@ -60,23 +66,37 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                             {
                                 // No condition, and no instruction previously chosen. Take this one.
                                 // We don't want a default instruction to override a conditional one.
-                                chosenInstruction = modelInstruction.Text;
+                                chosenInstruction =
+                                    model.ApplyFileRenamesToManualInstructions
+                                        ? renameGenerator.ApplyRenameToString(modelInstruction.Text)
+                                        : modelInstruction.Text;
                             }
                         }
                         else if (modelInstruction.EvaluateCondition(logger, rootVariableCollection))
                         {
-                            // condition is not blank and true, take this one. This results in a last-in-wins behaviour for conditions that are true.
-                            chosenInstruction = modelInstruction.Text;
+                            // condition is not blank and true, take this one. This results in a last-in-wins behavior for conditions that are true.
+                            chosenInstruction =
+                                model.ApplyFileRenamesToManualInstructions
+                                    ? renameGenerator.ApplyRenameToString(modelInstruction.Text)
+                                    : modelInstruction.Text;
                         }
                     }
                 }
 
+                Dictionary<string, string> processedArgs = new();
+
+                foreach (KeyValuePair<string, string> arg in model.Args)
+                {
+                    processedArgs[arg.Key] = model.ApplyFileRenamesToArgs.Contains(arg.Key, StringComparer.OrdinalIgnoreCase)
+                        ? renameGenerator.ApplyRenameToString(arg.Value)
+                        : arg.Value;
+                }
                 IPostAction postAction = new PostAction(
                     model.Description,
                     chosenInstruction,
                     model.ActionId,
                     model.ContinueOnError,
-                    model.Args);
+                    processedArgs);
 
                 actionList.Add(postAction);
             }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PrimaryOutput.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PrimaryOutput.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core;
-using Microsoft.TemplateEngine.Core.Contracts;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
@@ -27,9 +26,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             IEngineEnvironmentSettings environmentSettings,
             IReadOnlyList<PrimaryOutputModel> modelList,
             IVariableCollection rootVariableCollection,
-            string? sourceName,
-            object? resolvedName,
-            IReadOnlyList<IReplacementTokens>? filenameReplacements)
+            FileRenameGenerator renameGenerator)
         {
             List<ICreationPath> pathList = new();
 
@@ -44,13 +41,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                     continue;
                 }
 
-                string resolvedPath = FileRenameGenerator.ApplyRenameToPrimaryOutput(
-                                        model.Path,
-                                        environmentSettings,
-                                        sourceName,
-                                        resolvedName,
-                                        rootVariableCollection,
-                                        filenameReplacements);
+                string resolvedPath = renameGenerator.ApplyRenameToString(model.Path);
 
                 ICreationPath path = new PrimaryOutput(resolvedPath);
                 pathList.Add(path);

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/PublicAPI.Unshipped.txt
@@ -7,5 +7,7 @@ Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro<T>
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Abstractions.IMacro<T>.Evaluate(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! environmentSettings, Microsoft.TemplateEngine.Abstractions.IVariableCollection! variables, T config) -> void
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.BindSymbol.DataType.get -> string?
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.ConditionedConfigurationElement.EvaluateCondition(Microsoft.Extensions.Logging.ILogger! logger, Microsoft.TemplateEngine.Abstractions.IVariableCollection! variables) -> bool
+Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.PostActionModel.ApplyFileRenamesToArgs.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.PostActionModel.ApplyFileRenamesToManualInstructions.get -> bool
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.TemplateConfigModel.Identity.get -> string!
 Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.TemplateConfigModel.PreferDefaultName.get -> bool

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectConfig.cs
@@ -234,15 +234,24 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 
             _sources = EvaluateSources(rootVariableCollection, resolvedNameParamValue);
 
+            FileRenameGenerator renameGenerator = new(
+                EngineEnvironmentSettings,
+                ConfigurationModel.SourceName,
+                resolvedNameParamValue,
+                rootVariableCollection,
+                SymbolFilenameReplacements);
+
             _evaluatedPrimaryOutputs = PrimaryOutput.Evaluate(
                 EngineEnvironmentSettings,
                 ConfigurationModel.PrimaryOutputs,
                 rootVariableCollection,
-                ConfigurationModel.SourceName,
-                resolvedNameParamValue,
-                SymbolFilenameReplacements);
+                renameGenerator);
 
-            _evaluatedPostActions = PostAction.Evaluate(EngineEnvironmentSettings.Host.Logger, ConfigurationModel.PostActionModels, rootVariableCollection);
+            _evaluatedPostActions = PostAction.Evaluate(
+                EngineEnvironmentSettings,
+                ConfigurationModel.PostActionModels,
+                rootVariableCollection,
+                renameGenerator);
         }
 
         /// <summary>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
@@ -476,6 +476,18 @@
                 "description": "Defines identifier to be used when localizing the post action artifacts.",
                 "type": "string"
               },
+              "applyFileRenamesToArgs": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "A list of arguments names from 'args' to which the file renames configured in symbols should be applied."
+              },
+              "applyFileRenamesToManualInstructions": {
+                "description": "If set to true, the file renames configured in symbols should be applied to manual instructions.",
+                "type": "boolean",
+                "default": false
+              },
               "manualInstructions": {
                 "description": "An ordered list of possible instructions to display if the action cannot be performed. Each element in the list must contain a key named \"text\", whose value contains the instructions. Each element may also optionally provide a key named \"condition\" - a Boolean evaluate-able string. The first instruction whose condition is false or blank will be considered valid, all others are ignored.",
                 "type": "array",

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Validation/MandatoryValidationFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Validation/MandatoryValidationFactory.cs
@@ -115,6 +115,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.Validation
             public void ValidateTemplate(ITemplateValidationInfo templateValidationInfo)
             {
                 _validationChecks.ForEach(check => check.Process(templateValidationInfo));
+                templateValidationInfo.ConfigModel.ValidationErrors.ForEach(templateValidationInfo.AddValidationError);
             }
 
             private class TemplateSourcesCheck : BaseValidationCheck

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.cs.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">Soubor lokalizace by měl obsahovat pouze prvky typu řetězec“. Odeberte prvky, které nejsou typu řetězec.</target>
@@ -33,12 +56,6 @@
         <target state="translated">Nejméně jedna akce publikování postAction má poškozenou nebo chybějící hodnotu manualInstructions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">ID manuální instrukce {0} v indexu {1} není jedinečné. Lokalizuje se jen první manuální instrukce, která používá toto ID.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">Chybí {0}.</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">Pro symbol typu regexMatch se zadal typ DataType, který není logický.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">[{0}]: ID akce publikování {1} v indexu {2} není jedinečné. Lokalizuje se jen první akce publikování, která používá toto ID.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}]: Akce publikování u indexu {1} by měla mít hodnotu actionId deklarující akci, která se má provést.</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.de.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">Die Datei Lokalisierungsdatei darf nur Elemente mit dem Typ „Zeichenfolge“ enthalten. Entfernen Sie die Elemente, die keine Zeichenfolgen sind.</target>
@@ -33,12 +56,6 @@
         <target state="translated">Eine oder mehrere postActions weisen einen nicht wohlgeformten oder fehlenden „manualInstructions“-Wert auf.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">Die ID der manuellen Anweisung „{0}“ im Index {1} ist nicht eindeutig. Nur die erste manuelle Anweisung mit dieser ID wird lokalisiert.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">„{0}“ fehlt.</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">Für ein regexMatch-Typsymbol wurde ein Nicht-Boolesche-Datentyp angegeben.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">[{0}]: Die ID der POST-AKTION „{1}“ im Index „{2}“ ist nicht eindeutig. Nur die erste POST-Aktion, die diese ID verwendet, wird lokalisiert.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}]: die POST-Aktion im Index „{1}“ muss über eine „actionId“ verfügen, um die Aktion auszuführen.</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.es.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">El archivo de localización solo debería contener elementos con el tipo \"string\". Quite los elementos que no sean cadenas.</target>
@@ -33,12 +56,6 @@
         <target state="translated">Una o varias postActions tienen un valor manualInstructions con un formato incorrecto o faltante.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">El Id. de la instrucción manual \"{0}\" en el índice {1} no es único. Solo se localizará la primera instrucción manual que use este Id.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">Falta \"{0}\".</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">Se especificó un tipo de datos no booleano para un símbolo de tipo regexMatch</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">[{0}]: El Id. de la acción post \"{1}\" en el índice \"{2}\" no es único. Solo se localizará la primera acción post que use este Id.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}]: la acción post en el índice \"{1}\" debe tener un \"actionId\" para declarar la acción que se va a ejecutar.</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.fr.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">Le fichier de localisation doit contenir uniquement des éléments de type « chaîne ». Supprimez les éléments qui ne sont pas des chaînes.</target>
@@ -33,12 +56,6 @@
         <target state="translated">Une ou plusieurs postActions ont une valeur manualInstructions incorrecte ou manquante.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">«ID» de l’instruction manuelle «{0}» à l’index {1} n’est pas unique. Seule la première instruction manuelle qui utilise cet ID sera localisée.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">«{0}» manquant.</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">Un type de données non booléen a été spécifié pour un symbole de type regexMatch</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">[{0}] : l’ID de l’action de publication «{1}» à l’index «{2}» n’est pas unique. Seule la première action de publication qui utilise cet ID sera localisée.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}] : l’action de publication à l’index «{1}» doit avoir un 'actionId' pour déclarer l’action à exécuter.</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.it.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">Il file di localizzazione deve contenere solo elementi con tipo 'stringa'. Rimuovere gli elementi che non sono stringhe.</target>
@@ -33,12 +56,6 @@
         <target state="translated">Una o più postActions presentano un valore non valido o mancante.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">L''id' dell'istruzione manuale '{0}' in corrispondenza dell'indice {1} non è univoco. Solo la prima istruzione manuale che usa questo id verrà localizzata.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">Autorizzazione '{0}' mancante.</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">È stato specificato un tipo di dati non bool per un simbolo di tipo regexMatch</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">[{0}]: l’id dell'azione di pubblicazione '{1}' in corrispondenza dell'indice '{2}' non è univoco. Solo la prima azione di pubblicazione che usa questo id verrà localizzata.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}]: l'azione successiva all'indice '{1}' deve avere un'actionId ' per dichiarare l'azione da eseguire.</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ja.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">ローカライズ ファイルには、'string' 型の要素のみを含める必要があります。文字列以外の要素を削除してください。</target>
@@ -33,12 +56,6 @@
         <target state="translated">manualInstructions 値が正しくないか、または不足している postActions が一つ以上あります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">インデックス {1} の手動手順 {0} の 'ID' が一意ではありません。この ID を使用する最初の手動手順のみがローカライズされます。</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">'{0}' がありません。</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">ブール型ではない regexMatch 型のシンボルが指定されました</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">[{0}]: インデックス '{2}' の事後アクション '{1}' の ID が一意ではありません。この ID を使用する最初の事後アクションのみがローカライズされます。</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}]: インデックス '{1}' の事後アクションは、実行するアクションを宣言するために 'actionId' を含んでいなければなりません。</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ko.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">현지화 파일에는 ‘문자열’ 형식의 요소만 포함되어야 합니다. 문자열이 아닌 요소를 제거하세요.</target>
@@ -33,12 +56,6 @@
         <target state="translated">하나 이상의 postActions에 잘못된 형식의 수동 지침 값이 있거나 누락된 수동 지침 값이 있습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">인덱스 {1}에 있는 수동 명령 '{0}'의 'id'가 고유하지 않습니다. 이 ID를 사용하는 첫 번째 수동 명령만 현지화됩니다.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">'{0}'이(가) 없습니다.</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">regexMatch 유형 기호에 bool이 아닌 데이터 유형이 지정되었습니다.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">인덱스 ‘{2}’에서 게시 작업 ‘{1}’의 [{0}] ID가 고유하지 않습니다. 이 ID를 사용하는 첫 번째 게시 작업만 현지화됩니다.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}]: 인덱스 '{1}'의 게시 작업에는 실행할 작업을 선언하는 'actionId'가 있어야 합니다.</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pl.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">Plik lokalizacji powinien zawierać tylko elementy typu „ciąg”. Usuń elementy, które nie są ciągami.</target>
@@ -33,12 +56,6 @@
         <target state="translated">Co najmniej jeden element postActions ma źle sformułowaną lub brakującą wartość manualInstructions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">Identyfikator instrukcji ręcznej „{0}” pod indeksem {1} nie jest unikatowy. Zlokalizowana zostanie tylko pierwsza instrukcja ręczna, która używa tego identyfikatora.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">Brak elementu „{0}”.</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">Dla symbolu typu regexMatch określono nielogiczny typ danych.</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">[{0}]: identyfikator akcji publikowania „{1}” pod indeksem „{2}” nie jest unikatowy. Tylko pierwsza akcja publikowania, która używa tego identyfikatora, zostanie zlokalizowana.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}]: akcja publikowania pod indeksem „{1}” powinna mieć identyfikator „actionId”, aby zadeklarować akcję do wykonania.</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">O arquivo de localização deve conter somente elementos com o tipo 'cadeia de caracteres'. Remova elementos que não são cadeia de caracteres.</target>
@@ -33,12 +56,6 @@
         <target state="translated">Uma ou mais ações posteriores têm um valor de instruções manuais malformadas ou ausentes.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">'id' da instrução manual '{0}' no índice {1} não é exclusiva. Apenas a primeira instrução manual que usa esta id será localizada.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">'{0}' ausente.</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">Um DataType não booleano foi especificado para um símbolo de tipo regexMatch</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">[{0}]: a id da ação posterior '{1}' no índice '{2}' não é exclusiva. Apenas a primeira ação posterior que usa essa id será localizada.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}]: A ação posterior no índice '{1}' deve ter um 'actionId' para declarar a ação a ser executada.</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.ru.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">Файл локализации должен содержать только элементы типа \"строка\". Удалите элементы, которые не являются строками.</target>
@@ -33,12 +56,6 @@
         <target state="translated">Одно или несколько postActions имеют неправильное или отсутствующее значение manualInstructions.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">Идентификатор инструкции для выполнения вручную \"{0}\" по индексу {1} не является уникальным. Будет локализована только первая инструкция, использующая этот идентификатор.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">Отсутствует \"{0}\".</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">Для символа типа regexMatch был указан не-bool DataType</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">[{0}]: идентификатор операции POST \"{1}\" по индексу \"{2}\" не является уникальным. Будет локализована только первая операция POST, использующая этот идентификатор.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}]: операция POST по индексу \"{1}\" должна иметь \"actionId\", чтобы объявить выполняемое действие.</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.tr.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">Yerelleştirme dosyası yalnızca ‘dize’ türünde öğeler içermelidir. Dize olmayan öğeleri kaldırın.</target>
@@ -33,12 +56,6 @@
         <target state="translated">Bir veya daha fazla postActions öğesinin hatalı biçimlendirilmiş veya eksik bir değeri var.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">‘{1}‘ dizininde bulunan ‘{0}’ el ile yönergesinin ‘kimliği’ benzersiz değil. Yalnızca bu kimliği kullanan ilk el ile yönerge yerelleştirilecek.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">'{0}' eksik.</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">Bir regexMatch türü sembol için Boole olmayan bir DataType belirtildi</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">[{0}]: '{2}' dizinindeki ‘{1}’ gönderme eyleminin kimliği benzersiz değil. Yalnızca bu kimliği kullanan ilk gönderme eylemi yerelleştirilecek.</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}]: '{1}' dizinindeki gönderme eyleminin, yürütülecek eylemi bildirmek için bir 'actionId' değerine sahip olması gerekir.</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">本地化文件仅应包含类型为“字符串”的元素。请删除不是字符串的元素。</target>
@@ -33,12 +56,6 @@
         <target state="translated">一个或多个 postActions 中具有格式错误的 manualInstructions 值或缺少该值。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">索引 {1} 处的手动指令“{0}”的 ID 不唯一。将仅本地化使用此 ID 的第一个手动指令。</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">缺少“{0}”。</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">已为 regexMatch 类型符号指定非布尔数据类型</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">[{0}]:索引 {2} 处发布操作“{1}”的 id 不唯一。将仅本地化使用此 ID 的第一个发布操作。</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}]: 索引 “{1}” 处的发布操作应具有“actionId”以声明要执行的操作。</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,6 +2,29 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
+      <trans-unit id="Authoring_CONFIG0201_PostActionIdIsNotUnique">
+        <source>Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</source>
+        <target state="new">Id of the post action '{0}' at index '{1}' is not unique. Only the first post action that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
+{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0202_PostActionMustHaveActionId">
+        <source>Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</source>
+        <target state="new">Post action at index '{0}' should have an 'actionId' to declare the action to be executed.</target>
+        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
+Do not localize: actionId</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0203_ManualInstructionIdIsNotUnique">
+        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
+        <target state="new">'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</target>
+        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
+{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
+      </trans-unit>
+      <trans-unit id="Authoring_CONFIG0204_UnknownArgumentForReplace">
+        <source>The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</source>
+        <target state="new">The argument '{0}' configured in '{1}' is not listed in '{2}' and will be skipped for processing.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Authoring_InvalidJsonElementInLocalizationFile">
         <source>Localization file should only contain elements with type 'string'. Remove elements that are not strings.</source>
         <target state="translated">當地語系化檔案應只包含類型為 'string' 的元素。請移除非字串的元素。</target>
@@ -33,12 +56,6 @@
         <target state="translated">一或多個 postActions 具有格式錯誤或遺漏 manualInstructions 值。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Authoring_ManualInstructionIdIsNotUnique">
-        <source>'id' of the manual instruction '{0}' at index {1} is not unique. Only the first manual instruction that uses this id will be localized.</source>
-        <target state="translated">位於索引 {1} 之手動指令 '{0}' 的 'id' 不是唯一的。系統只會將使用此識別碼的第一個手動指令當地語系化。</target>
-        <note>{0} is any identifier string that user provided in the file. Such as: "myInstruction", "firstInstruction", "instruction1" etc.
-{1} is a whole number representing the zero-based index of the manual instruction. Such as "5", or "0".</note>
-      </trans-unit>
       <trans-unit id="Authoring_MissingValue">
         <source>Missing '{0}'.</source>
         <target state="translated">缺少 '{0}'。</target>
@@ -48,18 +65,6 @@
         <source>A non-bool DataType was specified for a regexMatch type symbol</source>
         <target state="translated">已針對 RegExMatch 類型符號指定非布林值 DataType</target>
         <note />
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionIdIsNotUnique">
-        <source>[{0}]: id of the post action '{1}' at index '{2}' is not unique. Only the first post action that uses this id will be localized.</source>
-        <target state="translated">[{0}]: 位於索引 '{2}' 之張貼動作 '{1}' 的識別碼不是唯一的。系統只會將使用此識別碼的第一個張貼動作當地語系化。</target>
-        <note>{0} is any identifier string that user provided in the file. Such as "myPostAction", "firstPostAction", "postAction1" etc.
-{1} is a number representing the zero-based index of the post action. Such as "5", or "0".</note>
-      </trans-unit>
-      <trans-unit id="Authoring_PostActionMustHaveActionId">
-        <source>[{0}]: Post action at index '{1}' should have an 'actionId' to declare the action to be executed.</source>
-        <target state="translated">[{0}]: 在索引 '{1}' 張貼動作應該有 'actionId' 來宣告要執行的動作。</target>
-        <note>{0} is a whole number representing the zero-based index of the post action. Such as "5" or "0".
-Do not localize: actionId</note>
       </trans-unit>
       <trans-unit id="Authoring_SourceDoesNotExist">
         <source>Source '{0}' in template does not exist.</source>

--- a/src/Shared/JExtensions.cs
+++ b/src/Shared/JExtensions.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 #endif
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
@@ -394,6 +395,15 @@ namespace Microsoft.TemplateEngine
         internal static string ToJsonString(object obj)
         {
             return JToken.FromObject(obj).ToString(Formatting.None);
+        }
+
+        internal static string ToCamelCase(this string str)
+        {
+            return str switch
+            {
+                "" => str,
+                _ => str.First().ToString().ToLower() + str.Substring(1),
+            };
         }
 
     }

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.Linux.verified.txt
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.Linux.verified.txt
@@ -7,7 +7,6 @@ fail: Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGene
       Failed to load template from %TEMPLATE_LOCATION%/MissingIdentity/.template.config/template.json.
       Details: 'identity' is missing or is an empty string.
 warn: Template Engine: %scrubbed%
-warn: Template Engine: %scrubbed%
 info: validate[0]
       Scanning completed
 info: validate[0]
@@ -46,7 +45,7 @@ info: validate[0]
       
 info: validate[0]
       Found template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
-         <no entries>
+         [Warning][CONFIG0201] Id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
       Found localization 'de-DE' for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
          [Error][LOC001] In localization file under the post action with id 'pa1', there are localized strings for manual instruction(s) with ids 'do-not-exist'. These manual instructions do not exist in the template.json file and should be removed from localization file.
          [Error][LOC002] Post action(s) with id(s) 'pa0' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.OSX.verified.txt
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.OSX.verified.txt
@@ -7,7 +7,6 @@ fail: Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGene
       Failed to load template from %TEMPLATE_LOCATION%/MissingIdentity/.template.config/template.json.
       Details: 'identity' is missing or is an empty string.
 warn: Template Engine: %scrubbed%
-warn: Template Engine: %scrubbed%
 info: validate[0]
       Scanning completed
 info: validate[0]
@@ -46,7 +45,7 @@ info: validate[0]
       
 info: validate[0]
       Found template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
-         <no entries>
+         [Warning][CONFIG0201] Id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
       Found localization 'de-DE' for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
          [Error][LOC001] In localization file under the post action with id 'pa1', there are localized strings for manual instruction(s) with ids 'do-not-exist'. These manual instructions do not exist in the template.json file and should be removed from localization file.
          [Error][LOC002] Post action(s) with id(s) 'pa0' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.Windows.verified.txt
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Snapshots/ValidateCommandTests.ValidateCommand_BasicTest.Windows.verified.txt
@@ -7,7 +7,6 @@ fail: Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGene
       Failed to load template from %TEMPLATE_LOCATION%\MissingIdentity/.template.config/template.json.
       Details: 'identity' is missing or is an empty string.
 warn: Template Engine: %scrubbed%
-warn: Template Engine: %scrubbed%
 info: validate[0]
       Scanning completed
 info: validate[0]
@@ -46,7 +45,7 @@ info: validate[0]
       
 info: validate[0]
       Found template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
-         <no entries>
+         [Warning][CONFIG0201] Id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
       Found localization 'de-DE' for template 'name' (TestAssets.Invalid.Localization.ValidationFailure):
          [Error][LOC001] In localization file under the post action with id 'pa1', there are localized strings for manual instruction(s) with ids 'do-not-exist'. These manual instructions do not exist in the template.json file and should be removed from localization file.
          [Error][LOC002] Post action(s) with id(s) 'pa0' specified in the localization file do not exist in the template.json file. Remove the localized strings from the localization file.

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/ScannerTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/ScannerTests.cs
@@ -137,9 +137,16 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
                 """,
                 errorMessages[1]);
 
-            Assert.Equal($"[{Path.GetFullPath(templatesLocation) + Path.DirectorySeparatorChar}.template.config/template.json]: id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.", warningMessages[0]);
-            Assert.Equal("Failed to load the 'de-DE' localization the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.", warningMessages[1]);
-            Assert.Equal("Failed to load the 'tr' localization the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.", warningMessages[2]);
+            Assert.Equal("Failed to load the 'de-DE' localization the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.", warningMessages[0]);
+            Assert.Equal("Failed to load the 'tr' localization the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.", warningMessages[1]);
+
+            Assert.Equal(
+        """
+                The template 'name' (TestAssets.Invalid.Localization.ValidationFailure) has the following validation warnings:
+                   [Warning][CONFIG0201] Id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
+
+                """,
+        warningMessages[2]);
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/LocalizationTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/LocalizationTests.cs
@@ -65,7 +65,11 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 
             string[] expectedWarnings = new[]
             {
-                $"[{testTemplateLocation}{Path.DirectorySeparatorChar}.template.config/template.json]: id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.",
+                """
+                The template 'name' (TestAssets.Invalid.Localization.ValidationFailure) has the following validation warnings:
+                   [Warning][CONFIG0201] Id of the post action 'pa2' at index '3' is not unique. Only the first post action that uses this id will be localized.
+
+                """,
                 "Failed to load the 'de-DE' localization the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped.",
                 "Failed to load the 'tr' localization the template 'name' (TestAssets.Invalid.Localization.ValidationFailure): the localization file is not valid. The localization will be skipped."
             };

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/PostActionTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/PostActionTests.cs
@@ -1,10 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Core;
 using Microsoft.TemplateEngine.Core.Contracts;
+using Microsoft.TemplateEngine.Core.Operations;
 using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel;
 using Microsoft.TemplateEngine.TestHelper;
 using Newtonsoft.Json.Linq;
@@ -12,13 +12,13 @@ using Xunit;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.TemplateConfigTests
 {
-    public class PostActionTests : IClassFixture<TestLoggerFactory>
+    public class PostActionTests : IClassFixture<EnvironmentSettingsHelper>
     {
-        private readonly Microsoft.Extensions.Logging.ILogger _logger;
+        private readonly IEngineEnvironmentSettings _environmentSettings;
 
-        public PostActionTests(TestLoggerFactory testLoggerFactory)
+        public PostActionTests(EnvironmentSettingsHelper environmentSettingsHelper)
         {
-            _logger = testLoggerFactory.CreateLogger();
+            _environmentSettings = environmentSettingsHelper.CreateEnvironment(virtualize: true);
         }
 
         private static JObject TestTemplateJson
@@ -109,7 +109,19 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
                 ["ActionOneCondition"] = condition1,
                 ["ActionTwoCondition"] = condition2
             };
-            List<IPostAction> postActions = PostAction.Evaluate(_logger, configModel.PostActionModels, vc);
+
+            FileRenameGenerator renameGenerator = new(
+                _environmentSettings,
+                "sourceName",
+                "MyProject",
+                vc,
+                Array.Empty<IReplacementTokens>());
+
+            List<IPostAction> postActions = PostAction.Evaluate(
+                _environmentSettings,
+                configModel.PostActionModels,
+                vc,
+                renameGenerator);
 
             Assert.Equal(expectedActionCount, postActions.Count);
             if (firstResult != null && firstResult.Length > 0)
@@ -148,7 +160,19 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
                 ["OperatingSystemKind"] = operatingSystemValue
             };
 
-            List<IPostAction> postActions = PostAction.Evaluate(_logger, configModel.PostActionModels, vc);
+            FileRenameGenerator renameGenerator = new(
+                    _environmentSettings,
+                    "sourceName",
+                    "MyProject",
+                    vc,
+                    Array.Empty<IReplacementTokens>());
+
+            List<IPostAction> postActions = PostAction.Evaluate(
+                _environmentSettings,
+                configModel.PostActionModels,
+                vc,
+                renameGenerator);
+
             Assert.Equal(expectedActionCount, postActions.Count);
 
             if (!string.IsNullOrEmpty(firstInstruction))
@@ -160,6 +184,160 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             {
                 Assert.Equal(secondInstruction, postActions[1].ManualInstructions);
             }
+        }
+
+        [Fact]
+        public void CanReadFileRenameSettings()
+        {
+            string configString = /*lang=json*/ """
+                {
+                  "Author": "Microsoft",
+                  "Classifications": "UnitTest",
+                  "name": "Dotnet Unit Test Template",
+                  "groupIdentity": "Dotnet.Testing",
+                  "identity": "Dotnet.UnitTest.Template",
+                  "shortName": "test",
+                  "PostActions": [
+                    {
+                      "Description": "Action1",
+                      "ActionId": "7F0CDCFC-839A-4625-88F6-27590E6299EF",
+                      "ContinueOnError": "false",
+                      "Args": {
+                        "Foo": "Bar",
+                        "Baz": "Blah"
+                      },
+                      "ApplyFileRenamesToArgs": [ "Foo" ],
+                      "ApplyFileRenamesToManualInstructions": true,
+                    },
+                  ]
+                }
+                """;
+
+            TemplateConfigModel configModel = TemplateConfigModel.FromJObject(JObject.Parse(configString));
+
+            Assert.Equal(1, configModel.PostActionModels.Count);
+            Assert.True(configModel.PostActionModels.Single().ApplyFileRenamesToManualInstructions);
+
+            Assert.Equal("Foo", configModel.PostActionModels.Single().ApplyFileRenamesToArgs.Single());
+
+            Assert.Empty(configModel.ValidationErrors);
+        }
+
+        [Fact]
+        public void CanAddWarningOnWrongFileRenameConfig()
+        {
+            string configString = /*lang=json*/ """
+                {
+                  "Author": "Microsoft",
+                  "Classifications": "UnitTest",
+                  "name": "Dotnet Unit Test Template",
+                  "groupIdentity": "Dotnet.Testing",
+                  "identity": "Dotnet.UnitTest.Template",
+                  "shortName": "test",
+                  "PostActions": [
+                    {
+                      "Description": "Action1",
+                      "ActionId": "7F0CDCFC-839A-4625-88F6-27590E6299EF",
+                      "ContinueOnError": "false",
+                      "Args": {
+                        "Foo": "Bar",
+                        "Baz": "Blah"
+                      },
+                      "ApplyFileRenamesToArgs": [ "NotFoo", "Baz" ],
+                      "ApplyFileRenamesToManualInstructions": true,
+                    },
+                  ]
+                }
+                """;
+
+            TemplateConfigModel configModel = TemplateConfigModel.FromJObject(JObject.Parse(configString));
+
+            Assert.Equal(1, configModel.PostActionModels.Count);
+            Assert.True(configModel.PostActionModels.Single().ApplyFileRenamesToManualInstructions);
+
+            Assert.Equal("Baz", configModel.PostActionModels.Single().ApplyFileRenamesToArgs.Single());
+
+            Assert.NotEmpty(configModel.ValidationErrors);
+
+            IValidationEntry validationError = configModel.ValidationErrors.Single();
+
+            Assert.Equal(IValidationEntry.SeverityLevel.Warning, validationError.Severity);
+            Assert.Equal("CONFIG0204", validationError.Code);
+            Assert.Equal("The argument 'NotFoo' configured in 'applyFileRenamesToArgs' is not listed in 'args' and will be skipped for processing.", validationError.ErrorMessage);
+        }
+
+        [Fact]
+        public void CanApplyFileRenames()
+        {
+            string configString = /*lang=json*/ """
+                {
+                  "Author": "Microsoft",
+                  "Classifications": "UnitTest",
+                  "name": "Dotnet Unit Test Template",
+                  "groupIdentity": "Dotnet.Testing",
+                  "identity": "Dotnet.UnitTest.Template",
+                  "shortName": "test",
+                  "sourceName": "SourceName",
+                  "symbols": {
+                    "param1": {
+                        "type": "parameter",
+                        "replaces": "textToReplace",
+                        "fileRename": "fileToReplace"
+                    }
+                  },
+                  "PostActions": [
+                    {
+                      "Description": "Action1",
+                      "ActionId": "7F0CDCFC-839A-4625-88F6-27590E6299EF",
+                      "ContinueOnError": "false",
+                      "Args": {
+                        "Foo": "fileToReplace.Bar",
+                        "Baz": "SourceName.Blah"
+                      },
+                      "ApplyFileRenamesToArgs": [ "Foo", "Baz" ],
+                      "ApplyFileRenamesToManualInstructions": true,
+                      "ManualInstructions": [
+                        {
+                          "Text": "fileToReplace and SourceName should be changed."
+                        }
+                      ]
+                    },
+                  ]
+                }
+                """;
+
+            TemplateConfigModel configModel = TemplateConfigModel.FromJObject(JObject.Parse(configString));
+
+            IVariableCollection vc = new VariableCollection
+            {
+                ["param1"] = "MyParam",
+                ["name"] = "MyProject",
+
+            };
+
+            List<IReplacementTokens> filenameReplacements = new()
+            {
+                new ReplacementTokens("param1", "fileToReplace".TokenConfigBuilder())
+            };
+
+            FileRenameGenerator renameGenerator = new(
+                _environmentSettings,
+                "SourceName",
+                "MyProject",
+                vc,
+                filenameReplacements);
+
+            List<IPostAction> postActions = PostAction.Evaluate(
+                _environmentSettings,
+                configModel.PostActionModels,
+                vc,
+                renameGenerator);
+
+            IPostAction postAction = Assert.Single(postActions);
+
+            Assert.Equal("MyParam.Bar", postAction.Args["Foo"]);
+            Assert.Equal("MyProject.Blah", postAction.Args["Baz"]);
+            Assert.Equal("MyParam and MyProject should be changed.", postAction.ManualInstructions);
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/PostActions/WithFileRename/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/PostActions/WithFileRename/.template.config/template.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json.schemastore.org/template.json",
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "TestAssets.PostActions.AddJsonProperty.WithSourceNameChangeInJson",
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.PostActions.AddJsonProperty.WithSourceNameChangeInJson",
+  "precedence": "100",
+  "identity": "TestAssets.PostActions.AddJsonProperty.WithSourceNameChangeInJson",
+  "shortName": "TestAssets.PostActions.AddJsonProperty.WithSourceNameChangeInJson",
+  "tags": { "type": "project" },
+  "sourceName": "MyTestProject",
+  "primaryOutputs": [
+    {
+      "path": "MyTestProject.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "description": "Modify JSON file",
+      "manualInstructions": [ { "text": "Add MyTestProject property to testfile.json manually." } ],
+      "args": {
+        "jsonFileName": "testfile.json",
+        "parentPropertyPath": "moduleConfiguration:edgeAgent:properties.desired:modules",
+        "newJsonPropertyName": "MyTestProject",
+        "newJsonPropertyValue": "${MODULEDIR<../MyTestProject>}"
+      },
+      "applyFileRenamesToArgs": [ "newJsonPropertyName", "newJsonPropertyValue" ],
+      "applyFileRenamesToManualInstructions": true,
+      "actionId": "695A3659-EB40-4FF5-A6A6-C9C4E629FCB0",
+      "continueOnError": true
+    }
+  ]
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/PostActions/WithFileRename/MyTestProject.csproj
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/PostActions/WithFileRename/MyTestProject.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/PostActions/WithFileRename/testfile.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/PostActions/WithFileRename/testfile.json
@@ -1,0 +1,11 @@
+{
+  "moduleConfiguration": {
+    "edgeAgent": {
+      "properties.desired": {
+        "modules": {
+          "module1": "someValue"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Problem
https://github.com/dotnet/templating/issues/1600
unblocking https://github.com/dotnet/sdk/pull/29880

### Solution
Added ability to apply file renames to post action arguments

TODOs:
- [x] validation
- [x] tests
- [x] documentation update
- [x] nth: `FileRenameGenerator` refactoring (processor can be setup once for all primary outputs and post actions replacements)

### Checks:
- [x] Added unit tests
- [x] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)