### PR TITLE
Disallow http

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
@@ -61,6 +61,11 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 
             IEnumerable<PackageSource> packagesSources = LoadNuGetSources(additionalSources?.ToArray() ?? Array.Empty<string>());
 
+            if (!force)
+            {
+                packagesSources = RemoveInsecurePackages(packagesSources);
+            }
+
             PackageSource source;
             IPackageSearchMetadata packageMetadata;
 
@@ -195,6 +200,32 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             var (_, package) = await GetLatestVersionInternalAsync(identifier, packageSources, floatRange, cancellationToken).ConfigureAwait(false);
             bool isLatestVersion = currentVersion != null && currentVersion >= package.Identity.Version;
             return (package.Identity.Version.ToNormalizedString(), isLatestVersion);
+        }
+
+        internal IEnumerable<PackageSource> RemoveInsecurePackages(IEnumerable<PackageSource> packagesSources)
+        {
+            var insecurePackages = new List<PackageSource>();
+            var securePackages = new List<PackageSource>();
+            foreach (var packageSource in packagesSources)
+            {
+                // NuGet IsHttp property can be both http and https sources
+                if (packageSource.IsHttps)
+                {
+                    securePackages.Add(packageSource);
+                }
+                else
+                {
+                    insecurePackages.Add(packageSource);
+                }
+            }
+
+            if (insecurePackages.Any())
+            {
+                var packagesString = string.Join(", ", insecurePackages);
+                _nugetLogger.LogWarning(string.Format("LocalizableStrings.NuGetApiPackageManager_Warning_InsecureFeed" + packagesString));
+            }
+
+            return securePackages;
         }
 
         private async Task<(PackageSource, IPackageSearchMetadata)> GetLatestVersionInternalAsync(

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
@@ -222,7 +222,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             if (insecurePackages.Any())
             {
                 var packagesString = string.Join(", ", insecurePackages);
-                _nugetLogger.LogWarning(string.Format("LocalizableStrings.NuGetApiPackageManager_Warning_InsecureFeed" + packagesString));
+                _nugetLogger.LogWarning(string.Format(LocalizableStrings.NuGetApiPackageManager_Warning_InsecureFeed, packagesString));
             }
 
             return securePackages;

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
@@ -406,6 +406,15 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force..
+        /// </summary>
+        internal static string NuGetApiPackageManager_Warning_InsecureFeed {
+            get {
+                return ResourceManager.GetString("NuGetApiPackageManager_Warning_InsecureFeed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} is not found in NuGet feeds {1}..
         /// </summary>
         internal static string NuGetApiPackageManager_Warning_PackageNotFound {

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -238,6 +238,9 @@
   <data name="NuGetApiPackageManager_Error_NoSources" xml:space="preserve">
     <value>No NuGet sources are defined or enabled.</value>
   </data>
+  <data name="NuGetApiPackageManager_Warning_InsecureFeed" xml:space="preserve">
+    <value>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</value>
+  </data>
   <data name="NuGetApiPackageManager_Warning_FailedToDelete" xml:space="preserve">
     <value>Failed to remove {0} after failed download. Remove the file manually if it exists.</value>
   </data>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Nepovedlo se načíst zdroj Nuget {0}: zdroj není platný. Při dalším zpracování se přeskočí.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">Balíček {0} se nenašel v informačních kanálech NuGet {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Fehler beim Laden der NuGet-Quelle {0}: die Quelle ist ungültig. Sie wird bei der weiteren Verarbeitung übersprungen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">\"{0}\" wurde in NuGet-Feeds \"{1}\" nicht gefunden.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -197,6 +197,11 @@
         <target state="translated">No se pudo cargar el origen de NuGet {0}: el origen no es válido. Se omitirá en un proceso posterior.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">No se encuentra {0} en las fuentes de NuGet {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Échec du chargement de la source NuGet {0} : la source n’est pas valide. Il sera ignoré en cours de traitement.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">{0} est introuvable dans les flux NuGet {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Non è stato possibile caricare l'origine NuGet {0}: l'origine non è valida. Verrà ignorata in elaborazioni successive.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">{0} non è stato trovato nei feed NuGet {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -197,6 +197,11 @@
         <target state="translated">NuGet ソース {0} の読み込みに失敗しました: このソースが有効ではありません。今後の処理ではスキップされます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">{0} が NuGet フィードに見つかりません{1}。</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -197,6 +197,11 @@
         <target state="translated">NuGet 원본 {0}을(를) 로드하지 못했습니다. 원본이 유효하지 않습니다. 추가 처리에서 건너뛰세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">{0}을(를) NuGet 피드 {1}에서 찾을 수 없습니다.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Nie można załadować źródła pakietu NuGet {0}: źródło jest nieprawidłowe. Zostanie ono pominięte podczas dalszego przetwarzania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">Nie znaleziono pakietu {0} w kanałach informacyjnych pakietu NuGet {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Falha no carregamento da fonte NuGet {0}: a fonte não é válida. Ela será ignorada num processamento posterior.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">{0} não é encontrado no NuGet feeds {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -197,6 +197,11 @@
         <target state="translated">Не удалось загрузить источник NuGet {0}: недопустимый источник. Он будет пропущен при дальнейшей обработке.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">{0} не найдено в веб-каналах NuGet {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -197,6 +197,11 @@
         <target state="translated">{0} NuGet kaynağı yüklenemedi: kaynak geçerli değil. Daha fazla işlemede atlanacak.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">{0}, {1} NuGet akışlarında bulunamadı.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -197,6 +197,11 @@
         <target state="translated">无法加载 NuGet 源 {0}: 源无效。进一步处理中将跳过它。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">在 NuGet 源 {1} 中找不到 {0}。</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -197,6 +197,11 @@
         <target state="translated">無法載入 NuGet 來源 {0}: 來源無效。進一步處理時會跳過此情況。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetApiPackageManager_Warning_InsecureFeed">
+        <source>The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</source>
+        <target state="new">The NuGet sources {0} are insecure and will not be searched. If you want to include those sources for search, use --force.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="NuGetApiPackageManager_Warning_PackageNotFound">
         <source>{0} is not found in NuGet feeds {1}.</source>
         <target state="translated">在 NuGet 摘要 {1} 中找不到 {0}。</target>

--- a/src/Microsoft.TemplateEngine.Utils/ListExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Utils/ListExtensions.cs
@@ -50,21 +50,21 @@ namespace Microsoft.TemplateEngine.Utils
             return allGrouped;
         }
 
-        private struct ValueWrapper<T>
+        private readonly struct ValueWrapper<T>
         {
             public ValueWrapper(T val)
             {
                 Val = val;
             }
 
-            public T Val { get; private set; }
+            public T Val { get; }
 
-            public override bool Equals(object obj)
+            public override readonly bool Equals(object obj)
             {
                 return obj is ValueWrapper<T> v && Equals(Val, v.Val);
             }
 
-            public override int GetHashCode()
+            public override readonly int GetHashCode()
             {
                 return Val?.GetHashCode() ?? 0;
             }

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetApiPackageManagerTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetApiPackageManagerTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Edge.Installers.NuGet;
 using Microsoft.TemplateEngine.TestHelper;
+using NuGet.Configuration;
 using Xunit;
 
 namespace Microsoft.TemplateEngine.Edge.UnitTests
@@ -130,6 +131,67 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
 
             exception.PackageIdentifier.Should().Be("Microsoft.DotNet.NotCommon.ProjectTemplates.5.0");
             exception.Message.Should().NotBeNullOrEmpty();
+        }
+
+        [Fact]
+        public void RemoveInsecurePackages_AllInsecure()
+        {
+            IEngineEnvironmentSettings engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+
+            NuGetApiPackageManager packageManager = new NuGetApiPackageManager(engineEnvironmentSettings);
+            List<PackageSource> allPackages = new List<PackageSource>()
+            {
+                new PackageSource("http://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"),
+                new PackageSource("http://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"),
+                new PackageSource("http://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json"),
+                new PackageSource("http://insecure-feed.org")
+            };
+            var securePackages = packageManager.RemoveInsecurePackages(allPackages);
+
+            securePackages.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void RemoveInsecurePackages_AllSecure()
+        {
+            IEngineEnvironmentSettings engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+
+            NuGetApiPackageManager packageManager = new NuGetApiPackageManager(engineEnvironmentSettings);
+            List<PackageSource> allPackages = new List<PackageSource>()
+            {
+                new PackageSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"),
+                new PackageSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"),
+                new PackageSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json")
+            };
+            var securePackages = packageManager.RemoveInsecurePackages(allPackages);
+
+            securePackages.Should().NotBeEmpty();
+            Assert.Equal(allPackages, securePackages);
+        }
+
+        [Fact]
+        public void RemoveInsecurePackages_Mixed()
+        {
+            IEngineEnvironmentSettings engineEnvironmentSettings = _environmentSettingsHelper.CreateEnvironment(virtualize: true);
+
+            NuGetApiPackageManager packageManager = new NuGetApiPackageManager(engineEnvironmentSettings);
+            List<PackageSource> allPackages = new List<PackageSource>()
+            {
+                new PackageSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"),
+                new PackageSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json"),
+                new PackageSource("http://pkgs.dev.azure.com/dnceng/public/_packaging/nuget-build/nuget/v3/index.json"),
+                new PackageSource("http://insecure-feed.org")
+            };
+            var securePackages = packageManager.RemoveInsecurePackages(allPackages);
+
+            var expectedOutcome = new List<PackageSource>()
+            {
+                new PackageSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"),
+                new PackageSource("https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json")
+            };
+
+            securePackages.Should().NotBeEmpty();
+            securePackages.Should().Equal(expectedOutcome);
         }
     }
 }


### PR DESCRIPTION
### Problem
Solution for this issue https://github.com/dotnet/templating/issues/5859

### Solution
When installing or updating packages, if --force is not specified, do not search feeds that are not secure (http feeds) and give a warning about that.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)