### PR TITLE
Edit output message on package identity dupe

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCache.cs
@@ -177,8 +177,8 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             {
                 // we print the message only if managed template wins and we have > 1 managed templates with overlapping identities
                 var lastTemplate = identityToTemplates.Value.Last();
-                var managedTemplates = identityToTemplates.Value.Where(templateInto => templateInto.TemplatePackage is IManagedTemplatePackage).Except(new[] { lastTemplate });
-                if (lastTemplate.TemplatePackage is IManagedTemplatePackage managedPackage && managedTemplates.Any())
+                var managedTemplates = identityToTemplates.Value.Where(templateInto => templateInto.TemplatePackage is IManagedTemplatePackage).ToArray();
+                if (lastTemplate.TemplatePackage is IManagedTemplatePackage managedPackage && managedTemplates.Length > 1)
                 {
                     var templatesList = new StringBuilder();
                     foreach (var (templateName, packageId, _, _) in managedTemplates)

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/TemplateCacheTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/TemplateCacheTests.cs
@@ -247,6 +247,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             var expectedOutput = "The following templates use the same identity 'testIdentity':" +
                 $"{Environment.NewLine}  • 'TemplateA' from 'PackageA'" +
                 $"{Environment.NewLine}  • 'TemplateB' from 'PackageB'" +
+                $"{Environment.NewLine}  • 'TemplateC' from 'PackageC'" +
                 $"{Environment.NewLine}The template from 'TemplateC' will be used. To resolve this conflict, uninstall the conflicting template packages.";
 
             ScanResult result = new ScanResult(A.Fake<IMountPoint>(), new[] { templateA, templateB, templateC }, Array.Empty<ILocalizationLocator>(), Array.Empty<(string AssemblyPath, Type InterfaceType, IIdentifiedComponent Instance)>());
@@ -276,6 +277,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
 
             var expectedOutput = "The following templates use the same identity 'testIdentity':" +
                 $"{Environment.NewLine}  • 'TemplateA' from 'PackageA'" +
+                $"{Environment.NewLine}  • 'TemplateC' from 'PackageC'" +
                 $"{Environment.NewLine}The template from 'TemplateC' will be used. To resolve this conflict, uninstall the conflicting template packages.";
 
             ScanResult result = new ScanResult(A.Fake<IMountPoint>(), new[] { templateA, templateB, templateC }, Array.Empty<ILocalizationLocator>(), Array.Empty<(string AssemblyPath, Type InterfaceType, IIdentifiedComponent Instance)>());


### PR DESCRIPTION
### Problem
It was agreed on the last PM sync to extend the list of entries with identity dupes with the selected one .

### Checks:
- [ * ] Added unit tests
- [ n/a ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)