### PR TITLE
Nuget package vulnerability check

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/Installer/InstallerErrorCode.cs
+++ b/src/Microsoft.TemplateEngine.Abstractions/Installer/InstallerErrorCode.cs
@@ -51,6 +51,11 @@ namespace Microsoft.TemplateEngine.Abstractions.Installer
         /// <summary>
         /// The requested package is invalid and cannot be processed.
         /// </summary>
-        InvalidPackage = 8
+        InvalidPackage = 8,
+
+        /// <summary>
+        /// The requested package has vulnerabilities and can only be processed with --force.
+        /// </summary>
+        VulnerablePackage = 9
     }
 }

--- a/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Abstractions/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿Microsoft.TemplateEngine.Abstractions.IExtendedTemplateLocator
+Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode.VulnerablePackage = 9 -> Microsoft.TemplateEngine.Abstractions.Installer.InstallerErrorCode
 Microsoft.TemplateEngine.Abstractions.ITemplate.Localization.get -> Microsoft.TemplateEngine.Abstractions.ILocalizationLocator?
 Microsoft.TemplateEngine.Abstractions.ITemplate.TemplateSourceRoot.get -> Microsoft.TemplateEngine.Abstractions.Mount.IDirectory!
 Microsoft.TemplateEngine.Abstractions.ITemplateMetadata.PreferDefaultName.get -> bool

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/Exceptions/VulnerablePackageException.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/Exceptions/VulnerablePackageException.cs
@@ -9,17 +9,15 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 {
     internal class VulnerablePackageException : Exception
     {
-        public VulnerablePackageException(string message, IEnumerable<PackageVulnerabilityMetadata> vulnerabilities)
+        public VulnerablePackageException(string message, string packageIdentifier, IEnumerable<PackageVulnerabilityMetadata> vulnerabilities)
             : base(message)
         {
+            PackageIdentifier = packageIdentifier;
             Vulnerabilities = vulnerabilities;
         }
 
-        public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get; private set; }
+        public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get; internal set; }
 
-        private string NiceTableFormat()
-        {
-            return "Some nice table format to list vulnerabilities";
-        }
+        public string PackageIdentifier { get; internal set; }
     }
 }

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/Exceptions/VulnerablePackageException.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/Exceptions/VulnerablePackageException.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using NuGet.Protocol;
+
+namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
+{
+    internal class VulnerablePackageException : Exception
+    {
+        public VulnerablePackageException(string message, IEnumerable<PackageVulnerabilityMetadata> vulnerabilities)
+            : base(message)
+        {
+            Vulnerabilities = vulnerabilities;
+        }
+
+        public IEnumerable<PackageVulnerabilityMetadata> Vulnerabilities { get; private set; }
+
+        private string NiceTableFormat()
+        {
+            return "Some nice table format to list vulnerabilities";
+        }
+    }
+}

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/IDownloader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/IDownloader.cs
@@ -15,22 +15,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 
     internal class NuGetPackageInfo
     {
-        public NuGetPackageInfo(string author, string fullPath, string? nuGetSource, string packageIdentifier, string packageVersion)
-        {
-            Author = author;
-            FullPath = fullPath;
-            NuGetSource = nuGetSource;
-            PackageIdentifier = packageIdentifier;
-            PackageVersion = packageVersion;
-        }
-
-        public NuGetPackageInfo(
-            string author,
-            string fullPath,
-            string? nuGetSource,
-            string packageIdentifier,
-            string packageVersion,
-            IEnumerable<PackageVulnerabilityMetadata> vulnerabilities)
+        public NuGetPackageInfo(string author, string fullPath, string? nuGetSource, string packageIdentifier, string packageVersion, IEnumerable<PackageVulnerabilityMetadata>? vulnerabilities = null)
         {
             Author = author;
             FullPath = fullPath;

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/IDownloader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/IDownloader.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using NuGet.Protocol;
 
 namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 {
@@ -23,6 +24,22 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             PackageVersion = packageVersion;
         }
 
+        public NuGetPackageInfo(
+            string author,
+            string fullPath,
+            string? nuGetSource,
+            string packageIdentifier,
+            string packageVersion,
+            IEnumerable<PackageVulnerabilityMetadata> vulnerabilities)
+        {
+            Author = author;
+            FullPath = fullPath;
+            NuGetSource = nuGetSource;
+            PackageIdentifier = packageIdentifier;
+            PackageVersion = packageVersion;
+            PackageVulnerabilities = vulnerabilities;
+        }
+
         public string Author { get; }
 
         public string FullPath { get; }
@@ -32,6 +49,8 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
         public string PackageIdentifier { get; }
 
         public string PackageVersion { get; }
+
+        public IEnumerable<PackageVulnerabilityMetadata>? PackageVulnerabilities { get; }
 
         internal NuGetPackageInfo WithFullPath(string newFullPath)
         {

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstaller.cs
@@ -210,7 +210,8 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                     installer: this,
                     provider,
                     nuGetPackageInfo.FullPath,
-                    nuGetPackageInfo.PackageIdentifier)
+                    nuGetPackageInfo.PackageIdentifier,
+                    nuGetPackageInfo.PackageVulnerabilities)
                 {
                     Author = nuGetPackageInfo.Author,
                     NuGetSource = nuGetPackageInfo.NuGetSource,
@@ -255,6 +256,13 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                     installRequest,
                     InstallerErrorCode.InvalidPackage,
                     string.Format(LocalizableStrings.NuGetInstaller_InstallResut_Error_InvalidPackage, e.PackageLocation));
+            }
+            catch (VulnerablePackageException e)
+            {
+                return InstallResult.CreateFailure(
+                    installRequest,
+                    InstallerErrorCode.VulnerablePackage,
+                    string.Format(LocalizableStrings.NuGetInstaller_InstallResut_Error_VulnerablePackage, e.PackageIdentifier));
             }
             catch (OperationCanceledException)
             {

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetManagedTemplatePackage.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetManagedTemplatePackage.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Installer;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
+using NuGet.Protocol;
 
 namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 {
@@ -26,7 +27,8 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
           IInstaller installer,
           IManagedTemplatePackageProvider provider,
           string mountPointUri,
-          string packageIdentifier)
+          string packageIdentifier,
+          IEnumerable<PackageVulnerabilityMetadata>? vulnerabilities = null)
         {
             if (string.IsNullOrWhiteSpace(mountPointUri))
             {
@@ -41,6 +43,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             ManagedProvider = provider ?? throw new ArgumentNullException(nameof(provider));
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
             _logger = settings.Host.LoggerFactory.CreateLogger<NuGetInstaller>();
+            Vulnerabilities = vulnerabilities;
 
             Details = new Dictionary<string, string>
             {
@@ -183,6 +186,8 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                 }
             }
         }
+
+        public IEnumerable<PackageVulnerabilityMetadata>? Vulnerabilities { get; }
 
         internal Dictionary<string, string> Details { get; }
 

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
@@ -80,9 +80,9 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                 (source, packageMetadata) = await GetPackageMetadataAsync(identifier, packageVersion, packagesSources, cancellationToken).ConfigureAwait(false);
             }
 
-            if (packageMetadata.Vulnerabilities.Any() && !force)
+            if (packageMetadata.Vulnerabilities is not null && !force)
             {
-                throw new Exception("Package has vulnerabilities");
+                throw new VulnerablePackageException("Found package is vulnerable", packageMetadata.Identity.Id, packageMetadata.Vulnerabilities);
             }
 
             FindPackageByIdResource resource;

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
@@ -80,6 +80,11 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                 (source, packageMetadata) = await GetPackageMetadataAsync(identifier, packageVersion, packagesSources, cancellationToken).ConfigureAwait(false);
             }
 
+            if (packageMetadata.Vulnerabilities.Any() && !force)
+            {
+                throw new Exception("Package has vulnerabilities");
+            }
+
             FindPackageByIdResource resource;
             SourceRepository repository = SourcesCache.GetOrAdd(source, Repository.Factory.GetCoreV3(source));
             try
@@ -115,7 +120,8 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                         filePath,
                         source.Source,
                         packageMetadata.Identity.Id,
-                        packageMetadata.Identity.Version.ToNormalizedString());
+                        packageMetadata.Identity.Version.ToNormalizedString(),
+                        packageMetadata.Vulnerabilities);
                 }
                 else
                 {

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.Designer.cs
@@ -544,6 +544,15 @@ namespace Microsoft.TemplateEngine.Edge {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The requested package {0} has vulnerabilities..
+        /// </summary>
+        internal static string NuGetInstaller_InstallResut_Error_VulnerablePackage {
+            get {
+                return ResourceManager.GetString("NuGetInstaller_InstallResut_Error_VulnerablePackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is not a valid operating system name. Allowed values are: {1}..
         /// </summary>
         internal static string OSConstraint_Error_InvalidOSName {

--- a/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
+++ b/src/Microsoft.TemplateEngine.Edge/LocalizableStrings.resx
@@ -272,6 +272,9 @@ Details: {1}.</value>
   <data name="NuGetInstaller_InstallResut_Error_InvalidPackage" xml:space="preserve">
     <value>The NuGet package {0} is invalid.</value>
   </data>
+  <data name="NuGetInstaller_InstallResut_Error_VulnerablePackage" xml:space="preserve">
+    <value>The requested package {0} has vulnerabilities.</value>
+  </data>
   <data name="NuGetInstaller_InstallResut_Error_InvalidSources" xml:space="preserve">
     <value>The configured NuGet sources are invalid: {0}.</value>
   </data>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.cs.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 Podrobnosti: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">{0} není platný název operačního systému. Povolené hodnoty jsou: {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.de.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 Details: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">„{0}“ ist kein gültiger Betriebssystemname. Zulässige Werte sind: {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.es.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 Detalles: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">'{0}' no es un nombre de sistema operativo válido. Los valores permitidos son: {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.fr.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 Détails : {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">'{0}' n’est pas un nom de système d’exploitation valide. Les valeurs autorisées sont : {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.it.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 Dettagli: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">'{0}' non è un nome di sistema operativo valido. I valori consentiti sono: {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ja.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 詳細: {1}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">'{0}' は有効なオペレーティング システム名ではありません。使用可能な値は {1} です。</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ko.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 세부 정보: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">'{0}'은(는) 올바른 운영 체제 이름이 아닙니다. 허용되는 값은 {1}입니다.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pl.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 Szczegóły: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">„{0}” nie jest prawidłową nazwą systemu operacyjnego. Dozwolone wartości to: {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.pt-BR.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 Detalhes: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">'{0}' não é um nome de sistema operacional válido. Os valores permitidos são: {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.ru.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 Сведения: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">«{0}» не является допустимым именем операционной системы. Допустимые значения: {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.tr.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 Ayrıntılar: {1}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">'{0}' geçerli bir işletim sistemi adı değil. İzin verilen değerler: {1}.</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hans.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 详细信息: {1}。</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">\"{0}\" 不是有效的操作系统名称。允许的值为: {1}。</target>

--- a/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/Microsoft.TemplateEngine.Edge/xlf/LocalizableStrings.zh-Hant.xlf
@@ -278,6 +278,11 @@ Details: {1}.</source>
 詳細資料: {1}</target>
         <note />
       </trans-unit>
+      <trans-unit id="NuGetInstaller_InstallResut_Error_VulnerablePackage">
+        <source>The requested package {0} has vulnerabilities.</source>
+        <target state="new">The requested package {0} has vulnerabilities.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="OSConstraint_Error_InvalidOSName">
         <source>'{0}' is not a valid operating system name. Allowed values are: {1}.</source>
         <target state="translated">'{0}' 不是有效的作業系統名稱。允許的值為: {1}。</target>

--- a/src/Microsoft.TemplateEngine.Utils/ListExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Utils/ListExtensions.cs
@@ -50,21 +50,21 @@ namespace Microsoft.TemplateEngine.Utils
             return allGrouped;
         }
 
-        private struct ValueWrapper<T>
+        private readonly struct ValueWrapper<T>
         {
             public ValueWrapper(T val)
             {
                 Val = val;
             }
 
-            public T Val { get; private set; }
+            public T Val { get; }
 
-            public override bool Equals(object obj)
+            public override readonly bool Equals(object obj)
             {
                 return obj is ValueWrapper<T> v && Equals(Val, v.Val);
             }
 
-            public override int GetHashCode()
+            public override readonly int GetHashCode()
             {
                 return Val?.GetHashCode() ?? 0;
             }


### PR DESCRIPTION
### Problem
For this issue: https://github.com/dotnet/templating/issues/5863

### Solution
Added a check if package metadata has any listed vulnerabilities. If it has and user did not specify `--force` throw an error that has the vulnerabilities listed.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)