### PR TITLE
Enable Dependabot for release/7.0.4xx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,13 @@ updates:
     labels:
       - "dependencies"
       - "dependabot: 7.0.3xx"
+
+  - package-ecosystem: "nuget"
+    directory: "/eng/dependabot"
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+    target-branch: "release/7.0.4xx"
+    labels:
+      - "dependencies"
+      - "dependabot: 7.0.4xx"


### PR DESCRIPTION
### Problem
Enable Dependabot for release/7.0.4xx

### Solution
Enable Dependabot for release/7.0.4xx

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)