### PR TITLE
Add NuGet to dependency flow

### DIFF
--- a/eng/Package.props
+++ b/eng/Package.props
@@ -14,9 +14,6 @@
     <PackageReference Update="Microsoft.Extensions.Logging" Condition="'$(MicrosoftExtensionsLoggingVersion)' != ''" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Condition="'$(MicrosoftExtensionsLoggingConsoleVersion)' != ''" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Condition="'$(MicrosoftExtensionsLoggingAbstractionsVersion)' != ''" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
-    <PackageReference Update="NuGet.Configuration" Condition="'$(NuGetConfigurationVersion)' != ''" Version="$(NuGetConfigurationVersion)" />
-    <PackageReference Update="NuGet.Credentials" Condition="'$(NuGetCredentialsVersion)' != ''" Version="$(NuGetCredentialsVersion)" />
-    <PackageReference Update="NuGet.Protocol" Condition="'$(NuGetProtocolVersion)' != ''" Version="$(NuGetProtocolVersion)" />
 
     <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' != ''" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" />
     <PackageReference Update="StyleCop.Analyzers" Condition="'$(StyleCopAnalyzersVersion)' != ''" Version="$(StyleCopAnalyzersVersion)" />
@@ -31,6 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Update="NuGet.Configuration" Version="$(NuGetCredentialsPackageVersion)" />
+    <PackageReference Update="NuGet.Credentials" Version="$(NuGetCredentialsPackageVersion)" />
+    <PackageReference Update="NuGet.Protocol" Version="$(NuGetCredentialsPackageVersion)" />
     <PackageReference Update="System.CommandLine" Version="$(SystemCommandLinePackageVersion)" />
     <!--Analyzer dependencies-->
     <PackageReference Update="Microsoft.CodeAnalysis.NetAnalyzers" Version="$(MicrosoftCodeAnalysisNetAnalyzersPackageVersion)" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -23,6 +23,11 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>42c58533cdf478b15120542be76f7cbaacaab024</Sha>
     </Dependency>
+    <Dependency Name="NuGet.Credentials" Version="6.6.0-preview.3.61">
+      <Uri>https://github.com/nuget/nuget.client</Uri>
+      <Sha>0fa557836fa35aee7d60776ef0c88176dbcd22ac</Sha>
+      <SourceBuild RepoName="nuget-client" ManagedOnly="true" />
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.23205.4">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -26,7 +26,6 @@
     <Dependency Name="NuGet.Credentials" Version="6.6.0-preview.3.61">
       <Uri>https://github.com/nuget/nuget.client</Uri>
       <Sha>0fa557836fa35aee7d60776ef0c88176dbcd22ac</Sha>
-      <SourceBuild RepoName="nuget-client" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,5 +20,7 @@
     <!-- Dependencies from https://github.com/dotnet/runtime -->
     <MicrosoftNETCoreAppRefPackageVersion>8.0.0-preview.3.23170.1</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftNETCoreAppRuntimewinx64PackageVersion>8.0.0-preview.3.23170.1</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <!-- Dependencies from https://github.com/nuget/nuget.client -->
+    <NuGetCredentialsPackageVersion>6.6.0-preview.3.61</NuGetCredentialsPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -12,9 +12,6 @@
     <PackageReference Update="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-    <PackageReference Update="NuGet.Configuration" Version="6.5.0" />
-    <PackageReference Update="NuGet.Credentials" Version="6.5.0" />
-    <PackageReference Update="NuGet.Protocol" Version="6.5.0" />
 
     <!--Analyzers-->
     <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />


### PR DESCRIPTION
### Problem

When attempting to enable [PVP flow](https://github.com/dotnet/source-build/issues/3043) for the templating repo, it was discovered that the repo has a dependency on the previously released version of NuGet (6.5.0) rather than the in-development version (6.6.0). This would require [SBRPs](https://github.com/dotnet/source-build-reference-packages) to be defined for those package versions. Instead, it seems more appropriate to update the repo to enable dependency flow for NuGet.

### Solution

I've enabled dependency flow for NuGet.Credentials (for the `VS 17.6` channel). Since the versions are consistent across the NuGet packages, I've reused that version for the other NuGet dependent packages that are also referenced.

Once merged, I'll create a darc subscription with the following settings:

```
https://github.com/nuget/nuget.client (VS 17.6) ==> 'https://github.com/dotnet/templating' ('main')
  - Update Frequency: EveryBuild
  - Enabled: True
  - Batchable: False
  - PR Failure Notification tags:
  - Merge Policies: Standard
```