### PR TITLE
Install .NET 7.0.200 using UseDotNet@2

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -93,13 +93,12 @@ steps:
     version: 7.0.100
     installationPath: $(Build.SourcesDirectory)/.dotnet
 
-- bash: >
-    curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin
-    -Channel 7.0.2xx
-    -Quality daily
-    -InstallDir $(Build.SourcesDirectory)/.dotnet
-    -SkipNonVersionedFiles
-  displayName: Install daily .NET 7.0.2xx
+- task: UseDotNet@2
+  displayName: 'Use .NET 7.0.200'
+  inputs:
+    packageType: sdk
+    version: 7.0.200
+    installationPath: $(Build.SourcesDirectory)/.dotnet
 
 - bash: >
     curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin


### PR DESCRIPTION
### Problem
Installing .NET 7.0.200 via dotnet-install.sh in search cache pipeline failed with the error `curl: (52) Empty reply from server` randomly. Then it caused cache test failed.

### Solution
Change the installation using `UseDotNet@2` since .NET 7.0.2xx was released.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)