### PR TITLE
Downgrade Verify.DiffPlex to 2.2.0

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -27,6 +27,6 @@
     <PackageReference Update="xunit.abstractions" Version="2.0.3" />
     <PackageReference Update="Newtonsoft.Json.Schema" Version="3.0.14" />
     <PackageReference Update="Verify.XUnit" Version="19.13.0" />
-    <PackageReference Update="Verify.DiffPlex" Version="2.2.1" />
+    <PackageReference Update="Verify.DiffPlex" Version="2.2.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Problem
Verify.DiffPlex package inconsistency with sdk https://github.com/dotnet/sdk/pull/32070#issuecomment-1524168390

### Solution
downgrade the version 

### Checks:
- [n/a ] Added unit tests
- [n/a ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)