### PR TITLE
[release/6.0.4xx] Fixup the version details xml

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -52,12 +52,8 @@
       <Sha>a90539fd502f9425311b34451cdd2965516f5d26</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Cli.CommandLine" Version="1.0.0-preview.19208.1">
-      <Uri>https://github.com/dotnet/clicommandlineparser</Uri>
-      <Sha />
-    </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.Toolset.x64" Version="">
-      <Uri>https://www.github.com/dotnet/installer</Uri>
-      <Sha />
+      <Uri>https://github.com/dotnet/cliCommandLineParser</Uri>
+      <Sha>0e89c2116ad28e404ba56c14d1c3f938caa25a01</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>


### PR DESCRIPTION
I think this is causing some performance problems figuring out the dependency graph. The installer dependency should not exist, and clicommandlineparser should have a sha.