### PR TITLE
Remove allowed nuget source-build prebuilt

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -5,8 +5,5 @@
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Ref/*" />
 
     <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
-
-    <!-- TODO: Ignore needed until https://github.com/NuGet/Home/issues/11059 is addressed. -->
-    <UsagePattern IdentityGlob="Nuget.*/*" />
   </IgnorePatterns>
 </UsageData>


### PR DESCRIPTION
### Problem
Related to https://github.com/dotnet/source-build/issues/3471

Some NuGet.Client 6.6.0 prebuilts were introduced into source-build by templating.  This was because the SourceBuildPrebuiltBaseline.xml was allowing all NuGet assemblies.  Because templating doesn't have a version.details.xml dependency on nuget, reference packages are utilized for the assemblies during source-build.  Because of that, they come from https://github.com/dotnet/source-build-reference-packages and the baseline exception should be removed.

### Solution
Remove the NuGet exclusion from SourceBuildPrebuiltBaseline.xml to prevent NuGet prebuilts from being introduced in the future.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)