### PR TITLE
Single selection or empty string parameter for Multi-Choice symbol should be converted to MultiValueParameter

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ParameterConverter.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ParameterConverter.cs
@@ -212,10 +212,6 @@ namespace Microsoft.TemplateEngine.Utils
                             .Where(r => !string.IsNullOrEmpty(r))
                             .Select(r => r!)
                             .ToList();
-                    if (val.Count <= 1)
-                    {
-                        return val.Count == 0 ? string.Empty : val[0];
-                    }
 
                     return new MultiValueParameter(val);
                 }

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Approvals/TestCoalesce_EmptyStringForMultiChoices._.verified/TestAssets.TemplateWithMultipleChoicesAndCoalesce/Program.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Approvals/TestCoalesce_EmptyStringForMultiChoices._.verified/TestAssets.TemplateWithMultipleChoicesAndCoalesce/Program.cs
@@ -1,0 +1,12 @@
+﻿namespace ConsoleApp
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Preset test is: unit|ui.");
+            Console.WriteLine("User's choice is: .");
+            Console.WriteLine("The final set is: .");
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Approvals/TestSingleSelectionForMultiChoices._.verified/TestAssets.TemplateWithMultipleChoicesAndCoalesce/Program.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Approvals/TestSingleSelectionForMultiChoices._.verified/TestAssets.TemplateWithMultipleChoicesAndCoalesce/Program.cs
@@ -1,0 +1,12 @@
+﻿namespace ConsoleApp
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Preset test is: unit|ui.");
+            Console.WriteLine("User's choice is: unit.");
+            Console.WriteLine("The final set is: unit.");
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/SnapshotTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/SnapshotTests.cs
@@ -225,6 +225,56 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
             VerificationEngine engine = new VerificationEngine(_log);
             return engine.Execute(options);
         }
+
+        [Fact]
+        public Task TestCoalesce_EmptyStringForMultiChoices()
+        {
+            string templateLocation = GetTestTemplateLocation("TemplateWithMultipleChoicesAndCoalesce");
+            var templateParams = new Dictionary<string, string?>()
+            {
+                { "tests", string.Empty }
+            };
+            string workingDir = TestUtils.CreateTemporaryFolder();
+
+            TemplateVerifierOptions options =
+                new TemplateVerifierOptions(templateName: "TestAssets.TemplateWithMultipleChoicesAndCoalesce")
+                {
+                    TemplatePath = templateLocation,
+                    OutputDirectory = workingDir,
+                    DoNotAppendTemplateArgsToScenarioName = true,
+                    DoNotPrependTemplateNameToScenarioName = true,
+                    SnapshotsDirectory = "Approvals"
+                }
+                .WithInstantiationThroughTemplateCreatorApi(templateParams);
+
+            VerificationEngine engine = new VerificationEngine(_log);
+            return engine.Execute(options);
+        }
+
+        [Fact]
+        public Task TestSingleSelectionForMultiChoices()
+        {
+            string templateLocation = GetTestTemplateLocation("TemplateWithMultipleChoicesAndCoalesce");
+            var templateParams = new Dictionary<string, string?>()
+            {
+                { "tests", "unit" }
+            };
+            string workingDir = TestUtils.CreateTemporaryFolder();
+
+            TemplateVerifierOptions options =
+                new TemplateVerifierOptions(templateName: "TestAssets.TemplateWithMultipleChoicesAndCoalesce")
+                {
+                    TemplatePath = templateLocation,
+                    OutputDirectory = workingDir,
+                    DoNotAppendTemplateArgsToScenarioName = true,
+                    DoNotPrependTemplateNameToScenarioName = true,
+                    SnapshotsDirectory = "Approvals"
+                }
+                .WithInstantiationThroughTemplateCreatorApi(templateParams);
+
+            VerificationEngine engine = new VerificationEngine(_log);
+            return engine.Execute(options);
+        }
     }
 }
 

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithMultipleChoicesAndCoalesce/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithMultipleChoicesAndCoalesce/.template.config/template.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json.schemastore.org/template.json",
+  "author": "Test Asset",
+  "classifications": [ "Test Asset" ],
+  "name": "TemplateWithMultipleChoicesAndCoalesce",
+  "tags": { "type": "project" },
+  "generatorVersions": "[1.0.0.0-*)",
+  "groupIdentity": "TestAssets.TemplateWithMultipleChoicesAndCoalesce",
+  "precedence": "100",
+  "identity": "TestAssets.TemplateWithMultipleChoicesAndCoalesce",
+  "shortName": "TestAssets.TemplateWithMultipleChoicesAndCoalesce",
+  "symbols": {
+    "preset": {
+      "displayName": "Preset",
+      "type": "parameter",
+      "datatype": "choice",
+      "defaultValue": "recommended",
+      "description": "Selects setup type",
+      "choices": [
+        {
+          "choice": "recommended",
+          "description": "Recommended set of options to create a production-ready app targeting multiple platforms",
+          "displayName": "Default"
+        },
+        {
+          "choice": "blank",
+          "description": "Smallest set of options, with no extra dependencies, to create an app targeting multiple platforms",
+          "displayName": "Blank"
+        }
+      ]
+    },
+    "tests": {
+      "displayName": "Tests",
+      "type": "parameter",
+      "datatype": "choice",
+      "replaces": "user_selectedtests",
+      "allowMultipleValues": true,
+      "enableQuotelessLiterals": true,
+      "choices": [
+        {
+          "choice": "unit",
+          "displayName": "Unit Tests"
+        },
+        {
+          "choice": "ui",
+          "displayName": "UI Tests"
+        }
+      ]
+    },
+    "presetTestsDefault": {
+      "type": "generated",
+      "generator": "switch",
+      "replaces": "preset_tests",
+      "parameters": {
+        "evaluator": "C++",
+        "datatype": "string",
+        "cases": [
+          {
+            "condition": "(preset == 'recommended')",
+            "value": "unit|ui"
+          },
+          {
+            "condition": "(preset == 'blank')",
+            "value": ""
+          }
+        ]
+      }
+    },
+    "testsEvaluator": {
+      "type": "generated",
+      "generator": "coalesce",
+      "replaces": "final_tests",
+      "parameters": {
+        "sourceVariableName": "tests",
+        "fallbackVariableName": "presetTestsDefault"
+      }
+    }
+  }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithMultipleChoicesAndCoalesce/Program.cs
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithMultipleChoicesAndCoalesce/Program.cs
@@ -1,0 +1,12 @@
+﻿namespace ConsoleApp
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Preset test is: preset_tests.");
+            Console.WriteLine("User's choice is: user_selectedtests.");
+            Console.WriteLine("The final set is: final_tests.");
+        }
+    }
+}


### PR DESCRIPTION
### Problem
Single selection or empty string parameter for multi-choice symbol is converted to be `string` type, not `MultiValueParameter`. 
For explicit empty string as user input for multi-choice symbol, this causes coalesce macro could not handle it as no choice selected. 

### Solution
Convert single selection or empty string parameter for multi-choice symbol to be `MultiValueParameter` type, same as multiple choices selected.

### Checks:
- [x] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)