### PR TITLE
rename trusted -> reserved according to nuget team request

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/IDownloader.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/IDownloader.cs
@@ -15,11 +15,11 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 
     internal class NuGetPackageInfo
     {
-        public NuGetPackageInfo(string author, string owners, bool trusted, string fullPath, string? nuGetSource, string packageIdentifier, string packageVersion, IReadOnlyList<VulnerabilityInfo> vulnerabilities)
+        public NuGetPackageInfo(string author, string owners, bool reserved, string fullPath, string? nuGetSource, string packageIdentifier, string packageVersion, IReadOnlyList<VulnerabilityInfo> vulnerabilities)
         {
             Author = author;
             Owners = owners;
-            Trusted = trusted;
+            Reserved = reserved;
             FullPath = fullPath;
             NuGetSource = nuGetSource;
             PackageIdentifier = packageIdentifier;
@@ -31,7 +31,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 
         public string Owners { get; }
 
-        public bool Trusted { get; }
+        public bool Reserved { get; }
 
         public string FullPath { get; }
 
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             return new NuGetPackageInfo(
                 Author,
                 Owners,
-                Trusted,
+                Reserved,
                 newFullPath,
                 NuGetSource,
                 PackageIdentifier,

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstaller.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetInstaller.cs
@@ -242,7 +242,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                 {
                     Author = nuGetPackageInfo.Author,
                     Owners = nuGetPackageInfo.Owners,
-                    Trusted = nuGetPackageInfo.Trusted.ToString(),
+                    Reserved = nuGetPackageInfo.Reserved.ToString(),
                     NuGetSource = nuGetPackageInfo.NuGetSource,
                     Version = nuGetPackageInfo.PackageVersion.ToString(),
                     IsLocalPackage = isLocalPackage
@@ -437,7 +437,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                 nuspec.GetAuthors(),
                 nuspec.GetOwners(),
                 // The prefix reservation is not applicable to local packages.
-                trusted: false,
+                reserved: false,
                 packageLocation,
                 null,
                 nuspec.GetId(),

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetManagedTemplatePackage.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NuGetManagedTemplatePackage.cs
@@ -17,7 +17,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
         private const string AuthorKey = "Author";
         private const string LocalPackageKey = "LocalPackage";
         private const string OwnersKey = "Owners";
-        private const string TrustedKey = "Trusted";
+        private const string ReservedKey = "Reserved";
         private const string NuGetSourceKey = "NuGetSource";
         private const string PackageIdKey = "PackageId";
         private const string PackageVersionKey = "Version";
@@ -113,10 +113,10 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             }
         }
 
-        public string? Trusted
+        public string? Reserved
         {
-            get => Details.TryGetValue(TrustedKey, out string trusted) ? trusted : false.ToString();
-            set => UpdateOrRemoveValue(Details, TrustedKey, value, (string entry) => !string.IsNullOrEmpty(entry));
+            get => Details.TryGetValue(ReservedKey, out string reserved) ? reserved : false.ToString();
+            set => UpdateOrRemoveValue(Details, ReservedKey, value, (string entry) => !string.IsNullOrEmpty(entry));
         }
 
         public string? Author
@@ -174,7 +174,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 
             details.TryAdd(AuthorKey, Author ?? string.Empty, (string entry) => !string.IsNullOrEmpty(entry));
             details.TryAdd(OwnersKey, Owners ?? string.Empty, (string entry) => !string.IsNullOrEmpty(entry));
-            details.TryAdd(TrustedKey, Trusted ?? string.Empty, (string entry) => !string.IsNullOrEmpty(entry));
+            details.TryAdd(ReservedKey, Reserved ?? string.Empty, (string entry) => !string.IsNullOrEmpty(entry));
             details.TryAdd(NuGetSourceKey, NuGetSource ?? string.Empty, (string entry) => !string.IsNullOrEmpty(entry));
 
             return details;

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
@@ -131,7 +131,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                     return new NuGetPackageInfo(
                         packageMetadata.Authors,
                         packageMetadata.Owners,
-                        trusted: packageMetadata.PrefixReserved,
+                        reserved: packageMetadata.PrefixReserved,
                         filePath,
                         source.Source,
                         packageMetadata.Identity.Id,
@@ -515,11 +515,11 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
 
         private class NugetPackageMetadata
         {
-            public NugetPackageMetadata(IPackageSearchMetadata metadata, string owners, bool trusted)
+            public NugetPackageMetadata(IPackageSearchMetadata metadata, string owners, bool reserved)
             {
                 Authors = metadata.Authors;
                 Identity = metadata.Identity;
-                PrefixReserved = trusted;
+                PrefixReserved = reserved;
                 Owners = owners;
                 Vulnerabilities = Vulnerabilities = metadata.Vulnerabilities?.ToList() ?? new List<PackageVulnerabilityMetadata>();
             }

--- a/src/Microsoft.TemplateSearch.Common/Abstractions/ITemplatePackageInfo.cs
+++ b/src/Microsoft.TemplateSearch.Common/Abstractions/ITemplatePackageInfo.cs
@@ -32,12 +32,12 @@ namespace Microsoft.TemplateSearch.Common.Abstractions
         public IReadOnlyList<string> Owners { get; }
 
         /// <summary>
-        /// Gets the indication if the package is trusted.
+        /// Gets the indication if the package is verified.
         /// </summary>
         /// <remarks>
         /// For NuGet.org 'verified' means that package ID is under reserved namespaces, see  <see href="https://docs.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation"/>.
         /// </remarks>
-        public bool Trusted { get; }
+        public bool Reserved { get; }
 
         /// <summary>
         /// Gets the NuGet package description.

--- a/src/Microsoft.TemplateSearch.Common/Abstractions/TemplatePackageSearchData.cs
+++ b/src/Microsoft.TemplateSearch.Common/Abstractions/TemplatePackageSearchData.cs
@@ -30,7 +30,7 @@ namespace Microsoft.TemplateSearch.Common
             Version = packInfo.Version;
             TotalDownloads = packInfo.TotalDownloads;
             Owners = packInfo.Owners;
-            Trusted = packInfo.Trusted;
+            Reserved = packInfo.Reserved;
             Templates = templates.ToList();
             Description = packInfo.Description;
             IconUrl = packInfo.IconUrl;
@@ -50,7 +50,7 @@ namespace Microsoft.TemplateSearch.Common
         public IReadOnlyList<string> Owners { get; }
 
         /// <inheritdoc/>
-        public bool Trusted { get; }
+        public bool Reserved { get; }
 
         /// <inheritdoc/>
         public string? Description { get; }

--- a/src/Microsoft.TemplateSearch.Common/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateSearch.Common/PublicAPI.Shipped.txt
@@ -3,7 +3,6 @@ Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo
 Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.Name.get -> string!
 Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.Owners.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.TotalDownloads.get -> long
-Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.Trusted.get -> bool
 Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.Version.get -> string?
 Microsoft.TemplateSearch.Common.Abstractions.ITemplateSearchProvider
 Microsoft.TemplateSearch.Common.Abstractions.ITemplateSearchProvider.Factory.get -> Microsoft.TemplateSearch.Common.Abstractions.ITemplateSearchProviderFactory!
@@ -24,7 +23,6 @@ Microsoft.TemplateSearch.Common.TemplatePackageSearchData.Owners.get -> System.C
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData.TemplatePackageSearchData(Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo! packInfo, System.Collections.Generic.IEnumerable<Microsoft.TemplateSearch.Common.TemplateSearchData!>! templates, System.Collections.Generic.IDictionary<string!, object!>? data = null) -> void
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData.Templates.get -> System.Collections.Generic.IReadOnlyList<Microsoft.TemplateSearch.Common.TemplateSearchData!>!
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData.TotalDownloads.get -> long
-Microsoft.TemplateSearch.Common.TemplatePackageSearchData.Trusted.get -> bool
 Microsoft.TemplateSearch.Common.TemplatePackageSearchData.Version.get -> string?
 Microsoft.TemplateSearch.Common.TemplateSearchCoordinator
 Microsoft.TemplateSearch.Common.TemplateSearchCoordinator.SearchAsync(System.Func<Microsoft.TemplateSearch.Common.TemplatePackageSearchData!, bool>! packFilter, System.Func<Microsoft.TemplateSearch.Common.TemplatePackageSearchData!, System.Collections.Generic.IReadOnlyList<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!>!>! matchingTemplatesFilter, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Microsoft.TemplateSearch.Common.SearchResult!>!>!

--- a/src/Microsoft.TemplateSearch.Common/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateSearch.Common/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 ﻿Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.Reserved.get -> bool
+Microsoft.TemplateSearch.Common.TemplatePackageSearchData.Reserved.get -> bool

--- a/src/Microsoft.TemplateSearch.Common/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateSearch.Common/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Microsoft.TemplateSearch.Common.Abstractions.ITemplatePackageInfo.Reserved.get -> bool

--- a/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/LegacySearchCacheReader.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/LegacySearchCacheReader.cs
@@ -49,7 +49,7 @@ namespace Microsoft.TemplateSearch.Common
                         templateData.Add(new TemplateSearchData(foundTemplate));
                     }
                 }
-                packageData.Add(new TemplatePackageSearchData(new PackInfo(package.Key, package.Value.Version, package.Value.TotalDownloads, package.Value.Owners, package.Value.Trusted), templateData));
+                packageData.Add(new TemplatePackageSearchData(new PackInfo(package.Key, package.Value.Version, package.Value.TotalDownloads, package.Value.Owners, package.Value.Reserved), templateData));
             }
             return new TemplateSearchCache(packageData);
         }

--- a/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/PackInfo.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/PackInfo.cs
@@ -18,13 +18,13 @@ namespace Microsoft.TemplateSearch.Common
             Version = version;
         }
 
-        internal PackInfo(string name, string version, long totalDownloads, IEnumerable<string> owners, bool trusted = false)
+        internal PackInfo(string name, string version, long totalDownloads, IEnumerable<string> owners, bool reserved = false)
         {
             Name = name;
             Version = version;
             TotalDownloads = totalDownloads;
             Owners = owners.ToList();
-            Trusted = trusted;
+            Reserved = reserved;
         }
 
         [JsonProperty]
@@ -40,7 +40,7 @@ namespace Microsoft.TemplateSearch.Common
         public IReadOnlyList<string> Owners { get; } = Array.Empty<string>();
 
         [JsonProperty]
-        public bool Trusted { get; }
+        public bool Reserved { get; }
 
         //not supported for v1
         public string? Description => null;

--- a/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/PackToTemplateEntry.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/PackToTemplateEntry.cs
@@ -26,7 +26,7 @@ namespace Microsoft.TemplateSearch.Common
         internal IReadOnlyList<string> Owners { get; set; } = Array.Empty<string>();
 
         [JsonProperty]
-        internal bool Trusted { get; set; }
+        internal bool Reserved { get; set; }
 
         [JsonProperty]
         internal IReadOnlyList<TemplateIdentificationEntry> TemplateIdentificationEntry { get; }

--- a/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplatePackageSearchData.Json.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplatePackageSearchData.Json.cs
@@ -31,7 +31,7 @@ namespace Microsoft.TemplateSearch.Common
             Version = jObject.ToString(nameof(Version));
             TotalDownloads = jObject.ToInt32(nameof(TotalDownloads));
             Owners = jObject.Get<JToken>(nameof(Owners)).JTokenStringOrArrayToCollection(Array.Empty<string>());
-            Trusted = jObject.ToBool(nameof(Trusted));
+            Reserved = jObject.ToBool(nameof(Reserved));
 
             Description = jObject.ToString(nameof(Description));
             IconUrl = jObject.ToString(nameof(IconUrl));
@@ -107,10 +107,10 @@ namespace Microsoft.TemplateSearch.Common
                     }
                 }
 
-                if (value.Trusted)
+                if (value.Reserved)
                 {
-                    writer.WritePropertyName(nameof(Trusted));
-                    writer.WriteValue(value.Trusted);
+                    writer.WritePropertyName(nameof(Reserved));
+                    writer.WriteValue(value.Reserved);
                 }
                 if (!string.IsNullOrWhiteSpace(value.Description))
                 {

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetApiPackageManagerTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetApiPackageManagerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             Assert.True(File.Exists(result.FullPath));
             result.PackageIdentifier.Should().Be("Microsoft.DotNet.Common.ProjectTemplates.5.0");
             result.Owners.Should().Be(string.Empty);
-            result.Trusted.Should().BeFalse();
+            result.Reserved.Should().BeFalse();
             result.PackageVersion.Should().NotBeNullOrEmpty();
             result.NuGetSource.Should().NotBeNullOrEmpty();
         }
@@ -62,7 +62,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             Assert.True(File.Exists(result.FullPath));
             result.PackageIdentifier.Should().Be("Microsoft.DotNet.Common.ProjectTemplates.5.0");
             result.Owners.Should().Be("dotnetframework, Microsoft");
-            result.Trusted.Should().BeTrue();
+            result.Reserved.Should().BeTrue();
             result.PackageVersion.Should().NotBeNullOrEmpty();
             result.NuGetSource.Should().NotBeNullOrEmpty();
         }

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetInstallerTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetInstallerTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
                          { "PackageId", "TestPackage" },
                          { "Version", "4.7.0.395" },
                          { "Owners", "test, test2" },
-                         { "Trusted", "true" }
+                         { "Reserved", "true" }
                      }),
                 "TestPackage", "4.7.0.395", "TestAuthor", "https://api.nuget.org/v3/index.json", false, "true", "test, test2"
             };
@@ -59,7 +59,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
                          { "PackageId", "TestPackage" },
                          { "Version", "4.7.0.395" },
                          { "Owners", "test, test2" },
-                         { "Trusted", "false" }
+                         { "Reserved", "false" }
                      }),
                 "TestPackage", "4.7.0.395", null, "https://api.nuget.org/v3/index.json", false, "false", "test, test2"
             };
@@ -155,7 +155,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             source!.MountPointUri.Should().ContainAll(new[] { installPath, "Microsoft.TemplateEngine.TestTemplates" });
             source.Author.Should().Be("Microsoft");
             source.Owners.Should().BeNull();
-            source.Trusted.Should().Be("False");
+            source.Reserved.Should().Be("False");
             source.Version.Should().NotBeNullOrEmpty();
             source.DisplayName.Should().StartWith("Microsoft.TemplateEngine.TestTemplates::");
             source.Identifier.Should().Be("Microsoft.TemplateEngine.TestTemplates");
@@ -238,7 +238,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             source!.MountPointUri.Should().ContainAll(new[] { installPath, "Microsoft.TemplateEngine.TestTemplates" });
             source.Author.Should().Be("Microsoft");
             source.Owners.Should().Be("Microsoft");
-            source.Trusted.Should().Be("True");
+            source.Reserved.Should().Be("True");
             source.Version.Should().Be("1.0.0");
             source.DisplayName.Should().Be("Microsoft.TemplateEngine.TestTemplates::1.0.0");
             source.Identifier.Should().Be("Microsoft.TemplateEngine.TestTemplates");
@@ -499,7 +499,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             string? author,
             string nugetFeed,
             bool local,
-            string trusted,
+            string reserved,
             string owners)
         {
             MockInstallerFactory factory = new MockInstallerFactory();
@@ -512,7 +512,7 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             NuGetManagedTemplatePackage source = (NuGetManagedTemplatePackage)installer.Deserialize(provider, data);
             source.MountPointUri.Should().Be(data.MountPointUri);
             source.Author.Should().Be(author);
-            source.Trusted.Should().Be(trusted);
+            source.Reserved.Should().Be(reserved);
             source.Owners.Should().Be(owners);
             source.Version.Should().Be(version);
             source.DisplayName.Should().Be($"{identifier}::{version}");

--- a/test/Microsoft.TemplateEngine.Mocks/MockTemplatePackageInfo.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockTemplatePackageInfo.cs
@@ -33,7 +33,7 @@ namespace Microsoft.TemplateEngine.Mocks
 
         public IReadOnlyList<string> Owners { get; }
 
-        public bool Trusted => false;
+        public bool Reserved => false;
 
         public string? Description => null;
 

--- a/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/NuGetTests.cs
+++ b/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/NuGetTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests
                     Assert.Equal("Microsoft.DotNet.Common.ProjectTemplates.5.0", packageInfo.Name);
                     Assert.NotEmpty(packageInfo.Version);
                     Assert.True(packageInfo.TotalDownloads > 0);
-                    Assert.True(packageInfo.Trusted);
+                    Assert.True(packageInfo.Reserved);
                     Assert.Contains("Microsoft", packageInfo.Owners);
                     packageInfo.Description.Should().NotBeNullOrEmpty();
                     packageInfo.IconUrl.Should().NotBeNullOrEmpty();

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/NuGet/NugetPackProvider.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/NuGet/NugetPackProvider.cs
@@ -264,7 +264,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
                 Name = packageSearchMetadata.Identity.Id;
                 Version = packageSearchMetadata.Identity.Version.ToString();
                 TotalDownloads = packageSearchMetadata.DownloadCount ?? 0;
-                Trusted = packageSearchMetadata.PrefixReserved;
+                Reserved = packageSearchMetadata.PrefixReserved;
                 Description = packageSearchMetadata.Description;
                 IconUrl = packageSearchMetadata.IconUrl?.ToString();
             }
@@ -277,7 +277,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
 
             public IReadOnlyList<string> Owners => Array.Empty<string>();
 
-            public bool Trusted { get; }
+            public bool Reserved { get; }
 
             public string? Description { get; }
 

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/NuGet/NugetPackageSourceInfo.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/NuGet/NugetPackageSourceInfo.cs
@@ -33,7 +33,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
 
         public IReadOnlyList<string> Owners { get; private set; } = Array.Empty<string>();
 
-        public bool Trusted { get; private set; }
+        public bool Reserved { get; private set; }
 
         public string? Description { get; private set; }
 
@@ -48,7 +48,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
             {
                 TotalDownloads = entry.ToInt32("totalDownloads"),
                 Owners = entry.Get<JToken>("owners").JTokenStringOrArrayToCollection(Array.Empty<string>()),
-                Trusted = entry.ToBool("verified"),
+                Reserved = entry.ToBool("verified"),
                 Description = entry.ToString("description"),
                 IconUrl = entry.ToString("iconUrl")
             };

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/DownloadedPackInfo.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/DownloadedPackInfo.cs
@@ -30,7 +30,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
 
         public IReadOnlyList<string> Owners => _info.Owners;
 
-        public bool Trusted => _info.Trusted;
+        public bool Reserved => _info.Reserved;
 
         public string? Description => _info.Description;
 

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/FilteredPackageInfo.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/FilteredPackageInfo.cs
@@ -15,7 +15,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
             Version = info.Version;
             Owners = info.Owners;
             TotalDownloads = info.TotalDownloads;
-            Trusted = info.Trusted;
+            Reserved = info.Reserved;
             Description = info.Description;
             IconUrl = info.IconUrl;
         }
@@ -43,7 +43,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
         public IReadOnlyList<string> Owners { get; private set; } = Array.Empty<string>();
 
         [JsonProperty]
-        public bool Trusted { get; private set; }
+        public bool Reserved { get; private set; }
 
         [JsonIgnore]
         public string? Description { get; private set; }

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyMetadataWriter.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Results/LegacyMetadataWriter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Results
                                     {
                                         TotalDownloads = r.TotalDownloads,
                                         Owners = r.Owners,
-                                        Trusted = r.Trusted
+                                        Reserved = r.Reserved
                                     };
                                     return packToTemplateEntry;
                                 });

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/TestProvider/TestPackProvider.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/TestProvider/TestPackProvider.cs
@@ -88,7 +88,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
 
             public IReadOnlyList<string> Owners => new[] { "TestAuthor" };
 
-            public bool Trusted => false;
+            public bool Reserved => false;
 
             public string? Description => "description";
 


### PR DESCRIPTION
### Problem
The previously selected property name "trusted" is misleading. Adjust it according to the discussion with PM.