### PR TITLE
add review comment to sb files

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,3 +1,5 @@
+<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+
 <Project>
 
   <PropertyGroup>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,4 +1,6 @@
-<!-- Prebuilt baseline changes must be reviewed by @dotnet/source-build-internal -->
+<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
+
 <UsageData>
   <IgnorePatterns>
     <!-- TODO: Ignore needed until https://github.com/dotnet/source-build/issues/3188 is addressed. -->


### PR DESCRIPTION
### Problem

Contributes to https://github.com/dotnet/source-build/issues/3435

In the past, non-reviewed changes to `SourceBuild*` files caused issues down the line, be it in the downstream repos or the product build (see https://github.com/dotnet/source-build/issues/3435#issuecomment-1570650046)

### Solution

Added comments to source-build files asking for the inclusion of the source-build team in PRs that alter `SourceBuild*` files.
