### PR TITLE
Remove the check on #nullable enable since it's applied to all projects

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,3 @@
 
 ### Checks:
 - [ ] Added unit tests
-- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)


### PR DESCRIPTION
### Problem
Remove the check on `#nullable enable` to modified files from pull request template once #2976 is done.

### Solution
Merge this PR after #6661 is merged.

### Checks:
- [ ] Added unit tests
- [ ] Added `#nullable enable` to all the modified files [?](https://github.com/dotnet/templating/wiki/Contributing#coding-style)