### PR TITLE
update short name for Authoring + readme.md 

### DIFF
--- a/template_feed/Microsoft.TemplateEngine.Authoring.Templates/README.md
+++ b/template_feed/Microsoft.TemplateEngine.Authoring.Templates/README.md
@@ -3,8 +3,8 @@
 The package contains the templates useful for the template authoring:
 | Template name | Short name | Description|
 |---|---|---|
+|Template Package|`templatepack`|A project for creating template package containing .NET templates.|
 |`template.json` configuration file|`template.json`|A template for template.json configuration file for .NET template.|
-|Template Package|`template-package`|A project for creating template package containing .NET templates.|
 
 The package is available for download from nuget.org.
 Please feel to contribute or provide the feedback in discussions or via opening the issue in dotnet/templating repo.

--- a/template_feed/Microsoft.TemplateEngine.Authoring.Templates/content/TemplatePackage/New.Template.Package.csproj
+++ b/template_feed/Microsoft.TemplateEngine.Authoring.Templates/content/TemplatePackage/New.Template.Package.csproj
@@ -11,7 +11,7 @@
     <PackageTags>TODO: fill the tags here</PackageTags>
     <PackageProjectUrl>TODO: include a link to an associated project, repository, or company website</PackageProjectUrl>
 
-    <!-- Keep package type as 'Template' to show the package as template package on nuget.org and make you template available in dotnet new search.-->
+    <!-- Keep package type as 'Template' to show the package as a template package on nuget.org and make your template available in dotnet new search.-->
     <PackageType>Template</PackageType>
     <TargetFramework>net8.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
@@ -19,6 +19,7 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <NoDefaultExcludes>true</NoDefaultExcludes>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <!--#if (EnableMSBuildTasks) -->
@@ -34,6 +35,10 @@
   <ItemGroup>
     <Content Include="content\**\*" Exclude="content\**\bin\**;content\**\obj\**" />
     <Compile Remove="**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Snapshots/templatepack.Basic.verified/templatepack/templatepack.csproj
+++ b/test/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Snapshots/templatepack.Basic.verified/templatepack/templatepack.csproj
@@ -11,7 +11,7 @@
     <PackageTags>TODO: fill the tags here</PackageTags>
     <PackageProjectUrl>TODO: include a link to an associated project, repository, or company website</PackageProjectUrl>
 
-    <!-- Keep package type as 'Template' to show the package as template package on nuget.org and make you template available in dotnet new search.-->
+    <!-- Keep package type as 'Template' to show the package as a template package on nuget.org and make your template available in dotnet new search.-->
     <PackageType>Template</PackageType>
     <TargetFramework>net8.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
@@ -19,6 +19,7 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <NoDefaultExcludes>true</NoDefaultExcludes>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -32,6 +33,10 @@
   <ItemGroup>
     <Content Include="content\**\*" Exclude="content\**\bin\**;content\**\obj\**" />
     <Compile Remove="**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Snapshots/templatepack.CLI.verified/templatepack/templatepack.csproj
+++ b/test/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Snapshots/templatepack.CLI.verified/templatepack/templatepack.csproj
@@ -11,7 +11,7 @@
     <PackageTags>TODO: fill the tags here</PackageTags>
     <PackageProjectUrl>TODO: include a link to an associated project, repository, or company website</PackageProjectUrl>
 
-    <!-- Keep package type as 'Template' to show the package as template package on nuget.org and make you template available in dotnet new search.-->
+    <!-- Keep package type as 'Template' to show the package as a template package on nuget.org and make your template available in dotnet new search.-->
     <PackageType>Template</PackageType>
     <TargetFramework>net8.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
@@ -19,6 +19,7 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <NoDefaultExcludes>true</NoDefaultExcludes>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -32,6 +33,10 @@
   <ItemGroup>
     <Content Include="content\**\*" Exclude="content\**\bin\**;content\**\obj\**" />
     <Compile Remove="**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Snapshots/templatepack.NoMSBuildTasks.verified/templatepack/templatepack.csproj
+++ b/test/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Snapshots/templatepack.NoMSBuildTasks.verified/templatepack/templatepack.csproj
@@ -11,7 +11,7 @@
     <PackageTags>TODO: fill the tags here</PackageTags>
     <PackageProjectUrl>TODO: include a link to an associated project, repository, or company website</PackageProjectUrl>
 
-    <!-- Keep package type as 'Template' to show the package as template package on nuget.org and make you template available in dotnet new search.-->
+    <!-- Keep package type as 'Template' to show the package as a template package on nuget.org and make your template available in dotnet new search.-->
     <PackageType>Template</PackageType>
     <TargetFramework>net8.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
@@ -19,11 +19,16 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <NoDefaultExcludes>true</NoDefaultExcludes>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <Content Include="content\**\*" Exclude="content\**\bin\**;content\**\obj\**" />
     <Compile Remove="**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/test/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Snapshots/templatepack.WithName.verified/templatepack/MyTemplatePackage.csproj
+++ b/test/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Snapshots/templatepack.WithName.verified/templatepack/MyTemplatePackage.csproj
@@ -11,7 +11,7 @@
     <PackageTags>TODO: fill the tags here</PackageTags>
     <PackageProjectUrl>TODO: include a link to an associated project, repository, or company website</PackageProjectUrl>
 
-    <!-- Keep package type as 'Template' to show the package as template package on nuget.org and make you template available in dotnet new search.-->
+    <!-- Keep package type as 'Template' to show the package as a template package on nuget.org and make your template available in dotnet new search.-->
     <PackageType>Template</PackageType>
     <TargetFramework>net8.0</TargetFramework>
     <IncludeContentInPack>true</IncludeContentInPack>
@@ -19,6 +19,7 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <NoDefaultExcludes>true</NoDefaultExcludes>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -32,6 +33,10 @@
   <ItemGroup>
     <Content Include="content\**\*" Exclude="content\**\bin\**;content\**\obj\**" />
     <Compile Remove="**\*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
update short name for Authoring + include readme.md in the package for preventing warning appearance 
```
 The package AdatumCorporation.Utility.Templates.1.0.0 is missing a readme. Go to https://aka.ms/nuget/authoring-best-
  practices/readme to learn why package readmes are important.
```