### PR TITLE
Remove dependabot on branch 7.0.1xx，7.0.2xx and 7.0.3xx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,36 +9,6 @@ updates:
     labels:
       - "dependencies"
       - "dependabot: main"
-  
-  - package-ecosystem: "nuget"
-    directory: "/eng/dependabot"
-    open-pull-requests-limit: 10
-    schedule:
-      interval: "weekly"
-    target-branch: "release/7.0.1xx"
-    labels:
-      - "dependencies"
-      - "dependabot: 7.0.1xx"
-
-  - package-ecosystem: "nuget"
-    directory: "/eng/dependabot"
-    open-pull-requests-limit: 10
-    schedule:
-      interval: "weekly"
-    target-branch: "release/7.0.2xx"
-    labels:
-      - "dependencies"
-      - "dependabot: 7.0.2xx"
-
-  - package-ecosystem: "nuget"
-    directory: "/eng/dependabot"
-    open-pull-requests-limit: 10
-    schedule:
-      interval: "weekly"
-    target-branch: "release/7.0.3xx"
-    labels:
-      - "dependencies"
-      - "dependabot: 7.0.3xx"
 
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot"


### PR DESCRIPTION
I noticed that PRs for branch 7.0.1xx，7.0.2xx and 7.0.3xx were closed, so I removed dependabot on those branches.