### PR TITLE
Remove sourcelink dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -35,10 +35,5 @@
       <Sha>d3553ca27fb1c128f302f52b73c0079e65d62ea8</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.SourceLink.GitHub" Version="8.0.0-beta.23361.2" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
-      <Uri>https://github.com/dotnet/sourcelink</Uri>
-      <Sha>d2e046aec870a5a7601cc51c5607f34463cc2d42</Sha>
-      <SourceBuild RepoName="sourcelink" ManagedOnly="true" />
-    </Dependency>
   </ToolsetDependencies>
 </Dependencies>


### PR DESCRIPTION
Sourcelink dependency isn't needed anymore. Arcade uses sourcelink tooling that is included in .NET SDK 8.0 preview 6.