### PR TITLE
Fix parameter in null/empty check

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
@@ -57,7 +57,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
             {
                 throw new ArgumentException($"{nameof(identifier)} cannot be null or empty", nameof(identifier));
             }
-            if (string.IsNullOrWhiteSpace(identifier))
+            if (string.IsNullOrWhiteSpace(downloadPath))
             {
                 throw new ArgumentException($"{nameof(downloadPath)} cannot be null or empty", nameof(downloadPath));
             }


### PR DESCRIPTION
Fixing a typo for `IsNullOrWhitespace` checking the wrong parameter 