### PR TITLE
Fix the search test behavior

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,9 +90,11 @@ stages:
               ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
                 _SignType: test
                 _DotNetPublishToBlobFeed : false
+                _Test: -integrationTest
               ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                 _SignType: real
                 _DotNetPublishToBlobFeed : true
+                _Test: ''
             ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
               Build_Debug:
                 _BuildConfig: Debug
@@ -113,7 +115,7 @@ stages:
         - script: eng/common/cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
-            -integrationTest
+            $(_Test)
             $(_InternalBuildArgs)
             $(_InternalRuntimeDownloadArgs)
           displayName: Windows Build / Publish

--- a/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
+++ b/test/dotnet-new3.UnitTests/DotnetNewSearch.cs
@@ -389,9 +389,7 @@ Examples:
             Assert.True(AtLeastOneRowIsNotEmpty(tableOutput, "Downloads"), "'Downloads' column contains empty values");
         }
 
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-        [Fact(Skip = "Broken by a localized template on nuget.org")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+        [Fact]
         public void CanSortByName()
         {
             var commandResult = new DotnetNewCommand(_log, "console", "--search")
@@ -413,7 +411,7 @@ Examples:
             // rows can be shrunk: ML.NET Console App for Training and ML.NET Console App for Train...
             // in this case ML.NET Console App for Training < ML.NET Console App for Train...
             // therefore use custom comparer 
-            var comparer = new ShrinkAwareOrdinalStringComparer();
+            var comparer = new ShrinkAwareCurrentCultureStringComparer();
             //first row is the header
             for (int i = 2; i < tableOutput.Count; i++)
             {
@@ -808,7 +806,7 @@ Examples:
             return parsedTable;
         }
 
-        private class ShrinkAwareOrdinalStringComparer : IComparer<string>
+        private class ShrinkAwareCurrentCultureStringComparer : IComparer<string>
         {
             public int Compare(string? left, string? right)
             {
@@ -831,18 +829,18 @@ Examples:
                 bool rightIsShrunk = right.EndsWith("...");
                 if (!(leftIsShrunk ^ rightIsShrunk))
                 {
-                    return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+                    return string.Compare(left, right, StringComparison.CurrentCultureIgnoreCase);
                 }
                 
-                if (rightIsShrunk && left.StartsWith(right.Substring(0, right.Length - 3), StringComparison.OrdinalIgnoreCase))
+                if (rightIsShrunk && left.StartsWith(right.Substring(0, right.Length - 3), StringComparison.CurrentCultureIgnoreCase))
                 {
                     return -1;
                 }
-                if (leftIsShrunk && right.StartsWith(left.Substring(0, left.Length - 3), StringComparison.OrdinalIgnoreCase))
+                if (leftIsShrunk && right.StartsWith(left.Substring(0, left.Length - 3), StringComparison.CurrentCultureIgnoreCase))
                 {
                     return 1;
                 }
-                return string.Compare(left, right, StringComparison.OrdinalIgnoreCase);
+                return string.Compare(left, right, StringComparison.CurrentCultureIgnoreCase);
             }
         }
     }


### PR DESCRIPTION
Port [fix ](https://github.com/dotnet/sdk/pull/34843/files) for localized template from SDK
Reenable test


### Problem
1. A customer pushed a new localzied tempalte which broke the search sort ordering in the test
2. This blocked internal codeflow as the CI build was running tests

### Solution
I ported the fix from the SDK repo: https://github.com/dotnet/sdk/pull/34843/files
I disabled running tests when running in internal CI
I reenabled the test