### PR TITLE
Remove loc from the release branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,18 +45,6 @@ stages:
   displayName: Build
   jobs:
   - ${{ if and( ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    # The localization setup for release/ branches. Note difference in package ID. Should not be used with main branch.
-    # Used for release/x.0.100, release/x.0.200, release/x.0.300, release/x.0.400 branches only.
-    # When the branch is setup for localizaiton, set 'EnableReleaseOneLocBuild' to true.
-    - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/release/') }}:
-      - template: /eng/common/templates/job/onelocbuild.yml
-        parameters:
-          MirrorRepo: templating
-          LclSource: lclFilesfromPackage
-          LclPackageId: 'LCL-JUNO-PROD-TEMPLATING'
-          MirrorBranch: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
-          JobNameSuffix: '_release'
-          condition: ${{ variables.EnableReleaseOneLocBuild }}
     # The localization setup for main branch. Note difference in package ID. Should not be used with release/ branches.
     - ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}:
       - template: /eng/common/templates/job/onelocbuild.yml


### PR DESCRIPTION
Our last release branch localization change was 6+ months ago. We almost entirely localize main so let's just do that from now on. We can revisit if we end up doing some big features in a preview release.
