### PR TITLE
Revert "Bump Verify.XUnit from 20.4.0 to 22.1.3 in /eng/dependabot"

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -26,7 +26,7 @@
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Update="xunit.abstractions" Version="2.0.3" />
     <PackageReference Update="Newtonsoft.Json.Schema" Version="3.0.15" />
-    <PackageReference Update="Verify.XUnit" Version="22.1.3" />
+    <PackageReference Update="Verify.XUnit" Version="20.4.0" />
     <PackageReference Update="Verify.DiffPlex" Version="2.2.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Reverts dotnet/templating#7145

For now, we're not updating the XUnit versions for release branches.