### PR TITLE
Remove dependabot updates to release/8.0.1xx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,3 @@ updates:
     labels:
       - "dependencies"
       - "dependabot: main"
-
-  - package-ecosystem: "nuget"
-    directory: "/eng/dependabot"
-    open-pull-requests-limit: 10
-    schedule:
-      interval: "weekly"
-    target-branch: "release/8.0.1xx"
-    labels:
-      - "dependencies"
-      - "dependabot: 8.0.1xx"


### PR DESCRIPTION
Related: https://github.com/dotnet/sdk/pull/36136#issuecomment-1771839358

## Summary
This removes dependabot taking action on updating dependences for the `release/8.0.1xx` branch. It should only be active for `main` currently.