### PR TITLE
Remove dotnet/runtime dependency

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,14 +4,6 @@
 
   <Import Project="$(RepositoryEngineeringDir)Package.props" />
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(BuildingInsideVisualStudio)' != 'true'">
-    <FrameworkReference
-        Update="Microsoft.NETCore.App"
-        TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
-        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)" />
-  </ItemGroup>
-
-
   <ItemGroup>
     <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true"/>
     <None Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" PackagePath="THIRD-PARTY-NOTICES.txt" Pack="true"/>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,18 +11,6 @@
       <Sha>b4fa7f2e1e65ef49881be2ab2df27624280a8c55</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="8.0.0-rc.2.23479.6">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>0b25e38ad32a69cd83ae246104b32449203cc71c</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="8.0.0-rc.2.23479.6">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>0b25e38ad32a69cd83ae246104b32449203cc71c</Sha>
-    </Dependency>
-    <Dependency Name="VS.Redist.Common.NetCore.SharedFramework.x64.8.0" Version="8.0.0-rc.2.23479.6">
-      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
-      <Sha>0b25e38ad32a69cd83ae246104b32449203cc71c</Sha>
-    </Dependency>
     <Dependency Name="System.CommandLine" Version="2.0.0-beta4.23407.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>a045dd54a4c44723c215d992288160eb1401bb7f</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,9 +21,5 @@
     <!-- Maestro-managed Package Versions - Ordered by repo name -->
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
     <SystemCommandLinePackageVersion>2.0.0-beta4.23407.1</SystemCommandLinePackageVersion>
-    <!-- Dependencies from https://github.com/dotnet/runtime -->
-    <MicrosoftNETCoreAppRefPackageVersion>8.0.0-rc.2.23479.6</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>8.0.0-rc.2.23479.6</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>8.0.0-rc.2.23479.6</VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,11 +1,6 @@
 {
   "tools": {
-    "dotnet": "8.0.100-rtm.23506.1",
-    "runtimes": {
-      "dotnet": [
-        "$(VSRedistCommonNetCoreSharedFrameworkx6480PackageVersion)"
-      ]
-    }
+    "dotnet": "8.0.100-rtm.23506.1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.23525.4"


### PR DESCRIPTION
Related: https://github.com/dotnet/templating/pull/7184#discussion_r1369216988

## Summary
There was an email discussion about this dependency being added in the past for testing purposes. We no longer think this is required as the SDK repo runs tests on templating when it flows into that. Having the extra dependency on runtime for this repo just complicates the code flow.