### PR TITLE
Remove Microsoft.SourceBuild.Intermediate from prebuilt baseline

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -5,7 +5,5 @@
   <IgnorePatterns>
     <!-- TODO: Ignore needed until https://github.com/dotnet/source-build/issues/3188 is addressed. -->
     <UsagePattern IdentityGlob="Microsoft.NETCore.App.Ref/*" />
-
-    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
   </IgnorePatterns>
 </UsageData>


### PR DESCRIPTION
Prebuilt detection no longer detects Microsoft.SourceBuild.Intermediates as prebuilts due to https://github.com/dotnet/arcade/pull/13935.

Addresses https://github.com/dotnet/source-build/issues/3010