### PR TITLE
Added WorkingDirectory property for #7471

### DIFF
--- a/docs/Binding-and-project-context-evaluation.md
+++ b/docs/Binding-and-project-context-evaluation.md
@@ -9,7 +9,7 @@ The feature is available for both `dotnet new` and Visual Studio.
 
 The symbol binds value from external sources. 
 By default, the following sources are available:
-- host parameters - parameters defined at certain host. For .NET SDK the following parameters are defined: `HostIdentifier: dotnetcli`, `GlobalJsonExists: true/false`.  Binding syntax is `host:<param name>`, example: `host:HostIdentifier`. 
+- host parameters - parameters defined at certain host. For .NET SDK the following parameters are defined: `HostIdentifier: dotnetcli`, `GlobalJsonExists: true/false`, `WorkingDirectory: <dotnet_new_context_directory>`.  Binding syntax is `host:<param name>`, example: `host:HostIdentifier`. 
 - environment variables - allows to bind environment variables. Binding syntax is `env:<environment variable name>`, example: `env:MYENVVAR`.
 
 It is also possible to bind the parameter without the prefix as a fallback behavior: `HostIdentifier`, `MYENVVAR`.
@@ -37,6 +37,10 @@ The higher value indicates higher priority.
    "HostIdentifier": {
       "type": "bind",
       "binding": "host:HostIdentifier"
+    },
+   "WorkingDirectory": {
+      "type": "bind",
+      "binding": "host:WorkingDirectory"
     }
 }
 ```  

--- a/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs
+++ b/src/Microsoft.TemplateEngine.Edge/DefaultTemplateEngineHost.cs
@@ -37,11 +37,15 @@ namespace Microsoft.TemplateEngine.Edge
             loggerFactory ??= NullLoggerFactory.Instance;
             _loggerFactory = loggerFactory;
             _logger = _loggerFactory.CreateLogger("Template Engine") ?? NullLogger.Instance;
+
+            WorkingDirectory = Environment.CurrentDirectory;
         }
 
         public IPhysicalFileSystem FileSystem { get; private set; }
 
         public string HostIdentifier { get; }
+
+        public string WorkingDirectory { get; }
 
         public IReadOnlyList<string> FallbackHostTemplateConfigNames { get; }
 
@@ -60,6 +64,9 @@ namespace Microsoft.TemplateEngine.Edge
             {
                 case "HostIdentifier":
                     value = HostIdentifier;
+                    return true;
+                case "WorkingDirectory":
+                    value = WorkingDirectory;
                     return true;
             }
 

--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Shipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Shipped.txt
@@ -267,3 +267,4 @@ static Microsoft.TemplateEngine.Edge.Template.InputDataStateUtil.GetInputDataSta
 static Microsoft.TemplateEngine.Edge.Template.TemplateEqualityComparer.Default.get -> System.Collections.Generic.IEqualityComparer<Microsoft.TemplateEngine.Abstractions.ITemplateInfo!>!
 static Microsoft.TemplateEngine.Edge.Template.TemplateMatchInfoEqualityComparer.Default.get -> System.Collections.Generic.IEqualityComparer<Microsoft.TemplateEngine.Edge.Template.ITemplateMatchInfo!>!
 ~Microsoft.TemplateEngine.Edge.FilterableTemplateInfo.ParameterDefinitions.get -> Microsoft.TemplateEngine.Abstractions.Parameters.IParameterDefinitionSet
+Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.WorkingDirectory.get -> string!

--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
@@ -8,4 +8,4 @@ Microsoft.TemplateEngine.Edge.VirtualEnvironment
 Microsoft.TemplateEngine.Edge.VirtualEnvironment.VirtualEnvironment(System.Collections.Generic.IReadOnlyDictionary<string!, string!>? virtualEnvironment, bool includeRealEnvironment) -> void
 static Microsoft.TemplateEngine.Edge.DefaultEnvironment.FetchEnvironmentVariables() -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
 Microsoft.TemplateEngine.Edge.FilterableTemplateInfo.PreferDefaultName.get -> bool
-Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.WorkingDirectory.get -> string
+Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.WorkingDirectory.get -> string!

--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
@@ -8,4 +8,3 @@ Microsoft.TemplateEngine.Edge.VirtualEnvironment
 Microsoft.TemplateEngine.Edge.VirtualEnvironment.VirtualEnvironment(System.Collections.Generic.IReadOnlyDictionary<string!, string!>? virtualEnvironment, bool includeRealEnvironment) -> void
 static Microsoft.TemplateEngine.Edge.DefaultEnvironment.FetchEnvironmentVariables() -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
 Microsoft.TemplateEngine.Edge.FilterableTemplateInfo.PreferDefaultName.get -> bool
-Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.WorkingDirectory.get -> string!

--- a/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.TemplateEngine.Edge/PublicAPI.Unshipped.txt
@@ -8,3 +8,4 @@ Microsoft.TemplateEngine.Edge.VirtualEnvironment
 Microsoft.TemplateEngine.Edge.VirtualEnvironment.VirtualEnvironment(System.Collections.Generic.IReadOnlyDictionary<string!, string!>? virtualEnvironment, bool includeRealEnvironment) -> void
 static Microsoft.TemplateEngine.Edge.DefaultEnvironment.FetchEnvironmentVariables() -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
 Microsoft.TemplateEngine.Edge.FilterableTemplateInfo.PreferDefaultName.get -> bool
+Microsoft.TemplateEngine.Edge.DefaultTemplateEngineHost.WorkingDirectory.get -> string


### PR DESCRIPTION
### Problem
<!-- Add the issue number if exists. Describe the problem otherwise. -->
#7471 

### Solution
<!-- Describe the solution. -->
Added a property that returns the current directory (have named it `WorkingDirectory`) from where the dotnet command is invoked.

### Checks:
- [ ] Added unit tests