### PR TITLE
Fix the broken template scanning pipeline job

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run template scanner",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${workspaceFolder}\\artifacts\\bin\\Microsoft.TemplateSearch.TemplateDiscovery\\Debug\\net9.0\\Microsoft.TemplateSearch.TemplateDiscovery.dll",
+      "args": [
+        "--basePath",
+        "./templates",
+        "--verbose",
+        "--savePacks",
+        "--diff",
+        "true",
+        "--test",
+        "--allowPreviewPacks"
+      ]
+    }
+  ]
+}

--- a/src/Microsoft.TemplateSearch.Common/Abstractions/TemplatePackageSearchData.cs
+++ b/src/Microsoft.TemplateSearch.Common/Abstractions/TemplatePackageSearchData.cs
@@ -11,6 +11,7 @@ namespace Microsoft.TemplateSearch.Common
     /// <summary>
     /// Template package searchable data.
     /// </summary>
+    [System.Diagnostics.DebuggerDisplay("{Name}@{Version}")]
     public partial class TemplatePackageSearchData : ITemplatePackageInfo
     {
         public TemplatePackageSearchData(ITemplatePackageInfo packInfo, IEnumerable<TemplateSearchData> templates, IDictionary<string, object>? data = null)

--- a/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplateSearchCache.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplateSearchCache.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 
 namespace Microsoft.TemplateSearch.Common
@@ -12,12 +14,14 @@ namespace Microsoft.TemplateSearch.Common
 
         internal TemplateSearchCache(IReadOnlyList<TemplatePackageSearchData> data)
         {
-            TemplatePackages = data;
+            // when creating from freshly-generated data, order the results for clarity
+            TemplatePackages = data.OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase).ToArray();
             Version = CurrentVersion;
         }
 
         private TemplateSearchCache(IReadOnlyList<TemplatePackageSearchData> data, string version)
         {
+            // don't order results when creating from a read file
             TemplatePackages = data;
             Version = version;
         }

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/NuGet/NugetPackProvider.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/NuGet/NugetPackProvider.cs
@@ -141,7 +141,6 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
             {
                 if (File.Exists(outputPackageFileNameFullPath))
                 {
-                    using Stream existingPackageStream = File.OpenRead(outputPackageFileNameFullPath);
                     return new DownloadedPackInfo(packinfo, outputPackageFileNameFullPath);
                 }
                 else

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/NuGet/NugetPackProvider.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/NuGet/NugetPackProvider.cs
@@ -45,11 +45,7 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
 
             _searchUriFormat = $"{searchResources[0].Uri}?{query}&skip={{0}}&take={{1}}&prerelease={includePreviewPacks}&semVerLevel=2.0.0";
 
-            if (Directory.Exists(_packageTempPath))
-            {
-                throw new Exception($"temp storage path for NuGet packages already exists: {_packageTempPath}");
-            }
-            else
+            if (!Directory.Exists(_packageTempPath))
             {
                 Directory.CreateDirectory(_packageTempPath);
             }
@@ -143,20 +139,28 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.NuGet
 
             try
             {
-                using Stream packageStream = File.Create(outputPackageFileNameFullPath);
-                if (await _downloadResource.CopyNupkgToStreamAsync(
-                    packinfo.Name,
-                    new NuGetVersion(packinfo.Version!),
-                    packageStream,
-                    _cacheContext,
-                    NullLogger.Instance,
-                    token).ConfigureAwait(false))
+                if (File.Exists(outputPackageFileNameFullPath))
                 {
+                    using Stream existingPackageStream = File.OpenRead(outputPackageFileNameFullPath);
                     return new DownloadedPackInfo(packinfo, outputPackageFileNameFullPath);
                 }
                 else
                 {
-                    throw new Exception($"Download failed: {nameof(_downloadResource.CopyNupkgToStreamAsync)} returned false.");
+                    using Stream packageStream = File.Create(outputPackageFileNameFullPath);
+                    if (await _downloadResource.CopyNupkgToStreamAsync(
+                        packinfo.Name,
+                        new NuGetVersion(packinfo.Version!),
+                        packageStream,
+                        _cacheContext,
+                        NullLogger.Instance,
+                        token).ConfigureAwait(false))
+                    {
+                        return new DownloadedPackInfo(packinfo, outputPackageFileNameFullPath);
+                    }
+                    else
+                    {
+                        throw new Exception($"Download failed: {nameof(_downloadResource.CopyNupkgToStreamAsync)} returned false.");
+                    }
                 }
             }
             catch (TaskCanceledException)

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/FilteredPackageInfo.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/FilteredPackageInfo.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 
 namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
 {
+    [System.Diagnostics.DebuggerDisplay("{Name}@{Version} - {Reason}")]
     internal class FilteredPackageInfo : ITemplatePackageInfo
     {
         internal FilteredPackageInfo(ITemplatePackageInfo info, string reason)

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/PackChecking/PackSourceChecker.cs
@@ -156,10 +156,10 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.PackChecking
                 var packageInfo = await provider.GetPackageInfoAsync(package.Name, cancellationToken).ConfigureAwait(false);
                 if (packageInfo == default)
                 {
-                    Console.WriteLine($"Package {package.Name} cannot be verified.");
-                    throw new Exception($"Package {package.Name} is missing and cannot be verified.");
+                    Console.WriteLine($"Package {package.Name} no longer exists in the provider.");
+                    scanningStats.RemovedTemplatePacks.Add(package);
                 }
-                if (packageInfo.Removed)
+                else if (packageInfo.Removed)
                 {
                     Console.WriteLine($"Package {package.Name} was unlisted.");
                     scanningStats.RemovedTemplatePacks.Add(package);

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Results/UnifiedPackCheckResultReportWriter.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Results/UnifiedPackCheckResultReportWriter.cs
@@ -48,7 +48,8 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Results
 
         private static void WriteNonTemplatePackList(string reportPath, IReadOnlyList<FilteredPackageInfo> packCheckResults)
         {
-            string serializedContent = JsonConvert.SerializeObject(packCheckResults, Formatting.None);
+            var orderedFilters = packCheckResults.OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase).ToArray();
+            string serializedContent = JsonConvert.SerializeObject(orderedFilters, Formatting.None);
             string outputFileName = Path.Combine(reportPath, NonTemplatePacksFileName);
             File.WriteAllText(outputFileName, serializedContent);
             Console.WriteLine($"Non template pack list was created: {outputFileName}");


### PR DESCRIPTION
### Problem
The [pipelines](https://dev.azure.com/dnceng/internal/_build?definitionId=1025) for the template cache scanner have been broken for some time now due to an invariant changing - the tools never expected that a template would just...be completely removed.

### Solution
We allow this case and add it to the set of removed templates. It can always be re-added back once it's back on NuGet.org.