### PR TITLE
Remove internal debug build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,6 @@ parameters:
   default:
   # Always build the Release configuration, but never sign for PRs.
   - buildConfig: Release
-  - buildConfig: Debug
 
 extends:
   ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
@@ -67,9 +66,6 @@ extends:
         name: $(DncEngInternalBuildPool)
         image: 1es-windows-2022
         os: windows
-    customBuildTags:
-    - ES365AIMigrationTooling
-
     stages:
     - stage: build
       displayName: Build


### PR DESCRIPTION
## Summary
This removes building the Debug configuration when doing internal builds. Also removed custom build tags as they aren't applicable.