### PR TITLE
Update referenced NuGet version

### DIFF
--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -12,9 +12,9 @@
     <PackageReference Update="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
-    <PackageReference Update="NuGet.Configuration" Version="6.7.0" />
-    <PackageReference Update="NuGet.Credentials" Version="6.7.0" />
-    <PackageReference Update="NuGet.Protocol" Version="6.7.0" />
+    <PackageReference Update="NuGet.Configuration" Version="6.7.1" />
+    <PackageReference Update="NuGet.Credentials" Version="6.7.1" />
+    <PackageReference Update="NuGet.Protocol" Version="6.7.1" />
 
     <!--Analyzers-->
     <PackageReference Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />


### PR DESCRIPTION
### Problem
Component governance is reporting this repo as referencing a vulnerable version of NuGet.Packaging: 6.7.0. This is a transitive dependency of the existing dependencies declared.

### Solution
Upgraded to NuGet 6.7.1.
