### PR TITLE
Call NuGetAuthenticate after SetupNuGetSources

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -112,6 +112,7 @@ stages:
               arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
             env:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
+          - task: NuGetAuthenticate@1
         # Use utility script to run script command dependent on agent OS.
         - script: eng/common/cibuild.cmd
             -configuration $(_BuildConfig)
@@ -142,6 +143,7 @@ stages:
                 arguments: $(Build.SourcesDirectory)/NuGet.config $Token
               env:
                 Token: $(dn-bot-dnceng-artifact-feeds-rw)
+            - task: NuGetAuthenticate@1
           - script: eng/common/cibuild.sh
               --configuration $(_BuildConfig)
               --prepareMachine
@@ -175,6 +177,7 @@ stages:
                 arguments: $(Build.SourcesDirectory)/NuGet.config $Token
               env:
                 Token: $(dn-bot-dnceng-artifact-feeds-rw)
+            - task: NuGetAuthenticate@1
           - script: eng/common/cibuild.sh
               --configuration $(_BuildConfig)
               --prepareMachine

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,6 +124,7 @@ extends:
                     arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
                   env:
                     Token: $(dn-bot-dnceng-artifact-feeds-rw)
+                - task: NuGetAuthenticate@1
               # Use utility script to run script command dependent on agent OS.
               - script: eng/common/cibuild.cmd
                   -configuration $(_BuildConfig)
@@ -151,6 +152,7 @@ extends:
                       arguments: $(Build.SourcesDirectory)/NuGet.config $Token
                     env:
                       Token: $(dn-bot-dnceng-artifact-feeds-rw)
+                  - task: NuGetAuthenticate@1
                 - script: eng/common/cibuild.sh
                     --configuration $(_BuildConfig)
                     --prepareMachine
@@ -184,6 +186,7 @@ extends:
                       arguments: $(Build.SourcesDirectory)/NuGet.config $Token
                     env:
                       Token: $(dn-bot-dnceng-artifact-feeds-rw)
+                  - task: NuGetAuthenticate@1
                 - script: eng/common/cibuild.sh
                     --configuration $(_BuildConfig)
                     --prepareMachine


### PR DESCRIPTION
The new version of the powershell script will not place the creds in the nuget.config file, instead it will use standard environment variables. Update the YAML file to use NuGetAuthenticate to avoid a build break that may happen if the credential provider is not available.