### PR TITLE
Remove unnecessary XML headers from msbuild files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
     <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
     <Import Project="$(RepositoryEngineeringDir)Analyzers.props" />

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$(RepositoryEngineeringDir)Package.props" />
 

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Specify the solutions to build. Add all new solutions/projects here as necessary or the main build won't build them! -->
   <ItemGroup>

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
    <PropertyGroup>
       <PublishingVersion>3</PublishingVersion>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <Import Project="..\Directory.Build.props" />

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="..\Directory.Build.targets" />
 

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <Import Project="..\Directory.Build.props" />


### PR DESCRIPTION
Those aren't needed by msbuild and already got
removed in most other core stack repositories
like runtime.