### PR TITLE
Remove unnecessary license header from files

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the MIT license. See License.txt in the project root for full license information. -->
 <Project>
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>


### PR DESCRIPTION
Non-shipping XML / msbuild files don't need the
.NET Foundation license header. This makes files
consistent with other core stack repositories.