### PR TITLE
dont generate docs for tests

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,5 +3,6 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
speeds up the build and the ide.
and reduces noise in the build output and the ide
