### PR TITLE
Fix PR inconsistent test failure

### DIFF
--- a/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
@@ -78,12 +78,12 @@ namespace Microsoft.TemplateEngine.TestHelper
                     {
                         Directory.Delete(f, true);
                     }
-                    catch (UnauthorizedAccessException)
+                    catch (Exception e) when (e is UnauthorizedAccessException or IOException)
                     {
                         // Failed to delete the temporary test folders.
-                        // This is more likely to happen in the TemplatePackageManagerTests.
-                        // There may be some access being released prior to this dispose.
-                        // No need to worry since these folders are in the Temp directory.
+                        // There may be some access being released prior to this dispose or the machine holding an handle to inner files/folders.
+                        // No need to worry that deletion failed since these folders are in the Temp directory anyway.
+                        // See: https://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true
                     }
                 }
             });

--- a/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
@@ -81,7 +81,7 @@ namespace Microsoft.TemplateEngine.TestHelper
                     catch (Exception e) when (e is UnauthorizedAccessException or IOException)
                     {
                         // Failed to delete the temporary test folders.
-                        // There may be some access being released prior to this dispose or the machine holding an handle to inner files/folders.
+                        // There may be some access being released prior to this dispose or the machine holding a handle to inner files/folders.
                         // No need to worry that deletion failed since these folders are in the Temp directory anyway.
                         // See: https://stackoverflow.com/questions/329355/cannot-delete-directory-with-directory-deletepath-true
                     }

--- a/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
@@ -78,10 +78,12 @@ namespace Microsoft.TemplateEngine.TestHelper
                     {
                         Directory.Delete(f, true);
                     }
-                    catch
+                    catch (UnauthorizedAccessException)
                     {
-                        Thread.Sleep(2000);
-                        Directory.Delete(f, true);
+                        // Failed to delete the temporary test folders.
+                        // This is more likely to happen in the TemplatePackageManagerTests.
+                        // There may be some access being released prior to this dispose.
+                        // No need to worry since these folders are in the Temp directory.
                     }
                 }
             });


### PR DESCRIPTION
## Summary

After looking over many PRs recently, I noticed that they inconsistently fail. However, no tests are failing (all tests pass). If you look over the test log, you'll see an exception at the very bottom:

```
[Test Class Cleanup Failure (Microsoft.TemplateEngine.Edge.UnitTests.TemplatePackageManagerTests)] System.UnauthorizedAccessException
      System.UnauthorizedAccessException : Access to the path 'C:\Users\cloudtest\AppData\Local\Temp\TemplateEngine.Tests\616c3c66-71d5-49cb-b691-65f94d387d3d\.templateengine' is denied.
      Stack Trace:
           at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
           at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
               /_/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs(84,0): at Microsoft.TemplateEngine.TestHelper.EnvironmentSettingsHelper.<>c.<Dispose>b__5_0(String f)
           at System.Collections.Generic.List`1.ForEach(Action`1 action)
               /_/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs(73,0): at Microsoft.TemplateEngine.TestHelper.EnvironmentSettingsHelper.Dispose()
```

Looking into this, there was a "hack" where if the temporary test folder could not be deleted, it slept for 2 seconds and then tried again. This second attempt is what was failing. This only seems to happen on the *last* test execution in the TemplatePackageManagerTests. My theory is the test framework is shutting down and, somehow, this Dispose runs after the point where it can still access this folder. So, it just fails.

Either way, since these folders are created in the Temp machine folder, it really doesn't matter if we cannot clean up the last test folder. I'd rather the PR runs not randomly fail. I've also made the catch specifically catch this UnauthorizedAccessException instead of everything. Other exceptions are not expected.
