### PR TITLE
Fix templates VMR build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,9 @@ bld/
 [Bb]in/
 [Oo]bj/
 dev/
+*.binlog
 
-# Visual Studio 2015 cache/options directory
+# Visual Studio cache/options directory
 .vs/
 # Visual Studio launch settings
 **/launchSettings.json

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,7 @@
     <PackageVersion Include="Verify.XUnit" Version="25.0.2" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <!-- Xunit version is managed by Arcade. -->
-    <PackageVersion Include="xunit" Version="$(XUnitVersion)" />
+    <PackageVersion Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />
   </ItemGroup>
 
   <!-- DotNetBuild overrides -->

--- a/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- Don't set IsTestUtilityProject=true because this project is referenced by tools and would otherwise be filtered out. -->
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <IsPackable>true</IsPackable>
@@ -16,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Protocol" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.extensibility.execution" />
     <PackageReference Include="xunit.abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />


### PR DESCRIPTION
The PackageReference to xunit caused the project
to have IsTestProject=true set which then caused
the project to get filtered out in source-build
and VMR builds.

Instead of referencing the meta xunit package,
just reference the extensibility.execution pkg
that provides the necessary API.