### PR TITLE
allow comparer to be omitted in EqualityExtensions

### DIFF
--- a/src/Microsoft.TemplateEngine.Utils/EqualityExtensions.cs
+++ b/src/Microsoft.TemplateEngine.Utils/EqualityExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.TemplateEngine.Utils
             return items.AllAreTheSame(selector, (x, y) => x?.Equals(y) ?? (y == null));
         }
 
-        public static bool AllAreTheSame<T, TValue>(this IEnumerable<T> items, Func<T, TValue?> selector, IEqualityComparer<TValue?> comparer)
+        public static bool AllAreTheSame<T, TValue>(this IEnumerable<T> items, Func<T, TValue?> selector, IEqualityComparer<TValue?>? comparer = null)
             where TValue : IEquatable<TValue?>
         {
             comparer ??= EqualityComparer<TValue?>.Default;
@@ -19,7 +19,7 @@ namespace Microsoft.TemplateEngine.Utils
             return items.AllAreTheSame(selector, comparer.Equals);
         }
 
-        public static bool AllAreTheSame<T, TValue>(this IEnumerable<T> items, Func<T, TValue?> selector, Func<TValue?, TValue?, bool> comparer)
+        public static bool AllAreTheSame<T, TValue>(this IEnumerable<T> items, Func<T, TValue?> selector, Func<TValue?, TValue?, bool>? comparer = null)
             where TValue : IEquatable<TValue?>
         {
             comparer ??= EqualityComparer<TValue?>.Default.Equals;


### PR DESCRIPTION
it would seem the intent of AllAreTheSame is to allow people to omit passing a comparer ?

given the defaulting of the comparer to a value
```
comparer ??= EqualityComparer<TValue?>.Default;
```

but the api does not allow null to be passed?

if this is not the intent, i will do a PR that removed the defaulting