### PR TITLE
Remove live runtime dependencies

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,13 +2,6 @@
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(BuildingInsideVisualStudio)' != 'true'">
-    <FrameworkReference
-        Update="Microsoft.NETCore.App"
-        TargetingPackVersion="$(MicrosoftNETCoreAppRefPackageVersion)"
-        RuntimeFrameworkVersion="$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Include="$(RepoRoot)LICENSE.txt" PackagePath="LICENSE.txt" Pack="true" />
     <None Include="$(RepoRoot)THIRD-PARTY-NOTICES.txt" PackagePath="THIRD-PARTY-NOTICES.txt" Pack="true" />

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -29,15 +29,6 @@ variables:
     value: false
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: Templating-SDLValidation-Params
-    
-  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    # Variable replaced by enable-internal-runtimes.yml
-    - name: _InternalRuntimeDownloadArgs
-      value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal 
-        /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-    - name: _InternalRuntimeDownloadArgs
-      value: ''
   - template: /eng/common/templates/variables/pool-providers.yml
 
 stages:
@@ -106,16 +97,12 @@ stages:
         - checkout: self
           clean: true
 
-        - template: /eng/common/templates/steps/enable-internal-runtimes.yml
-        - template: /eng/common/templates/steps/enable-internal-sources.yml
-
         # Use utility script to run script command dependent on agent OS.
         - script: eng/common/cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
             -integrationTest
             $(_InternalBuildArgs)
-            $(_InternalRuntimeDownloadArgs)
           displayName: Windows Build / Publish
 
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
@@ -131,15 +118,10 @@ stages:
                 _BuildConfig: Release
                 _SignType: none
           steps:
-
-          - template: /eng/common/templates/steps/enable-internal-runtimes.yml
-          - template: /eng/common/templates/steps/enable-internal-sources.yml
-
           - script: eng/common/cibuild.sh
               --configuration $(_BuildConfig)
               --prepareMachine
               --integrationTest
-              $(_InternalRuntimeDownloadArgs)
             name: Build
             displayName: Build
 
@@ -147,7 +129,7 @@ stages:
         - job: Linux
           pool:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              vmImage: ubuntu-latest 
+              vmImage: ubuntu-latest
             ${{ if eq(variables['System.TeamProject'], 'internal') }}:
               name: $(DncEngInternalBuildPool)
               demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
@@ -160,15 +142,10 @@ stages:
                 _BuildConfig: Release
                 _SignType: none
           steps:
-
-          - template: /eng/common/templates/steps/enable-internal-runtimes.yml
-          - template: /eng/common/templates/steps/enable-internal-sources.yml
-
           - script: eng/common/cibuild.sh
               --configuration $(_BuildConfig)
               --prepareMachine
               --integrationTest
-              $(_InternalRuntimeDownloadArgs)
             name: Build
             displayName: Build
             condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,14 +29,6 @@ variables:
     value: false
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: Templating-SDLValidation-Params
-  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    # Variable replaced by enable-internal-runtimes.yml
-    - name: _InternalRuntimeDownloadArgs
-      value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal 
-        /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-    - name: _InternalRuntimeDownloadArgs
-      value: ''
   - template: /eng/common/templates-official/variables/pool-providers.yml
 
 resources:
@@ -106,7 +98,7 @@ extends:
               - _SignType: test
               - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
                 - _SignType: real
-              - _InternalBuildArgs: ''              
+              - _InternalBuildArgs: ''
               # Only enable publishing in non-public, non PR scenarios.
               - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                 # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat, symweb-symbol-server-pat
@@ -119,16 +111,12 @@ extends:
               - checkout: self
                 clean: true
 
-              - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
-              - template: /eng/common/templates-official/steps/enable-internal-sources.yml
-
               # Use utility script to run script command dependent on agent OS.
               - script: eng/common/cibuild.cmd
                   -configuration $(_BuildConfig)
                   -prepareMachine
                   -integrationTest
                   $(_InternalBuildArgs)
-                  $(_InternalRuntimeDownloadArgs)
                 displayName: Windows Build / Publish
 
           - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
@@ -141,18 +129,13 @@ extends:
                 - _BuildConfig: ${{ config.buildConfig }}
                 - _SignType: none
                 steps:
-                
-                - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
-                - template: /eng/common/templates-official/steps/enable-internal-sources.yml
-                
                 - script: eng/common/cibuild.sh
                     --configuration $(_BuildConfig)
                     --prepareMachine
                     --integrationTest
-                    $(_InternalRuntimeDownloadArgs)
                   name: Build
                   displayName: Build
-    
+
           - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
             - ${{ each config in parameters.buildConfigurations }}:
               - job: Linux_${{ config.buildConfig }}
@@ -170,19 +153,14 @@ extends:
                 - _BuildConfig: ${{ config.buildConfig }}
                 - _SignType: none
                 steps:
-                
-                - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml
-                - template: /eng/common/templates-official/steps/enable-internal-sources.yml
-                
                 - script: eng/common/cibuild.sh
                     --configuration $(_BuildConfig)
                     --prepareMachine
                     --integrationTest
-                    $(_InternalRuntimeDownloadArgs)
                   name: Build
                   displayName: Build
                   condition: succeeded()
-    
+
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - template: eng/common/templates-official/post-build/post-build.yml@self
         parameters:

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -3,7 +3,5 @@
 
 <UsageData>
   <IgnorePatterns>
-    <!-- TODO: Ignore needed until https://github.com/dotnet/source-build/issues/3188 is addressed. -->
-    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Ref/*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,14 +13,6 @@
       <Sha>9ae78a4e6412926d19ba97cfed159bf9de70b538</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="9.0.0-preview.6.24316.2">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f4fd3ea470aeef5a7c843e9fd5fa1ce50b6b5b70</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.6.24316.2">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>f4fd3ea470aeef5a7c843e9fd5fa1ce50b6b5b70</Sha>
-    </Dependency>
     <Dependency Name="System.CommandLine" Version="2.0.0-beta4.24209.3">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>963d34b1fb712c673bfb198133d7e988182c9ef4</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,8 +15,5 @@
   <PropertyGroup>
     <!-- Command-line-api dependencies -->
     <SystemCommandLinePackageVersion>2.0.0-beta4.24209.3</SystemCommandLinePackageVersion>
-    <!-- Runtime dependencies -->
-    <MicrosoftNETCoreAppRefPackageVersion>9.0.0-preview.6.24316.2</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>9.0.0-preview.6.24316.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
   </PropertyGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,11 +1,6 @@
 {
   "tools": {
-    "dotnet": "9.0.100-preview.5.24307.3",
-    "runtimes": {
-      "dotnet": [
-        "$(MicrosoftNETCoreAppRefPackageVersion)"
-      ]
-    }
+    "dotnet": "9.0.100-preview.5.24307.3"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.24317.3"

--- a/template_feed/Microsoft.TemplateEngine.Authoring.Templates/Microsoft.TemplateEngine.Authoring.Templates.csproj
+++ b/template_feed/Microsoft.TemplateEngine.Authoring.Templates/Microsoft.TemplateEngine.Authoring.Templates.csproj
@@ -24,7 +24,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Remove="Microsoft.NETCore.App" />
     <Content Include="content\**">
       <PackagePath>content</PackagePath>
     </Content>


### PR DESCRIPTION
... use the shared framework that comes with the
SDK instead.

We determined that a live runtime doesn't provide
much benefit anymore and in contrast often
causes pain when flowing dependencies to
dotnet/sdk.

Note: The VMR should react to this when the change reaches dotnet/sdk. This line should be removed: https://github.com/dotnet/sdk/blob/a5ccfef7bea1d8883142ffa632439ca848da9378/src/SourceBuild/content/repo-projects/templating.proj#L12