### PR TITLE
[release/8.0.4xx] Remove internal runtime args

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -29,15 +29,6 @@ variables:
     value: false
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: Templating-SDLValidation-Params
-    
-  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    - group: DotNetBuilds storage account read tokens
-    - name: _InternalRuntimeDownloadArgs
-      value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal 
-        /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-    - name: _InternalRuntimeDownloadArgs
-      value: ''
   - template: /eng/common/templates/variables/pool-providers.yml
 
 stages:
@@ -104,21 +95,12 @@ stages:
         steps:
         - checkout: self
           clean: true
-        - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - task: PowerShell@2
-            displayName: Setup Private Feeds Credentials
-            inputs:
-              filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-              arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-            env:
-              Token: $(dn-bot-dnceng-artifact-feeds-rw)
         # Use utility script to run script command dependent on agent OS.
         - script: eng/common/cibuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
             -integrationTest
             $(_InternalBuildArgs)
-            $(_InternalRuntimeDownloadArgs)
           displayName: Windows Build / Publish
 
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
@@ -134,19 +116,10 @@ stages:
                 _BuildConfig: Release
                 _SignType: none
           steps:
-          - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            - task: Bash@3
-              displayName: Setup Private Feeds Credentials
-              inputs:
-                filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-                arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-              env:
-                Token: $(dn-bot-dnceng-artifact-feeds-rw)
           - script: eng/common/cibuild.sh
               --configuration $(_BuildConfig)
               --prepareMachine
               --integrationTest
-              $(_InternalRuntimeDownloadArgs)
             name: Build
             displayName: Build
 
@@ -154,7 +127,7 @@ stages:
         - job: Linux
           pool:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
-              vmImage: ubuntu-latest 
+              vmImage: ubuntu-latest
             ${{ if eq(variables['System.TeamProject'], 'internal') }}:
               name: $(DncEngInternalBuildPool)
               demands: ImageOverride -equals Build.Ubuntu.2204.Amd64
@@ -167,19 +140,10 @@ stages:
                 _BuildConfig: Release
                 _SignType: none
           steps:
-          - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            - task: Bash@3
-              displayName: Setup Private Feeds Credentials
-              inputs:
-                filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-                arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-              env:
-                Token: $(dn-bot-dnceng-artifact-feeds-rw)
           - script: eng/common/cibuild.sh
               --configuration $(_BuildConfig)
               --prepareMachine
               --integrationTest
-              $(_InternalRuntimeDownloadArgs)
             name: Build
             displayName: Build
             condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,14 +29,6 @@ variables:
     value: false
   - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
     - group: Templating-SDLValidation-Params
-  - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-    - group: DotNetBuilds storage account read tokens
-    - name: _InternalRuntimeDownloadArgs
-      value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal 
-        /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-  - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-    - name: _InternalRuntimeDownloadArgs
-      value: ''
   - template: /eng/common/templates-official/variables/pool-providers.yml
 
 resources:
@@ -104,7 +96,7 @@ extends:
               - _SignType: test
               - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
                 - _SignType: real
-              - _InternalBuildArgs: ''              
+              - _InternalBuildArgs: ''
               # Only enable publishing in non-public, non PR scenarios.
               - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                 # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat, symweb-symbol-server-pat
@@ -116,21 +108,12 @@ extends:
               steps:
               - checkout: self
                 clean: true
-              - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                - task: PowerShell@2
-                  displayName: Setup Private Feeds Credentials
-                  inputs:
-                    filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-                    arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-                  env:
-                    Token: $(dn-bot-dnceng-artifact-feeds-rw)
               # Use utility script to run script command dependent on agent OS.
               - script: eng/common/cibuild.cmd
                   -configuration $(_BuildConfig)
                   -prepareMachine
                   -integrationTest
                   $(_InternalBuildArgs)
-                  $(_InternalRuntimeDownloadArgs)
                 displayName: Windows Build / Publish
 
           - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
@@ -143,22 +126,13 @@ extends:
                 - _BuildConfig: ${{ config.buildConfig }}
                 - _SignType: none
                 steps:
-                - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                  - task: Bash@3
-                    displayName: Setup Private Feeds Credentials
-                    inputs:
-                      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-                      arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-                    env:
-                      Token: $(dn-bot-dnceng-artifact-feeds-rw)
                 - script: eng/common/cibuild.sh
                     --configuration $(_BuildConfig)
                     --prepareMachine
                     --integrationTest
-                    $(_InternalRuntimeDownloadArgs)
                   name: Build
                   displayName: Build
-    
+
           - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
             - ${{ each config in parameters.buildConfigurations }}:
               - job: Linux_${{ config.buildConfig }}
@@ -176,23 +150,14 @@ extends:
                 - _BuildConfig: ${{ config.buildConfig }}
                 - _SignType: none
                 steps:
-                - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                  - task: Bash@3
-                    displayName: Setup Private Feeds Credentials
-                    inputs:
-                      filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-                      arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-                    env:
-                      Token: $(dn-bot-dnceng-artifact-feeds-rw)
                 - script: eng/common/cibuild.sh
                     --configuration $(_BuildConfig)
                     --prepareMachine
                     --integrationTest
-                    $(_InternalRuntimeDownloadArgs)
                   name: Build
                   displayName: Build
                   condition: succeeded()
-    
+
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - template: eng/common/templates-official/post-build/post-build.yml@self
         parameters:

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -17,9 +17,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24328.2">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24352.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>761c516b64fee3941d8909d24205ced835eed83e</Sha>
+      <Sha>8b879da4e449c48d99f3f642fc429379a64e8fe8</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23475.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
     "dotnet": "8.0.101"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24328.2"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24352.1"
   }
 }


### PR DESCRIPTION
Removes internal runtime args and creds. Not needed for this repo (doesn't take live updates from runtime) and removes use of existing SAS tokens