### PR TITLE
Remove 6.0 automated codeflow

### DIFF
--- a/github-merge-flow.jsonc
+++ b/github-merge-flow.jsonc
@@ -1,16 +1,6 @@
 // IMPORTANT: This file is read by the merge flow from main branch only. 
 {
     "merge-flow-configurations": {
-        // Automate opening PRs to merge cli release/6.0.1xx to .4xx
-        "release/6.0.1xx":{
-            "MergeToBranch": "release/6.0.4xx",
-            "ExtraSwitches": "-QuietComments"
-        },
-        // Automate opening PRs to merge cli release/6.0.4xx to 8.0.1xx
-        "release/6.0.4xx":{
-            "MergeToBranch": "release/8.0.1xx",
-            "ExtraSwitches": "-QuietComments"
-        },
         // Automate opening PRs to merge cli release/8.0.1xx to 8.0.3xx
         "release/8.0.1xx":{
             "MergeToBranch": "release/8.0.3xx",


### PR DESCRIPTION
It doesn't look like we've been taking branch to branch flow in a while as there are now over a hundred commits. Looks like it's been more than a year. Scanning the PRs, I don't' see anything critical that's missing. Let's just disable the codeflow as it's probably not worth fixing at this point.

We should keep the 8.0 flow for now.

#8185