### PR TITLE
Avoid allocations from calls to CultureInfo.GetCultures

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/DirectoryBasedTemplate.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/DirectoryBasedTemplate.cs
@@ -136,9 +136,14 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         {
             string filename = locFile.Name;
             string localeStr = filename.Substring(LocalizationFilePrefix.Length, filename.Length - LocalizationFilePrefix.Length - LocalizationFileExtension.Length);
+            CultureInfo? locale = null;
 
-            CultureInfo? locale = CultureInfo.GetCultures(CultureTypes.AllCultures).FirstOrDefault(c => c.Name.Equals(localeStr, StringComparison.OrdinalIgnoreCase));
-            if (locale == null)
+            try
+            {
+                // PERF: Avoid calling CultureInfo.GetCultures and searching the results as it heavily allocates on each invocation.
+                locale = CultureInfo.GetCultureInfo(localeStr);
+            }
+            catch (CultureNotFoundException)
             {
                 Logger.LogWarning(LocalizableStrings.LocalizationModelDeserializer_Error_UnknownLocale, localeStr);
             }


### PR DESCRIPTION
A local profile taken during running the vsixinstaller on roslyn indicated this call was allocating quite heavily in the "devenv /updateconfiguration" process the vsixinstaller kicks off. DirectoryBasedTemplate.ParseLocFileName was allocating 8.1% of all allocations in that devenv process, nearly all of which comes from the CultureInfo.GetCultures call.

Instead of allocating all cultures and an array to hold them by calling CultureInfo.GetCultures, this code can use CultureInfo.GetCultureInfo with the requested culture name and use that result instead. Note that GetCultureInfo throws if the requested culture name isn't supported, so we need to catch the corresponding CultureNotFoundException.

![image](https://github.com/user-attachments/assets/2627501a-c430-4b8a-bdec-fea539483a8e)
