### PR TITLE
Add a direct reference to asn1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,4 +22,8 @@
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
     <SystemCommandLinePackageVersion>2.0.0-beta4.24324.3</SystemCommandLinePackageVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Non-maestro versions -->
+    <SystemFormatsAsn1Version>6.0.1</SystemFormatsAsn1Version>
+  </PropertyGroup>
 </Project>

--- a/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
+++ b/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Abstractions\Microsoft.TemplateEngine.Abstractions.csproj" />
     <ProjectReference Include="$(SrcDir)Microsoft.TemplateEngine.Utils\Microsoft.TemplateEngine.Utils.csproj" />
+    <PackageReference Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
 in the most shared project to resolve the CG alerts. This is because pkcs depends on a version of this package that's not compliant but hasn't re-released a new version. That's pulled in by msbuild but the easiest way to fix is just add the direct reference.
