### PR TITLE
Update Auth0 Templates reference in Available-templates-for-dotnet-new.md

### DIFF
--- a/docs/Available-templates-for-dotnet-new.md
+++ b/docs/Available-templates-for-dotnet-new.md
@@ -24,7 +24,7 @@ Below is a list of selected NuGet.org templates which are available for use with
 | Name     | Quick Install |
 |----------|:--------------|
 | [.NET Boxed](https://github.com/Dotnet-Boxed/Templates) | `dotnet new install "Boxed.Templates"`|
-| [Auth0 Templates](https://github.com/auth0/auth0-dotnet-templates) | `dotnet new install Auth0.Templates"` |
+| [Auth0 Templates](https://github.com/auth0/auth0-dotnet-templates) | `dotnet new install Auth0.Templates` |
 | [AWS Lambda .NET Core Templates](https://github.com/aws/aws-lambda-dotnet/tree/master/Blueprints) | `dotnet new install "Amazon.Lambda.Templates"`|
 | [Avalonia UI Templates](https://github.com/AvaloniaUI/Avalonia) - Avalonia is a framework for creating cross platform UI | `dotnet new install "Avalonia.Templates"`|
 | [Blazor](http://blazor.net) - Full stack web development with C# and WebAssembly | `dotnet new install "Microsoft.AspNetCore.Blazor.Templates::3.0.0-*"`|

--- a/docs/Available-templates-for-dotnet-new.md
+++ b/docs/Available-templates-for-dotnet-new.md
@@ -24,7 +24,7 @@ Below is a list of selected NuGet.org templates which are available for use with
 | Name     | Quick Install |
 |----------|:--------------|
 | [.NET Boxed](https://github.com/Dotnet-Boxed/Templates) | `dotnet new install "Boxed.Templates"`|
-| [Auth0 Templates](https://github.com/auth0/auth0-dotnet-templates) | `dotnet new install Auth0.Templates::2.0.0"` |
+| [Auth0 Templates](https://github.com/auth0/auth0-dotnet-templates) | `dotnet new install Auth0.Templates"` |
 | [AWS Lambda .NET Core Templates](https://github.com/aws/aws-lambda-dotnet/tree/master/Blueprints) | `dotnet new install "Amazon.Lambda.Templates"`|
 | [Avalonia UI Templates](https://github.com/AvaloniaUI/Avalonia) - Avalonia is a framework for creating cross platform UI | `dotnet new install "Avalonia.Templates"`|
 | [Blazor](http://blazor.net) - Full stack web development with C# and WebAssembly | `dotnet new install "Microsoft.AspNetCore.Blazor.Templates::3.0.0-*"`|


### PR DESCRIPTION
### Problem
The current reference to the Auth0 Templates points to a specific NuGet package version, which is obsolete.

### Solution
Point to the latest NuGet package version

