### PR TITLE
Having folders in the binskim config causes it to fail. 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ extends:
       tsa:
         enabled: true
       binskim:
-        analyzeTargetGlob: $(Build.SourcesDirectory)/artifacts/bin/**.dll;$(Build.SourcesDirectory)/artifacts/bin/**.exe;
+        analyzeTargetGlob: +:f|**\*.dll;+:f|**\*.exe;
     stages:
     - stage: build
       displayName: Build


### PR DESCRIPTION
This was the only regex that worked so far. We'll fix again later if they give us something that works better. Right now 9.0.1xx CI builds are blocked so this at least unblocks that.