### PR TITLE
Allow using TemplateDiscovery on newer shared frameworks

### DIFF
--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>$(NetCurrent)</TargetFramework>
+    <OutputType>Exe</OutputType>
     <IsPackable>true</IsPackable>
     <IsShipping>false</IsShipping>
     <PackAsTool>true</PackAsTool>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
dotnet/sdk invokes this tool with its current SDK which might be lagging behind the SDK beind used in dotnet/templating. Avoid this torn state by allowing the TemplateDiscovery tool to be invoked on newer shared frameworks.

### Problem
<!-- Add the issue number if exists. Describe the problem otherwise. -->

### Solution
<!-- Describe the solution. -->

### Checks:
- [ ] Added unit tests