### PR TITLE
Add snake_case ValueForm support

### DIFF
--- a/docs/Value-Forms.md
+++ b/docs/Value-Forms.md
@@ -157,3 +157,12 @@ When the value say, `Test ©` is supplied as the value for the parameter `exampl
     }
 }
 ```
+
+**`snakeCase`** - Converts the value to snake case using the casing rules of the invariant culture. Available since .NET 9.0.100.
+```json
+"forms": {
+    "snakeCase": {
+      "identifier": "snakeCase"
+    }
+}
+```

--- a/dotnet-template-samples/content/16-string-value-transform/MyProject.Con/.template.config/template.json
+++ b/dotnet-template-samples/content/16-string-value-transform/MyProject.Con/.template.config/template.json
@@ -36,6 +36,12 @@
       "valueSource": "pascalCasedName",
       "replaces": "John Smith (kebab-case)",
       "valueTransform": "kebabCase"
+    },
+    "snakeCasedName": {
+      "type": "derived",
+      "valueSource": "snakeCasedName",
+      "replaces": "John Smith (snake_case)",
+      "valueTransform": "snakeCase"
     }
   },
   "forms" :{
@@ -56,6 +62,9 @@
     },
     "kebabCase": {
       "identifier": "kebabCase"
+    },
+    "snakeCase": {
+      "identifier": "snakeCase"
     },
     "firtstLowerCase": {
       "identifier": "firstLowerCaseInvariant"

--- a/dotnet-template-samples/content/16-string-value-transform/README.md
+++ b/dotnet-template-samples/content/16-string-value-transform/README.md
@@ -14,7 +14,7 @@ See
 Details
 
  - A `derived` `type` with a value transformation is performed using [value forms](https://github.com/dotnet/templating/blob/main/docs/Value-Forms.md) (`ValueForms` type).
- - The sample uses `replace`, `titleCase`, `kebabCase`, `firstLowerCaseInvariant` and `chain` value forms.
+ - The sample uses `replace`, `titleCase`, `kebabCase`, `snakeCase`, `firstLowerCaseInvariant` and `chain` value forms.
  - More value forms can be found in [the source code](https://github.com/dotnet/templating/tree/main/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms).
 
 Related

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Schemas/JSON/template.json
@@ -877,7 +877,8 @@
                     "firstUpperCase",
                     "firstUpperCaseInvariant",
                     "titleCase",
-                    "kebabCase"
+                    "kebabCase",
+                    "snakeCase"
                   ]
                 }
               }
@@ -1049,6 +1050,14 @@
             "properties": {
               "identifier": {
                 "enum": ["kebabCase"]
+              }
+            }
+          },
+          {
+            "description": "Converts the value to snake case using the casing rules of the invariant culture.",
+            "properties": {
+              "identifier": {
+                "enum": ["snakeCase"]
               }
             }
           }

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueFormRegistry.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueFormRegistry.cs
@@ -29,6 +29,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 new FirstUpperCaseInvariantValueFormFactory(),
                 new FirstLowerCaseInvariantValueFormFactory(),
                 new KebabCaseValueFormFactory(),
+                new SnakeCaseValueFormFactory(),
                 new TitleCaseValueFormFactory(),
             };
 

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/SnakeCaseValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/SnakeCaseValueFormFactory.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
+{
+    internal class SnakeCaseValueFormFactory : ActionableValueFormFactory
+    {
+        internal const string FormIdentifier = "snakeCase";
+
+        internal SnakeCaseValueFormFactory() : base(FormIdentifier) { }
+
+        protected override string Process(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            Regex pattern = new(@"(?:\p{Lu}\p{M}*)?(?:\p{Ll}\p{M}*)+|(?:\p{Lu}\p{M}*)+(?!\p{Ll})|\p{N}+|[^\p{C}\p{P}\p{Z}]+|[\u2700-\u27BF]");
+            return string.Join("_", pattern.Matches(value).Cast<Match>().Select(m => m.Value)).ToLowerInvariant();
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/SnakeCaseValueFormTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/ValueFormTests/SnakeCaseValueFormTests.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms;
+
+namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.ValueFormTests
+{
+    public class SnakeCaseValueFormTests
+    {
+        [Theory]
+        [InlineData("I", "i")]
+        [InlineData("IO", "io")]
+        [InlineData("FileIO", "file_io")]
+        [InlineData("SignalR", "signal_r")]
+        [InlineData("IOStream", "io_stream")]
+        [InlineData("COMObject", "com_object")]
+        [InlineData("WebAPI", "web_api")]
+        [InlineData("XProjectX", "x_project_x")]
+        [InlineData("NextXXXProject", "next_xxx_project")]
+        [InlineData("NoNewProject", "no_new_project")]
+        [InlineData("NONewProject", "no_new_project")]
+        [InlineData("NewProjectName", "new_project_name")]
+        [InlineData("ABBREVIATIONAndSomeName", "abbreviation_and_some_name")]
+        [InlineData("NoNoNoNoNoNoNoName", "no_no_no_no_no_no_no_name")]
+        [InlineData("AnotherNewNewNewNewNewProjectName", "another_new_new_new_new_new_project_name")]
+        [InlineData("Param1TestValue", "param_1_test_value")]
+        [InlineData("Windows10", "windows_10")]
+        [InlineData("WindowsServer2016R2", "windows_server_2016_r_2")]
+        [InlineData("", "")]
+        [InlineData(";MyWord;", "my_word")]
+        [InlineData("My Word", "my_word")]
+        [InlineData("My    Word", "my_word")]
+        [InlineData(";;;;;", "")]
+        [InlineData("       ", "")]
+        [InlineData("Simple TEXT_here", "simple_text_here")]
+        [InlineData("НоваяПеременная", "новая_переменная")]
+        public void SnakeCaseWorksAsExpected(string input, string expected)
+        {
+            IValueForm? model = new SnakeCaseValueFormFactory().Create("test");
+            string actual = model.Process(input, new Dictionary<string, IValueForm>());
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CanHandleNullValue()
+        {
+            IValueForm model = new SnakeCaseValueFormFactory().Create("test");
+            Assert.Throws<ArgumentNullException>(() => model.Process(null!, new Dictionary<string, IValueForm>()));
+        }
+    }
+}

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/.template.config/template.json
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithValueForms/.template.config/template.json
@@ -80,6 +80,9 @@
     "kebab": {
       "identifier": "kebabCase"
     },
+    "snake": {
+      "identifier": "snakeCase"
+    },
     "title": {
       "identifier": "titleCase"
     }


### PR DESCRIPTION
Introduce `snake_case` transformation in template engine. This includes both implementation and unit tests for `snake_case`, as well as updates to documentation and sample configurations.

### Problem
Resolves #8302 
The existing system does not support snake_case transformation for value forms.

### Solution
Implement snake_case transformation to support more flexible data handling.

### Checks:
- [x] Added unit tests