### PR TITLE
Change binskim to filter and only run on build legs

### DIFF
--- a/artifacts/bin/binskim.md
+++ b/artifacts/bin/binskim.md
@@ -1,0 +1,1 @@
+This file was added to the repo to allow binskim filtering to work as they required the folder to exist and not be empty.

--- a/artifacts/bin/binskim.md
+++ b/artifacts/bin/binskim.md
@@ -1,1 +1,0 @@
-This file was added to the repo to allow binskim filtering to work as they required the folder to exist and not be empty.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,8 +45,6 @@ parameters:
   default:
   # Always build the Release configuration, but never sign for PRs.
   - buildConfig: Release
-  ### ARCADE ###
-  preSteps: []
 
 extends:
   ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
@@ -93,7 +91,10 @@ extends:
             enableInternalSources: true
           enableTelemetry: true
           helixRepo: dotnet/templating
-          preSteps: ${{ parameters.preSteps }}
+          # WORKAROUND: BinSkim requires the folder exist prior to scanning.
+          preSteps:
+          - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force
+            displayName: Create artifacts/bin directory
           jobs:
           - ${{ each config in parameters.buildConfigurations }}:
             - job: Windows_NT_${{ config.buildConfig }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,6 @@ variables:
     value: true
   - name: EnableReleaseOneLocBuild
     value: false
-  - name: GDN_ALLOW_ANALYZE_NO_TARGETS
-    value: true
   - template: /eng/common/templates-official/variables/pool-providers.yml
 
 resources:
@@ -89,11 +87,11 @@ extends:
             enableInternalSources: true
           enableTelemetry: true
           helixRepo: dotnet/templating
-          # WORKAROUND: BinSkim requires the folder exist prior to scanning.
           templateContext:
             sdl:
               binskim:
                 analyzeTargetGlob: +:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;
+          # WORKAROUND: BinSkim requires the folder exist prior to scanning.
           preSteps:
           - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force
             displayName: Create artifacts/bin directory

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,7 @@ extends:
       tsa:
         enabled: true
       binskim:
+        preReleaseVersion: '4.3.1'
         analyzeTargetGlob: +:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;
     stages:
     - stage: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,6 +45,8 @@ parameters:
   default:
   # Always build the Release configuration, but never sign for PRs.
   - buildConfig: Release
+  ### ARCADE ###
+  preSteps: []
 
 extends:
   ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
@@ -90,6 +92,7 @@ extends:
             enableInternalSources: true
           enableTelemetry: true
           helixRepo: dotnet/templating
+          preSteps: ${{ parameters.preSteps }}
           jobs:
           - ${{ each config in parameters.buildConfigurations }}:
             - job: Windows_NT_${{ config.buildConfig }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,8 +61,6 @@ extends:
         enabled: true
       tsa:
         enabled: true
-      binskim:
-        analyzeTargetGlob: +:f|eng\**\*.props;+:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;
     stages:
     - stage: build
       displayName: Build
@@ -92,6 +90,10 @@ extends:
           enableTelemetry: true
           helixRepo: dotnet/templating
           # WORKAROUND: BinSkim requires the folder exist prior to scanning.
+          templateContext:
+            sdl:
+              binskim:
+                analyzeTargetGlob: +:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;
           preSteps:
           - powershell: New-Item -ItemType Directory -Path $(Build.SourcesDirectory)/artifacts/bin -Force
             displayName: Create artifacts/bin directory

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,6 +27,8 @@ variables:
     value: true
   - name: EnableReleaseOneLocBuild
     value: false
+  - name: GDN_ALLOW_ANALYZE_NO_TARGETS
+    value: true
   - template: /eng/common/templates-official/variables/pool-providers.yml
 
 resources:
@@ -60,7 +62,7 @@ extends:
       tsa:
         enabled: true
       binskim:
-        analyzeTargetGlob: +:f|**\*.dll;+:f|**\*.exe;
+        analyzeTargetGlob: +:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;
     stages:
     - stage: build
       displayName: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,8 +62,7 @@ extends:
       tsa:
         enabled: true
       binskim:
-        preReleaseVersion: '4.3.1'
-        analyzeTargetGlob: +:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;
+        analyzeTargetGlob: +:f|eng\**\*.props;+:f|artifacts\bin\**\*.dll;+:f|artifacts\bin\**\*.exe;
     stages:
     - stage: build
       displayName: Build


### PR DESCRIPTION
Binskim by default doesn't filter the output folder. This changes that but we have to be careful about how we do it to ensure that the folder exists every time we choose to scan it.