### PR TITLE
Update the search cache to mark it as a release job

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -150,6 +150,8 @@ extends:
             image: 1es-windows-2022
             os: windows
           templateContext:
+            type: releaseJob
+            isProduction: true
             inputs:
             - input: pipelineArtifact
               targetPath: $(System.DefaultWorkingDirectory)/ArtifactsToPublish/


### PR DESCRIPTION
Our builds are getting 1ES alerts that a release task can't be used outside of a release job. Per the instructions on this page, I think this is how we mark the job to be a release job: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/releasepipelines/releaseworkflows/releasejob