### PR TITLE
Remove parallel call Fixes #7946

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Constraints/WorkloadConstraintFactory.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Constraints/WorkloadConstraintFactory.cs
@@ -11,6 +11,8 @@ namespace Microsoft.TemplateEngine.Edge.Constraints
 {
     public sealed class WorkloadConstraintFactory : ITemplateConstraintFactory
     {
+        private static readonly SemaphoreSlim Mutex = new(1);
+
         Guid IIdentifiedComponent.Id { get; } = Guid.Parse("{F8BA5B13-7BD6-47C8-838C-66626526817B}");
 
         string ITemplateConstraintFactory.Type => "workload";
@@ -97,8 +99,17 @@ namespace Microsoft.TemplateEngine.Edge.Constraints
                 }
 
                 token.ThrowIfCancellationRequested();
-                IEnumerable<WorkloadInfo> currentProviderWorkloads = await providers[0].GetInstalledWorkloadsAsync(token).ConfigureAwait(false);
-                workloads = currentProviderWorkloads.ToList();
+
+                await Mutex.WaitAsync(token).ConfigureAwait(false);
+                try
+                {
+                    IEnumerable<WorkloadInfo> currentProviderWorkloads = await providers[0].GetInstalledWorkloadsAsync(token).ConfigureAwait(false);
+                    workloads = currentProviderWorkloads.ToList();
+                }
+                finally
+                {
+                    Mutex.Release();
+                }
 
                 if (workloads.Select(w => w.Id).HasDuplicates(StringComparer.InvariantCultureIgnoreCase))
                 {


### PR DESCRIPTION
Fixes #7946

dsplaisted found a stack [here](https://github.com/dotnet/templating/issues/7946#issuecomment-2108859222) that was very helpful in helping me find the source of the parallel call to the workload resolver. As seen in the top stack, this call fairly quickly reaches the WorkloadResolver, where it attempts to initialize everything concurrently, causing the issue. It's called from TemplatePackageCoordinator in the SDK repo, which in turn is called by various things.

I do not think the Parallel.For call in TemplatePackageManager (see https://github.com/dotnet/templating/issues/7946#issuecomment-2108853692) is an issue in this case. As I understand it, ScanAsync just looks at a precomputed set of ITemplatePackages, which means it doesn't have to hit the resolver to find them.

@dsplaisted @nagilson