### PR TITLE
Set PackageProjectUrl

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,7 @@
     <Product>Microsoft .NET</Product>
     <Copyright>$(CopyrightNetFoundation)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/dotnet/templating</PackageProjectUrl>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU5105;NU5128;NU5100;NU5118;0419,0649</NoWarn>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>


### PR DESCRIPTION
Avoids showing dotnet/dotnet when building in the VMR repo