### PR TITLE
Added *.slnx with Xml conditions to OperationConfigDefault.

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/OperationConfigDefault.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/OperationConfig/OperationConfigDefault.cs
@@ -110,6 +110,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.OperationConfig
                         new OperationConfigDefault("**/*.xaml", "<!--", EvaluatorType.CPP, ConditionalType.Xml),
                         new OperationConfigDefault("**/*.axaml", "<!--", EvaluatorType.CPP, ConditionalType.Xml),
                         new OperationConfigDefault("**/*.sln", "#-", EvaluatorType.CPP, ConditionalType.HashSignLineComment),
+                        new OperationConfigDefault("**/*.slnx", "#-", EvaluatorType.CPP, ConditionalType.Xml),
                         new OperationConfigDefault("**/*.yaml", "#-", EvaluatorType.CPP, ConditionalType.HashSignLineComment),
                         new OperationConfigDefault("**/*.yml", "#-", EvaluatorType.CPP, ConditionalType.HashSignLineComment),
                         new OperationConfigDefault("**/Dockerfile", "#-", EvaluatorType.CPP, ConditionalType.HashSignLineComment),

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/End2EndTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/End2EndTests.cs
@@ -221,7 +221,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Assert.Equal(
                 """
                 var str = "myVal";
-
+                
                 """,
                 fileContent);
         }

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/End2EndTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/End2EndTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
                 """
                 The port is (\d{4,5})
                 The port is (\d{4,5})
-                
+
                 """).Success);
             Assert.NotEqual(
                 """
@@ -192,7 +192,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Assert.Equal(
                 """
                 var str = "fallback";
-                
+
                 """,
                 fileContent);
         }
@@ -221,7 +221,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Assert.Equal(
                 """
                 var str = "myVal";
-                
+
                 """,
                 fileContent);
         }
@@ -252,7 +252,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Assert.Equal(
                 """
                 var str = "fallback";
-                
+
                 """,
                 fileContent);
         }
@@ -281,7 +281,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Assert.Equal(
                 """
                 var str = "A";
-                
+
                 """,
                 fileContent);
         }
@@ -560,6 +560,13 @@ common text
                 {
 "test.sln",
 @"# comment bar
+bar
+baz
+"
+                },
+                {
+"test.slnx",
+@"<!-- comment bar -->
 bar
 baz
 "

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/End2EndTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/End2EndTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
                 """
                 The port is (\d{4,5})
                 The port is (\d{4,5})
-
+                
                 """).Success);
             Assert.NotEqual(
                 """
@@ -192,7 +192,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Assert.Equal(
                 """
                 var str = "fallback";
-
+                
                 """,
                 fileContent);
         }
@@ -252,7 +252,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Assert.Equal(
                 """
                 var str = "fallback";
-
+                
                 """,
                 fileContent);
         }
@@ -281,7 +281,7 @@ namespace Microsoft.TemplateEngine.IDE.IntegrationTests
             Assert.Equal(
                 """
                 var str = "A";
-
+                
                 """,
                 fileContent);
         }

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/test.slnx
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/test.slnx
@@ -1,0 +1,9 @@
+﻿#if (A)
+# comment foo
+foo
+#endif
+##if (B)
+## comment bar
+#bar
+#endif
+baz

--- a/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/test.slnx
+++ b/test/Microsoft.TemplateEngine.TestTemplates/test_templates/TemplateWithConditions/test.slnx
@@ -1,9 +1,9 @@
-﻿#if (A)
-# comment foo
+﻿<!--#if (A) -->
+<!-- comment foo -->
 foo
-#endif
-##if (B)
-## comment bar
-#bar
-#endif
+<!--#endif -->
+<!--#if (B)
+<!-- comment bar -- >
+bar
+#endif -->
 baz


### PR DESCRIPTION
### Problem
*.slnx files doesn't support conditional processing as described in #8784

### Solution
Added *.slnx with `ConditionalType.Xml` in `OperationConfigDefault.cs`. 

### Checks:
- [X] Added unit tests

I've added tests, but I'm running into some problems.

1. Can't build the `main` branch using `build.sh`, I'm getting a ton of IDE0055 errors all over the project.
2. If I disable IDE0055 in editorconfig the project builds, but I get 8 failed tests in `Microsoft.TemplateEngine.Edge.UnitTests`, still in `main`.
3. Due to the failed tests I'm not even sure if it gets to running the test I added in `End2EndTests.cs`.