### PR TITLE
Switch to the unstable nuget versions to match the SDK

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <Copyright>$(CopyrightNetFoundation)</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn);NU5105;NU5128;NU5100;NU5118;0419,0649</NoWarn>
+    <NoWarn>$(NoWarn);NU5105;NU5128;NU5100;NU5118;0419,0649;NU5104</NoWarn>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,9 +16,9 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.8.3" />
    
     <!-- NuGet dependencies -->
-    <PackageVersion Include="NuGet.Configuration" Version="6.13.2" />
-    <PackageVersion Include="NuGet.Credentials" Version="6.13.2" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.13.2" />
+    <PackageVersion Include="NuGet.Configuration" Version="6.13.2-rc.1" />
+    <PackageVersion Include="NuGet.Credentials" Version="6.13.2-rc.1" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.13.2-rc.1" />
 
     <!-- Roslyn-analyzers dependencies -->
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />


### PR DESCRIPTION
SDK uses the unstable transport packages which is causing package downgrade errors. Prepping this in case we need it but consulting offline first.