### PR TITLE
[release/9.0.1xx] Fix tasks not loading on .NET Framework (#8952)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,6 +27,9 @@
     <EnableAnalyzers>true</EnableAnalyzers>
     <!-- Disable analyzers in sourcebuild -->
     <EnableAnalyzers Condition="'$(DotNetBuildSourceOnly)' == 'true'">false</EnableAnalyzers>
+
+    <!-- Make packages target net472 instead of net481 for compatibility with the msbuild task package. -->
+    <NetFrameworkCurrent>net472</NetFrameworkCurrent>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Microsoft.TemplateEngine.IDE.IntegrationTests.csproj
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Microsoft.TemplateEngine.IDE.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net481</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);net481</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Partial backport of https://github.com/dotnet/templating/pull/8952/

/cc @marcpopMSFT

This fixes a regression due to a TFM mismatch in msbuild task dependencies that was merged 10 days ago . The regression hasn't shipped anywhere yet but **affects upcoming releases: release/9.0.106 up to 9.0.300**.

## Customer Impact

- [ ] Customer reported
- [x] Found internally

The msbuild task assemblies from the Microsoft.TemplateEngine.Authoring.Tasks package throw the following exception when loaded with desktop msbuild (i.e. in VS):

```
C:\Users\vihofer.nuget\packages\microsoft.templateengine.authoring.tasks\10.0.100-preview.4.25215.8\build\Microsoft.
TemplateEngine.Authoring.Tasks.targets(14,5): error MSB4018: The "LocalizeTemplates" task failed unexpectedly. [C:\temp
\templmsbuild\templmsbuild.csproj]
C:\Users\vihofer.nuget\packages\microsoft.templateengine.authoring.tasks\10.0.100-preview.4.25215.8\build\Microsoft.Te
mplateEngine.Authoring.Tasks.targets(14,5): error MSB4018: System.IO.FileNotFoundException->Microsoft.Build.Framework.B
uildException.GenericBuildTransferredException: Could not load file or assembly 'Microsoft.Extensions.Logging.Abstracti
ons, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' or one of its dependencies. The system cannot f
ind the file specified. [C:\temp\templmsbuild\templmsbuild.csproj]
```

Change the .NET Framework assemblies TFM from net481 to net472 so that the task project resolves the .NET Framework dependencies instead of the .NET Standard dependencies which have a different assembly version and need binding redirects.

## Regression

- [x] Yes
- [ ] No

Regressed with https://github.com/dotnet/templating/commit/7fa9bf93e5ce8e9e775e5c642247ba10ba586cf2

## Testing

Filed https://github.com/dotnet/templating/issues/8955 for comprehensive tests. Verified that the referenced assembly version now matches the deployed binaries assembly version for both msbuild task assemblies.

## Risk

Medium - Changing the TFM of the .NETFramework assemblies in packages from net481 to net472.