### PR TITLE
Move template verifier to the shipping artifacts path

### DIFF
--- a/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.csproj
+++ b/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.csproj
@@ -6,6 +6,7 @@
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsShipping>true</IsShipping>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.csproj
+++ b/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.csproj
@@ -6,7 +6,8 @@
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <IsShipping>true</IsShipping>
+    <!-- Unset IsTestProject which gets set by xunit.props which gets imported by the xunit PackageReference below. -->
+    <IsTestProject />
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Mark template verifier for shipping as we publish this package to nuget.org to enable template authors to do validation.

Doing this will get the VMR to correctly check and do validation.
