### PR TITLE
File system changes

### DIFF
--- a/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
+++ b/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
@@ -698,58 +698,8 @@ namespace Microsoft.TemplateEngine.Utils
 
         private bool IsPathInCone(string path, out string processedPath)
         {
-            if (!Path.IsPathRooted(path))
-            {
-                path = Path.Combine(GetCurrentDirectory(), path);
-            }
-
-            path = path.Replace('\\', '/');
-
-            bool leadSlash = path[0] == '/';
-
-            if (leadSlash)
-            {
-                path = path.Substring(1);
-            }
-
-            string[] parts = path.Split('/');
-
-            List<string> realParts = new();
-
-            for (int i = 0; i < parts.Length; ++i)
-            {
-                if (string.IsNullOrEmpty(parts[i]))
-                {
-                    continue;
-                }
-
-                switch (parts[i])
-                {
-                    case ".":
-                        continue;
-                    case "..":
-                        realParts.RemoveAt(realParts.Count - 1);
-                        break;
-                    default:
-                        realParts.Add(parts[i]);
-                        break;
-                }
-            }
-
-            if (leadSlash)
-            {
-                realParts.Insert(0, string.Empty);
-            }
-
-            processedPath = string.Join(Path.DirectorySeparatorChar + string.Empty, realParts);
-            if (processedPath.Equals(_root.FullPath) || processedPath.StartsWith(_root.FullPath.TrimEnd('/', '\\') + Path.DirectorySeparatorChar))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            processedPath = Path.IsPathRooted(path) ? path : Path.Combine(GetCurrentDirectory(), path);
+            return processedPath.Equals(_root.FullPath) || processedPath.StartsWith(_root.FullPath);
         }
 
         private class FileSystemDirectory

--- a/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
+++ b/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
@@ -81,8 +81,6 @@ namespace Microsoft.TemplateEngine.Utils
                 currentDir = dir;
             }
 
-            Console.WriteLine($"Creating file {parts[parts.Length - 1]} in {currentDir.FullPath}");
-
             if (!currentDir.Files.TryGetValue(parts[parts.Length - 1], out FileSystemFile targetFile))
             {
                 targetFile = new FileSystemFile(parts[parts.Length - 1], Path.Combine(currentDir.FullPath, parts[parts.Length - 1]));

--- a/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
+++ b/src/Microsoft.TemplateEngine.Utils/InMemoryFileSystem.cs
@@ -81,6 +81,8 @@ namespace Microsoft.TemplateEngine.Utils
                 currentDir = dir;
             }
 
+            Console.WriteLine($"Creating file {parts[parts.Length - 1]} in {currentDir.FullPath}");
+
             if (!currentDir.Files.TryGetValue(parts[parts.Length - 1], out FileSystemFile targetFile))
             {
                 targetFile = new FileSystemFile(parts[parts.Length - 1], Path.Combine(currentDir.FullPath, parts[parts.Length - 1]));

--- a/test/Microsoft.TemplateEngine.Utils.UnitTests/InMemoryFileSystemTests.cs
+++ b/test/Microsoft.TemplateEngine.Utils.UnitTests/InMemoryFileSystemTests.cs
@@ -22,5 +22,18 @@ namespace Microsoft.TemplateEngine.Utils.UnitTests
             Assert.True(virtualized1.FileExists(testFilePath));
             Assert.True(virtualized2.FileExists(testFilePath));
         }
+
+        [Fact]
+        public void VerifyRootCanBeVirtualized()
+        {
+            IPhysicalFileSystem mockFileSystem = new MockFileSystem();
+            IPhysicalFileSystem virtualized = new InMemoryFileSystem(Path.GetPathRoot(Directory.GetCurrentDirectory())!, mockFileSystem);
+
+            string testFilePath = Path.Combine(Directory.GetCurrentDirectory(), "test.txt");
+            virtualized.WriteAllText(testFilePath, "test");
+
+            var entries = virtualized.EnumerateFileSystemEntries(Directory.GetCurrentDirectory(), "*", SearchOption.TopDirectoryOnly).ToList();
+            Assert.Single(entries);
+        }
     }
 }

--- a/test/Microsoft.TemplateEngine.Utils.UnitTests/InMemoryFileSystemTests.cs
+++ b/test/Microsoft.TemplateEngine.Utils.UnitTests/InMemoryFileSystemTests.cs
@@ -34,6 +34,8 @@ namespace Microsoft.TemplateEngine.Utils.UnitTests
 
             var entries = virtualized.EnumerateFileSystemEntries(Directory.GetCurrentDirectory(), "*", SearchOption.TopDirectoryOnly).ToList();
             Assert.Single(entries);
+
+            Assert.Equal(testFilePath, entries[0]);
         }
     }
 }


### PR DESCRIPTION
### Problem
When virtualziing the root, file paths come back from EnumerateFileSystemEntries without the "/" on Linux and Mac. The virtualization also has issues with net475 on Windows.

### Solution
The solution is to change IsPathInCone to no longer do unnecessary checks and mangling of the original path.

### Checks:
- [ /] Added unit tests