### PR TITLE
Use System.Text.Json in tests instead of unlisted log4net

### DIFF
--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
@@ -376,7 +376,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                 IEnumerable<IPackageSearchMetadata> packageMetadata = await resource.GetMetadataAsync(
                     packageIdentifier,
                     includePrerelease: includePrerelease,
-                    includeUnlisted: true,
+                    includeUnlisted: false,
                     _cacheSettings,
                     _nugetLogger,
                     cancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Installers/NuGet/NugetApiPackageManager.cs
@@ -376,7 +376,7 @@ namespace Microsoft.TemplateEngine.Edge.Installers.NuGet
                 IEnumerable<IPackageSearchMetadata> packageMetadata = await resource.GetMetadataAsync(
                     packageIdentifier,
                     includePrerelease: includePrerelease,
-                    includeUnlisted: false,
+                    includeUnlisted: true,
                     _cacheSettings,
                     _nugetLogger,
                     cancellationToken).ConfigureAwait(false);

--- a/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetApiPackageManagerTests.cs
+++ b/test/Microsoft.TemplateEngine.Edge.UnitTests/NuGetApiPackageManagerTests.cs
@@ -146,13 +146,13 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
 
             var exception = await Assert.ThrowsAsync<VulnerablePackageException>(() => packageManager.DownloadPackageAsync(
                 installPath,
-                "log4net",
-                "2.0.3",
+                "System.Text.Json",
+                "8.0.4",
                 // add the source for getting vulnerability info
                 additionalSources: _additionalSources));
 
-            exception.PackageIdentifier.Should().Be("log4net");
-            exception.PackageVersion.Should().Be("2.0.3");
+            exception.PackageIdentifier.Should().Be("System.Text.Json");
+            exception.PackageVersion.Should().Be("8.0.4");
             exception.Vulnerabilities.Should().NotBeNullOrEmpty();
         }
 
@@ -167,15 +167,15 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
 
             var result = await packageManager.DownloadPackageAsync(
                 installPath,
-                "log4net",
-                "2.0.3",
+                "System.Text.Json",
+                "8.0.4",
                 // add the source for getting vulnerability info
                 additionalSources: _additionalSources,
                 force: true);
 
-            result.PackageIdentifier.Should().Be("log4net");
-            result.Author.Should().Be("Apache Software Foundation");
-            result.PackageVersion.Should().Be("2.0.3");
+            result.PackageIdentifier.Should().Be("System.Text.Json");
+            result.Author.Should().Be("Microsoft");
+            result.PackageVersion.Should().Be("8.0.4");
             Assert.True(File.Exists(result.FullPath));
             result.PackageVulnerabilities.Should().NotBeNullOrEmpty();
             result.NuGetSource.Should().Be(_additionalSources[0]);


### PR DESCRIPTION

The original test package `log4net 2.0.3` has been unlisted on NuGet, which caused metadata retrieval to fail and led to test failures.

Instead of modifying product code to include unlisted packages, this PR updates the tests to use `System.Text.Json 8.0.4`, which is still listed and has known vulnerabilities. This keeps the product logic unchanged while ensuring the tests remain valid and meaningful.
