### PR TITLE
We build for NetMinimum when not in source build so target that

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -128,7 +128,7 @@ extends:
           displayName: Install latest daily .NET version
 
         - bash: >
-            $(Build.SourcesDirectory)/.dotnet/dotnet $(Build.SourcesDirectory)/artifacts/bin/Microsoft.TemplateSearch.TemplateDiscovery/Debug/net10.0/Microsoft.TemplateSearch.TemplateDiscovery.dll --basePath $(System.DefaultWorkingDirectory)/NugetDownloadDirectory --allowPreviewPacks -v --test --diff $(EnableDiffMode)
+            $(Build.SourcesDirectory)/.dotnet/dotnet $(Build.SourcesDirectory)/artifacts/bin/Microsoft.TemplateSearch.TemplateDiscovery/Debug/net8.0/Microsoft.TemplateSearch.TemplateDiscovery.dll --basePath $(System.DefaultWorkingDirectory)/NugetDownloadDirectory --allowPreviewPacks -v --test --diff $(EnableDiffMode)
           displayName: Run Cache Updater
 
         - task: CopyFiles@2


### PR DESCRIPTION
The search cache was broken by [Fix tasks not loading on .NET Framework by ViktorHofer · Pull Request #8952 · dotnet/templating](https://github.com/dotnet/templating/pull/8952)