### PR TITLE
Update the nuget version to the latest and update STJ to the in-product one that's being used already in most of the build here

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,9 +16,9 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.8.3" />
    
     <!-- NuGet dependencies -->
-    <PackageVersion Include="NuGet.Configuration" Version="6.12.1" />
-    <PackageVersion Include="NuGet.Credentials" Version="6.12.1" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.12.1" />
+    <PackageVersion Include="NuGet.Configuration" Version="6.12.4" />
+    <PackageVersion Include="NuGet.Credentials" Version="6.12.4" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.12.4" />
 
     <!-- Roslyn-analyzers dependencies -->
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
@@ -29,6 +29,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
+    <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)" />
   </ItemGroup>
 
   <!-- External dependencies -->
@@ -57,5 +58,6 @@
     <PackageVersion Update="NuGet.Configuration" Version="$(NuGetConfigurationVersion)" Condition="'$(NuGetConfigurationVersion)' != ''" />
     <PackageVersion Update="NuGet.Credentials" Version="$(NuGetCredentialsVersion)" Condition="'$(NuGetCredentialsVersion)' != ''" />
     <PackageVersion Update="NuGet.Protocol" Version="$(NuGetProtocolVersion)" Condition="'$(NuGetProtocolVersion)' != ''" />
+    <PackageVersion Update="System.Text.Json" Version="$(SystemTextJsonVersion)" Condition="'$(SystemTextJsonVersion)' != ''" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,6 +52,5 @@
     <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" Condition="'$(MicrosoftBuildUtilitiesCoreVersion)' != ''" />
     <PackageVersion Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' != ''" />
     <PackageVersion Update="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" Condition="'$(NewtonsoftJsonVersion)' != ''" />
-    <PackageVersion Update="System.Text.Json" Version="$(SystemTextJsonVersion)" Condition="'$(SystemTextJsonVersion)' != ''" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,20 +16,20 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.8.3" />
    
     <!-- NuGet dependencies -->
-    <PackageVersion Include="NuGet.Configuration" Version="6.12.4" />
-    <PackageVersion Include="NuGet.Credentials" Version="6.12.4" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.12.4" />
+    <PackageVersion Include="NuGet.Configuration" Version="$(NuGetConfigurationVersion)" />
+    <PackageVersion Include="NuGet.Credentials" Version="$(NuGetCredentialsVersion)" />
+    <PackageVersion Include="NuGet.Protocol" Version="$(NuGetProtocolVersion)" />
 
     <!-- Roslyn-analyzers dependencies -->
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
 
     <!-- Runtime dependencies -->    
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsolePackageVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.0.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
-    <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)" />
+    <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 
   <!-- External dependencies -->
@@ -51,13 +51,7 @@
     <PackageVersion Update="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" Condition="'$(MicrosoftBuildFrameworkVersion)' != ''" />
     <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" Condition="'$(MicrosoftBuildUtilitiesCoreVersion)' != ''" />
     <PackageVersion Update="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)" Condition="'$(MicrosoftCodeAnalysisPublicApiAnalyzersVersion)' != ''" />
-    <PackageVersion Update="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsVersion)" Condition="'$(MicrosoftExtensionsLoggingAbstractionsVersion)' != ''" />
-    <PackageVersion Update="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsoleVersion)" Condition="'$(MicrosoftExtensionsLoggingConsoleVersion)' != ''" />
-    <PackageVersion Update="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" Condition="'$(MicrosoftExtensionsLoggingVersion)' != ''" />
     <PackageVersion Update="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" Condition="'$(NewtonsoftJsonVersion)' != ''" />
-    <PackageVersion Update="NuGet.Configuration" Version="$(NuGetConfigurationVersion)" Condition="'$(NuGetConfigurationVersion)' != ''" />
-    <PackageVersion Update="NuGet.Credentials" Version="$(NuGetCredentialsVersion)" Condition="'$(NuGetCredentialsVersion)' != ''" />
-    <PackageVersion Update="NuGet.Protocol" Version="$(NuGetProtocolVersion)" Condition="'$(NuGetProtocolVersion)' != ''" />
     <PackageVersion Update="System.Text.Json" Version="$(SystemTextJsonVersion)" Condition="'$(SystemTextJsonVersion)' != ''" />
   </ItemGroup>
 </Project>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -10,5 +10,15 @@
     <UsagePattern IdentityGlob="Microsoft.Extensions.DependencyInjection.Abstractions/9.0.*" />
     <UsagePattern IdentityGlob="Microsoft.Extensions.Logging.Abstractions/9.0.*" />
     <UsagePattern IdentityGlob="System.Diagnostics.DiagnosticSource/9.0.*" />
+    <UsagePattern IdentityGlob="NuGet.Common/6.12.*" />
+    <UsagePattern IdentityGlob="NuGet.Configuration/6.12.*" />
+    <UsagePattern IdentityGlob="NuGet.Credentials/6.12.*" />
+    <UsagePattern IdentityGlob="NuGet.Frameworks/6.12.*" />
+    <UsagePattern IdentityGlob="NuGet.Packaging/6.12.*" />
+    <UsagePattern IdentityGlob="NuGet.Protocol/6.12.*" />
+    <UsagePattern IdentityGlob="NuGet.Versioning/6.12.*" />
+    <UsagePattern IdentityGlob="System.IO.Pipelines/9.0.*" />
+    <UsagePattern IdentityGlob="System.Text.Encodings.Web/9.0.*" />
+    <UsagePattern IdentityGlob="System.Text.Json/9.0.*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -34,6 +34,18 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>d3981726bc8b0e179db50301daf9f22d42393096</Sha>
     </Dependency>
+    <Dependency Name="System.IO.Pipelines" Version="9.0.3">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
+      <Sha>831d23e56149cd59c40fc00c7feb7c5334bd19c4</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Encodings.Web" Version="9.0.3">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
+      <Sha>831d23e56149cd59c40fc00c7feb7c5334bd19c4</Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Json" Version="9.0.3">
+      <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
+      <Sha>831d23e56149cd59c40fc00c7feb7c5334bd19c4</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.Extensions.Logging" Version="9.0.3">
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>831d23e56149cd59c40fc00c7feb7c5334bd19c4</Sha>
@@ -50,9 +62,33 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>831d23e56149cd59c40fc00c7feb7c5334bd19c4</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Json" Version="9.0.3">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>831d23e56149cd59c40fc00c7feb7c5334bd19c4</Sha>
+    <Dependency Name="NuGet.Common" Version="6.12.4">
+      <Uri>https://github.com/nuget/nuget.client</Uri>
+      <Sha>95a470a557091cdbdc9f68a178b60bd19329942c</Sha>
+    </Dependency>
+    <Dependency Name="NuGet.Configuration" Version="6.12.4">
+      <Uri>https://github.com/nuget/nuget.client</Uri>
+      <Sha>95a470a557091cdbdc9f68a178b60bd19329942c</Sha>
+    </Dependency>
+    <Dependency Name="NuGet.Credentials" Version="6.12.4">
+      <Uri>https://github.com/nuget/nuget.client</Uri>
+      <Sha>95a470a557091cdbdc9f68a178b60bd19329942c</Sha>
+    </Dependency>
+    <Dependency Name="NuGet.Frameworks" Version="6.12.4">
+      <Uri>https://github.com/nuget/nuget.client</Uri>
+      <Sha>95a470a557091cdbdc9f68a178b60bd19329942c</Sha>
+    </Dependency>
+    <Dependency Name="NuGet.Packaging" Version="6.12.4">
+      <Uri>https://github.com/nuget/nuget.client</Uri>
+      <Sha>95a470a557091cdbdc9f68a178b60bd19329942c</Sha>
+    </Dependency>
+    <Dependency Name="NuGet.Protocol" Version="6.12.4">
+      <Uri>https://github.com/nuget/nuget.client</Uri>
+      <Sha>95a470a557091cdbdc9f68a178b60bd19329942c</Sha>
+    </Dependency>
+    <Dependency Name="NuGet.Versioning" Version="6.12.4">
+      <Uri>https://github.com/nuget/nuget.client</Uri>
+      <Sha>95a470a557091cdbdc9f68a178b60bd19329942c</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -50,5 +50,9 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>831d23e56149cd59c40fc00c7feb7c5334bd19c4</Sha>
     </Dependency>
+    <Dependency Name="System.Text.Json" Version="9.0.3">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>831d23e56149cd59c40fc00c7feb7c5334bd19c4</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,5 +24,6 @@
     <MicrosoftExtensionsLoggingAbstractionsPackageVersion>9.0.3</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>9.0.3</MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>9.0.3</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
+    <SystemTextJsonPackageVersion>9.0.3</SystemTextJsonPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,12 +27,12 @@
     <MicrosoftExtensionsLoggingAbstractionsVersion>9.0.3</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>9.0.3</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>9.0.3</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <NuGetCommonVersion>9.0.3</NuGetCommonVersion>
-    <NuGetConfigurationVersion>9.0.3</NuGetConfigurationVersion>
-    <NuGetCredentialsVersion>9.0.3</NuGetCredentialsVersion>
-    <NuGetFrameworksVersion>9.0.3</NuGetFrameworksVersion>
-    <NuGetPackagingVersion>9.0.3</NuGetPackagingVersion>
-    <NuGetProtocolVersion>9.0.3</NuGetProtocolVersion>
-    <NuGetVersioningVersion>9.0.3</NuGetVersioningVersion>
+    <NuGetCommonVersion>16.12.4</NuGetCommonVersion>
+    <NuGetConfigurationVersion>16.12.4</NuGetConfigurationVersion>
+    <NuGetCredentialsVersion>16.12.4</NuGetCredentialsVersion>
+    <NuGetFrameworksVersion>16.12.4</NuGetFrameworksVersion>
+    <NuGetPackagingVersion>16.12.4</NuGetPackagingVersion>
+    <NuGetProtocolVersion>16.12.4</NuGetProtocolVersion>
+    <NuGetVersioningVersion>16.12.4</NuGetVersioningVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,10 +20,19 @@
   <PropertyGroup>
     <!-- Non-maestro versions -->
     <SystemFormatsAsn1Version>9.0.0</SystemFormatsAsn1Version>
-    <MicrosoftExtensionsLoggingPackageVersion>9.0.3</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>9.0.3</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
-    <MicrosoftExtensionsLoggingConsolePackageVersion>9.0.3</MicrosoftExtensionsLoggingConsolePackageVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>9.0.3</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
-    <SystemTextJsonPackageVersion>9.0.3</SystemTextJsonPackageVersion>
+    <SystemIOPipelinesVersion>9.0.3</SystemIOPipelinesVersion>
+    <SystemTextEncodingsWebVersion>9.0.3</SystemTextEncodingsWebVersion>
+    <SystemTextJsonVersion>9.0.3</SystemTextJsonVersion>
+    <MicrosoftExtensionsLoggingVersion>9.0.3</MicrosoftExtensionsLoggingVersion>
+    <MicrosoftExtensionsLoggingAbstractionsVersion>9.0.3</MicrosoftExtensionsLoggingAbstractionsVersion>
+    <MicrosoftExtensionsLoggingConsoleVersion>9.0.3</MicrosoftExtensionsLoggingConsoleVersion>
+    <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>9.0.3</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
+    <NuGetCommonVersion>9.0.3</NuGetCommonVersion>
+    <NuGetConfigurationVersion>9.0.3</NuGetConfigurationVersion>
+    <NuGetCredentialsVersion>9.0.3</NuGetCredentialsVersion>
+    <NuGetFrameworksVersion>9.0.3</NuGetFrameworksVersion>
+    <NuGetPackagingVersion>9.0.3</NuGetPackagingVersion>
+    <NuGetProtocolVersion>9.0.3</NuGetProtocolVersion>
+    <NuGetVersioningVersion>9.0.3</NuGetVersioningVersion>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,12 +27,12 @@
     <MicrosoftExtensionsLoggingAbstractionsVersion>9.0.3</MicrosoftExtensionsLoggingAbstractionsVersion>
     <MicrosoftExtensionsLoggingConsoleVersion>9.0.3</MicrosoftExtensionsLoggingConsoleVersion>
     <MicrosoftExtensionsDependencyInjectionAbstractionsVersion>9.0.3</MicrosoftExtensionsDependencyInjectionAbstractionsVersion>
-    <NuGetCommonVersion>16.12.4</NuGetCommonVersion>
-    <NuGetConfigurationVersion>16.12.4</NuGetConfigurationVersion>
-    <NuGetCredentialsVersion>16.12.4</NuGetCredentialsVersion>
-    <NuGetFrameworksVersion>16.12.4</NuGetFrameworksVersion>
-    <NuGetPackagingVersion>16.12.4</NuGetPackagingVersion>
-    <NuGetProtocolVersion>16.12.4</NuGetProtocolVersion>
-    <NuGetVersioningVersion>16.12.4</NuGetVersioningVersion>
+    <NuGetCommonVersion>6.12.4</NuGetCommonVersion>
+    <NuGetConfigurationVersion>6.12.4</NuGetConfigurationVersion>
+    <NuGetCredentialsVersion>6.12.4</NuGetCredentialsVersion>
+    <NuGetFrameworksVersion>6.12.4</NuGetFrameworksVersion>
+    <NuGetPackagingVersion>6.12.4</NuGetPackagingVersion>
+    <NuGetProtocolVersion>6.12.4</NuGetProtocolVersion>
+    <NuGetVersioningVersion>6.12.4</NuGetVersioningVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
I tried just updating to 8.0.5 but I found that much of the build was already implicitly targeting 9.0.3. So instead, I just retargeted to that. Not sure if this will have negative impact on SDK or VS though so will need to consult on that.

I could just move the edge assembly as that was the only one flagged by CG or I could get nuget to fix their reference.