### PR TITLE
Fix NullReferenceException

### DIFF
--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizationModelDeserializer.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/LocalizationModelDeserializer.cs
@@ -134,7 +134,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
                 string postActionId = postActionParts.Key;
                 string? description = postActionParts.SingleOrDefault(p => p.NameParts.Skip(1).FirstOrDefault() == "description").LocalizedString;
                 var instructions = LoadManualInstructionModels(postActionParts
-                    .Where(s => s.NameParts.Skip(1).FirstOrDefault().StartsWith("manualInstructions"))
+                    .Where(s => s.NameParts.Skip(1).FirstOrDefault()?.StartsWith("manualInstructions") == true)
                     .Select(s => (s.NameParts.Skip(2), s.LocalizedString)));
 
                 results[postActionId] = new PostActionLocalizationModel()


### PR DESCRIPTION
`FirstOrDefault` can return null, so it's not safe to dereference unconditionally.

Observed while debugging VS:

```
System.NullReferenceException: Object reference not set to an instance of an object.

Microsoft.TemplateEngine.Orchestrator.RunnableProjects.LocalizationModelDeserializer.LoadPostActionModels.AnonymousMethod__4_4((System.Collections.Generic.IEnumerable<string> NameParts, string LocalizedString) s)
System.Linq.Enumerable.WhereSelectEnumerableIterator<(System.Collections.Generic.IEnumerable<string>, string), (System.Collections.Generic.IEnumerable<string>, string)>.MoveNext()
System.Linq.Lookup<string, (System.Collections.Generic.IEnumerable<string>, string)>.Create<(System.Collections.Generic.IEnumerable<string>, string)>(System.Collections.Generic.IEnumerable<(System.Collections.Generic.IEnumerable<string>, string)> source, System.Func<(System.Collections.Generic.IEnumerable<string>, string), string> keySelector, System.Func<(System.Collections.Generic.IEnumerable<string>, string), (System.Collections.Generic.IEnumerable<string>, string)> elementSelector, System.Collections.Generic.IEqualityComparer<string> comparer)
System.Linq.GroupedEnumerable<(System.Collections.Generic.IEnumerable<string>, string), string, (System.Collections.Generic.IEnumerable<string>, string)>.GetEnumerator()
Microsoft.TemplateEngine.Orchestrator.RunnableProjects.LocalizationModelDeserializer.LoadManualInstructionModels(System.Collections.Generic.IEnumerable<(System.Collections.Generic.IEnumerable<string> NameParts, string LocalizedString)> strings)
Microsoft.TemplateEngine.Orchestrator.RunnableProjects.LocalizationModelDeserializer.LoadPostActionModels(System.Collections.Generic.List<(string Key, string Value)> localizedStrings)
Microsoft.TemplateEngine.Orchestrator.RunnableProjects.LocalizationModelDeserializer.Deserialize(Microsoft.TemplateEngine.Abstractions.Mount.IFile file)
Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ScannedTemplateInfo.FindLocalizations()
Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ScannedTemplateInfo.ScannedTemplateInfo(Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings settings, Microsoft.TemplateEngine.Abstractions.IGenerator generator, Microsoft.TemplateEngine.Abstractions.Mount.IFile templateFile)
Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator.GetTemplatesFromMountPointInternalAsync(Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint source, System.Threading.CancellationToken cancellationToken) Microsoft.TemplateEngine.Orchestrator.RunnableProjects.RunnableProjectGenerator.Microsoft.TemplateEngine.Abstractions.IGenerator.GetTemplatesFromMountPointAsync(Microsoft.TemplateEngine.Abstractions.Mount.IMountPoint source, System.Threading.CancellationToken cancellationToken)
Microsoft.TemplateEngine.Edge.Settings.Scanner.ScanMountPointForTemplatesAsync(Microsoft.TemplateEngine.Edge.Settings.Scanner.MountPointScanSource source, bool logValidationResults, bool returnInvalidTemplates, System.Threading.CancellationToken cancellationToken)
Microsoft.TemplateEngine.Edge.Settings.Scanner.ScanAsync(string mountPointUri, System.Threading.CancellationToken cancellationToken)
Microsoft.TemplateEngine.Edge.Settings.TemplatePackageManager.UpdateTemplateCacheAsync.AnonymousMethod__2(int index)
```
