### PR TITLE
Remove auditSources from NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -17,10 +17,6 @@
     <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="dotnet10-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10-transport/nuget/v3/index.json" />
   </packageSources>
-  <auditSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </auditSources>
   <disabledPackageSources>
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->


### PR DESCRIPTION
The api.nuget.org source will clash with the CFSClean network isolation policy and the same data is provided by AzDO now.
