### PR TITLE
Disable tests on official build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -127,13 +127,14 @@ extends:
                     -prepareMachine
                     -integrationTest
                     $(_InternalBuildArgs)
+                  displayName: Windows Build / Publish
               - ${{ else }}:
                 - script: eng/common/cibuild.cmd
                     -configuration $(_BuildConfig)
                     -prepareMachine
                     /p:Test=false
                     $(_InternalBuildArgs)
-                displayName: Windows Build / Publish
+                  displayName: Windows Build / Publish
 
           - ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
             - ${{ each config in parameters.buildConfigurations }}:


### PR DESCRIPTION
Fixes: https://github.com/dotnet/templating/issues/9429

## Summary
In the official pipeline, `-integrationTest` was specified. However, the build would run both integration tests and unit tests. It seems the easiest way was to specify `/p:Test=false` on these builds, which disabled running tests altogether.

## Build Run
- ~~No tests running: https://dnceng.visualstudio.com/internal/_build/results?buildId=2817954&view=results~~
- New run with review changes: https://dnceng.visualstudio.com/internal/_build/results?buildId=2818053&view=results