### PR TITLE
Upgrade to MSBuild 17.11.48

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,9 +12,9 @@
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLinePackageVersion)" />
 
     <!-- MSBuild dependencies -->
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.8.3" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.8.3" />
-   
+    <PackageVersion Include="Microsoft.Build.Framework" Version="17.11.48" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.11.48" />
+
     <!-- NuGet dependencies -->
     <PackageVersion Include="NuGet.Configuration" Version="6.13.2" />
     <PackageVersion Include="NuGet.Credentials" Version="6.13.2" />


### PR DESCRIPTION
Fixes CI failure:

`
##[error]test\Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests\Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests.csproj(0,0): error NU1903: (NETCORE_ENGINEERING_TELEMETRY=Restore) Warning As Error: Package 'Microsoft.Build.Utilities.Core' 17.8.3 has a known high severity vulnerability, https://github.com/advisories/GHSA-w3q9-fxm7-j8fq
`

Backport of https://github.com/dotnet/templating/commit/9d06a2a9d5660811c83f697cf826509cbd8a1b63