### PR TITLE
Remove obsolete FSharp.NET.Sdk references

### DIFF
--- a/dotnet-template-samples/content/06-console-csharp-fsharp/MyProject.Con.FSharp/MyProject.Con.fsproj
+++ b/dotnet-template-samples/content/06-console-csharp-fsharp/MyProject.Con.FSharp/MyProject.Con.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="FSharp.NET.Sdk;Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,11 +7,6 @@
 
   <ItemGroup>
     <Compile Include="Program.fs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.1.*" />
-    <PackageReference Include="FSharp.NET.Sdk" Version="1.0.*" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Problem
Related to: https://github.com/dotnet/sdk/issues/48818

### Solution
Removed the obsolete FSharp.NET.Sdk references in the samples.  While this isn't strictly necessary for the linked issue, it is good hygiene to cleanup all FSharp.NET.Sdk references within .NET.
