### PR TITLE
Allows unofficial build pipeline to function

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ parameters:
   - buildConfig: Release
 
 extends:
-  ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'templating-official-ci')) }}:
     template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   ${{ else }}:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
@@ -87,6 +87,8 @@ extends:
             enableInternalSources: true
           enableTelemetry: true
           helixRepo: dotnet/templating
+          ${{ if ne(variables['Build.DefinitionName'], 'templating-official-ci') }}:
+            microbuildUseESRP: false
           templateContext:
             sdl:
               binskim:
@@ -107,7 +109,7 @@ extends:
               variables:
               - _BuildConfig: ${{ config.buildConfig }}
               - _SignType: test
-              - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+              - ${{ if and(notin(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'templating-official-ci')) }}:
                 - _SignType: real
               - _InternalBuildArgs: ''
               # Only enable publishing in non-public, non PR scenarios.


### PR DESCRIPTION
Follow-up to: https://github.com/dotnet/templating/pull/9555

## Summary

This allows the normal official build pipeline to also run in the unofficial pipeline. This does not change the build to be assetless yet. I'll do that in a follow-up PR.

These changes are based on the ones I did in Installer here: https://github.com/dotnet/installer/pull/20657

Additionally, there is an issue with the SourceBuild job, but that is unrelated to this change. I'm following up with @MichaelSimons for that problem.

## Builds
- Official: https://dnceng.visualstudio.com/internal/_build/results?buildId=2879558&view=results
- Unofficial: https://dnceng.visualstudio.com/internal/_build/results?buildId=2879559&view=results