### PR TITLE
Upgrade to xunit v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,11 +44,10 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.0.0" />
-    <PackageVersion Include="Verify.XUnit" Version="25.0.2" />
-    <PackageVersion Include="XUnit" Version="$(XUnitVersion)" />
-    <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
+    <PackageVersion Include="Verify.XunitV3" Version="28.12.0" />
     <!-- Xunit version is managed by Arcade. -->
-    <PackageVersion Include="xunit.extensibility.execution" Version="$(XUnitVersion)" />
+    <PackageVersion Include="xunit.v3.assert" Version="$(XUnitV3Version)" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="$(XUnitV3Version)" />
   </ItemGroup>
 
   <!-- Overrides needed until https://github.com/dotnet/source-build/issues/4467 is implemented. -->

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -4,6 +4,13 @@
 
   <PropertyGroup>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
+    <TestRunnerName>XUnitV3</TestRunnerName>
+    <!-- TODO: Fix xUnit1051 (use TestContext.Current.CancellationToken) incrementally and remove this suppression. -->
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
 </Project>

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ExportCommandFailureTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ExportCommandFailureTests.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using Microsoft.TemplateEngine.CommandUtils;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
 {

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ValidateCommandTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ValidateCommandTests.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.TemplateEngine.CommandUtils;
 using Microsoft.TemplateEngine.Tests;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
 {

--- a/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/VerifyCommandTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/VerifyCommandTests.cs
@@ -6,7 +6,6 @@ using Microsoft.TemplateEngine.Authoring.TemplateVerifier;
 using Microsoft.TemplateEngine.CommandUtils;
 using Microsoft.TemplateEngine.TestHelper;
 using Microsoft.TemplateEngine.Tests;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
 {

--- a/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/LocalizeTemplateTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/LocalizeTemplateTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.TemplateEngine.CommandUtils;
 using Microsoft.TemplateEngine.TestHelper;
 using Microsoft.TemplateEngine.Tests;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests
 {

--- a/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests.csproj
+++ b/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests.csproj
@@ -10,9 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Verify.Xunit" />
+    <PackageReference Include="Verify.XunitV3" />
     <PackageReference Include="Verify.DiffPlex" />
-    <PackageReference Include="Xunit" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/ValidateTemplatesTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/ValidateTemplatesTests.cs
@@ -4,7 +4,6 @@
 using Microsoft.TemplateEngine.CommandUtils;
 using Microsoft.TemplateEngine.TestHelper;
 using Microsoft.TemplateEngine.Tests;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests
 {

--- a/test/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/ExampleTemplateTest.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/ExampleTemplateTest.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Authoring.TemplateApiVerifier;
 using Microsoft.TemplateEngine.TestHelper;
 using Microsoft.TemplateEngine.Tests;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests
 {

--- a/test/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/TemplateEngineSamplesTest.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/TemplateEngineSamplesTest.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Authoring.TemplateApiVerifier;
 using Microsoft.TemplateEngine.TestHelper;
 using Microsoft.TemplateEngine.Tests;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests
 {

--- a/test/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/VerificationEngineTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/VerificationEngineTests.cs
@@ -4,7 +4,6 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.TestHelper;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests
 {

--- a/test/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests/VerificationEngineTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests/VerificationEngineTests.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Authoring.TemplateVerifier.Commands;
 using Microsoft.TemplateEngine.CommandUtils;
 using Microsoft.TemplateEngine.TestHelper;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests
 {

--- a/test/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/AuthoringTemplatesTests.cs
+++ b/test/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/AuthoringTemplatesTests.cs
@@ -6,7 +6,6 @@ using Microsoft.TemplateEngine.Authoring.TemplateApiVerifier;
 using Microsoft.TemplateEngine.Authoring.TemplateVerifier;
 using Microsoft.TemplateEngine.TestHelper;
 using Microsoft.TemplateEngine.Tests;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Authoring.Templates.Tests
 {

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Microsoft.TemplateEngine.IDE.IntegrationTests.csproj
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/Microsoft.TemplateEngine.IDE.IntegrationTests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
-    <PackageReference Include="Verify.XUnit" />
+    <PackageReference Include="Verify.XunitV3" />
     <PackageReference Include="Verify.DiffPlex" />
   </ItemGroup>
 

--- a/test/Microsoft.TemplateEngine.IDE.IntegrationTests/SnapshotTests.cs
+++ b/test/Microsoft.TemplateEngine.IDE.IntegrationTests/SnapshotTests.cs
@@ -7,7 +7,6 @@ using Microsoft.TemplateEngine.Authoring.TemplateApiVerifier;
 using Microsoft.TemplateEngine.Authoring.TemplateVerifier;
 using Microsoft.TemplateEngine.TestHelper;
 using Microsoft.TemplateEngine.Tests;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.IDE.IntegrationTests
 {

--- a/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
+++ b/test/Microsoft.TemplateEngine.Mocks/Microsoft.TemplateEngine.Mocks.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.abstractions" />
+    <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.TemplateEngine.Mocks/MockCreationEffects.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockCreationEffects.cs
@@ -3,7 +3,7 @@
 
 using System.Text;
 using Microsoft.TemplateEngine.Abstractions;
-using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Microsoft.TemplateEngine.Mocks
 {
@@ -49,9 +49,9 @@ namespace Microsoft.TemplateEngine.Mocks
 
         public void Deserialize(IXunitSerializationInfo info)
         {
-            _primaryOutputs = info.GetValue<string[]>("primaryOutputs");
-            _mockFileChanges = info.GetValue<MockFileChange[]>("fileChanges");
-            _absentFiles = info.GetValue<string[]>("absentFiles");
+            _primaryOutputs = info.GetValue<string[]>("primaryOutputs")!;
+            _mockFileChanges = info.GetValue<MockFileChange[]>("fileChanges")!;
+            _absentFiles = info.GetValue<string[]>("absentFiles")!;
         }
 
         public void Serialize(IXunitSerializationInfo info)

--- a/test/Microsoft.TemplateEngine.Mocks/MockFileChange.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockFileChange.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.TemplateEngine.Abstractions;
-using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Microsoft.TemplateEngine.Mocks
 {

--- a/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
@@ -7,7 +7,7 @@ using Microsoft.TemplateEngine.Abstractions.Constraints;
 using Microsoft.TemplateEngine.Abstractions.Parameters;
 using Microsoft.TemplateEngine.Utils;
 using Newtonsoft.Json;
-using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Microsoft.TemplateEngine.Mocks
 {
@@ -241,15 +241,15 @@ namespace Microsoft.TemplateEngine.Mocks
             GroupIdentity = info.GetValue<string>("template_group");
             Description = info.GetValue<string>("template_description");
             Author = info.GetValue<string>("template_author");
-            _tags = JsonConvert.DeserializeObject<Dictionary<string, string>>(info.GetValue<string>("template_tags"))
+            _tags = JsonConvert.DeserializeObject<Dictionary<string, string>>(info.GetValue<string>("template_tags")!)
                 ?? throw new Exception("Deserialiation failed");
-            _parameters = JsonConvert.DeserializeObject<Dictionary<string, TemplateParameter>>(info.GetValue<string>("template_params"))
+            _parameters = JsonConvert.DeserializeObject<Dictionary<string, TemplateParameter>>(info.GetValue<string>("template_params")!)
                          ?? throw new Exception("Deserialiation failed");
-            _baselineInfo = JsonConvert.DeserializeObject<string[]>(info.GetValue<string>("template_baseline"))
+            _baselineInfo = JsonConvert.DeserializeObject<string[]>(info.GetValue<string>("template_baseline")!)
                          ?? throw new Exception("Deserialiation failed");
-            _classifications = JsonConvert.DeserializeObject<string[]>(info.GetValue<string>("template_classifications"))
+            _classifications = JsonConvert.DeserializeObject<string[]>(info.GetValue<string>("template_classifications")!)
                          ?? throw new Exception("Deserialiation failed");
-            _shortNameList = JsonConvert.DeserializeObject<string[]>(info.GetValue<string>("template_shortname"))
+            _shortNameList = JsonConvert.DeserializeObject<string[]>(info.GetValue<string>("template_shortname")!)
                          ?? throw new Exception("Deserialiation failed");
         }
 

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json.Schema" />
     <PackageReference Include="FakeItEasy" />
-    <PackageReference Include="Verify.XUnit" />
+    <PackageReference Include="Verify.XunitV3" />
     <PackageReference Include="Verify.DiffPlex" />
   </ItemGroup>
 

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/SnapshotTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/SnapshotTests.cs
@@ -8,7 +8,6 @@ using Microsoft.TemplateEngine.Authoring.TemplateApiVerifier;
 using Microsoft.TemplateEngine.Authoring.TemplateVerifier;
 using Microsoft.TemplateEngine.TestHelper;
 using Microsoft.TemplateEngine.Tests;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 {

--- a/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/EnvironmentSettingsHelper.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Edge;
 using Microsoft.TemplateEngine.Utils;
-using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Microsoft.TemplateEngine.TestHelper
 {

--- a/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
+++ b/test/Microsoft.TemplateEngine.TestHelper/Microsoft.TemplateEngine.TestHelper.csproj
@@ -17,8 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="NuGet.Protocol" />
-    <PackageReference Include="xunit.extensibility.execution" />
-    <PackageReference Include="xunit.abstractions" />
+    <PackageReference Include="xunit.v3.extensibility.core" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="AwesomeAssertions" />

--- a/test/Microsoft.TemplateEngine.TestHelper/PublicAPI.Unshipped.txt
+++ b/test/Microsoft.TemplateEngine.TestHelper/PublicAPI.Unshipped.txt
@@ -12,7 +12,7 @@ Microsoft.TemplateEngine.TestHelper.EnvironmentSettingsHelper
 Microsoft.TemplateEngine.TestHelper.EnvironmentSettingsHelper.CreateEnvironment(string? locale = null, bool virtualize = false, string! hostIdentifier = "", bool loadDefaultGenerator = true, Microsoft.TemplateEngine.Abstractions.IEnvironment? environment = null, System.Collections.Generic.IReadOnlyList<(System.Type!, Microsoft.TemplateEngine.Abstractions.IIdentifiedComponent!)>? additionalComponents = null, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.ILoggerProvider!>? addLoggerProviders = null) -> Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings!
 Microsoft.TemplateEngine.TestHelper.EnvironmentSettingsHelper.CreateTemporaryFolder(string! name = "") -> string!
 Microsoft.TemplateEngine.TestHelper.EnvironmentSettingsHelper.Dispose() -> void
-Microsoft.TemplateEngine.TestHelper.EnvironmentSettingsHelper.EnvironmentSettingsHelper(Xunit.Abstractions.IMessageSink! messageSink) -> void
+Microsoft.TemplateEngine.TestHelper.EnvironmentSettingsHelper.EnvironmentSettingsHelper(Xunit.Sdk.IMessageSink! messageSink) -> void
 Microsoft.TemplateEngine.TestHelper.InMemoryLoggerProvider
 Microsoft.TemplateEngine.TestHelper.InMemoryLoggerProvider.CreateLogger(string! categoryName) -> Microsoft.Extensions.Logging.ILogger!
 Microsoft.TemplateEngine.TestHelper.InMemoryLoggerProvider.Dispose() -> void
@@ -60,7 +60,10 @@ Microsoft.TemplateEngine.TestHelper.PackageManager.GetNuGetPackage(string! templ
 Microsoft.TemplateEngine.TestHelper.PackageManager.PackageManager() -> void
 Microsoft.TemplateEngine.TestHelper.PackageManager.PackNuGetPackage(string! projectPath, NuGet.Common.ILogger? logger = null) -> string!
 Microsoft.TemplateEngine.TestHelper.SharedTestOutputHelper
-Microsoft.TemplateEngine.TestHelper.SharedTestOutputHelper.SharedTestOutputHelper(Xunit.Abstractions.IMessageSink! sink) -> void
+Microsoft.TemplateEngine.TestHelper.SharedTestOutputHelper.Output.get -> string!
+Microsoft.TemplateEngine.TestHelper.SharedTestOutputHelper.SharedTestOutputHelper(Xunit.Sdk.IMessageSink! sink) -> void
+Microsoft.TemplateEngine.TestHelper.SharedTestOutputHelper.Write(string! format, params object![]! args) -> void
+Microsoft.TemplateEngine.TestHelper.SharedTestOutputHelper.Write(string! message) -> void
 Microsoft.TemplateEngine.TestHelper.SharedTestOutputHelper.WriteLine(string! format, params object![]! args) -> void
 Microsoft.TemplateEngine.TestHelper.SharedTestOutputHelper.WriteLine(string! message) -> void
 Microsoft.TemplateEngine.TestHelper.StringExtensions
@@ -79,14 +82,14 @@ Microsoft.TemplateEngine.TestHelper.TestLoggerFactory.AddProvider(Microsoft.Exte
 Microsoft.TemplateEngine.TestHelper.TestLoggerFactory.CreateLogger() -> Microsoft.Extensions.Logging.ILogger!
 Microsoft.TemplateEngine.TestHelper.TestLoggerFactory.CreateLogger(string! categoryName) -> Microsoft.Extensions.Logging.ILogger!
 Microsoft.TemplateEngine.TestHelper.TestLoggerFactory.Dispose() -> void
-Microsoft.TemplateEngine.TestHelper.TestLoggerFactory.TestLoggerFactory(Xunit.Abstractions.IMessageSink? messageSink = null) -> void
+Microsoft.TemplateEngine.TestHelper.TestLoggerFactory.TestLoggerFactory(Xunit.Sdk.IMessageSink? messageSink = null) -> void
 Microsoft.TemplateEngine.TestHelper.TestUtils
 Microsoft.TemplateEngine.TestHelper.XunitLoggerProvider
 Microsoft.TemplateEngine.TestHelper.XunitLoggerProvider.CreateLogger(string! categoryName) -> Microsoft.Extensions.Logging.ILogger!
 Microsoft.TemplateEngine.TestHelper.XunitLoggerProvider.Dispose() -> void
-Microsoft.TemplateEngine.TestHelper.XunitLoggerProvider.XunitLoggerProvider(Xunit.Abstractions.ITestOutputHelper! output) -> void
-Microsoft.TemplateEngine.TestHelper.XunitLoggerProvider.XunitLoggerProvider(Xunit.Abstractions.ITestOutputHelper! output, Microsoft.Extensions.Logging.LogLevel minLevel) -> void
-Microsoft.TemplateEngine.TestHelper.XunitLoggerProvider.XunitLoggerProvider(Xunit.Abstractions.ITestOutputHelper! output, Microsoft.Extensions.Logging.LogLevel minLevel, System.DateTimeOffset? logStart) -> void
+Microsoft.TemplateEngine.TestHelper.XunitLoggerProvider.XunitLoggerProvider(Xunit.ITestOutputHelper! output) -> void
+Microsoft.TemplateEngine.TestHelper.XunitLoggerProvider.XunitLoggerProvider(Xunit.ITestOutputHelper! output, Microsoft.Extensions.Logging.LogLevel minLevel) -> void
+Microsoft.TemplateEngine.TestHelper.XunitLoggerProvider.XunitLoggerProvider(Xunit.ITestOutputHelper! output, Microsoft.Extensions.Logging.LogLevel minLevel, System.DateTimeOffset? logStart) -> void
 static Microsoft.TemplateEngine.TestHelper.BuiltInTemplatePackagesProviderFactory.GetComponents(params string![]! pathsToProbe) -> System.Collections.Generic.List<(System.Type!, Microsoft.TemplateEngine.Abstractions.IIdentifiedComponent!)>!
 static Microsoft.TemplateEngine.TestHelper.StringExtensions.UnixifyLineBreaks(this string! input) -> string!
 static Microsoft.TemplateEngine.TestHelper.TestFileSystemUtils.GetTempVirtualizedPath(this Microsoft.TemplateEngine.Abstractions.IEngineEnvironmentSettings! environmentSettings) -> string!

--- a/test/Microsoft.TemplateEngine.TestHelper/SharedTestOutputHelper.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/SharedTestOutputHelper.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit.Abstractions;
+using System.Text;
+using Xunit;
 using Xunit.Sdk;
+using Xunit.v3;
 
 namespace Microsoft.TemplateEngine.TestHelper
 {
@@ -13,20 +15,39 @@ namespace Microsoft.TemplateEngine.TestHelper
     public class SharedTestOutputHelper : ITestOutputHelper
     {
         private readonly IMessageSink _sink;
+        private readonly StringBuilder _output = new();
 
         public SharedTestOutputHelper(IMessageSink sink)
         {
             this._sink = sink;
         }
 
+        public string Output => _output.ToString();
+
+        public void Write(string message)
+        {
+            _output.Append(message);
+            _sink.OnMessage(new DiagnosticMessage(message));
+        }
+
+        public void Write(string format, params object[] args)
+        {
+            string message = string.Format(format, args);
+            _output.Append(message);
+            _sink.OnMessage(new DiagnosticMessage(message));
+        }
+
         public void WriteLine(string message)
         {
+            _output.AppendLine(message);
             _sink.OnMessage(new DiagnosticMessage(message));
         }
 
         public void WriteLine(string format, params object[] args)
         {
-            _sink.OnMessage(new DiagnosticMessage(format, args));
+            string message = string.Format(format, args);
+            _output.AppendLine(message);
+            _sink.OnMessage(new DiagnosticMessage(message));
         }
     }
 }

--- a/test/Microsoft.TemplateEngine.TestHelper/TestLoggerFactory.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/TestLoggerFactory.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Microsoft.TemplateEngine.TestHelper
 {

--- a/test/Microsoft.TemplateEngine.TestHelper/XunitLoggerProvider.cs
+++ b/test/Microsoft.TemplateEngine.TestHelper/XunitLoggerProvider.cs
@@ -3,7 +3,7 @@
 
 using System.Text;
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Microsoft.TemplateEngine.TestHelper
 {

--- a/test/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
+++ b/test/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.abstractions" />
     <PackageReference Include="AwesomeAssertions" />
   </ItemGroup>
 

--- a/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/TemplateDiscoveryTests.cs
+++ b/test/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/TemplateDiscoveryTests.cs
@@ -5,7 +5,6 @@ using Microsoft.TemplateEngine.CommandUtils;
 using Microsoft.TemplateEngine.TestHelper;
 using Microsoft.TemplateEngine.Tests;
 using Newtonsoft.Json.Linq;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests
 {

--- a/tools/Microsoft.TemplateEngine.Authoring.CLI/Microsoft.TemplateEngine.Authoring.CLI.csproj
+++ b/tools/Microsoft.TemplateEngine.Authoring.CLI/Microsoft.TemplateEngine.Authoring.CLI.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="System.CommandLine" />
-    <PackageReference Include="Verify.Xunit" />
+    <PackageReference Include="Verify.XunitV3" />
     <PackageReference Include="Verify.DiffPlex" />
   </ItemGroup>
 

--- a/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.csproj
+++ b/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.csproj
@@ -13,9 +13,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
-    <PackageReference Include="Verify.Xunit" />
+    <PackageReference Include="Verify.XunitV3" />
     <PackageReference Include="Verify.DiffPlex" />
-    <PackageReference Include="Xunit" />
+    <PackageReference Include="xunit.v3.extensibility.core" />
+    <PackageReference Include="xunit.v3.assert" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/VerificationEngine.cs
+++ b/tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/VerificationEngine.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -363,9 +362,6 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier
             return result;
         }
 
-        private static void DummyMethod()
-        { }
-
         private static async IAsyncEnumerable<(string FilePath, string ScrubbedContent)> GetVerificationContent(
             string contentDir,
             List<IPatternMatcher> includeMatchers,
@@ -429,14 +425,6 @@ namespace Microsoft.TemplateEngine.Authoring.TemplateVerifier
 
         private async Task VerifyResult(TemplateVerifierOptions args, IInstantiationResult commandResultData, CallerInfo callerInfo)
         {
-            UseVerifyAttribute a = new UseVerifyAttribute();
-
-            // https://github.com/VerifyTests/Verify/blob/d8cbe38f527d6788ecadd6205c82803bec3cdfa6/src/Verify.Xunit/Verifier.cs#L10
-            //  need to simulate execution from tests
-            var v = DummyMethod;
-            MethodInfo mi = v.Method;
-            a.Before(mi);
-
             if (args.VerifyCommandOutput)
             {
                 if (_fileSystem.DirectoryExists(Path.Combine(commandResultData.InstantiatedContentDirectory, SpecialFiles.StandardStreamsDir)))

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
@@ -10,8 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xunit" />
-    <PackageReference Include="Verify.Xunit" />
+    <PackageReference Include="xunit.v3.extensibility.core" />
+    <PackageReference Include="xunit.v3.assert" />
+    <PackageReference Include="Verify.XunitV3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NuGet.Configuration" />

--- a/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/TestLogger.cs
+++ b/tools/Microsoft.TemplateSearch.TemplateDiscovery/Test/TestLogger.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Xunit.Abstractions;
+using System.Text;
 
 namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
 {
@@ -9,8 +9,34 @@ namespace Microsoft.TemplateSearch.TemplateDiscovery.Test
     {
         public static readonly TestOutputLogger Instance = new TestOutputLogger();
 
-        public void WriteLine(string message) => Console.WriteLine(message);
+        private readonly StringBuilder _output = new();
 
-        public void WriteLine(string format, params object[] args) => Console.WriteLine(format, args);
+        public string Output => _output.ToString();
+
+        public void Write(string message)
+        {
+            _output.Append(message);
+            Console.Write(message);
+        }
+
+        public void Write(string format, params object[] args)
+        {
+            string message = string.Format(format, args);
+            _output.Append(message);
+            Console.Write(message);
+        }
+
+        public void WriteLine(string message)
+        {
+            _output.AppendLine(message);
+            Console.WriteLine(message);
+        }
+
+        public void WriteLine(string format, params object[] args)
+        {
+            string message = string.Format(format, args);
+            _output.AppendLine(message);
+            Console.WriteLine(message);
+        }
     }
 }

--- a/tools/Shared/Microsoft.TemplateEngine.CommandUtils/BasicCommand.cs
+++ b/tools/Shared/Microsoft.TemplateEngine.CommandUtils/BasicCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.CommandUtils
 {

--- a/tools/Shared/Microsoft.TemplateEngine.CommandUtils/DotnetCommand.cs
+++ b/tools/Shared/Microsoft.TemplateEngine.CommandUtils/DotnetCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.CommandUtils
 {

--- a/tools/Shared/Microsoft.TemplateEngine.CommandUtils/DotnetNewCommand.cs
+++ b/tools/Shared/Microsoft.TemplateEngine.CommandUtils/DotnetNewCommand.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.Extensions.Logging;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.CommandUtils
 {

--- a/tools/Shared/Microsoft.TemplateEngine.CommandUtils/TestCommand.cs
+++ b/tools/Shared/Microsoft.TemplateEngine.CommandUtils/TestCommand.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Utils;
-using Xunit.Abstractions;
 
 namespace Microsoft.TemplateEngine.CommandUtils
 {


### PR DESCRIPTION
Configuration:

- test/Directory.Build.props: Added TestRunnerName=XUnitV3, OutputType=Exe, suppressed xUnit1051
- Directory.Packages.props: Removed v2 packages, added xunit.v3.* and Verify.XunitV3

Package references updated in 8 csproj files (3 test, 3 tool, 2 utility)

Code changes across ~30 files:

- using Xunit.Abstractions; → removed/replaced with Xunit.Sdk; or Xunit.v3;
- SharedTestOutputHelper & TestOutputLogger: Added Write(), Output (new v3 ITestOutputHelper members)
- VerificationEngine.cs: Removed UseVerifyAttribute (no longer needed in v3)
- PublicAPI.Unshipped.txt: Updated type signatures
- Nullable fixes in Mock serialization code

Note: xUnit1051 (TestContext.Current.CancellationToken) is suppressed for now — 522 instances to fix incrementally.