### PR TITLE
[release/9.0.3xx] Update branding to 9.0.313

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>9.0.312</VersionPrefix>
+    <VersionPrefix>9.0.313</VersionPrefix>
     <!-- When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>


### PR DESCRIPTION
This PR updates version branding on branch `release/9.0.3xx`.

**Changes:**
- Repository: templating
  - PatchVersion: `12` → `13`

**Files Modified:**
- eng/Versions.props (+1 -1)
