### PR TITLE
[release/9.0.1xx] Update branding to 9.0.116

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>9.0.115</VersionPrefix>
+    <VersionPrefix>9.0.116</VersionPrefix>
     <!-- When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>


### PR DESCRIPTION
This PR updates version branding on branch `release/9.0.1xx`.

**Changes:**
- Repository: templating
  - PatchVersion: `15` → `16`

**Files Modified:**
- eng/Versions.props (+1 -1)
