### PR TITLE
[release/8.0.1xx] Update branding to 8.0.126

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <UsingToolXliff>true</UsingToolXliff>
     <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
-    <VersionPrefix>8.0.125</VersionPrefix>
+    <VersionPrefix>8.0.126</VersionPrefix>
     <!-- When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>


### PR DESCRIPTION
This PR updates version branding on branch `release/8.0.1xx`.

**Changes:**
- Repository: templating
  - PatchVersion: `25` → `26`

**Files Modified:**
- eng/Versions.props (+1 -1)
