### PR TITLE
Make projects AOT compatible

### DIFF
--- a/src/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
+++ b/src/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
@@ -6,6 +6,11 @@
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsAotCompatible>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/Microsoft.TemplateEngine.Core.Contracts/Microsoft.TemplateEngine.Core.Contracts.csproj
+++ b/src/Microsoft.TemplateEngine.Core.Contracts/Microsoft.TemplateEngine.Core.Contracts.csproj
@@ -5,6 +5,11 @@
     <Description>Contracts for extending Microsoft.TemplateEngine.Core</Description>
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
+++ b/src/Microsoft.TemplateEngine.Core/Microsoft.TemplateEngine.Core.csproj
@@ -5,6 +5,11 @@
     <Description>Common operations for instantiating templates using forward-only input stream operations</Description>
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsAotCompatible>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettings.cs
@@ -133,7 +133,7 @@ namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
                 {
                     // Ignore FSW notifications received during writing changes (we'll notify synchronously)
                     _watcher?.Dispose();
-                    _environmentSettings.Host.FileSystem.WriteObject(_globalSettingsFile, globalSettingsData);
+                    _environmentSettings.Host.FileSystem.WriteObject(_globalSettingsFile, globalSettingsData, GlobalSettingsJsonSerializerContext.Default.GlobalSettingsData);
                     // We are ready for new notifications now
                     _watcher = CreateWatcherIfRequested();
                     SettingsChanged?.Invoke();

--- a/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsJsonSerializerContext.cs
+++ b/src/Microsoft.TemplateEngine.Edge/BuiltInManagedProvider/GlobalSettingsJsonSerializerContext.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.TemplateEngine.Edge.BuiltInManagedProvider
+{
+    [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonSerializable(typeof(GlobalSettingsData))]
+    internal partial class GlobalSettingsJsonSerializerContext : JsonSerializerContext;
+}

--- a/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
+++ b/src/Microsoft.TemplateEngine.Edge/Microsoft.TemplateEngine.Edge.csproj
@@ -6,6 +6,11 @@
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsAotCompatible>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/Microsoft.TemplateEngine.Edge/ReflectionLoadProbingPath.cs
+++ b/src/Microsoft.TemplateEngine.Edge/ReflectionLoadProbingPath.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 #if NET
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Loader;
 #endif
 
@@ -43,6 +44,7 @@ namespace Microsoft.TemplateEngine.Edge
         }
 
 #if NET
+        [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "Assembly probing loads assemblies by path at runtime.")]
         private static Assembly? SelectBestMatch(AssemblyLoadContext loadContext, AssemblyName match, IEnumerable<FileInfo> candidates)
 #else
         private static Assembly? SelectBestMatch(object sender, AssemblyName match, IEnumerable<FileInfo> candidates)
@@ -195,6 +197,7 @@ namespace Microsoft.TemplateEngine.Edge
         }
 
 #if NET
+        [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "Assembly resolution probes and loads assemblies at runtime.")]
         private static Assembly? Resolving(AssemblyLoadContext assemblyLoadContext, AssemblyName assemblyName)
 #else
         private static Assembly? Resolving(object sender, ResolveEventArgs resolveEventArgs)

--- a/src/Microsoft.TemplateEngine.Edge/Settings/ComponentManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/ComponentManager.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Reflection;
 using Microsoft.TemplateEngine.Abstractions;
 #if NET
@@ -18,6 +21,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         private readonly SettingsFilePaths _paths;
         private readonly IEngineEnvironmentSettings _engineEnvironmentSettings;
 
+#if NET7_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2057", Justification = "Component types are resolved by assembly-qualified name from the settings store.")]
+#endif
         public ComponentManager(IEngineEnvironmentSettings engineEnvironmentSettings)
         {
             _engineEnvironmentSettings = engineEnvironmentSettings;
@@ -119,6 +125,12 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             }
         }
 
+#if NET7_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "Components are resolved by name and instantiated via reflection.")]
+        [UnconditionalSuppressMessage("AOT", "IL2067", Justification = "Component type is resolved at runtime from stored assembly-qualified name.")]
+        [UnconditionalSuppressMessage("AOT", "IL2072", Justification = "Component type is resolved at runtime from stored assembly-qualified name.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "Component instantiation uses Activator.CreateInstance with runtime-resolved types.")]
+#endif
         public bool TryGetComponent<T>(Guid id, out T? component)
                     where T : class, IIdentifiedComponent
         {
@@ -173,6 +185,13 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         }
 
         // This method does not save the settings, it just registers into the memory cache.
+#if NET7_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "Component registration inspects and instantiates types via reflection.")]
+        [UnconditionalSuppressMessage("AOT", "IL2067", Justification = "Component type metadata is inspected at runtime.")]
+        [UnconditionalSuppressMessage("AOT", "IL2070", Justification = "Component type interfaces are enumerated at runtime.")]
+        [UnconditionalSuppressMessage("AOT", "IL3000", Justification = "Assembly.Location is used to register probing paths for component resolution.")]
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "Component instantiation uses Activator.CreateInstance with runtime-resolved types.")]
+#endif
         private bool RegisterType(Type type)
         {
             if (!typeof(IIdentifiedComponent).IsAssignableFrom(type) || type.GetConstructor(Type.EmptyTypes) == null || !type.IsClass)
@@ -239,7 +258,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             {
                 try
                 {
-                    _engineEnvironmentSettings.Host.FileSystem.WriteObject(_paths.SettingsFile, _settings);
+                    _engineEnvironmentSettings.Host.FileSystem.WriteObject(_paths.SettingsFile, _settings, SettingsStoreJsonSerializerContext.Default.SettingsStore);
                     successfulWrite = true;
                 }
                 catch (IOException)
@@ -273,6 +292,10 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             ids.Add(component.Id);
         }
 
+#if NET7_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "Assembly loading resolves assemblies by name at runtime.")]
+        [UnconditionalSuppressMessage("AOT", "IL2057", Justification = "Component type is resolved by stored assembly-qualified name.")]
+#endif
         private Type GetType(string typeName)
         {
             int commaIndex = typeName.IndexOf(',');

--- a/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/Scanner.cs
@@ -3,6 +3,7 @@
 
 using System.Reflection;
 #if NET
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Loader;
 #endif
 using Microsoft.Extensions.Logging;
@@ -128,6 +129,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
             throw new Exception(string.Format(LocalizableStrings.Scanner_Error_TemplatePackageLocationIsNotSupported, sourceLocation));
         }
 
+#if NET
+        [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "Component scanning uses Assembly.GetTypes() on dynamically loaded assemblies.")]
+#endif
         private void ScanForComponents(MountPointScanSource source)
         {
             _ = source ?? throw new ArgumentNullException(nameof(source));
@@ -258,6 +262,9 @@ namespace Microsoft.TemplateEngine.Edge.Settings
         /// <param name="pattern">Filename pattern to use when searching for files.</param>
         /// <param name="searchOption"><see cref="SearchOption"/> to use when searching for files.</param>
         /// <returns>The list of loaded assemblies in format (filename, loaded assembly).</returns>
+#if NET
+        [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "Assembly loading via AssemblyLoadContext.LoadFromStream() is inherently reflection-based.")]
+#endif
         private IEnumerable<KeyValuePair<string, Assembly>> LoadAllFromPath(
             out IEnumerable<string> loadFailures,
             string path,

--- a/src/Microsoft.TemplateEngine.Edge/Settings/SettingsStoreJsonSerializerContext.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/SettingsStoreJsonSerializerContext.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.TemplateEngine.Edge.Settings
+{
+    [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonSerializable(typeof(SettingsStore))]
+    internal partial class SettingsStoreJsonSerializerContext : JsonSerializerContext;
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCacheJsonSerializerContext.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplateCacheJsonSerializerContext.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.TemplateEngine.Edge.Settings
+{
+    [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonSerializable(typeof(TemplateCache))]
+    internal partial class TemplateCacheJsonSerializerContext : JsonSerializerContext;
+}

--- a/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
+++ b/src/Microsoft.TemplateEngine.Edge/Settings/TemplatePackageManager.cs
@@ -373,7 +373,7 @@ namespace Microsoft.TemplateEngine.Edge.Settings
 
             try
             {
-                _environmentSettings.Host.FileSystem.WriteObject(_paths.TemplateCacheFile, cache);
+                _environmentSettings.Host.FileSystem.WriteObject(_paths.TemplateCacheFile, cache, TemplateCacheJsonSerializerContext.Default.TemplateCache);
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs
+++ b/src/Microsoft.TemplateEngine.IDE/Bootstrapper.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
+#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Installer;
 using Microsoft.TemplateEngine.Abstractions.TemplatePackage;
@@ -371,6 +374,9 @@ namespace Microsoft.TemplateEngine.IDE
         }
 
         [Obsolete("Use ITemplateEngineHost.BuiltInComponents or AddComponent to add components.")]
+#if NET7_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "Obsolete method; Assembly.GetTypes() is inherently reflection-based.")]
+#endif
         public void Register(Assembly assembly)
         {
             _engineEnvironmentSettings.Components.RegisterMany(assembly.GetTypes());

--- a/src/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj
+++ b/src/Microsoft.TemplateEngine.IDE/Microsoft.TemplateEngine.IDE.csproj
@@ -6,6 +6,11 @@
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsAotCompatible>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.csproj
@@ -5,6 +5,11 @@
     <Description>An extension for Template Engine that allows projects that still run to be used as templates</Description>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsAotCompatible>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/JsonEncodeValueFormFactory.cs
+++ b/src/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/ValueForms/JsonEncodeValueFormFactory.cs
@@ -3,23 +3,27 @@
 
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ValueForms
 {
+    [JsonSerializable(typeof(string))]
+    internal partial class JsonEncodeSerializerContext : JsonSerializerContext;
+
     internal class JsonEncodeValueFormFactory : ActionableValueFormFactory
     {
         internal const string FormIdentifier = "jsonEncode";
 
-        private static readonly JsonSerializerOptions JsonEncodeOptions = new()
+        private static readonly JsonEncodeSerializerContext JsonEncodeContext = new(new JsonSerializerOptions
         {
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-        };
+        });
 
         internal JsonEncodeValueFormFactory() : base(FormIdentifier) { }
 
         protected override string Process(string value)
         {
-            return JsonSerializer.Serialize(value, JsonEncodeOptions);
+            return JsonSerializer.Serialize(value, JsonEncodeContext.String);
         }
     }
 }

--- a/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
+++ b/src/Microsoft.TemplateEngine.Utils/Microsoft.TemplateEngine.Utils.csproj
@@ -6,6 +6,11 @@
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsAotCompatible>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/Microsoft.TemplateSearch.Common/Microsoft.TemplateSearch.Common.csproj
+++ b/src/Microsoft.TemplateSearch.Common/Microsoft.TemplateSearch.Common.csproj
@@ -6,6 +6,11 @@
     <IsPackable>true</IsPackable>
     <EnablePublicApiAnalyzer>true</EnablePublicApiAnalyzer>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!--
+      Mark as Native AOT compatible. This will enable relevant analyzers.
+      https://learn.microsoft.com/dotnet/core/deploying/native-aot/#aot-compatibility-analyzers
+    -->
+    <IsAotCompatible Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsAotCompatible>
   </PropertyGroup>
 
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/TemplateDiscoveryMetadata.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateDiscoveryMetadata/TemplateDiscoveryMetadata.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Microsoft.TemplateEngine;
@@ -31,6 +34,10 @@ namespace Microsoft.TemplateSearch.Common
         [JsonInclude]
         internal IReadOnlyDictionary<string, object> AdditionalData { get; }
 
+#if NET7_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "Serializes a known internal type (TemplateDiscoveryMetadata).")]
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "Serializes a known internal type (TemplateDiscoveryMetadata).")]
+#endif
         internal JsonObject ToJObject()
         {
             return JExtensions.FromObject(this);

--- a/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplatePackageSearchData.Json.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplatePackageSearchData.Json.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
@@ -67,6 +70,10 @@ namespace Microsoft.TemplateSearch.Common
             public override TemplatePackageSearchData Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
                 => throw new NotImplementedException();
 
+#if NET7_0_OR_GREATER
+            [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "Templates and AdditionalData are serialized with known types.")]
+            [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "Templates and AdditionalData are serialized with known types.")]
+#endif
             public override void Write(Utf8JsonWriter writer, TemplatePackageSearchData value, JsonSerializerOptions options)
             {
                 if (value == null)

--- a/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplateSearchCache.Json.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplateSearchCache.Json.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine;
@@ -96,6 +99,10 @@ namespace Microsoft.TemplateSearch.Common
             return additionalData;
         }
 
+#if NET7_0_OR_GREATER
+        [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "Serializes a known internal type (TemplateSearchCache).")]
+        [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "Serializes a known internal type (TemplateSearchCache).")]
+#endif
         internal JsonObject ToJObject()
         {
             return JExtensions.FromObject(this);

--- a/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplateSearchData.Json.cs
+++ b/src/Microsoft.TemplateSearch.Common/TemplateSearchCache/TemplateSearchData.Json.cs
@@ -1,6 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
@@ -40,6 +43,10 @@ namespace Microsoft.TemplateSearch.Common
             public override TemplateSearchData Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
                 => throw new NotImplementedException();
 
+#if NET7_0_OR_GREATER
+            [UnconditionalSuppressMessage("AOT", "IL2026:RequiresUnreferencedCode", Justification = "BaselineInfo and AdditionalData are serialized with known types.")]
+            [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "BaselineInfo and AdditionalData are serialized with known types.")]
+#endif
             public override void Write(Utf8JsonWriter writer, TemplateSearchData value, JsonSerializerOptions options)
             {
                 if (value == null)

--- a/src/Shared/JExtensions.cs
+++ b/src/Shared/JExtensions.cs
@@ -1,9 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if NET7_0_OR_GREATER
+using System.Diagnostics.CodeAnalysis;
+#endif
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 using Microsoft.TemplateEngine.Abstractions.PhysicalFileSystem;
@@ -396,10 +400,10 @@ namespace Microsoft.TemplateEngine
                 ?? throw new InvalidOperationException($"Failed to parse JSON from '{path}'.");
         }
 
-        internal static void WriteObject(this IPhysicalFileSystem fileSystem, string path, object obj)
+        internal static void WriteObject<T>(this IPhysicalFileSystem fileSystem, string path, T obj, JsonTypeInfo<T> jsonTypeInfo)
         {
             using Stream fileStream = fileSystem.CreateFile(path);
-            JsonSerializer.Serialize(fileStream, obj, SerializerOptions);
+            JsonSerializer.Serialize(fileStream, obj, jsonTypeInfo);
         }
 
         internal static IReadOnlyList<string> JTokenStringOrArrayToCollection(this JsonNode? token, IReadOnlyList<string> defaultSet)
@@ -421,6 +425,10 @@ namespace Microsoft.TemplateEngine
         /// <summary>
         /// Converts <paramref name="obj"/> to valid JSON string.
         /// </summary>
+#if NET7_0_OR_GREATER
+        [RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed.")]
+        [RequiresDynamicCode("JSON serialization and deserialization might require runtime code generation.")]
+#endif
         internal static string ToJsonString(object obj)
         {
             return JsonSerializer.Serialize(obj, SerializerOptions);
@@ -488,6 +496,10 @@ namespace Microsoft.TemplateEngine
         /// Serializes an object to a JsonObject via JSON round-trip.
         /// Equivalent to Newtonsoft's JObject.FromObject().
         /// </summary>
+#if NET7_0_OR_GREATER
+        [RequiresUnreferencedCode("JSON serialization and deserialization might require types that cannot be statically analyzed.")]
+        [RequiresDynamicCode("JSON serialization and deserialization might require runtime code generation.")]
+#endif
         internal static JsonObject FromObject(object obj)
         {
             string json = JsonSerializer.Serialize(obj, SerializerOptions);


### PR DESCRIPTION
Contributes to https://github.com/dotnet/templating/issues/9193

Summary of changes.

## 1. Enable AOT compatibility analyzers on all `src/` projects

Each `.csproj` under `src/` received:

```xml
<IsAotCompatible Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) == '.NETCoreApp'">true</IsAotCompatible>
```

The condition restricts it to .NET Core TFMs, avoiding errors on `netstandard2.0` / `net472`.

## 2. Replace reflection-based JSON serialization with source-generated contexts

Three new `JsonSerializerContext` files were added to eliminate AOT-unsafe `JsonSerializer.Serialize(obj)` calls:

| New file | Serializable type |
|---|---|
| `GlobalSettingsJsonSerializerContext.cs` | `GlobalSettingsData` |
| `SettingsStoreJsonSerializerContext.cs` | `SettingsStore` |
| `TemplateCacheJsonSerializerContext.cs` | `TemplateCache` |

The callers in `GlobalSettings.cs`, `ComponentManager.cs`, and `TemplatePackageManager.cs` were updated to use the new typed `WriteObject<T>` overload with `JsonTypeInfo<T>`.

## 3. Convert `WriteObject` to a type-safe generic

In `JExtensions.cs`, the untyped `WriteObject(string, object)` was replaced with:

```csharp
WriteObject<T>(string path, T obj, JsonTypeInfo<T> jsonTypeInfo)
```

This uses `JsonSerializer.Serialize(stream, obj, jsonTypeInfo)` — fully AOT-safe.

## 4. Source-gen context for `JsonEncodeValueFormFactory`

In `JsonEncodeValueFormFactory.cs`, the static `JsonSerializerOptions` + `JsonSerializer.Serialize(value, options)` was replaced with a `JsonEncodeSerializerContext` using `[JsonSerializable(typeof(string))]`, calling `JsonSerializer.Serialize(value, context.String)`.

## 5. AOT suppression attributes on reflection-heavy methods

Methods that inherently use reflection (assembly loading, `Type.GetType()`, `Activator.CreateInstance`) received method-level `[UnconditionalSuppressMessage]` attributes with specific IL warning codes:

| File | Methods annotated | Warning codes |
|---|---|---|
| `ComponentManager.cs` | Constructor, `TryGetComponent<T>`, `RegisterType`, `GetType` | IL2026, IL2057, IL2067, IL2070, IL2072, IL3000, IL3050 |
| `Scanner.cs` | `ScanForComponents`, `LoadAllFromPath` | IL2026 |
| `ReflectionLoadProbingPath.cs` | `SelectBestMatch`, `Resolving` | IL2026 |
| `Bootstrapper.cs` | `Register(Assembly)` | IL2026 |

## 6. AOT annotations on remaining unsafe shared methods

`ToJsonString(object)` and `FromObject(object)` in `JExtensions.cs` received `[RequiresUnreferencedCode]` + `[RequiresDynamicCode]` attributes, propagating warnings to callers. The callers in `TemplateSearchCache.Json.cs`, `TemplateSearchData.Json.cs`, `TemplatePackageSearchData.Json.cs`, and `TemplateDiscoveryMetadata.cs` received corresponding `[UnconditionalSuppressMessage]` attributes with justifications.

All attributes are guarded with `#if NET7_0_OR_GREATER` (or `#if NET` where appropriate) so they compile cleanly on older TFMs.
