### PR TITLE
Fix search-cache-pipeline: use dotnet run and publish test results

### DIFF
--- a/search-cache-pipeline.yml
+++ b/search-cache-pipeline.yml
@@ -69,6 +69,16 @@ extends:
           continueOnError: true
           condition: always()
 
+        - task: PublishTestResults@2
+          displayName: Publish Test Results
+          inputs:
+            testResultsFormat: xUnit
+            testResultsFiles: '*.xml'
+            searchFolder: $(Build.SourcesDirectory)/artifacts/TestResults/Debug
+            mergeTestResults: true
+          continueOnError: true
+          condition: always()
+
         - task: UseDotNet@2
           displayName: Use .NET 6.0.100
           inputs:
@@ -128,7 +138,9 @@ extends:
           displayName: Install latest daily .NET version
 
         - bash: >
-            $(Build.SourcesDirectory)/.dotnet/dotnet $(Build.SourcesDirectory)/artifacts/bin/Microsoft.TemplateSearch.TemplateDiscovery/Debug/net8.0/Microsoft.TemplateSearch.TemplateDiscovery.dll --basePath $(System.DefaultWorkingDirectory)/NugetDownloadDirectory --allowPreviewPacks -v --test --diff $(EnableDiffMode)
+            $(Build.SourcesDirectory)/.dotnet/dotnet run --no-build
+            --project $(Build.SourcesDirectory)/tools/Microsoft.TemplateSearch.TemplateDiscovery/Microsoft.TemplateSearch.TemplateDiscovery.csproj
+            -- --basePath $(System.DefaultWorkingDirectory)/NugetDownloadDirectory --allowPreviewPacks -v --test --diff $(EnableDiffMode)
           displayName: Run Cache Updater
 
         - task: CopyFiles@2


### PR DESCRIPTION
The pipeline hardcoded net8.0 in the path to the TemplateDiscovery DLL, but the Arcade SDK NetMinimum changed from net8.0 to net10.0 in January 2026, so the DLL is no longer produced at that path. This has caused every hourly run to fail since Jan 12.

Use 'dotnet run --no-build --project' instead of a hardcoded DLL path so the pipeline is TFM-agnostic and won't break when TFMs change.

Also add PublishTestResults@2 task so test results from the build step are published to Azure DevOps, matching the pattern used by the CI pipelines.

### Problem
<!-- Add the issue number if exists. Describe the problem otherwise. -->

### Solution
<!-- Describe the solution. -->

### Checks:
- [ ] Added unit tests