### PR TITLE
Fix duplicate key handling

### DIFF
--- a/src/Shared/JExtensions.cs
+++ b/src/Shared/JExtensions.cs
@@ -17,7 +17,6 @@ namespace Microsoft.TemplateEngine
     internal static class JExtensions
     {
         private static readonly JsonDocumentOptions DocOptions = new() { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true };
-        private static readonly JsonNodeOptions NodeOptions = new() { PropertyNameCaseInsensitive = true };
         private static readonly JsonSerializerOptions SerializerOptions = new()
         {
             PropertyNameCaseInsensitive = true,
@@ -387,7 +386,7 @@ namespace Microsoft.TemplateEngine
             using Stream s = file.OpenRead();
             using TextReader tr = new StreamReader(s, System.Text.Encoding.UTF8, true);
             string json = tr.ReadToEnd();
-            return (JsonObject?)JsonNode.Parse(json, NodeOptions, DocOptions)
+            return (JsonObject?)JsonNode.Parse(json, null, DocOptions)
                 ?? throw new InvalidOperationException("Failed to parse JSON from file.");
         }
 
@@ -396,7 +395,7 @@ namespace Microsoft.TemplateEngine
             using Stream fileStream = fileSystem.OpenRead(path);
             using var textReader = new StreamReader(fileStream, System.Text.Encoding.UTF8, true);
             string json = textReader.ReadToEnd();
-            return (JsonObject?)JsonNode.Parse(json, NodeOptions, DocOptions)
+            return (JsonObject?)JsonNode.Parse(json, null, DocOptions)
                 ?? throw new InvalidOperationException($"Failed to parse JSON from '{path}'.");
         }
 
@@ -480,7 +479,7 @@ namespace Microsoft.TemplateEngine
         /// </summary>
         internal static JsonObject ParseJsonObject(string json)
         {
-            return (JsonObject?)JsonNode.Parse(json, NodeOptions, DocOptions)
+            return (JsonObject?)JsonNode.Parse(json, null, DocOptions)
                 ?? throw new InvalidOperationException("Failed to parse JSON string as JsonObject.");
         }
 
@@ -489,7 +488,7 @@ namespace Microsoft.TemplateEngine
         /// </summary>
         internal static JsonNode? ParseJsonNode(string json)
         {
-            return JsonNode.Parse(json, NodeOptions, DocOptions);
+            return JsonNode.Parse(json, null, DocOptions);
         }
 
         /// <summary>
@@ -503,7 +502,7 @@ namespace Microsoft.TemplateEngine
         internal static JsonObject FromObject(object obj)
         {
             string json = JsonSerializer.Serialize(obj, SerializerOptions);
-            return (JsonObject?)JsonNode.Parse(json, NodeOptions, DocOptions)
+            return (JsonObject?)JsonNode.Parse(json, null, DocOptions)
                 ?? throw new InvalidOperationException("Failed to round-trip object to JsonObject.");
         }
 
@@ -512,7 +511,7 @@ namespace Microsoft.TemplateEngine
         /// </summary>
         internal static JsonObject DeepCloneObject(this JsonObject source)
         {
-            return (JsonObject?)JsonNode.Parse(source.ToJsonString(), NodeOptions, DocOptions)
+            return (JsonObject?)JsonNode.Parse(source.ToJsonString(), null, DocOptions)
                 ?? throw new InvalidOperationException("Failed to deep clone JsonObject.");
         }
 

--- a/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/GenericTests.cs
+++ b/test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/GenericTests.cs
@@ -54,5 +54,44 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests.Templ
             Assert.Equal(2, templateConfigModel.PrimaryOutputs.Count);
             Assert.Equal(new[] { "bar.cs", "bar/bar.cs" }, templateConfigModel.PrimaryOutputs.Select(po => po.Path).OrderBy(po => po));
         }
+
+        [Fact]
+        public void CanReadTemplateWithDuplicateCaseInsensitiveSymbolKeys()
+        {
+            // Regression test: template.json with symbols that differ only by case
+            // (e.g. "Empty" and "empty") should load without throwing.
+            // See https://github.com/dotnet/templating/issues/10047
+            string templateWithDuplicateKeys = /*lang=json*/ """
+                {
+                  "author": "Test Asset",
+                  "classifications": [ "Test Asset" ],
+                  "name": "TemplateWithDuplicateKeys",
+                  "identity": "TestAssets.TemplateWithDuplicateKeys",
+                  "shortName": "dupkeys",
+                  "symbols": {
+                    "Empty": {
+                      "type": "parameter",
+                      "datatype": "bool",
+                      "defaultValue": "false",
+                      "description": "PascalCase variant"
+                    },
+                    "empty": {
+                      "type": "parameter",
+                      "datatype": "bool",
+                      "defaultValue": "false",
+                      "description": "lowercase variant"
+                    }
+                  }
+                }
+                """;
+
+            var exception = Record.Exception(() => TemplateConfigModel.FromString(templateWithDuplicateKeys));
+            Assert.Null(exception);
+
+            TemplateConfigModel configModel = TemplateConfigModel.FromString(templateWithDuplicateKeys);
+            Assert.Equal("TemplateWithDuplicateKeys", configModel.Name);
+            // Both symbols should be accessible (last-in-wins for case-sensitive dict, both kept)
+            Assert.NotEmpty(configModel.Symbols);
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/templating/issues/10025

## Problem

After migrating from Newtonsoft.Json to System.Text.Json, loading template.json files with duplicate case-insensitive property keys (e.g. `"Empty"` and `"empty"`) throws an `ArgumentException`:

```
System.ArgumentException: An item with the same key has already been added. Key: empty (Parameter 'key')
   at System.Collections.Generic.OrderedDictionary`2.Add(TKey key, TValue value)
   at System.Text.Json.Nodes.JsonObject.InitializeDictionary()
   at System.Text.Json.Nodes.JsonObject.get_Count()
   ...
   at Microsoft.TemplateEngine.Orchestrator.RunnableProjects.ConfigModel.TemplateConfigModel..ctor(...)
```

This affected MAUI templates (`maui-blazor`, `maui-blazor-solution`) which intentionally had both `"Empty"` (PascalCase backward-compat alias) and `"empty"` (lowercase) symbol definitions.

## Root Cause

In `src/Shared/JExtensions.cs`, the `NodeOptions` field was configured with `PropertyNameCaseInsensitive = true`:

```csharp
private static readonly JsonNodeOptions NodeOptions = new() { PropertyNameCaseInsensitive = true };
```

This caused `JsonObject` to use a case-insensitive internal dictionary. When any operation triggered `JsonObject.InitializeDictionary()` (e.g. accessing `.Count`, iterating via `.ToList()`), it attempted to insert both `"Empty"` and `"empty"` into the same case-insensitive dictionary, throwing on the duplicate.

This setting was **redundant** — all case-insensitive property lookups in the codebase already go through the `GetPropertyCaseInsensitive()` helper method, which manually performs a case-insensitive fallback search.

## Fix

**File changed:** `src/Shared/JExtensions.cs`

- Removed the `NodeOptions` field entirely (it only existed to set `PropertyNameCaseInsensitive = true`)
- Replaced all 6 usages of `NodeOptions` in `JsonNode.Parse()` calls with `null` (uses default `JsonNodeOptions`, which is case-sensitive)

This means `JsonObject` now stores properties with their original casing and uses a case-sensitive internal dictionary — which tolerates keys like `"Empty"` and `"empty"` coexisting. Case-insensitive lookups continue to work through the existing `GetPropertyCaseInsensitive()` helper.

## Test Added

**File:** `test/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/TemplateConfigTests/GenericTests.cs`

Added `CanReadTemplateWithDuplicateCaseInsensitiveSymbolKeys` — a regression test that verifies a template.json with symbols `"Empty"` and `"empty"` loads without throwing.
