### PR TITLE
Fix MockTemplateInfo for System.Text.Json serialization

### DIFF
--- a/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
+++ b/test/Microsoft.TemplateEngine.Mocks/MockTemplateInfo.cs
@@ -92,10 +92,10 @@ namespace Microsoft.TemplateEngine.Mocks
         public bool PreferDefaultName => _preferDefaultName;
 
         [Obsolete("Use ParameterDefinitionSet instead.")]
-        IReadOnlyDictionary<string, ICacheTag> ITemplateInfo.Tags => throw new NotImplementedException();
+        IReadOnlyDictionary<string, ICacheTag> ITemplateInfo.Tags => null!;
 
         [Obsolete("Use ParameterDefinitionSet instead.")]
-        IReadOnlyDictionary<string, ICacheParameter> ITemplateInfo.CacheParameters => throw new NotImplementedException();
+        IReadOnlyDictionary<string, ICacheParameter> ITemplateInfo.CacheParameters => null!;
 
         public IParameterDefinitionSet ParameterDefinitions
         {


### PR DESCRIPTION
## Problem

After the Newtonsoft.Json → System.Text.Json migration ([#9956](https://github.com/dotnet/templating/pull/9956)), `MockTemplateInfo`'s explicit `ITemplateInfo.Tags` and `ITemplateInfo.CacheParameters` implementations throw `NotImplementedException`. Newtonsoft never visited these during serialization, but System.Text.Json walks all interface properties when serializing, causing `TemplateDiscoveryMetadata.ToJObject()` to crash:

```
System.NotImplementedException : The method or operation is not implemented.
  at MockTemplateInfo.ITemplateInfo.get_Tags()
  at System.Text.Json.Serialization...JsonPropertyInfo`1.GetMemberAndWriteJson
```

This breaks all `CacheSearchCoordinatorTests` in the SDK CI ([sdk#53613](https://github.com/dotnet/sdk/pull/53613)).

## Fix

Return empty dictionaries instead of throwing. Both properties are `[Obsolete]` — the mock's real tag data lives in the `TagsCollection` property.