### PR TITLE
Remove Publish-Build-Assets variable group from release/9.0.1xx

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -113,8 +113,6 @@ extends:
               # Only enable publishing in non-public, non PR scenarios.
               - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                 # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat, symweb-symbol-server-pat
-                # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-                - group: Publish-Build-Assets
                 - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
                     /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                     /p:OfficialBuildId=$(BUILD.BUILDNUMBER)


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `azure-pipelines.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131